### PR TITLE
test(bot): smoke test PR bot on OSS repo

### DIFF
--- a/packages/core/src/repowise/core/ingestion/graph.py
+++ b/packages/core/src/repowise/core/ingestion/graph.py
@@ -1,10 +1,9 @@
 """Dependency graph builder for the repowise ingestion pipeline.
 
-GraphBuilder constructs a directed graph from ParsedFile objects with two
-tiers of nodes:
+Builds a directed graph from ``ParsedFile`` objects across two tiers:
 
     File-level nodes:
-        "file"     — every source file
+        "file"     — every source file in the repo
         "external" — third-party / unresolvable imports (prefix "external:")
 
     Symbol-level nodes:


### PR DESCRIPTION
Tiny docstring tightening in a hotspot file (packages/core/src/repowise/core/ingestion/graph.py — 99.9th %ile churn) to fire the bot's hotspot rule. No behavioral change. Close after the bot comments.