### PR TITLE
Fix #666: Probe submodules for python package imports

### DIFF
--- a/packages/core/src/repowise/core/ingestion/graph/builder.py
+++ b/packages/core/src/repowise/core/ingestion/graph/builder.py
@@ -342,6 +342,10 @@ class GraphBuilder(MetricsMixin, ResolveMixin, EdgesMixin, SerializeMixin, Rehyd
                     from ..resolvers.cpp import resolve_cpp_import_all
 
                     targets = resolve_cpp_import_all(imp.module_path, path, ctx)
+                elif _lang == "python":
+                    from ..resolvers.python import resolve_python_import_all
+
+                    targets = resolve_python_import_all(imp, path, ctx)
                 else:
                     single = resolve_import(imp.module_path, path, _lang, ctx)
                     targets = (single,) if single else ()

--- a/packages/core/src/repowise/core/ingestion/resolvers/python.py
+++ b/packages/core/src/repowise/core/ingestion/resolvers/python.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 from ..languages.python_modules import build_python_module_index
 from .context import ResolverContext
@@ -67,6 +68,24 @@ def resolve_python_import(module_path: str, importer_path: str, ctx: ResolverCon
         if c in ctx.path_set:
             return c
 
-    # Stem-only fallback
+# Stem-only fallback
     stem = module_path.split(".")[-1].lower()
     return ctx.stem_lookup(stem)
+
+
+def resolve_python_import_all(imp: Any, importer_path: str, ctx: ResolverContext) -> tuple[str, ...]:
+    """Resolve a Python import, additionally probing submodules for package imports."""
+    targets = []
+    base = resolve_python_import(imp.module_path, importer_path, ctx)
+    if base:
+        targets.append(base)
+        if base.endswith("__init__.py"):
+            base_dir = Path(base).parent.as_posix()
+            for name in (imp.imported_names or []):
+                c1 = f"{base_dir}/{name}.py"
+                c2 = f"{base_dir}/{name}/__init__.py"
+                if c1 in ctx.path_set:
+                    targets.append(c1)
+                elif c2 in ctx.path_set:
+                    targets.append(c2)
+    return tuple(targets)

--- a/tests/unit/ingestion/test_python_resolver.py
+++ b/tests/unit/ingestion/test_python_resolver.py
@@ -1,0 +1,52 @@
+import pytest
+from repowise.core.ingestion.models import Import
+from repowise.core.ingestion.resolvers.context import ResolverContext
+from repowise.core.ingestion.resolvers.python import resolve_python_import, resolve_python_import_all
+
+
+def test_resolve_python_import_all_submodules():
+    path_set = {
+        "src/app.py",
+        "src/routers/__init__.py",
+        "src/routers/workspace.py",
+        "src/routers/git/__init__.py",
+    }
+    
+    ctx = ResolverContext(path_set=path_set, stem_map={}, graph=None)
+    
+    # 1. Single submodule without __init__.py package
+    imp = Import(
+        module_path="routers",
+        module_type="python",
+        imported_names=("workspace", "git", "overview"),
+        range_start=0,
+        range_end=0,
+        is_type_only=False,
+    )
+    
+    targets = resolve_python_import_all(imp, "src/app.py", ctx)
+    assert "src/routers/__init__.py" in targets
+    assert "src/routers/workspace.py" in targets
+    assert "src/routers/git/__init__.py" in targets
+    assert len(targets) == 3
+
+
+def test_resolve_python_import_all_no_submodules():
+    path_set = {
+        "src/app.py",
+        "src/routers/__init__.py",
+    }
+    
+    ctx = ResolverContext(path_set=path_set, stem_map={}, graph=None)
+    
+    imp = Import(
+        module_path="routers",
+        module_type="python",
+        imported_names=("missing",),
+        range_start=0,
+        range_end=0,
+        is_type_only=False,
+    )
+    
+    targets = resolve_python_import_all(imp, "src/app.py", ctx)
+    assert targets == ("src/routers/__init__.py",)


### PR DESCRIPTION
### Summary
This PR fixes the false-positive `unreachable_file` reports on Python router modules caused by the resolver missing submodules when they are imported via a package `__init__.py`. 

The root cause was that `resolve_python_import` would resolve statements like `from repowise.server.routers import workspace` strictly to `repowise/server/routers/__init__.py`, meaning the submodules themselves never received inbound edges and were falsely flagged by the dead-code analyzer with `in_degree=0`.

**Changes:**
- Added a `resolve_python_import_all` helper function in `repowise.core.ingestion.resolvers.python`.
- `resolve_python_import_all` resolves the base package, then properly iterates over the `Import.imported_names` to probe for `<name>.py` and `<name>/__init__.py` submodules in the package directory.
- Updated `_resolve_imports` in `graph/builder.py` to route Python resolutions through this new function, appending missing edges.

### Related Issues
Fixes #666

### Test Plan
- [x] Tests pass (`pytest`)
- [x] Lint passes (`ruff check .`)
- [ ] Web build passes (`npm run build`) (if frontend changes)

*Added a dedicated regression test (`test_python_resolver.py`) ensuring `resolve_python_import_all` properly identifies and returns submodule file paths when a module uses the `from pkg import submodule1, submodule2` format.*

### Checklist
- [x] My code follows the project's code style
- [x] I have added tests for new functionality
- [x] All existing tests still pass
- [ ] I have updated documentation if needed
