### PR TITLE
Fix #838: Use Next.js Middleware for dynamic proxying of API routes

### DIFF
--- a/packages/web/next.config.ts
+++ b/packages/web/next.config.ts
@@ -24,23 +24,6 @@ const nextConfig: NextConfig = {
   images: {
     unoptimized: true,
   },
-  async rewrites() {
-    const apiUrl = process.env.REPOWISE_API_URL || "http://localhost:7337";
-    return [
-      {
-        source: "/api/:path*",
-        destination: `${apiUrl}/api/:path*`,
-      },
-      {
-        source: "/health",
-        destination: `${apiUrl}/health`,
-      },
-      {
-        source: "/metrics",
-        destination: `${apiUrl}/metrics`,
-      },
-    ];
-  },
 };
 
 export default nextConfig;

--- a/packages/web/src/middleware.ts
+++ b/packages/web/src/middleware.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+export function middleware(request: NextRequest) {
+  const apiUrl = process.env.REPOWISE_API_URL || "http://localhost:7337";
+  
+  // Construct the destination URL using the runtime API base URL
+  const destination = new URL(
+    request.nextUrl.pathname + request.nextUrl.search,
+    apiUrl
+  );
+
+  return NextResponse.rewrite(destination);
+}
+
+export const config = {
+  matcher: [
+    '/api/:path*',
+    '/health',
+    '/metrics'
+  ],
+};


### PR DESCRIPTION
### Summary
This PR fixes the issue where Next.js proxy routes (specifically `/api/graph/*`) ignored the `--port` argument provided to the CLI and defaulted to `7337`.

### Root Cause
When the UI is built in Next.js `standalone` mode, the `next.config.ts` environment variables are evaluated entirely at **build time**. Because of this, the `rewrites()` array was compiled into `.next/routes-manifest.json` with the static fallback `http://localhost:7337`, permanently baking in the default port.

While client components (which route through the UI proxy) hitting `/api/graph/*` resulted in `ECONNREFUSED` or `500` errors due to this hardcoded fallback, server components completely bypassed the proxy and fetched using the runtime `process.env.REPOWISE_API_URL` natively, creating the illusion that only some routes were broken.

### Changes
* Removed the static `rewrites()` logic from `packages/web/next.config.ts`.
* Introduced a runtime edge middleware at `packages/web/src/middleware.ts` utilizing `NextResponse.rewrite()`. This properly reads `process.env.REPOWISE_API_URL` dynamically at runtime and routes `/api/*`, `/health`, and `/metrics` requests to the correct backend port instantiated by the CLI command.

### Related Issues
Fixes #838 

### Test Plan
- [x] Verified that Next.js build no longer generates static rewrites in `.next/routes-manifest.json`.
- [x] Tested `repowise serve --port 1679` locally.
- [x] Confirmed the Architecture and Knowledge Graph views correctly load on custom ports without proxy `ECONNREFUSED` errors.
