### PR TITLE
Fix #840: Use SO_REUSEADDR in port probe to ignore TIME_WAIT

### DIFF
--- a/packages/cli/src/repowise/cli/commands/serve_cmd.py
+++ b/packages/cli/src/repowise/cli/commands/serve_cmd.py
@@ -253,6 +253,8 @@ def _load_local_provider_config() -> None:
 def _is_port_free(host: str, port: int) -> bool:
     """Return True if *port* can be bound on *host* right now."""
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        if os.name != "nt":
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         try:
             sock.bind((host, port))
         except OSError:

--- a/tests/unit/cli/test_serve_port_fallback.py
+++ b/tests/unit/cli/test_serve_port_fallback.py
@@ -68,3 +68,28 @@ def test_find_free_port_handles_contiguous_busy_block(
     chosen = serve_cmd._find_free_port("127.0.0.1", 3000, "web UI", max_attempts=5)
     assert isinstance(chosen, int)
     assert 1024 <= chosen <= 65535
+
+
+def test_is_port_free_ignores_time_wait() -> None:
+    """Regression test for issue #840: TIME_WAIT sockets shouldn't block the probe."""
+    import os
+    
+    host = "127.0.0.1"
+    lis = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    if os.name != "nt":
+        lis.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    lis.bind((host, 0))
+    port = lis.getsockname()[1]
+    lis.listen(1)
+    
+    cli = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    cli.connect((host, port))
+    conn, _ = lis.accept()
+    
+    # Active close from the server side pushes the listener's port into TIME_WAIT
+    lis.close()
+    conn.close()
+    cli.close()
+    
+    # The probe should report it as free because it uses SO_REUSEADDR too
+    assert serve_cmd._is_port_free(host, port) is True

--- a/tests/unit/cli/test_serve_port_fallback.py
+++ b/tests/unit/cli/test_serve_port_fallback.py
@@ -7,6 +7,7 @@ port instead of crashing with EADDRINUSE.
 
 from __future__ import annotations
 
+import os
 import socket
 
 import pytest
@@ -70,10 +71,9 @@ def test_find_free_port_handles_contiguous_busy_block(
     assert 1024 <= chosen <= 65535
 
 
+@pytest.mark.skipif(os.name == "nt", reason="SO_REUSEADDR probe fix is POSIX-only (issue #840)")
 def test_is_port_free_ignores_time_wait() -> None:
     """Regression test for issue #840: TIME_WAIT sockets shouldn't block the probe."""
-    import os
-    
     host = "127.0.0.1"
     lis = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     if os.name != "nt":


### PR DESCRIPTION
### Summary
This PR fixes the issue where `repowise serve` would silently fallback to an alternative port (e.g. `7338` or `3001`) during quick restarts due to the preferred ports being temporarily held in a `TIME_WAIT` state by the operating system.

### Root Cause
The `_is_port_free` check used a plain `socket.bind()` probe. When a previous instance of the server exits, the listening sockets linger in a `TIME_WAIT` state for ~60s. A standard probe treats these ports as "in use", even though actual web servers (like `uvicorn` and Next.js) configure `SO_REUSEADDR` to safely rebind them immediately. 

This resulted in a silent fallback that broke the UI proxy configuration, causing an `ECONNREFUSED` error loop as the Next.js UI continued attempting to reach the API on the preferred port (`7337`) while the backend API was stealthily moved to `7338`.

### Changes
* Modified `_is_port_free` in `packages/cli/src/repowise/cli/commands/serve_cmd.py` to enable `SO_REUSEADDR` on POSIX systems (`os.name != "nt"`). This accurately aligns the pre-flight probe with the real bind semantics of the downstream servers.
* Appended a regression test `test_is_port_free_ignores_time_wait` in `tests/unit/cli/test_serve_port_fallback.py` to assert that `TIME_WAIT` states (simulated via an active close sequence) are properly ignored by the probe.

### Related Issues
Fixes #840

### Test Plan
- [x] Run `pytest tests/unit/cli/test_serve_port_fallback.py` to verify the regression test logic locally.
- [x] Tested clean binding behavior when forcefully stopping and starting the server consecutively.
