### PR TITLE
feat(cli): add --verbose to reindex quiet logging

### DIFF
--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -907,6 +907,7 @@ Rebuild the vector search index by re-embedding all wiki pages. No LLM calls, on
 |------|-------------|
 | `--embedder` | `gemini`, `openai`, `openrouter`, `ollama`, `mock`, or `auto` (default: auto) |
 | `--batch-size` | Embedding batch size (default: 32) |
+| `--verbose`, `-v` | Show debug logs from the pipeline |
 
 ```bash
 repowise reindex

--- a/packages/cli/src/repowise/cli/commands/reindex_cmd.py
+++ b/packages/cli/src/repowise/cli/commands/reindex_cmd.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import click
 from rich.progress import BarColumn, Progress, SpinnerColumn, TextColumn, TimeElapsedColumn
 
+from repowise.cli._setup import configure_cli_logging
 from repowise.cli.helpers import (
     console,
     ensure_repowise_dir,
@@ -24,13 +25,26 @@ from repowise.cli.ui import BRAND_STYLE, OWL_SPINNER
     help="Embedder to use. 'auto' detects from env vars / config.",
 )
 @click.option("--batch-size", type=int, default=32, help="Pages per embedding batch.")
-def reindex_command(path: str | None, embedder: str, batch_size: int) -> None:
+@click.option(
+    "--verbose",
+    "-v",
+    is_flag=True,
+    default=False,
+    help="Show debug logs from the pipeline.",
+)
+def reindex_command(
+    path: str | None, embedder: str, batch_size: int, verbose: bool = False
+) -> None:
     """Rebuild vector search index from existing wiki pages.
 
     Reads all pages from the database, embeds them using the configured
     embedder, and persists the vectors to LanceDB. No LLM calls — only
     embedding API calls. Fast and cheap.
     """
+    # Quiet library/structlog output so it doesn't interleave with the live
+    # progress bar; `-v` lets repowise's debug lines through for troubleshooting.
+    configure_cli_logging(verbose=verbose)
+
     repo_path = resolve_repo_path(path)
     ensure_repowise_dir(repo_path)
 

--- a/tests/unit/cli/test_reindex_cmd.py
+++ b/tests/unit/cli/test_reindex_cmd.py
@@ -69,3 +69,40 @@ async def test_reindex_uses_shared_database_engine(
     assert created["url"] == db_url
     assert created["init_engine"] is created["engine"]
     assert created["engine"].disposed is True
+
+
+def test_reindex_command_forwards_verbose_to_configure_cli_logging(monkeypatch, tmp_path: Path) -> None:
+    """`--verbose` must reach configure_cli_logging before any pipeline work."""
+    seen: dict[str, object] = {}
+
+    def fake_configure(*, verbose: bool = False) -> None:
+        seen["verbose"] = verbose
+
+    def fake_resolve_repo_path(_path: str | None) -> Path:
+        return tmp_path
+
+    def fake_ensure_repowise_dir(_repo_path: Path) -> Path:
+        return tmp_path / ".repowise"
+
+    def fake_run_async(_coro) -> None:
+        # Do not execute the coroutine body; just close it.
+        _coro.close()
+
+    monkeypatch.setattr(reindex_cmd, "configure_cli_logging", fake_configure)
+    monkeypatch.setattr(reindex_cmd, "resolve_repo_path", fake_resolve_repo_path)
+    monkeypatch.setattr(reindex_cmd, "ensure_repowise_dir", fake_ensure_repowise_dir)
+    monkeypatch.setattr(reindex_cmd, "run_async", fake_run_async)
+    monkeypatch.setattr("repowise.cli.ui.load_dotenv", lambda _repo_path: None)
+
+    # Invoke the underlying function (not the Click wrapper) so we control kwargs.
+    reindex_cmd.reindex_command.callback(
+        path=None, embedder="mock", batch_size=32, verbose=True
+    )
+    assert seen.get("verbose") is True
+
+    seen.clear()
+    reindex_cmd.reindex_command.callback(
+        path=None, embedder="mock", batch_size=32, verbose=False
+    )
+    assert seen.get("verbose") is False
+

--- a/tests/unit/cli/test_reindex_cmd.py
+++ b/tests/unit/cli/test_reindex_cmd.py
@@ -71,38 +71,25 @@ async def test_reindex_uses_shared_database_engine(
     assert created["engine"].disposed is True
 
 
-def test_reindex_command_forwards_verbose_to_configure_cli_logging(monkeypatch, tmp_path: Path) -> None:
-    """`--verbose` must reach configure_cli_logging before any pipeline work."""
-    seen: dict[str, object] = {}
+def test_reindex_verbose_flag_reaches_configure_cli_logging(tmp_path, monkeypatch):
+    """`--verbose/-v` must reach configure_cli_logging via CliRunner (not .callback)."""
+    from click.testing import CliRunner
+    from repowise.cli.main import cli
 
-    def fake_configure(*, verbose: bool = False) -> None:
-        seen["verbose"] = verbose
-
-    def fake_resolve_repo_path(_path: str | None) -> Path:
-        return tmp_path
-
-    def fake_ensure_repowise_dir(_repo_path: Path) -> Path:
-        return tmp_path / ".repowise"
-
-    def fake_run_async(_coro) -> None:
-        # Do not execute the coroutine body; just close it.
-        _coro.close()
-
-    monkeypatch.setattr(reindex_cmd, "configure_cli_logging", fake_configure)
-    monkeypatch.setattr(reindex_cmd, "resolve_repo_path", fake_resolve_repo_path)
-    monkeypatch.setattr(reindex_cmd, "ensure_repowise_dir", fake_ensure_repowise_dir)
-    monkeypatch.setattr(reindex_cmd, "run_async", fake_run_async)
+    calls: list[bool] = []
+    monkeypatch.setattr(
+        reindex_cmd, "configure_cli_logging", lambda *, verbose: calls.append(verbose)
+    )
+    monkeypatch.setattr(reindex_cmd, "resolve_repo_path", lambda _p: tmp_path)
+    monkeypatch.setattr(reindex_cmd, "ensure_repowise_dir", lambda _p: tmp_path / ".repowise")
+    monkeypatch.setattr(reindex_cmd, "run_async", lambda coro: coro.close())
     monkeypatch.setattr("repowise.cli.ui.load_dotenv", lambda _repo_path: None)
 
-    # Invoke the underlying function (not the Click wrapper) so we control kwargs.
-    reindex_cmd.reindex_command.callback(
-        path=None, embedder="mock", batch_size=32, verbose=True
-    )
-    assert seen.get("verbose") is True
+    result = CliRunner().invoke(cli, ["reindex", str(tmp_path), "-v"])
+    assert result.exit_code == 0, result.output
+    assert calls == [True]
 
-    seen.clear()
-    reindex_cmd.reindex_command.callback(
-        path=None, embedder="mock", batch_size=32, verbose=False
-    )
-    assert seen.get("verbose") is False
-
+    calls.clear()
+    result = CliRunner().invoke(cli, ["reindex", str(tmp_path)])
+    assert result.exit_code == 0, result.output
+    assert calls == [False]


### PR DESCRIPTION
## Summary

- Add `--verbose` / `-v` to `repowise reindex`, wired to `configure_cli_logging` (same helper as `init` / `update`)
- Default stays quiet so Rich progress bars are not flooded by library/structlog debug lines
- Unit test asserts the flag reaches `configure_cli_logging` before pipeline work

## Related Issues

Part of #930 (reindex slice only; other commands left for follow-ups as the issue suggests)

## Test Plan

- [x] `pytest tests/unit/cli/test_reindex_cmd.py` (2 passed)
- [ ] Lint passes (`ruff check .`) *(not run full tree this PR)*
- [ ] Web build N/A

## Checklist

- [x] My code follows the project's code style
- [x] I have added tests for new functionality
- [x] Existing reindex tests still pass
- [x] Documentation N/A (flag help text added on the option)
