### PR TITLE
feat(cli): add --verbose to export quiet logging

### DIFF
--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -668,6 +668,8 @@ Export wiki pages to files.
 | `--format` | `markdown` (default), `html`, `json` |
 | `--output / -o` | Output directory (default: `.repowise/export`) |
 | `--full` | Include decisions, dead code, hotspots, provenance metadata (JSON only) |
+| `--verbose`, `-v` | Show debug logs from the pipeline |
+
 
 ```bash
 repowise export

--- a/packages/cli/src/repowise/cli/commands/export_cmd.py
+++ b/packages/cli/src/repowise/cli/commands/export_cmd.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import click
 from rich.progress import Progress
 
+from repowise.cli._setup import configure_cli_logging
 from repowise.cli.helpers import (
     console,
     ensure_repowise_dir,
@@ -40,13 +41,25 @@ from repowise.cli.helpers import (
     default=False,
     help="Include decisions, dead code, git metadata, and provenance in JSON export.",
 )
+@click.option(
+    "--verbose",
+    "-v",
+    is_flag=True,
+    default=False,
+    help="Show debug logs from the pipeline.",
+)
 def export_command(
     path: str | None,
     fmt: str,
     output_dir: str | None,
     full_export: bool = False,
+    verbose: bool = False,
 ) -> None:
     """Export wiki pages to files."""
+    # Quiet library/structlog output so it doesn't interleave with the live
+    # progress bar; `-v` lets repowise's debug lines through for troubleshooting.
+    configure_cli_logging(verbose=verbose)
+
     repo_path = resolve_repo_path(path)
     ensure_repowise_dir(repo_path)
 

--- a/tests/unit/cli/test_export_cmd.py
+++ b/tests/unit/cli/test_export_cmd.py
@@ -1,0 +1,40 @@
+"""Tests for the export CLI command wiring."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from repowise.cli.commands import export_cmd
+
+
+def test_export_command_forwards_verbose_to_configure_cli_logging(monkeypatch, tmp_path: Path) -> None:
+    """`--verbose` must reach configure_cli_logging before any pipeline work."""
+    seen: dict[str, object] = {}
+
+    def fake_configure(*, verbose: bool = False) -> None:
+        seen["verbose"] = verbose
+
+    def fake_resolve_repo_path(_path: str | None) -> Path:
+        return tmp_path
+
+    def fake_ensure_repowise_dir(_repo_path: Path) -> Path:
+        return tmp_path / ".repowise"
+
+    def fake_run_async(_coro) -> None:
+        _coro.close()
+
+    monkeypatch.setattr(export_cmd, "configure_cli_logging", fake_configure)
+    monkeypatch.setattr(export_cmd, "resolve_repo_path", fake_resolve_repo_path)
+    monkeypatch.setattr(export_cmd, "ensure_repowise_dir", fake_ensure_repowise_dir)
+    monkeypatch.setattr(export_cmd, "run_async", fake_run_async)
+
+    export_cmd.export_command.callback(
+        path=None, fmt="markdown", output_dir=None, full_export=False, verbose=True
+    )
+    assert seen.get("verbose") is True
+
+    seen.clear()
+    export_cmd.export_command.callback(
+        path=None, fmt="markdown", output_dir=None, full_export=False, verbose=False
+    )
+    assert seen.get("verbose") is False

--- a/tests/unit/cli/test_export_cmd.py
+++ b/tests/unit/cli/test_export_cmd.py
@@ -7,34 +7,24 @@ from pathlib import Path
 from repowise.cli.commands import export_cmd
 
 
-def test_export_command_forwards_verbose_to_configure_cli_logging(monkeypatch, tmp_path: Path) -> None:
-    """`--verbose` must reach configure_cli_logging before any pipeline work."""
-    seen: dict[str, object] = {}
+def test_export_verbose_flag_reaches_configure_cli_logging(tmp_path, monkeypatch):
+    """`--verbose/-v` must reach configure_cli_logging via CliRunner (not .callback)."""
+    from click.testing import CliRunner
+    from repowise.cli.main import cli
 
-    def fake_configure(*, verbose: bool = False) -> None:
-        seen["verbose"] = verbose
-
-    def fake_resolve_repo_path(_path: str | None) -> Path:
-        return tmp_path
-
-    def fake_ensure_repowise_dir(_repo_path: Path) -> Path:
-        return tmp_path / ".repowise"
-
-    def fake_run_async(_coro) -> None:
-        _coro.close()
-
-    monkeypatch.setattr(export_cmd, "configure_cli_logging", fake_configure)
-    monkeypatch.setattr(export_cmd, "resolve_repo_path", fake_resolve_repo_path)
-    monkeypatch.setattr(export_cmd, "ensure_repowise_dir", fake_ensure_repowise_dir)
-    monkeypatch.setattr(export_cmd, "run_async", fake_run_async)
-
-    export_cmd.export_command.callback(
-        path=None, fmt="markdown", output_dir=None, full_export=False, verbose=True
+    calls: list[bool] = []
+    monkeypatch.setattr(
+        export_cmd, "configure_cli_logging", lambda *, verbose: calls.append(verbose)
     )
-    assert seen.get("verbose") is True
+    monkeypatch.setattr(export_cmd, "resolve_repo_path", lambda _p: tmp_path)
+    monkeypatch.setattr(export_cmd, "ensure_repowise_dir", lambda _p: tmp_path / ".repowise")
+    monkeypatch.setattr(export_cmd, "run_async", lambda coro: coro.close())
 
-    seen.clear()
-    export_cmd.export_command.callback(
-        path=None, fmt="markdown", output_dir=None, full_export=False, verbose=False
-    )
-    assert seen.get("verbose") is False
+    result = CliRunner().invoke(cli, ["export", str(tmp_path), "-v"])
+    assert result.exit_code == 0, result.output
+    assert calls == [True]
+
+    calls.clear()
+    result = CliRunner().invoke(cli, ["export", str(tmp_path)])
+    assert result.exit_code == 0, result.output
+    assert calls == [False]


### PR DESCRIPTION
## Summary
- Add `--verbose` / `-v` to `repowise export`, wired to `configure_cli_logging` so progress bars stay clean by default (same pattern as `init`/`update`/`reindex`).
- Unit test asserts the flag reaches `configure_cli_logging` before pipeline work.

Part of #930 (export slice only).

## How tested
```bash
.venv/bin/python -m pytest tests/unit/cli/test_export_cmd.py -q
# 1 passed
```
