### PR TITLE
fix(augment): keep log output off the hook's stdout

### DIFF
--- a/packages/cli/src/repowise/cli/commands/augment_cmd/command.py
+++ b/packages/cli/src/repowise/cli/commands/augment_cmd/command.py
@@ -79,6 +79,8 @@ from pathlib import Path
 
 import click
 
+from repowise.cli.helpers import silence_logs_for_machine_output
+
 from .bash_staleness import _handle_bash_post
 from .codex import _handle_codex_context_event, _handle_post_edit_use
 from .read_state import _handle_edit_post, _handle_read_post, _record_edit
@@ -99,6 +101,7 @@ _EDIT_TOOL_NAMES = {"apply_patch", "Edit", "Write"}
 def augment_command(client: str | None = None) -> None:
     """Enrich AI agent tool calls with codebase graph context (hook mode)."""
     try:
+        silence_logs_for_machine_output()
         _run_augment(client=client)
     except (SystemExit, KeyboardInterrupt):
         raise

--- a/tests/unit/cli/test_augment_cmd.py
+++ b/tests/unit/cli/test_augment_cmd.py
@@ -57,7 +57,6 @@ def test_augment_silences_logs_before_hook_dispatch(monkeypatch: pytest.MonkeyPa
         augment_cmd,
         "silence_logs_for_machine_output",
         fake_silence_logs_for_machine_output,
-        raising=False,
     )
     monkeypatch.setattr(augment_cmd, "_run_augment", fake_run_augment)
 

--- a/tests/unit/cli/test_augment_cmd.py
+++ b/tests/unit/cli/test_augment_cmd.py
@@ -8,6 +8,7 @@ from typing import Any
 import pytest
 from click.testing import CliRunner
 
+from repowise.cli.commands.augment_cmd import command as augment_cmd
 from repowise.cli.main import cli
 
 
@@ -41,6 +42,29 @@ def _init_repowise_repo(path: Path) -> None:
         ),
         encoding="utf-8",
     )
+
+
+def test_augment_silences_logs_before_hook_dispatch(monkeypatch: pytest.MonkeyPatch) -> None:
+    events: list[tuple[str, bool]] = []
+
+    def fake_silence_logs_for_machine_output() -> None:
+        events.append(("logging", True))
+
+    def fake_run_augment(*, client: str | None = None) -> None:
+        events.append(("dispatch", client is not None))
+
+    monkeypatch.setattr(
+        augment_cmd,
+        "silence_logs_for_machine_output",
+        fake_silence_logs_for_machine_output,
+        raising=False,
+    )
+    monkeypatch.setattr(augment_cmd, "_run_augment", fake_run_augment)
+
+    result = CliRunner().invoke(cli, ["augment"])
+
+    assert result.exit_code == 0
+    assert events == [("logging", True), ("dispatch", False)]
 
 
 def test_codex_session_start_payload_returns_mcp_context(runner: CliRunner, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- Silence Repowise/core logging before `repowise augment` dispatches hook payloads so machine-readable stdout stays clean.
- Add focused `CliRunner` coverage proving log silencing happens before hook dispatch.

## Related issue

Addresses the machine-output behavior of the `augment` slice in #930.

## Test plan

- [x] `uv run pytest tests/unit/cli/test_augment_cmd.py -q` (8 passed)
- [x] `uv run ruff check packages/cli/src/repowise/cli/commands/augment_cmd/command.py tests/unit/cli/test_augment_cmd.py`
- [x] `uv run ruff format --check tests/unit/cli/test_augment_cmd.py`
- [x] `git diff --check`
- [x] No web build required (CLI only)

## Checklist

- [x] My code follows the project style
- [x] I added tests for the changed behavior
- [x] I updated the PR metadata to match the final implementation