### PR TITLE
fix(init): attribute page failures to the current generation

### DIFF
--- a/docs/superpowers/plans/2026-07-26-init-report-partial-failures-design.md
+++ b/docs/superpowers/plans/2026-07-26-init-report-partial-failures-design.md
@@ -1,0 +1,157 @@
+# Init Partial-Failure Reporting Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `repowise init` clearly report page-generation failures and the recovery command while preserving its successful exit status and zero-failure output.
+
+**Architecture:** The generation phase already writes the current run's failed page IDs to its `JobSystem` checkpoint. Add an optional completion callback to `run_generation`; after `PageGenerator.generate_all` returns, it reads that run's checkpoint and sends the failed IDs to the CLI generation wrapper. The wrapper formats the IDs by their `page_type:` prefix and prints one warning only when the callback reports failures.
+
+**Tech Stack:** Python 3.11+, Click/Rich CLI, pytest, existing JSON-backed `JobSystem`.
+
+---
+
+### Task 1: Expose the current generation run's failure IDs
+
+**Files:**
+- Modify: `packages/core/src/repowise/core/pipeline/phases/generation.py:22-156`
+- Test: `tests/unit/cli/test_generation_persist.py`
+
+- [ ] **Step 1: Write the failing pipeline callback test**
+
+Add a focused async test that supplies a completion callback to `run_generation`, uses a provider that raises for one page, and asserts the callback receives the failed page ID after generation returns.
+
+```python
+failed: list[str] = []
+
+pages = await run_generation(
+    ...,
+    on_generation_complete=failed.extend,
+)
+
+assert pages
+assert failed == ["file_page:broken.py"]
+```
+
+- [ ] **Step 2: Run the focused test and confirm it fails because the callback is unsupported**
+
+Run: `uv run pytest tests/unit/cli/test_generation_persist.py -q`
+
+Expected: failure reporting that `run_generation()` does not accept `on_generation_complete`.
+
+- [ ] **Step 3: Add the callback without altering generation results**
+
+Extend `run_generation` with `on_generation_complete: Callable[[list[str]], None] | None = None`. After `generate_all` returns, read `job_system.get_checkpoint(...)` for this run and invoke the callback with a copied `failed_page_ids` list. Keep the existing return value as `list[GeneratedPage]` and treat callback failures as non-fatal.
+
+```python
+if on_generation_complete is not None:
+    try:
+        jobs = job_system.list_jobs()
+        failed_page_ids = list(jobs[0].failed_page_ids) if jobs else []
+        on_generation_complete(failed_page_ids)
+    except Exception as exc:
+        logger.debug("generation.failure_summary_callback_failed", error=str(exc))
+```
+
+- [ ] **Step 4: Run the focused test and confirm it passes**
+
+Run: `uv run pytest tests/unit/cli/test_generation_persist.py -q`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit the pipeline callback**
+
+```bash
+git add packages/core/src/repowise/core/pipeline/phases/generation.py tests/unit/cli/test_generation_persist.py
+git commit -m "feat(generation): expose failed page IDs to callers"
+```
+
+### Task 2: Render the init warning from the pipeline failure summary
+
+**Files:**
+- Modify: `packages/cli/src/repowise/cli/commands/init_cmd/generation.py:184-297`
+- Test: `tests/unit/cli/test_generation_persist.py`
+
+- [ ] **Step 1: Write failing formatter tests**
+
+Add tests for a small formatter that verifies: (a) an empty ID list produces no output, and (b) `file_page:src/a.py`, `module_page:core`, and `file_page:src/b.py` produce a warning containing `3 pages failed`, `file_page (2)`, `module_page (1)`, `incomplete`, and `repowise init --resume`.
+
+```python
+assert _format_generation_failure_summary([]) is None
+
+summary = _format_generation_failure_summary(
+    ["file_page:src/a.py", "module_page:core", "file_page:src/b.py"]
+)
+assert "3 pages failed" in summary
+assert "file_page (2)" in summary
+assert "module_page (1)" in summary
+assert "repowise init --resume" in summary
+```
+
+- [ ] **Step 2: Run the formatter tests and confirm they fail because the formatter is absent**
+
+Run: `uv run pytest tests/unit/cli/test_generation_persist.py -q`
+
+Expected: import or attribute failure for `_format_generation_failure_summary`.
+
+- [ ] **Step 3: Implement warning formatting and wire the callback**
+
+Add `_format_generation_failure_summary(failed_page_ids: list[str]) -> str | None`, grouping each ID on its first `:` and sorting types alphabetically. In `run_repo_generation`, register the callback before calling `run_generation_with_persistence`; after the progress context closes and `result.generated_pages` is assigned, print the warning only if the formatted summary is non-empty.
+
+```python
+failure_summary = _format_generation_failure_summary(failed_page_ids)
+if failure_summary:
+    console.print(f"[yellow]{failure_summary}[/yellow]")
+```
+
+The warning must say the wiki is incomplete and name `repowise init --resume`; it must not change the command's exit status or print on a zero-failure run.
+
+- [ ] **Step 4: Run the focused tests and confirm they pass**
+
+Run: `uv run pytest tests/unit/cli/test_generation_persist.py -q`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit the CLI reporting change**
+
+```bash
+git add packages/cli/src/repowise/cli/commands/init_cmd/generation.py tests/unit/cli/test_generation_persist.py
+git commit -m "fix(init): report partial page generation failures"
+```
+
+### Task 3: Verify the contribution end-to-end
+
+**Files:**
+- Verify: `packages/core/src/repowise/core/pipeline/phases/generation.py`
+- Verify: `packages/cli/src/repowise/cli/commands/init_cmd/generation.py`
+- Verify: `tests/unit/cli/test_generation_persist.py`
+
+- [ ] **Step 1: Run the focused tests**
+
+Run: `uv run pytest tests/unit/cli/test_generation_persist.py -q`
+
+Expected: PASS with no failures.
+
+- [ ] **Step 2: Run generation checkpoint regression tests**
+
+Run: `uv run pytest tests/unit/generation/test_job_system.py -q`
+
+Expected: PASS with no failures.
+
+- [ ] **Step 3: Run static checks on changed files**
+
+Run: `uv run ruff check packages/core/src/repowise/core/pipeline/phases/generation.py packages/cli/src/repowise/cli/commands/init_cmd/generation.py tests/unit/cli/test_generation_persist.py`
+
+Expected: `All checks passed!`.
+
+- [ ] **Step 4: Inspect the final change**
+
+Run: `git diff origin/main --check && git diff origin/main --stat`
+
+Expected: no whitespace errors; only the planned pipeline, CLI, test, and plan files change.
+
+- [ ] **Step 5: Commit the implementation plan**
+
+```bash
+git add docs/superpowers/plans/2026-07-26-init-report-partial-failures-design.md
+git commit -m "docs: plan init partial-failure reporting"
+```

--- a/packages/cli/src/repowise/cli/commands/init_cmd/generation.py
+++ b/packages/cli/src/repowise/cli/commands/init_cmd/generation.py
@@ -17,6 +17,7 @@ from collections import Counter
 from pathlib import Path
 from typing import Any
 
+from rich.markup import escape
 from rich.progress import BarColumn, Progress, SpinnerColumn, TextColumn, TimeElapsedColumn
 
 # The cost-gate helpers moved to ``repowise.cli.cost_gate`` so ``init`` and
@@ -312,8 +313,11 @@ def run_repo_generation(
     result.preserved_page_ids = preserved_page_ids
 
     failed_page_ids: list[str] = []
+    generation_reported = False
 
     def _record_generation_failures(page_ids: list[str]) -> None:
+        nonlocal generation_reported
+        generation_reported = True
         failed_page_ids[:] = page_ids
 
     with Progress(*columns, console=console) as gen_progress:
@@ -354,6 +358,25 @@ def run_repo_generation(
             )
         )
 
+    # Tests and integrations can replace the async generation boundary, so the
+    # completion callback is not guaranteed to run. Preserve the checkpoint
+    # lookup as a fallback, but never let stale job data override a callback
+    # that explicitly reported zero failures for the current run.
+    if not generation_reported:
+        jobs_dir = Path(repo_path) / ".repowise" / "jobs"
+        if jobs_dir.exists():
+            with contextlib.suppress(Exception):
+                from repowise.core.generation import JobSystem
+
+                js = JobSystem(jobs_dir)
+                job_id = getattr(result, "job_id", None)
+                if job_id:
+                    failed_page_ids[:] = js.get_checkpoint(job_id).failed_page_ids
+                else:
+                    jobs = js.list_jobs()
+                    if jobs:
+                        failed_page_ids[:] = jobs[0].failed_page_ids
+
     result.generated_pages = generated_pages
     result.failed_page_ids = failed_page_ids
 
@@ -365,7 +388,7 @@ def run_repo_generation(
         )
         console.print("  [bold yellow]Failed pages by type:[/bold yellow]")
         for page_type, count in sorted(type_counts.items(), key=lambda x: -x[1]):
-            console.print(f"    • {page_type}: {count}")
+            console.print(f"    • {escape(page_type)}: {count}")
         console.print(
             "\n  [yellow]The wiki is incomplete due to provider failures.[/yellow]\n"
             "  [dim]Run [bold]repowise init --resume[/bold] to generate missing pages "

--- a/packages/cli/src/repowise/cli/commands/init_cmd/generation.py
+++ b/packages/cli/src/repowise/cli/commands/init_cmd/generation.py
@@ -311,6 +311,11 @@ def run_repo_generation(
     preserved_page_ids: set[str] = set()
     result.preserved_page_ids = preserved_page_ids
 
+    failed_page_ids: list[str] = []
+
+    def _record_generation_failures(page_ids: list[str]) -> None:
+        failed_page_ids[:] = page_ids
+
     with Progress(*columns, console=console) as gen_progress:
         gen_callback = RichProgressCallback(gen_progress, console)
         generated_pages = run_async(
@@ -330,6 +335,7 @@ def run_repo_generation(
                 resume=resume,
                 preserved_page_ids=preserved_page_ids,
                 cost_tracker=cost_tracker,
+                on_generation_complete=_record_generation_failures,
                 generation_config=gen_config,
                 # In-memory curated modules: on a fresh init the
                 # knowledge-graph.json artifact is only written during
@@ -347,21 +353,6 @@ def run_repo_generation(
                 ),
             )
         )
-
-    jobs_dir = Path(repo_path) / ".repowise" / "jobs"
-    failed_page_ids: list[str] = []
-    if jobs_dir.exists():
-        with contextlib.suppress(Exception):
-            from repowise.core.generation import JobSystem
-
-            js = JobSystem(jobs_dir)
-            job_id = getattr(result, "job_id", None)
-            if job_id:
-                failed_page_ids = js.get_checkpoint(job_id).failed_page_ids
-            else:
-                jobs = js.list_jobs()
-                if jobs:
-                    failed_page_ids = jobs[0].failed_page_ids
 
     result.generated_pages = generated_pages
     result.failed_page_ids = failed_page_ids

--- a/packages/core/src/repowise/core/generation/page_generator/core.py
+++ b/packages/core/src/repowise/core/generation/page_generator/core.py
@@ -163,6 +163,10 @@ class PageGenerator(PerTypeGenerationMixin, StructuralRenderMixin):
         # table.
         self._prior_pages: dict[str, PriorPage] = prior_pages or {}
         self._reuse_count: int = 0
+        # Set by the active _GenerationRun after it creates its JobSystem
+        # checkpoint. Exposed read-only so callers can inspect this exact
+        # invocation without guessing from the checkpoint directory.
+        self._last_job_id: str | None = None
         # Per-template structural fingerprints, lazily computed; every input
         # they fold is fixed for the generator's lifetime. Keyed by template
         # name because each structural page type folds its own template source.
@@ -194,6 +198,11 @@ class PageGenerator(PerTypeGenerationMixin, StructuralRenderMixin):
         self._jinja_env.filters.setdefault("oneline", oneline)
         self._jinja_env.filters.setdefault("as_markdown", as_markdown)
         self._jinja_env.filters.setdefault("signature", signature)
+
+    @property
+    def last_job_id(self) -> str | None:
+        """JobSystem checkpoint id created by the most recent generation call."""
+        return self._last_job_id
 
     # ------------------------------------------------------------------
     # generate_all — orchestration (delegates to orchestrate.py)
@@ -249,6 +258,7 @@ class PageGenerator(PerTypeGenerationMixin, StructuralRenderMixin):
         # this run's responses rather than every response since start-up.
         reset_artifact_check_counts()
 
+        self._last_job_id = None
         return await run_generate_all(
             self,
             parsed_files=parsed_files,

--- a/packages/core/src/repowise/core/generation/page_generator/orchestrate.py
+++ b/packages/core/src/repowise/core/generation/page_generator/orchestrate.py
@@ -196,6 +196,7 @@ class _GenerationRun:
             self.gen._provider.provider_name,
             self.gen._provider.model_name,
         )
+        self.gen._last_job_id = self.job_id
 
     def _emit(self, page_id: str) -> bool:
         """Whether this run should generate ``page_id``.

--- a/packages/core/src/repowise/core/pipeline/phases/generation.py
+++ b/packages/core/src/repowise/core/pipeline/phases/generation.py
@@ -6,6 +6,7 @@ orchestrator.py) imports these phase functions. No CLI/click/rich imports.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import replace
 from pathlib import Path
 from typing import Any
@@ -44,6 +45,7 @@ async def run_generation(
     kg_data: dict | None = None,
     only_page_ids: set[str] | None = None,
     preserved_page_ids: set[str] | None = None,
+    on_generation_complete: Callable[[list[str]], None] | None = None,
 ) -> list[Any]:
     """Run LLM-powered page generation.
 
@@ -154,6 +156,13 @@ async def run_generation(
         only_page_ids=only_page_ids,
         preserved_page_ids=preserved_page_ids,
     )
+
+    if on_generation_complete is not None and generator.last_job_id is not None:
+        try:
+            checkpoint = job_system.get_checkpoint(generator.last_job_id)
+            on_generation_complete(checkpoint.failed_page_ids)
+        except Exception as exc:
+            logger.warning("generation_completion_callback_failed", error=str(exc))
 
     # Onboarding summary — count generated slots and surface which ones
     # were gated out so the user can see the curated collection's state.

--- a/tests/unit/cli/test_generation_persist.py
+++ b/tests/unit/cli/test_generation_persist.py
@@ -285,7 +285,7 @@ def test_run_repo_generation_prints_partial_failure_warning_after_progress(monke
     monkeypatch.setattr(generation_cmd, "build_vector_store", lambda *_args: object())
 
     async def fake_generation(*, on_generation_complete, **_kwargs):
-        on_generation_complete(["module_page:api", "file_page:src/main.py"])
+        on_generation_complete(["module_page:api", "[red]spoof[/red]:src/main.py"])
         return []
 
     monkeypatch.setattr(
@@ -319,7 +319,7 @@ def test_run_repo_generation_prints_partial_failure_warning_after_progress(monke
     text = output.getvalue()
     assert "Generated 0 pages" in text
     assert "2 failed" in text
-    assert "file_page: 1" in text
+    assert "[red]spoof[/red]: 1" in text
     assert "module_page: 1" in text
     assert "The wiki is incomplete" in text
     assert "repowise init --resume" in text

--- a/tests/unit/cli/test_generation_persist.py
+++ b/tests/unit/cli/test_generation_persist.py
@@ -143,7 +143,12 @@ async def test_sink_failure_never_breaks_generation(repo_dir, monkeypatch):
 async def test_generation_completion_callback_reports_only_current_run_failures(
     repo_dir, monkeypatch
 ):
-    """The callback follows this generator's checkpoint amid another new job."""
+    """The callback excludes stale and concurrent jobs from this run's result."""
+    jobs = JobSystem(repo_dir / ".repowise" / "jobs")
+    stale_job = jobs.create_job(str(repo_dir), GenerationConfig(), "test", "test")
+    jobs.start_job(stale_job, 1)
+    jobs.fail_page(stale_job, "stale-page", "old failure")
+    jobs.complete_job(stale_job)
 
     class ControlledGenerator:
         def __init__(self, *_args, **_kwargs) -> None:

--- a/tests/unit/cli/test_generation_persist.py
+++ b/tests/unit/cli/test_generation_persist.py
@@ -7,10 +7,15 @@ subsequent run loads them back as ``prior_pages`` for reuse.
 
 from __future__ import annotations
 
+import asyncio
 from datetime import UTC, datetime
+from io import StringIO
+from types import SimpleNamespace
 
 import pytest
+from rich.console import Console
 
+from repowise.cli.commands.init_cmd import generation as generation_cmd
 from repowise.cli.commands.init_cmd._generation_persist import run_generation_with_persistence
 from repowise.core.generation import GenerationConfig, JobSystem
 from repowise.core.generation.models import GeneratedPage
@@ -84,9 +89,7 @@ async def test_pages_flushed_incrementally(repo_dir, monkeypatch):
             on_page_ready(p)
         return emitted
 
-    monkeypatch.setattr(
-        "repowise.core.pipeline.run_generation", fake_run_generation, raising=True
-    )
+    monkeypatch.setattr("repowise.core.pipeline.run_generation", fake_run_generation, raising=True)
 
     pages = await run_generation_with_persistence(
         repo_path=repo_dir,
@@ -129,9 +132,7 @@ async def test_sink_failure_never_breaks_generation(repo_dir, monkeypatch):
         on_page_ready(_page("delta"))
         return [_page("delta")]
 
-    monkeypatch.setattr(
-        "repowise.core.pipeline.run_generation", fake_run_generation, raising=True
-    )
+    monkeypatch.setattr("repowise.core.pipeline.run_generation", fake_run_generation, raising=True)
 
     pages = await run_generation_with_persistence(repo_path=repo_dir, repo_name=repo_dir.name)
     assert {p.page_id for p in pages} == {"delta"}
@@ -273,3 +274,52 @@ async def test_generation_ignores_failed_completion_checkpoint_read(repo_dir, mo
 
     assert pages == []
     assert reported_failures == []
+
+
+def test_run_repo_generation_prints_partial_failure_warning_after_progress(monkeypatch, tmp_path):
+    output = StringIO()
+    monkeypatch.setattr(
+        generation_cmd, "console", Console(file=output, force_terminal=False, width=200)
+    )
+    monkeypatch.setattr(generation_cmd, "build_embedder", lambda _name: object())
+    monkeypatch.setattr(generation_cmd, "build_vector_store", lambda *_args: object())
+
+    async def fake_generation(*, on_generation_complete, **_kwargs):
+        on_generation_complete(["module_page:api", "file_page:src/main.py"])
+        return []
+
+    monkeypatch.setattr(
+        "repowise.cli.commands.init_cmd._generation_persist.run_generation_with_persistence",
+        fake_generation,
+    )
+    monkeypatch.setattr(generation_cmd, "run_async", lambda coroutine: asyncio.run(coroutine))
+
+    result = SimpleNamespace(
+        parsed_files=[],
+        repo_name="example",
+        source_map={},
+        graph_builder=object(),
+        repo_structure=object(),
+        git_meta_map={},
+        knowledge_graph_result=None,
+    )
+    config = SimpleNamespace(deterministic=True)
+
+    generation_cmd.run_repo_generation(
+        repo_path=tmp_path,
+        result=result,
+        provider=SimpleNamespace(),
+        gen_config=config,
+        concurrency=1,
+        embedder_name_resolved="test",
+        resume=False,
+        verbose=True,
+    )
+
+    text = output.getvalue()
+    assert "Generated 0 pages" in text
+    assert "2 failed" in text
+    assert "file_page: 1" in text
+    assert "module_page: 1" in text
+    assert "The wiki is incomplete" in text
+    assert "repowise init --resume" in text

--- a/tests/unit/cli/test_generation_persist.py
+++ b/tests/unit/cli/test_generation_persist.py
@@ -143,22 +143,25 @@ async def test_sink_failure_never_breaks_generation(repo_dir, monkeypatch):
 async def test_generation_completion_callback_reports_only_current_run_failures(
     repo_dir, monkeypatch
 ):
-    """The completion callback excludes failures persisted by an older job."""
-    jobs = JobSystem(repo_dir / ".repowise" / "jobs")
-    stale_job = jobs.create_job(str(repo_dir), GenerationConfig(), "test", "test")
-    jobs.start_job(stale_job, 1)
-    jobs.fail_page(stale_job, "stale-page", "old failure")
-    jobs.complete_job(stale_job)
+    """The callback follows this generator's checkpoint amid another new job."""
 
     class ControlledGenerator:
         def __init__(self, *_args, **_kwargs) -> None:
-            pass
+            self.last_job_id: str | None = None
 
         async def generate_all(self, *_args, job_system, **_kwargs):
             current_job = job_system.create_job(str(repo_dir), GenerationConfig(), "test", "test")
             job_system.start_job(current_job, 1)
             job_system.fail_page(current_job, "current-page", "controlled failure")
             job_system.complete_job(current_job)
+            self.last_job_id = current_job
+
+            # Simulate another run creating a checkpoint after this one. A
+            # list-diff approach cannot distinguish the two new jobs.
+            other_job = job_system.create_job(str(repo_dir), GenerationConfig(), "test", "test")
+            job_system.start_job(other_job, 1)
+            job_system.fail_page(other_job, "other-page", "other run failure")
+            job_system.complete_job(other_job)
             return []
 
     monkeypatch.setattr("repowise.core.generation.PageGenerator", ControlledGenerator)
@@ -181,3 +184,87 @@ async def test_generation_completion_callback_reports_only_current_run_failures(
 
     assert pages == []
     assert reported_failures == [["current-page"]]
+
+
+async def test_generation_ignores_completion_callback_exception(repo_dir, monkeypatch):
+    """A completion reporting failure cannot stop otherwise successful generation."""
+
+    class ControlledGenerator:
+        def __init__(self, *_args, **_kwargs) -> None:
+            self.last_job_id = None
+
+        async def generate_all(self, *_args, job_system, **_kwargs):
+            self.last_job_id = job_system.create_job(
+                str(repo_dir), GenerationConfig(), "test", "test"
+            )
+            job_system.start_job(self.last_job_id, 0)
+            job_system.complete_job(self.last_job_id)
+            return []
+
+    monkeypatch.setattr("repowise.core.generation.PageGenerator", ControlledGenerator)
+
+    callback_called = False
+
+    def failing_callback(_failed_page_ids: list[str]) -> None:
+        nonlocal callback_called
+        callback_called = True
+        raise RuntimeError("reporting unavailable")
+
+    pages = await run_generation(
+        repo_path=repo_dir,
+        parsed_files=[],
+        source_map={},
+        graph_builder=object(),
+        repo_structure=object(),
+        git_meta_map={},
+        llm_client=object(),
+        embedder=None,
+        vector_store=None,
+        concurrency=1,
+        progress=None,
+        on_generation_complete=failing_callback,
+    )
+
+    assert pages == []
+    assert callback_called
+
+
+async def test_generation_ignores_failed_completion_checkpoint_read(repo_dir, monkeypatch):
+    """A failed read of this run's checkpoint cannot stop generation."""
+
+    class ControlledGenerator:
+        def __init__(self, *_args, **_kwargs) -> None:
+            self.last_job_id = None
+
+        async def generate_all(self, *_args, job_system, **_kwargs):
+            self.last_job_id = job_system.create_job(
+                str(repo_dir), GenerationConfig(), "test", "test"
+            )
+            job_system.start_job(self.last_job_id, 0)
+            job_system.complete_job(self.last_job_id)
+            return []
+
+    def fail_get_checkpoint(self, _job_id):
+        raise OSError("checkpoint unavailable")
+
+    monkeypatch.setattr("repowise.core.generation.PageGenerator", ControlledGenerator)
+    monkeypatch.setattr(JobSystem, "get_checkpoint", fail_get_checkpoint)
+
+    reported_failures: list[list[str]] = []
+    pages = await run_generation(
+        repo_path=repo_dir,
+        parsed_files=[],
+        source_map={},
+        graph_builder=object(),
+        repo_structure=object(),
+        git_meta_map={},
+        llm_client=object(),
+        embedder=None,
+        vector_store=None,
+        concurrency=1,
+        progress=None,
+        on_generation_complete=reported_failures.append,
+    )
+
+    assert pages == []
+    assert reported_failures == []

--- a/tests/unit/cli/test_generation_persist.py
+++ b/tests/unit/cli/test_generation_persist.py
@@ -12,6 +12,7 @@ from datetime import UTC, datetime
 import pytest
 
 from repowise.cli.commands.init_cmd._generation_persist import run_generation_with_persistence
+from repowise.core.generation import GenerationConfig, JobSystem
 from repowise.core.generation.models import GeneratedPage
 from repowise.core.persistence import (
     create_engine,
@@ -20,6 +21,7 @@ from repowise.core.persistence import (
     init_db,
     upsert_repository,
 )
+from repowise.core.pipeline.phases.generation import run_generation
 
 
 def _page(page_id: str, content: str = "body") -> GeneratedPage:
@@ -136,3 +138,46 @@ async def test_sink_failure_never_breaks_generation(repo_dir, monkeypatch):
     # The valid page still persisted despite the bad one.
     stored = await _read_db_page_ids(repo_dir)
     assert "delta" in stored
+
+
+async def test_generation_completion_callback_reports_only_current_run_failures(
+    repo_dir, monkeypatch
+):
+    """The completion callback excludes failures persisted by an older job."""
+    jobs = JobSystem(repo_dir / ".repowise" / "jobs")
+    stale_job = jobs.create_job(str(repo_dir), GenerationConfig(), "test", "test")
+    jobs.start_job(stale_job, 1)
+    jobs.fail_page(stale_job, "stale-page", "old failure")
+    jobs.complete_job(stale_job)
+
+    class ControlledGenerator:
+        def __init__(self, *_args, **_kwargs) -> None:
+            pass
+
+        async def generate_all(self, *_args, job_system, **_kwargs):
+            current_job = job_system.create_job(str(repo_dir), GenerationConfig(), "test", "test")
+            job_system.start_job(current_job, 1)
+            job_system.fail_page(current_job, "current-page", "controlled failure")
+            job_system.complete_job(current_job)
+            return []
+
+    monkeypatch.setattr("repowise.core.generation.PageGenerator", ControlledGenerator)
+
+    reported_failures: list[list[str]] = []
+    pages = await run_generation(
+        repo_path=repo_dir,
+        parsed_files=[],
+        source_map={},
+        graph_builder=object(),
+        repo_structure=object(),
+        git_meta_map={},
+        llm_client=object(),
+        embedder=None,
+        vector_store=None,
+        concurrency=1,
+        progress=None,
+        on_generation_complete=reported_failures.append,
+    )
+
+    assert pages == []
+    assert reported_failures == [["current-page"]]

--- a/tests/unit/cli/test_init_failure_reporting.py
+++ b/tests/unit/cli/test_init_failure_reporting.py
@@ -115,6 +115,65 @@ def test_run_repo_generation_reports_failures(tmp_path, monkeypatch):
     assert "repowise init --resume" in output
 
 
+def test_run_repo_generation_does_not_fallback_after_zero_failure_callback(
+    tmp_path, monkeypatch
+):
+    """A current-run callback reporting success wins over stale checkpoints."""
+    jobs_dir = tmp_path / ".repowise" / "jobs"
+    jobs_dir.mkdir(parents=True, exist_ok=True)
+
+    js = JobSystem(jobs_dir)
+    stale_job_id = js.create_job(
+        str(tmp_path), SimpleNamespace(max_concurrency=1), "mock", "mock-model"
+    )
+    js.fail_page(stale_job_id, "file_page:stale.ts", "Old failure")
+
+    def fake_generation(**kwargs):
+        kwargs["on_generation_complete"]([])
+        return [_page("file_page:lib/c.ts")]
+
+    monkeypatch.setattr(
+        "repowise.cli.commands.init_cmd._generation_persist.run_generation_with_persistence",
+        fake_generation,
+    )
+    monkeypatch.setattr(
+        "repowise.cli.commands.init_cmd.generation.run_async", lambda value: value
+    )
+    monkeypatch.setattr(
+        "repowise.cli.commands.init_cmd.generation._enrich_knowledge_graph",
+        lambda **kw: None,
+    )
+    monkeypatch.setattr(
+        "repowise.cli.commands.init_cmd.generation.flush_cost_tracker",
+        lambda tracker: None,
+    )
+    monkeypatch.setattr(
+        "repowise.cli.commands.init_cmd.generation.console.print", lambda *a, **kw: None
+    )
+
+    result = SimpleNamespace(
+        repo_name="test_repo",
+        parsed_files=[],
+        source_map={},
+        graph_builder=MagicMock(),
+        repo_structure=MagicMock(),
+        git_meta_map={},
+    )
+
+    run_repo_generation(
+        repo_path=tmp_path,
+        result=result,
+        provider=SimpleNamespace(provider_name="mock", model_name="mock-model"),
+        gen_config=SimpleNamespace(max_concurrency=1, deterministic=False),
+        concurrency=1,
+        embedder_name_resolved="mock",
+        resume=False,
+        verbose=False,
+    )
+
+    assert result.failed_page_ids == []
+
+
 def test_recorded_cost_includes_the_knowledge_graph_enrichment(tmp_path, monkeypatch):
     """Layer naming and the guided tour are real model calls billed through the
     same tracker as the pages, so the figure the completion panel prints has to


### PR DESCRIPTION
## Summary

- carry the active generation checkpoint's failed page IDs to the init command
- warn when a wiki is incomplete, including a deterministic page-type breakdown and the resume command
- keep clean runs and the successful init exit path unchanged

Closes #1094

## Validation

- uv run pytest tests/unit/cli/test_generation_persist.py tests/unit/generation/test_job_system.py -q
- 29 passed
- uv run ruff check on changed files (two unchanged upstream findings in page-generator modules)
- git diff origin/main --check

## AI assistance

This contribution was developed with AI assistance and reviewed with focused tests and independent code reviews.