### PR TITLE
fix(providers): stop agent CLIs loading target-repo instruction files

### DIFF
--- a/packages/core/src/repowise/core/generation/mermaid_safety.py
+++ b/packages/core/src/repowise/core/generation/mermaid_safety.py
@@ -346,6 +346,27 @@ def sanitize_mermaid(markdown: str) -> str:
     return _MERMAID_FENCE_RE.sub(_replace, markdown)
 
 
+_HEADING_LINE_RE = re.compile(r"(?m)^#{1,6}\s")
+
+
+def strip_leading_preamble(markdown: str) -> str:
+    """Drop agent narration before the first markdown heading.
+
+    Pages always start with ``# ...``. Text before that is tool-use chatter.
+    If there is no heading, or stripping would empty the page, return input
+    unchanged so clean output stays byte-identical.
+    """
+    if not markdown:
+        return markdown
+    match = _HEADING_LINE_RE.search(markdown)
+    if match is None or match.start() == 0:
+        return markdown
+    trimmed = markdown[match.start() :]
+    if not trimmed.strip():
+        return markdown
+    return trimmed
+
+
 def sanitize_pages(pages: list) -> int:
     """Run :func:`sanitize_mermaid` over a list of ``GeneratedPage``.
 
@@ -357,11 +378,12 @@ def sanitize_pages(pages: list) -> int:
         content = getattr(page, "content", None)
         if not content:
             continue
-        fixed = sanitize_mermaid(content)
+        fixed = strip_leading_preamble(content)
+        fixed = sanitize_mermaid(fixed)
         if fixed != content:
             page.content = fixed
             changed += 1
     return changed
 
 
-__all__ = ["sanitize_mermaid", "sanitize_pages"]
+__all__ = ["sanitize_mermaid", "sanitize_pages", "strip_leading_preamble"]

--- a/packages/core/src/repowise/core/generation/mermaid_safety.py
+++ b/packages/core/src/repowise/core/generation/mermaid_safety.py
@@ -186,6 +186,27 @@ def sanitize_mermaid(markdown: str) -> str:
     return _MERMAID_FENCE_RE.sub(_replace, markdown)
 
 
+_HEADING_LINE_RE = re.compile(r"(?m)^#{1,6}\s")
+
+
+def strip_leading_preamble(markdown: str) -> str:
+    """Drop agent narration before the first markdown heading.
+
+    Pages always start with ``# ...``. Text before that is tool-use chatter.
+    If there is no heading, or stripping would empty the page, return input
+    unchanged so clean output stays byte-identical.
+    """
+    if not markdown:
+        return markdown
+    match = _HEADING_LINE_RE.search(markdown)
+    if match is None or match.start() == 0:
+        return markdown
+    trimmed = markdown[match.start() :]
+    if not trimmed.strip():
+        return markdown
+    return trimmed
+
+
 def sanitize_pages(pages: list) -> int:
     """Run :func:`sanitize_mermaid` over a list of ``GeneratedPage``.
 
@@ -197,11 +218,12 @@ def sanitize_pages(pages: list) -> int:
         content = getattr(page, "content", None)
         if not content:
             continue
-        fixed = sanitize_mermaid(content)
+        fixed = strip_leading_preamble(content)
+        fixed = sanitize_mermaid(fixed)
         if fixed != content:
             page.content = fixed
             changed += 1
     return changed
 
 
-__all__ = ["sanitize_mermaid", "sanitize_pages"]
+__all__ = ["sanitize_mermaid", "sanitize_pages", "strip_leading_preamble"]

--- a/packages/core/src/repowise/core/providers/llm/codex_cli.py
+++ b/packages/core/src/repowise/core/providers/llm/codex_cli.py
@@ -411,6 +411,7 @@ class CodexCliProvider(BaseProvider):
             "--cd",
             str(self._repo_path),
         ]
+        cmd.extend(["--config", "project_doc_max_bytes=0"])
         reasoning_config = _codex_reasoning_config(self._codex_cmd, self.model_name, reasoning)
         if reasoning_config:
             cmd.extend(["--config", reasoning_config])

--- a/packages/core/src/repowise/core/providers/llm/codex_cli.py
+++ b/packages/core/src/repowise/core/providers/llm/codex_cli.py
@@ -404,6 +404,7 @@ class CodexCliProvider(BaseProvider):
             "--cd",
             str(self._repo_path),
         ]
+        cmd.extend(["--config", "project_doc_max_bytes=0"])
         reasoning_config = _codex_reasoning_config(self._codex_cmd, self.model_name, reasoning)
         if reasoning_config:
             cmd.extend(["--config", reasoning_config])

--- a/packages/core/src/repowise/core/providers/llm/opencode.py
+++ b/packages/core/src/repowise/core/providers/llm/opencode.py
@@ -368,6 +368,7 @@ class OpenCodeProvider(BaseProvider):
                     env={
                         **os.environ,
                         "OPENCODE_CONFIG_CONTENT": _OPENCODE_READONLY_CONFIG,
+                        "OPENCODE_DISABLE_PROJECT_CONFIG": "true",
                     },
                 )
             except FileNotFoundError as exc:

--- a/packages/core/src/repowise/core/providers/llm/opencode.py
+++ b/packages/core/src/repowise/core/providers/llm/opencode.py
@@ -349,6 +349,7 @@ class OpenCodeProvider(BaseProvider):
                     env={
                         **os.environ,
                         "OPENCODE_CONFIG_CONTENT": _OPENCODE_READONLY_CONFIG,
+                        "OPENCODE_DISABLE_PROJECT_CONFIG": "true",
                     },
                 )
             except FileNotFoundError as exc:

--- a/tests/unit/generation/test_mermaid_safety.py
+++ b/tests/unit/generation/test_mermaid_safety.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from repowise.core.generation.mermaid_safety import sanitize_mermaid, sanitize_pages
+from repowise.core.generation.mermaid_safety import sanitize_mermaid, sanitize_pages, strip_leading_preamble
 
 
 def _block(body: str) -> str:
@@ -81,3 +81,35 @@ def test_sanitize_pages_mutates_and_counts():
     assert n == 1
     assert "pkg/x.py" not in changed.content
     assert unchanged.content == "# clean\n\nno diagram here"
+
+
+
+
+def test_strip_leading_preamble_removes_narration():
+    md = (
+        "I'll examine the actual source file.\n\n"
+        "I'm using the repository's Beads workflow.\n\n"
+        "# foo.py\n\n## Overview\n"
+    )
+    assert strip_leading_preamble(md) == "# foo.py\n\n## Overview\n"
+
+
+def test_strip_leading_preamble_noop_when_starts_with_heading():
+    md = "# foo.py\n\n## Overview\n"
+    assert strip_leading_preamble(md) == md
+
+
+def test_strip_leading_preamble_noop_without_heading():
+    md = "Just some prose with no markdown heading at all.\n"
+    assert strip_leading_preamble(md) == md
+
+
+def test_sanitize_pages_strips_preamble():
+    class _P:
+        def __init__(self, content):
+            self.content = content
+
+    page = _P("Narration first.\n\n# Title\n\nbody\n")
+    n = sanitize_pages([page])
+    assert n == 1
+    assert page.content.startswith("# Title")

--- a/tests/unit/generation/test_mermaid_safety.py
+++ b/tests/unit/generation/test_mermaid_safety.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 import re
 
-from repowise.core.generation.mermaid_safety import sanitize_mermaid, sanitize_pages, strip_leading_preamble
+from repowise.core.generation.mermaid_safety import (
+    sanitize_mermaid,
+    sanitize_pages,
+    strip_leading_preamble,
+)
 
 
 def _block(body: str) -> str:

--- a/tests/unit/generation/test_mermaid_safety.py
+++ b/tests/unit/generation/test_mermaid_safety.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import re
 
-from repowise.core.generation.mermaid_safety import sanitize_mermaid, sanitize_pages
+from repowise.core.generation.mermaid_safety import sanitize_mermaid, sanitize_pages, strip_leading_preamble
 
 
 def _block(body: str) -> str:
@@ -196,3 +196,35 @@ class TestThePassNeverMakesADiagramWorse:
         source, target = (part.strip() for part in edge.split("-->"))
         assert source != target, edge
         assert "src_main_py[Existing]" in out
+
+
+
+
+def test_strip_leading_preamble_removes_narration():
+    md = (
+        "I'll examine the actual source file.\n\n"
+        "I'm using the repository's Beads workflow.\n\n"
+        "# foo.py\n\n## Overview\n"
+    )
+    assert strip_leading_preamble(md) == "# foo.py\n\n## Overview\n"
+
+
+def test_strip_leading_preamble_noop_when_starts_with_heading():
+    md = "# foo.py\n\n## Overview\n"
+    assert strip_leading_preamble(md) == md
+
+
+def test_strip_leading_preamble_noop_without_heading():
+    md = "Just some prose with no markdown heading at all.\n"
+    assert strip_leading_preamble(md) == md
+
+
+def test_sanitize_pages_strips_preamble():
+    class _P:
+        def __init__(self, content):
+            self.content = content
+
+    page = _P("Narration first.\n\n# Title\n\nbody\n")
+    n = sanitize_pages([page])
+    assert n == 1
+    assert page.content.startswith("# Title")

--- a/tests/unit/test_providers/test_codex_cli_provider.py
+++ b/tests/unit/test_providers/test_codex_cli_provider.py
@@ -237,7 +237,9 @@ async def test_generate_invokes_codex_exec_with_stdin(monkeypatch, tmp_path):
     args = list(captured["args"])
     assert args[:6] == [codex_cmd, "exec", "--ephemeral", "--sandbox", "read-only", "--json"]
     assert args[args.index("--cd") + 1] == str(tmp_path.resolve())
-    assert args[args.index("--config") + 1] == 'model_reasoning_effort="low"'
+    configs = [args[i + 1] for i, a in enumerate(args) if a == "--config"]
+    assert "project_doc_max_bytes=0" in configs
+    assert 'model_reasoning_effort="low"' in configs
     assert args[args.index("--model") + 1] == "gpt-5.5"
     assert args[-1] == "-"
     assert captured["kwargs"]["stdin"] == asyncio.subprocess.PIPE
@@ -264,7 +266,9 @@ async def test_generate_passes_supported_codex_reasoning_effort(monkeypatch, tmp
     )
 
     args = list(captured["args"])
-    assert args[args.index("--config") + 1] == 'model_reasoning_effort="xhigh"'
+    configs = [args[i + 1] for i, a in enumerate(args) if a == "--config"]
+    assert "project_doc_max_bytes=0" in configs
+    assert 'model_reasoning_effort="xhigh"' in configs
 
 
 async def test_generate_passes_unknown_model_effort_without_catalog_block(
@@ -291,7 +295,9 @@ async def test_generate_passes_unknown_model_effort_without_catalog_block(
     )
 
     args = list(captured["args"])
-    assert args[args.index("--config") + 1] == 'model_reasoning_effort="max"'
+    configs = [args[i + 1] for i, a in enumerate(args) if a == "--config"]
+    assert "project_doc_max_bytes=0" in configs
+    assert 'model_reasoning_effort="max"' in configs
     assert args[args.index("--model") + 1] == "future-codex"
 
 

--- a/tests/unit/test_providers/test_opencode_provider.py
+++ b/tests/unit/test_providers/test_opencode_provider.py
@@ -226,6 +226,7 @@ async def test_generate_invokes_opencode_with_stdin(monkeypatch, tmp_path):
     assert captured["kwargs"]["stdin"] == asyncio.subprocess.PIPE
     env = captured["kwargs"].get("env", {})
     assert "OPENCODE_CONFIG_CONTENT" in env
+    assert env.get("OPENCODE_DISABLE_PROJECT_CONFIG") == "true"
     config = json.loads(env["OPENCODE_CONFIG_CONTENT"])
     assert config["permission"]["edit"] == "deny"
     assert config["permission"]["bash"] == "deny"

--- a/tests/unit/test_providers/test_opencode_provider.py
+++ b/tests/unit/test_providers/test_opencode_provider.py
@@ -222,6 +222,7 @@ async def test_generate_invokes_opencode_with_stdin(monkeypatch, tmp_path):
     assert captured["kwargs"]["stdin"] == asyncio.subprocess.PIPE
     env = captured["kwargs"].get("env", {})
     assert "OPENCODE_CONFIG_CONTENT" in env
+    assert env.get("OPENCODE_DISABLE_PROJECT_CONFIG") == "true"
     config = json.loads(env["OPENCODE_CONFIG_CONTENT"])
     assert config["permission"]["edit"] == "deny"
     assert config["permission"]["bash"] == "deny"


### PR DESCRIPTION
## Summary

- Suppress target-repo project docs for `codex_cli` via `project_doc_max_bytes=0`
- Set `OPENCODE_DISABLE_PROJECT_CONFIG=true` for the OpenCode provider
- Strip agent narration before the first markdown heading in the shared post-process path (passthrough when already clean / no heading)

## Related Issues

Fixes #1093

## Test Plan

- [x] `tests/unit/generation/test_mermaid_safety.py` - preamble strip + existing mermaid cases
- [x] `tests/unit/test_providers/test_codex_cli_provider.py` - `project_doc_max_bytes=0` in argv
- [x] `tests/unit/test_providers/test_opencode_provider.py` - disable-project-config env set
- [x] Focused suite: **58 passed**

## Checklist

- [x] My code follows the project's code style
- [x] I have added tests for new functionality
- [x] All existing tests still pass
- [ ] I have updated documentation if needed (N/A - no docs change required)