### PR TITLE
docs(website): sync CLI and Claude plugin pages with shipped surface

### DIFF
--- a/website/claude-code-plugin.md
+++ b/website/claude-code-plugin.md
@@ -31,7 +31,7 @@ The Claude Code plugin integrates repowise directly into Claude Code. It handles
 Open Claude Code and run:
 
 ```
-/plugin marketplace add repowise-dev/repowise-plugin
+/plugin marketplace add repowise-dev/repowise
 /plugin install repowise@repowise
 ```
 
@@ -54,12 +54,12 @@ Claude will guide you through:
 
 1. **Mode selection** — choose between:
    - **Full** — complete wiki generation with LLM docs (requires API key)
-   - **Index-only** — graph + git + dead code, no LLM (free)
+   - **Index-only** — graph + git + dead code + code health, no LLM (free)
    - **Advanced** — manual control over provider, concurrency, exclude patterns
 
-2. **Provider selection** — Anthropic, OpenAI, Gemini, or local Ollama
+2. **Provider selection** — Anthropic, OpenAI, Gemini, Codex CLI, OpenCode, or local Ollama
 
-3. **API key entry** — saved to `.repowise/.env` (gitignored)
+3. **API key entry** — saved to `.repowise/.env` (gitignored) when a hosted provider needs one
 
 4. **Indexing** — runs in the background with live progress updates
 
@@ -104,6 +104,51 @@ Use this after switching embedding providers, or if semantic search results seem
 
 ---
 
+### `/repowise:health`
+
+Code-health KPIs, lowest-scoring files, refactoring targets, or trends
+(`repowise health`).
+
+---
+
+### `/repowise:risk`
+
+Defect-risk score for a commit or `base..head` range (`repowise risk`).
+
+---
+
+### `/repowise:coverage`
+
+Ingest or inspect coverage reports (`repowise coverage add` / `status`).
+Lights up untested-hotspot markers and builds the per-test map when contexts
+are present.
+
+---
+
+### `/repowise:impacted-tests`
+
+Tests whose coverage intersects a change (`repowise impacted-tests`).
+
+---
+
+### `/repowise:dead-code`
+
+Unreachable files, unused exports, and zombie packages by confidence.
+
+---
+
+### `/repowise:decision`
+
+List, inspect, add, or confirm architectural decisions.
+
+---
+
+### `/repowise:doctor`
+
+Diagnose (and optionally repair) setup, keys, and index drift.
+
+---
+
 ## Automatic behaviors
 
 Beyond the slash commands, the plugin teaches Claude skills it uses automatically — without being asked.
@@ -113,6 +158,7 @@ Beyond the slash commands, the plugin teaches Claude skills it uses automaticall
 Before reading raw source files, Claude calls:
 
 - `get_overview()` at the start of new tasks to orient itself
+- `get_answer(question)` for direct how/where/why questions
 - `search_codebase(query)` to locate code instead of using grep
 - `get_context(targets)` to get docs and ownership before opening files
 
@@ -120,11 +166,20 @@ Before reading raw source files, Claude calls:
 
 Before editing any file, Claude calls `get_risk(targets)` to assess:
 
+- Bug-fix history (`defect_profile` / `bug_magnet`) when present
 - Whether the file is a hotspot (high churn)
 - How many other files depend on it
 - Whether there are co-change patterns to be aware of
 
 If the risk is high, Claude surfaces this before making changes.
+
+### Change review
+
+For a PR / branch / working-tree diff, Claude combines `get_change_risk` (whole-change score) with `get_risk`'s per-file `directive` block.
+
+### Code health
+
+Quality / complexity / "what to refactor" questions go through `get_health`.
 
 ### Architectural decision queries
 
@@ -138,7 +193,7 @@ During refactoring or cleanup tasks, Claude calls `get_dead_code()` to find conf
 
 ## How skills work
 
-Skills in Claude Code are prompt instructions that modify Claude's behavior. The repowise plugin registers four skills that Claude loads when working in an indexed repo.
+Skills in Claude Code are prompt instructions that modify Claude's behavior. The repowise plugin registers six skills that Claude loads when working in an indexed repo.
 
 You don't need to trigger them manually. When Claude detects it's working in a repo with a connected repowise MCP server, the skills activate automatically.
 

--- a/website/claude-code-plugin.md
+++ b/website/claude-code-plugin.md
@@ -117,6 +117,15 @@ Defect-risk score for a commit or `base..head` range (`repowise risk`).
 
 ---
 
+### `/repowise:security`
+
+Full-history secret scan (`repowise security scan --history`). Working-tree
+scanning already runs during init/update; without `--history` the CLI only
+prints a hint. Default history mode is secrets-only; `--all-patterns` also
+reports code-smell patterns.
+
+---
+
 ### `/repowise:coverage`
 
 Ingest or inspect coverage reports (`repowise coverage add` / `status`).

--- a/website/cli-reference.md
+++ b/website/cli-reference.md
@@ -327,7 +327,7 @@ repowise dead-code [PATH] [OPTIONS]
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
-| `--min-confidence` | float | 0.4 | Minimum confidence threshold (0.0–1.0) |
+| `--min-confidence` | float | 0.5 | Minimum confidence threshold (0.0–1.0) |
 | `--safe-only` | flag | false | Only show findings marked `safe_to_delete` |
 | `--kind` | choice | — | Filter by type: `unreachable_file`, `unused_export`, `unused_internal`, `zombie_package` |
 | `--format` | choice | table | Output format: `table`, `json`, or `md` |
@@ -340,6 +340,191 @@ repowise dead-code --safe-only              # Only confirmed safe to delete
 repowise dead-code --kind unused_export     # Only unused exports
 repowise dead-code --format json            # Machine-readable output
 repowise dead-code --min-confidence 0.8     # High confidence only
+```
+
+---
+
+## `health`
+
+Compute per-file code-health scores from deterministic markers. No LLM by
+default.
+
+```bash
+repowise health [PATH] [OPTIONS]
+```
+
+### Options
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--file` | string | — | Deep-dive a single file (relative path) |
+| `--module` | string | — | Restrict to files whose path starts with this prefix |
+| `--refactoring-targets` | flag | false | Ranked refactoring candidates by impact/effort |
+| `--trend` | flag | false | Last health snapshots + declining alerts |
+| `--badge` | flag | false | Ready-to-paste health badge Markdown |
+| `--format` | choice | table | `table`, `json`, or `md` |
+| `--generate-code` | string | — | Opt-in LLM refactoring patch for one target (needs a provider) |
+
+### Examples
+
+```bash
+repowise health
+repowise health --refactoring-targets
+repowise health --file packages/server/app.py
+repowise health --trend
+```
+
+---
+
+## `risk`
+
+Score the defect risk of a *change* (commit or `base..head` range). No LLM.
+
+```bash
+repowise risk [REVSPEC] [OPTIONS]
+```
+
+### Options
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--path` | path | cwd | Git repository path |
+| `--ext` | string | all | Comma-separated suffixes to count (e.g. `.py,.ts`) |
+| `-x, --exclude` | pattern | — | Gitignore-style exclude (repeatable) |
+| `--format` | choice | table | `table` or `json` |
+
+### Examples
+
+```bash
+repowise risk                 # score HEAD
+repowise risk main..HEAD      # score a branch / PR range
+repowise risk --ext .ts,.tsx
+```
+
+---
+
+## `security`
+
+Security signal scanning. Working-tree scanning already runs during `init` /
+`update`. Use this group to walk **full git history** for leaked secrets.
+
+```bash
+repowise security scan --history [OPTIONS]
+```
+
+Without `--history`, the command prints a hint and exits (it does not re-run
+the working-tree scan).
+
+### Options
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--history` | flag | false | Required for a real scan: walk full git history |
+| `--since` | rev | all | Lower bound (exclusive) |
+| `--to` | rev | HEAD | Upper bound (inclusive) |
+| `--path` | string | cwd | Repo path |
+| `--all-patterns` | flag | false | Also report code-smell patterns (default: secrets only) |
+| `--output` | choice | table | `table` or `json` |
+
+### Examples
+
+```bash
+repowise security scan --history
+repowise security scan --history --since v1.0.0 --output json
+```
+
+---
+
+## `coverage`
+
+Ingest and inspect test-coverage reports (LCOV, Cobertura/Clover, coverage.py).
+
+```bash
+repowise coverage SUBCOMMAND [OPTIONS]
+```
+
+### Subcommands
+
+| Subcommand | Description |
+|-----------|-------------|
+| `add [PATHS...]` | Ingest reports (auto-discovers when none given); builds per-test map when contexts are present |
+| `status` | Show ingested coverage + test-to-code map counts |
+
+### Examples
+
+```bash
+repowise coverage add
+repowise coverage add coverage.lcov
+repowise coverage add .coverage
+repowise coverage status
+```
+
+---
+
+## `impacted-tests`
+
+Print the tests whose coverage intersects a change's changed lines. Requires a
+per-test map from `coverage add`.
+
+```bash
+repowise impacted-tests [REVSPEC] [OPTIONS]
+```
+
+### Options
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--path` | string | cwd | Repo path |
+| `--staged` | flag | when no revspec | Diff staged changes |
+| `--format` | choice | table | `table`, `json`, or `list` (pipeable test ids) |
+
+### Examples
+
+```bash
+repowise impacted-tests
+repowise impacted-tests main..HEAD
+repowise impacted-tests main..HEAD --format list | xargs pytest
+```
+
+---
+
+## `workspace`
+
+Manage multi-repo workspaces.
+
+```bash
+repowise workspace SUBCOMMAND [OPTIONS]
+```
+
+### Subcommands
+
+| Subcommand | Description |
+|-----------|-------------|
+| `add` | Add a repo and (by default) index it |
+| `list` | Show workspace repos and status |
+| `remove` | Remove a repo from the workspace |
+| `scan` | Find new repos under the workspace root |
+| `set-default` | Change the primary repo |
+| `check` | Architecture lint (dependency rules / cycles) |
+| `metrics` | Architecture metrics |
+| `diagnostics` | Explain cross-repo contract link counts |
+
+---
+
+## `distill`
+
+Run a command and print a compact, reversible rendering of its output.
+
+```bash
+repowise distill <command>...
+```
+
+### Examples
+
+```bash
+repowise distill pytest -x
+repowise distill git status
+repowise distill npm run build
 ```
 
 ---


### PR DESCRIPTION
## Summary
- Expand \`website/cli-reference.md\` with shipped analysis commands: \`health\`, \`risk\`, \`security\`, \`coverage\`, \`impacted-tests\`, plus \`workspace\` and \`distill\`.
- Align \`website/claude-code-plugin.md\` slash commands with the plugin (including coverage/impacted-tests/health/risk/dead-code/decision/doctor), fix marketplace install path, and document six skills.

## Test plan
- [x] Flags cross-checked against \`repowise <cmd> --help\`
- [x] Slash-command list cross-checked against \`plugins/claude-code/commands/\`
- [x] Marketplace path matches \`plugins/claude-code/README.md\`