### PR TITLE
feat(generation): configure documentation temperature

### DIFF
--- a/docs/reference/CONFIG.md
+++ b/docs/reference/CONFIG.md
@@ -33,8 +33,9 @@ flags like `--commit-limit`, `--follow-renames`, or `--wiki-style`.
 
 > **Limited schema validation.** `config.yaml` is loaded as a plain YAML dict.
 > Unknown or misspelled keys are silently ignored, they won't error and won't
-> take effect. `max_tokens` must be a positive integer when documentation is
-> generated. The `distill:` block is validated only when you run
+> take effect. `max_tokens` must be a positive integer and `temperature` must
+> be a finite, non-negative number when documentation is generated. The
+> `distill:` block is validated only when you run
 > `repowise doctor`. If a setting doesn't seem to be taking effect, check
 > spelling and indentation first.
 
@@ -45,6 +46,7 @@ embedder: mock                       # Embedding provider (mock if no key detect
 embedding_model: text-embedding-3-small  # Embedding model (provider default if omitted)
 reasoning: auto                      # auto | off | none | minimal | low | medium | high | xhigh | max
 max_tokens: 16384                    # Max output tokens for each generated documentation page
+temperature: 0.3                     # Sampling temperature for generated documentation
 commit_limit: 500                    # Max commits per file for git analysis (clamped 1-10000)
 follow_renames: false                # Track file renames in git history
 wiki_style: comprehensive            # comprehensive | caveman | reference | tutorial | custom
@@ -77,6 +79,7 @@ You can edit this file directly. Changes take effect on the next `init`,
 | `embedding_model` | provider default | Embedding model identifier |
 | `reasoning` | `auto` | `auto`, `off`, `none`, `minimal`, `low`, `medium`, `high`, `xhigh`, `max` |
 | `max_tokens` | `16384` | Maximum output tokens requested for each model-written documentation page |
+| `temperature` | `0.3` | Sampling temperature requested for each model-written documentation page |
 | `commit_limit` | `500` | Max commits per file walked for git analysis, clamped to 1-10000 |
 | `follow_renames` | `false` | Track file renames through git history |
 | `exclude_patterns` | `[]` | Extra gitignore-style patterns, on top of `.gitignore` |
@@ -105,6 +108,12 @@ persistent repository setting rather than a per-command flag: `init`, `update`,
 all use the same value. Providers may enforce a lower model limit. If
 generation reaches a token limit before the page is complete, repowise rejects
 the partial page instead of saving it.
+
+`temperature` controls sampling for the same model-written documentation
+calls. It is a persistent repository setting consumed by the same generation
+entry points as `max_tokens`. The value must be finite and non-negative.
+Providers may enforce a narrower range or normalize the requested value for
+particular model families.
 
 `wiki_style` controls the voice and density of generated wiki pages. Set it with
 `init --wiki-style` or switch later with `repowise restyle <style>` (which also

--- a/packages/core/src/repowise/core/generation/models.py
+++ b/packages/core/src/repowise/core/generation/models.py
@@ -10,6 +10,7 @@ import graph stays one-directional:
 from __future__ import annotations
 
 import hashlib
+import math
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
@@ -53,6 +54,21 @@ GENERATION_LEVELS: dict[str, int] = {
 
 FreshnessStatus = Literal["fresh", "stale", "expired", "unknown"]
 DEFAULT_MAX_TOKENS = 16384
+DEFAULT_TEMPERATURE = 0.3
+
+
+def normalize_temperature(value: object) -> float:
+    """Return a finite, non-negative sampling temperature."""
+
+    if isinstance(value, bool) or not isinstance(value, (int, float, str)):
+        raise ValueError("temperature must be a finite, non-negative number")
+    try:
+        temperature = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("temperature must be a finite, non-negative number") from exc
+    if not math.isfinite(temperature) or temperature < 0:
+        raise ValueError("temperature must be a finite, non-negative number")
+    return temperature
 
 
 # ---------------------------------------------------------------------------
@@ -80,7 +96,7 @@ class GenerationConfig:
     """
 
     max_tokens: int = DEFAULT_MAX_TOKENS
-    temperature: float = 0.3
+    temperature: float = DEFAULT_TEMPERATURE
     token_budget: int = 48000
     max_concurrency: int = 12
     embed_concurrency: int | None = None
@@ -212,11 +228,11 @@ class GenerationConfig:
         config: Mapping[str, Any],
         **overrides: Any,
     ) -> GenerationConfig:
-        """Build a generation config with the repo's documentation output limit.
+        """Build a generation config from persisted documentation settings.
 
-        ``max_tokens`` is the persisted user-facing setting. Keeping its parsing
-        here gives CLI, server, and core entry points one owner for translating
-        repo configuration into the provider request budget.
+        Keeping persisted sampling and output settings here gives CLI, server,
+        and core entry points one owner for translating repository configuration
+        into provider request parameters.
         """
         raw_max_tokens = config.get("max_tokens", DEFAULT_MAX_TOKENS)
         if isinstance(raw_max_tokens, bool):
@@ -230,7 +246,13 @@ class GenerationConfig:
         if max_tokens <= 0:
             raise ValueError("max_tokens must be a positive integer")
 
-        values = {"max_tokens": max_tokens, **overrides}
+        temperature = normalize_temperature(config.get("temperature", DEFAULT_TEMPERATURE))
+
+        values = {
+            "max_tokens": max_tokens,
+            "temperature": temperature,
+            **overrides,
+        }
         return cls(**values)
 
     def __post_init__(self) -> None:
@@ -240,6 +262,7 @@ class GenerationConfig:
             or self.max_tokens <= 0
         ):
             raise ValueError("max_tokens must be a positive integer")
+        object.__setattr__(self, "temperature", normalize_temperature(self.temperature))
         if self.embed_concurrency is None:
             object.__setattr__(self, "embed_concurrency", self.max_concurrency)
         object.__setattr__(self, "reasoning", normalize_reasoning(self.reasoning))

--- a/tests/unit/generation/test_models.py
+++ b/tests/unit/generation/test_models.py
@@ -162,6 +162,26 @@ def test_generation_config_reads_repo_max_tokens():
     assert config.max_tokens == 2345
 
 
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [(0, 0.0), (0.15, 0.15), ("0.7", 0.7)],
+)
+def test_generation_config_reads_repo_temperature(value, expected):
+    config = GenerationConfig.from_repo_config({"temperature": value})
+    assert config.temperature == expected
+
+
+@pytest.mark.parametrize("value", [-0.1, True, float("inf"), float("nan"), "not-a-number"])
+def test_generation_config_rejects_invalid_repo_temperature(value):
+    with pytest.raises(ValueError, match="finite, non-negative number"):
+        GenerationConfig.from_repo_config({"temperature": value})
+
+
+def test_generation_config_rejects_invalid_direct_temperature():
+    with pytest.raises(ValueError, match="finite, non-negative number"):
+        GenerationConfig(temperature=-0.1)
+
+
 @pytest.mark.parametrize("value", [0, -1, True, 1.5, "not-a-number"])
 def test_generation_config_rejects_invalid_repo_max_tokens(value):
     with pytest.raises(ValueError, match="positive integer"):

--- a/tests/unit/generation/test_page_generator.py
+++ b/tests/unit/generation/test_page_generator.py
@@ -194,6 +194,21 @@ async def test_repo_output_limit_reaches_provider_request(sample_config):
     assert provider.calls[0]["max_tokens"] == 2345
 
 
+async def test_repo_temperature_reaches_provider_request(sample_config):
+    """Exercise the public config-to-provider path without a network call."""
+    provider = MockProvider()
+    config = GenerationConfig.from_repo_config(
+        {"temperature": "0.15"},
+        token_budget=sample_config.token_budget,
+        cache_enabled=False,
+    )
+    generator = PageGenerator(provider, ContextAssembler(config), config)
+
+    await generator._call_provider("module_page", "Document this module.", "request-id")
+
+    assert provider.calls[0]["temperature"] == 0.15
+
+
 async def test_invalid_provider_output_raises_and_is_not_cached(sample_config):
     provider = MockProvider(
         responses=[

--- a/tests/unit/server/test_job_executor.py
+++ b/tests/unit/server/test_job_executor.py
@@ -199,14 +199,18 @@ def test_repo_wiki_style_defaults_and_tolerates_bad_input(tmp_path):
     )
 
 
-def test_server_generation_config_reads_repo_output_limit(tmp_path):
+def test_server_generation_config_reads_repo_sampling_and_output_settings(tmp_path):
     config_dir = tmp_path / ".repowise"
     config_dir.mkdir()
-    (config_dir / "config.yaml").write_text("max_tokens: 2468\n", encoding="utf-8")
+    (config_dir / "config.yaml").write_text(
+        "max_tokens: 2468\ntemperature: 0.15\n",
+        encoding="utf-8",
+    )
 
     config = _build_generation_config(tmp_path, {}, "comprehensive")
 
     assert config.max_tokens == 2468
+    assert config.temperature == 0.15
 
 
 @pytest.mark.asyncio
@@ -696,4 +700,3 @@ async def test_execute_job_dispatches_generate_mode(session_factory, tmp_path):
         await execute_job(job_id, app_state)
 
     run_generate_mock.assert_awaited_once()
-

--- a/website/configuration.md
+++ b/website/configuration.md
@@ -48,6 +48,7 @@ model: claude-sonnet-4-6             # Model identifier
 embedder: gemini                     # Embedding provider
 reasoning: auto                      # auto | off/none | minimal | low | medium | high | xhigh | max
 max_tokens: 16384                    # Max output tokens per generated documentation page
+temperature: 0.3                     # Sampling temperature for generated documentation
 exclude_patterns:                    # Gitignore-style patterns
   - vendor/
   - "*.generated.*"
@@ -80,6 +81,10 @@ persistent repository setting used by `init`, `update`, `generate`, `restyle`,
 workspace generation, and server-triggered generation. If generation reaches a
 token limit before the page is complete, repowise rejects the partial page
 instead of saving it.
+
+`temperature` controls sampling for the same model-written documentation
+calls. It must be finite and non-negative. Providers may enforce a narrower
+range or normalize the requested value for particular model families.
 
 ---
 


### PR DESCRIPTION
## Summary

- read `temperature` from `.repowise/config.yaml` through the existing `GenerationConfig.from_repo_config()` translation point
- validate configured and directly constructed temperatures as finite, non-negative numbers while preserving provider-specific normalization and limits
- document the persistent setting and test core, provider-request, and server-triggered propagation

## Why

`GenerationConfig` already carried a temperature and `PageGenerator` already forwarded it, but repository configuration could not set it. Every normal documentation-generation entry point therefore used the hard-coded `0.3` default. This adds the missing configuration integration without adding a parallel CLI flag or imposing one provider’s upper bound on every backend.

## Validation

- `uv run pytest tests/unit/generation tests/unit/server/test_job_executor.py tests/unit/cli/test_commands.py tests/unit/cli/test_init_noninteractive.py tests/unit/cli/test_restyle_cmd.py tests/unit/cli/test_update_e2e.py -q` — 966 passed
- Ruff check and format verification on changed Python files
- `uv run mypy packages/core/src/repowise/core/generation/models.py`
- `uv run repowise risk upstream/main..HEAD` — typical change risk, 34th percentile