### PR TITLE
feat(pages): a retired page can hand off to the repository's overview

### DIFF
--- a/packages/core/src/repowise/core/generation/page_redirects.py
+++ b/packages/core/src/repowise/core/generation/page_redirects.py
@@ -6,15 +6,21 @@ something.  This module owns that mapping and nothing else: it turns a retired
 page id into the id of the page that took over its material.
 
 Page ids are ``{page_type}:{target_path}`` (see ``models.compute_page_id``).
-Retirements come in two shapes and the tables mirror that:
+Retirements come in three shapes and the tables mirror that:
 
-* **A whole page type folds into another.**  Its target path is usually the
-  repository name, which differs per repo, so the rule cannot be written as a
-  literal id.  :data:`SUPERSEDED_TYPES` rewrites the type and carries the path
-  across unchanged.
+* **A whole page type folds into another, keeping its path.**  Its target path
+  is usually the repository name, which differs per repo, so the rule cannot be
+  written as a literal id.  :data:`SUPERSEDED_TYPES` rewrites the type and
+  carries the path across unchanged.
 * **One page with a fixed target path retires.**  The onboarding slots are
   ``onboarding/{slot}`` for every repo, so these can be written as exact ids in
   :data:`SUPERSEDED_IDS`.
+* **A page folds into the repository's single page of some other type.**  Here
+  the retired id carries nothing that identifies the successor — a layer page is
+  keyed by its layer slug, and the overview by the repository name — so the
+  successor cannot be named without reading the store.
+  :data:`SUPERSEDED_TO_REPO_WIDE` names the successor *type* and the serving
+  layer resolves it.
 
 Retirements chain: a page folded into a second page that later folds into a
 third must land on the third, not the second, or the redirect leads somewhere
@@ -41,6 +47,24 @@ SUPERSEDED_TYPES: dict[str, str] = {
 # Retired page id → successor page id, in full.  For pages whose target path is
 # the same in every repository.
 SUPERSEDED_IDS: dict[str, str] = {}
+
+# Retired page type → the page type of the *one* repo-wide page that took over.
+#
+# The other two tables can name their successor from the retired id alone.  This
+# one cannot: a layer page is keyed by its layer slug (``layer_page:layer:core``)
+# and the overview is keyed by the repository name, which the id does not carry.
+# Rewriting the type would produce ``repo_overview:layer:core`` — an id no page
+# has ever had.
+#
+# So these resolve at serving time instead, against the store, which is the only
+# place that knows which repository is being read.  :func:`repo_wide_successor_type`
+# reports the type to look up; the caller finds that repository's page of it.
+SUPERSEDED_TO_REPO_WIDE: dict[str, str] = {
+    # Layers stopped being pages and became grouping rows in the docs tree,
+    # built from provenance stamped on their members.  A row is not a page, so
+    # an inbound link to a retired layer page lands on the overview.
+    "layer_page": "repo_overview",
+}
 
 # A chain longer than this is a table authoring mistake rather than a real
 # history — the orientation set has never held more than a handful of pages.
@@ -139,3 +163,17 @@ def resolve_superseded(
     raise SupersededCycleError(
         f"Retirement chain from {page_id!r} exceeded {_MAX_CHAIN} hops: " + " -> ".join(seen)
     )
+
+
+def repo_wide_successor_type(page_id: str) -> str | None:
+    """The page type a retired repo-wide page hands off to, if any.
+
+    Returns the *type* rather than an id because the successor is keyed by the
+    repository, which ``page_id`` does not carry.  The caller resolves it
+    against the store it is already reading.
+
+    Raises:
+        SupersededTargetError: ``page_id`` is not ``{page_type}:{target_path}``.
+    """
+    page_type, _ = _split(page_id)
+    return SUPERSEDED_TO_REPO_WIDE.get(page_type)

--- a/packages/server/src/repowise/server/routers/pages.py
+++ b/packages/server/src/repowise/server/routers/pages.py
@@ -12,7 +12,11 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from repowise.core.generation.page_redirects import SupersededError, resolve_superseded
+from repowise.core.generation.page_redirects import (
+    SupersededError,
+    repo_wide_successor_type,
+    resolve_superseded,
+)
 from repowise.core.persistence import crud
 from repowise.core.persistence.models import _now_utc
 from repowise.server.deps import get_db_session, verify_api_key
@@ -36,6 +40,35 @@ router = APIRouter(
 REDIRECTED_FROM_HEADER = "X-Repowise-Redirected-From"
 
 
+async def _sole_page_of_type(session: AsyncSession, page_type: str, retired_id: str):
+    """The store's single page of *page_type*, or ``None``.
+
+    Some retirements hand off to "the repository's overview" rather than to a
+    named id, because the retired id carries nothing that identifies the
+    successor. The store is what knows, so it is asked here.
+
+    Requires exactly one match. Zero means the index never produced the
+    successor; more than one means the store holds several repositories and
+    picking either would send readers of one repository into another's wiki.
+    Both are refusals rather than guesses, and both are logged, because either
+    strands every inbound link to the retired page.
+    """
+    from sqlalchemy import select
+
+    from repowise.core.persistence.models import Page
+
+    rows = (await session.execute(select(Page).where(Page.page_type == page_type))).scalars().all()
+    if len(rows) == 1:
+        return rows[0]
+    logger.warning(
+        "page_redirect_repo_wide_unresolved",
+        page_id=retired_id,
+        successor_type=page_type,
+        matches=len(rows),
+    )
+    return None
+
+
 async def _get_page_or_successor(session: AsyncSession, page_id: str, response: Response):
     """The requested page, or the page that took over from it.
 
@@ -52,11 +85,20 @@ async def _get_page_or_successor(session: AsyncSession, page_id: str, response: 
 
     try:
         successor_id = resolve_superseded(page_id)
+        repo_wide_type = None if successor_id else repo_wide_successor_type(page_id)
     except SupersededError:
         # The table is static and a test resolves every entry in it, so this
         # means a real bug. It must not take page serving down with it.
         logger.warning("page_redirect_table_broken", page_id=page_id, exc_info=True)
         return None
+
+    if repo_wide_type is not None:
+        successor = await _sole_page_of_type(session, repo_wide_type, page_id)
+        if successor is None:
+            return None
+        logger.info("page_redirect_served", page_id=page_id, successor_id=successor.id)
+        response.headers[REDIRECTED_FROM_HEADER] = page_id
+        return successor
 
     if successor_id is None:
         return None

--- a/tests/unit/server/test_pages.py
+++ b/tests/unit/server/test_pages.py
@@ -404,3 +404,66 @@ async def test_broken_redirect_table_does_not_500_the_reader(client: AsyncClient
     with patch(_REDIRECTS, side_effect=SupersededCycleError("a -> b -> a")):
         resp = await client.get("/api/pages/architecture_diagram:gone")
     assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Retirements that hand off to "this repository's overview"
+#
+# A layer page is keyed by its layer slug, so its id carries nothing that names
+# the overview. The successor is resolved against the store instead.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_retired_layer_page_lands_on_the_overview(client: AsyncClient, app) -> None:
+    repo = await create_test_repo(client)
+    async with get_session(app.state.session_factory) as session:
+        await crud.upsert_page(
+            session,
+            page_id="repo_overview:demo",
+            repository_id=repo["id"],
+            page_type="repo_overview",
+            title="Repository Overview",
+            content="# Overview",
+            target_path="demo",
+            source_hash="h",
+            model_name="mock",
+            provider_name="mock",
+        )
+    resp = await client.get("/api/pages/layer_page:layer:analysis")
+    assert resp.status_code == 200
+    assert resp.json()["id"] == "repo_overview:demo"
+    assert resp.headers["x-repowise-redirected-from"] == "layer_page:layer:analysis"
+
+
+@pytest.mark.asyncio
+async def test_retired_layer_page_404s_when_no_overview_exists(
+    client: AsyncClient, app
+) -> None:
+    """No successor is a refusal, not a guess."""
+    await _create_page(client, app.state.session_factory)
+    resp = await client.get("/api/pages/layer_page:layer:analysis")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_ambiguous_overview_is_refused_not_guessed(client: AsyncClient, app) -> None:
+    """Two repositories in one store must not cross-link their wikis."""
+    repo_a = await create_test_repo(client)
+    repo_b = await create_test_repo(client)
+    async with get_session(app.state.session_factory) as session:
+        for repo, name in ((repo_a, "a"), (repo_b, "b")):
+            await crud.upsert_page(
+                session,
+                page_id=f"repo_overview:{name}",
+                repository_id=repo["id"],
+                page_type="repo_overview",
+                title=f"Overview {name}",
+                content="# Overview",
+                target_path=name,
+                source_hash="h",
+                model_name="mock",
+                provider_name="mock",
+            )
+    resp = await client.get("/api/pages/layer_page:layer:analysis")
+    assert resp.status_code == 404


### PR DESCRIPTION
The redirect tables added in #1163 can name a successor from the retired id alone. Two shapes of retirement fit that: a page type folding into another and keeping its path (#1164 used this), and a page whose target path is identical in every repository.

A third shape does not fit, and the next retirement needs it.

## The gap

A layer page is keyed by its layer slug — `layer_page:layer:analysis` — while the overview is keyed by the repository name. The retired id carries nothing that identifies the successor. Rewriting the type would produce `repo_overview:layer:analysis`, an id no page has ever had.

## The fix

The store is the only thing that knows which repository is being read, so these resolve there. `SUPERSEDED_TO_REPO_WIDE` names the successor page *type*; `repo_wide_successor_type()` reports it, and the serving layer finds that repository's page of it.

## Ambiguity is refused, not guessed

Exactly one match is required.

- **Zero** — the index never produced the successor.
- **More than one** — the store holds several repositories, and picking either would drop a reader of one repository into another's wiki.

Both refuse and both log, because either strands every inbound link to the retired page. This is the case where a silent best-guess would be worst: the reader would get a confident, wrong page rather than a 404 they can act on.

## Nothing is retired by this

The `layer_page` entry only takes effect for an id that **misses**. A repository that still has its layer pages is completely unchanged — `crud.get_page` hits first. This lands the mechanism ahead of the change that uses it, so each is revertable alone.

## Tests

`test_pages.py` (+3) — a retired layer id lands on the overview with the redirect header set; no overview means 404; two overviews in one store means 404 rather than a cross-repository link.

Verified the first catches the bug: stubbing the lookup out returns 404 instead of 200. The two refusal tests pass either way by construction — they guard against a future over-eager implementation rather than against the absence of this one, which is worth saying plainly rather than counting them as proof.

## Gates

- `47 passed` across `test_pages.py` + `test_page_redirects.py`
- `uv run ruff check .` clean