### PR TITLE
fix(answer): stop the prompt formatter halving every page excerpt it fetches

### DIFF
--- a/packages/server/src/repowise/server/mcp_server/_answer_context.py
+++ b/packages/server/src/repowise/server/mcp_server/_answer_context.py
@@ -94,7 +94,15 @@ _MAX_PRELUDE_COMMITS_PER_HIT = 2
 # have to thread through the orchestrator.
 _MAX_SYMBOL_DOC_CHARS = 120
 _MATCHED_SYMBOL_DOC_CHARS = 400
+# A hit's fallback text is a one-line LLM summary or a 200-char page opener,
+# so 800 is already generous for those.
 _MAX_CHARS_PER_HIT_SUMMARY = 800
+# A real page excerpt is a different thing and gets its own cap. It was
+# sharing the summary cap, which truncated fetched page content to less than
+# half of what the fetch had asked the database for. This value must stay at
+# or above the fetch size — tool_answer.answer checks that at import time,
+# since the fetch size lives in another module.
+_MAX_CHARS_PER_HIT_EXCERPT = 1500
 
 
 def is_why_question(question: str) -> bool:
@@ -302,6 +310,7 @@ def build_context_block(
     decisions: list[dict] | None = None,
     *,
     max_chars_per_hit: int = _MAX_CHARS_PER_HIT_SUMMARY,
+    max_chars_per_excerpt: int = _MAX_CHARS_PER_HIT_EXCERPT,
 ) -> str:
     """Format the LLM prompt body: prelude + decisions block + per-hit excerpts.
 
@@ -315,7 +324,7 @@ def build_context_block(
         parts.append(prelude.rstrip())
     if decisions:
         parts.append(_format_decisions_block(decisions))
-    parts.append(_format_hits_block(hits, max_chars_per_hit))
+    parts.append(_format_hits_block(hits, max_chars_per_hit, max_chars_per_excerpt))
     return "\n\n".join(p for p in parts if p)
 
 
@@ -331,16 +340,24 @@ def _format_decisions_block(decisions: list[dict]) -> str:
     return "\n".join(lines)
 
 
-def _format_hits_block(hits: list[dict], max_chars_per_hit: int) -> str:
+def _format_hits_block(
+    hits: list[dict],
+    max_chars_per_hit: int,
+    max_chars_per_excerpt: int = _MAX_CHARS_PER_HIT_EXCERPT,
+) -> str:
     """Format the per-hit excerpts. Mirrors the prior tool_answer behaviour."""
     parts: list[str] = []
     for i, h in enumerate(hits, start=1):
-        # Prefer a real page excerpt when one was attached (the ambiguous-
-        # retrieval / always-synthesize path enriches non-dominant hits with
-        # actual page content so the LLM reads across the candidates, not just
-        # one-line summaries). Falls back to the summary/snippet otherwise.
-        body_src = h.get("excerpt") or h.get("summary") or h.get("snippet") or ""
-        body = body_src[:max_chars_per_hit]
+        # Prefer a real page excerpt when one was attached, so the LLM reads
+        # the page's actual prose rather than a one-line summary of it. It is
+        # capped separately: the excerpt's size was already decided by the
+        # fetch, and re-applying the (smaller) summary cap here threw away
+        # content the query had paid for.
+        excerpt = h.get("excerpt") or ""
+        if excerpt:
+            body = excerpt[:max_chars_per_excerpt]
+        else:
+            body = (h.get("summary") or h.get("snippet") or "")[:max_chars_per_hit]
         # Tag expanded hits so the LLM knows they didn't surface in retrieval
         # directly — useful context when deciding how much weight to put on
         # them in the answer.

--- a/packages/server/src/repowise/server/mcp_server/tool_answer/answer.py
+++ b/packages/server/src/repowise/server/mcp_server/tool_answer/answer.py
@@ -54,6 +54,9 @@ from repowise.core.persistence.database import get_session
 from repowise.core.persistence.models import AnswerCache
 from repowise.core.registry import mcp_tool_registry as mcp
 from repowise.server.mcp_server._answer_context import (
+    _MAX_CHARS_PER_HIT_EXCERPT,
+)
+from repowise.server.mcp_server._answer_context import (
     build_context_block as _build_context_block_v2,
 )
 from repowise.server.mcp_server._answer_context import (
@@ -112,6 +115,7 @@ from repowise.server.mcp_server.tool_answer.config import (
     _ANSWER_SCHEMA_VERSION,
     _DOMINANCE_RATIO,
     _ENRICH_TOP_N_HITS,
+    _GATED_EXCERPT_CHARS,
     _GATED_RETURN_HITS,
     _HIGH_CONFIDENCE_SCORE_FLOOR,
     _INLINE_BODY_MAX_LINES,
@@ -150,6 +154,18 @@ from repowise.server.mcp_server.tool_answer.synthesis import (
 )
 
 _log = logging.getLogger("repowise.mcp.answer")
+
+# The excerpt fetch and the prompt formatter each cap page content, and they
+# live in different modules — which is how the formatter came to discard more
+# than half of every excerpt the fetch had paid a database round-trip for.
+# Checked here, at import, because this is the only module that sees both.
+if _MAX_CHARS_PER_HIT_EXCERPT < _GATED_EXCERPT_CHARS:
+    raise RuntimeError(
+        "get_answer would truncate the page content it fetches: the prompt "
+        f"formatter caps an excerpt at {_MAX_CHARS_PER_HIT_EXCERPT} chars "
+        f"while the fetch asks for {_GATED_EXCERPT_CHARS}. Raise "
+        "_MAX_CHARS_PER_HIT_EXCERPT or lower _GATED_EXCERPT_CHARS."
+    )
 
 # Always-synthesize flag. Default ON: synthesis runs for every retrieval and the
 # post-synthesis grading cascade demotes confidence instead of the tool

--- a/tests/unit/server/mcp/test_answer_excerpt_cap.py
+++ b/tests/unit/server/mcp/test_answer_excerpt_cap.py
@@ -1,0 +1,134 @@
+"""The formatter must not shrink a page excerpt below what the fetch bought.
+
+``_GATED_EXCERPT_CHARS`` decides how much page content a hit's excerpt is
+worth fetching from the database. The context-block formatter then applied
+its own, smaller cap to the same string, so half of every fetched excerpt
+was thrown away after being paid for. The two constants live in different
+modules, which is why the mismatch went unnoticed; the relationship is now
+checked at import time and asserted here.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+import pytest
+
+from repowise.core.persistence.models import Page
+
+_PAGE_IDS = ("file_page:pkg/alpha/one.py", "file_page:pkg/alpha/two.py")
+_NOW = datetime(2026, 3, 19, 12, 0, 0, tzinfo=UTC)
+
+
+async def _add_pages(factory, repo_id: str, content: str) -> None:
+    """Two file pages carrying `content` as their body."""
+    async with factory() as s:
+        for page_id in _PAGE_IDS:
+            s.add(
+                Page(
+                    id=page_id,
+                    repository_id=repo_id,
+                    page_type="file_page",
+                    title=page_id.removeprefix("file_page:"),
+                    content=content,
+                    target_path=page_id.removeprefix("file_page:"),
+                    source_hash=page_id,
+                    model_name="mock",
+                    provider_name="mock",
+                    generation_level=2,
+                    confidence=0.9,
+                    freshness_status="fresh",
+                    created_at=_NOW,
+                    updated_at=_NOW,
+                )
+            )
+        await s.commit()
+
+
+def _patch_pipeline(monkeypatch, answer_mod, page_id: str) -> None:
+    """An ambiguous hit pair (ratio 1.05) on a real Page row — the path that
+    already fetches page content today."""
+
+    async def _fake_retrieve(question, ctx):
+        return [
+            {"page_id": page_id, "score": 2.0, "_sources": {"fts"}},
+            {"page_id": "file_page:pkg/alpha/two.py", "score": 1.9, "_sources": {"fts"}},
+        ]
+
+    async def _fake_hydrate(hits, ctx, *, scope=None):
+        for h in hits:
+            h["target_path"] = h["page_id"].removeprefix("file_page:")
+            h["title"] = h["target_path"]
+            h["summary"] = "One-line summary of the page."
+            h["snippet"] = ""
+            h["page_type"] = "file_page"
+        return hits
+
+    monkeypatch.setattr(answer_mod, "_hybrid_retrieve", _fake_retrieve)
+    monkeypatch.setattr(answer_mod, "_hydrate_hits", _fake_hydrate)
+
+
+def _capture_prompt(monkeypatch, answer_mod, answer_text: str) -> list[str]:
+    """Record the user prompt handed to synthesis; short-circuit the LLM."""
+    seen: list[str] = []
+
+    class _Provider:
+        provider_name = "mock"
+        model_name = "mock-1"
+
+        async def generate(self, **kwargs):
+            return SimpleNamespace(content=answer_text)
+
+    async def _fake_synthesize(provider, system_prompt, user_prompt):
+        seen.append(user_prompt)
+        return answer_text, None
+
+    monkeypatch.setattr(answer_mod, "_resolve_provider_for_answer", lambda _p: _Provider())
+    monkeypatch.setattr(answer_mod, "synthesize", _fake_synthesize)
+    return seen
+
+
+@pytest.mark.asyncio
+async def test_whole_fetched_excerpt_survives_formatting(setup_mcp, factory, monkeypatch):
+    import repowise.server.mcp_server.tool_answer.answer as answer_mod
+    from repowise.server.mcp_server import get_answer
+    from repowise.server.mcp_server.tool_answer.config import _GATED_EXCERPT_CHARS
+
+    body = "abcdefghij" * 400  # 4000 chars — longer than any cap in play
+    await _add_pages(factory, setup_mcp, body)
+    _patch_pipeline(monkeypatch, answer_mod, _PAGE_IDS[0])
+    prompts = _capture_prompt(monkeypatch, answer_mod, "Alpha writes (pkg/alpha/one.py).")
+
+    await get_answer("how does the alpha module handle the write path")
+
+    assert prompts, "synthesis must run"
+    assert body[:_GATED_EXCERPT_CHARS] in prompts[0], (
+        f"the whole {_GATED_EXCERPT_CHARS}-char fetched excerpt must reach the prompt"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_hit_without_page_content_still_formats(setup_mcp, factory, monkeypatch):
+    """No page body is a normal state, not an error: the hit falls back to its
+    summary and the prompt is still built."""
+    import repowise.server.mcp_server.tool_answer.answer as answer_mod
+    from repowise.server.mcp_server import get_answer
+
+    await _add_pages(factory, setup_mcp, "")
+    _patch_pipeline(monkeypatch, answer_mod, _PAGE_IDS[0])
+    prompts = _capture_prompt(monkeypatch, answer_mod, "Alpha writes (pkg/alpha/one.py).")
+
+    await get_answer("how does the alpha module handle the write path")
+
+    assert prompts, "synthesis must run"
+    assert "One-line summary of the page." in prompts[0]
+
+
+def test_format_excerpt_cap_is_at_least_the_fetch_size():
+    """Guard the relationship directly, so an edit to either constant fails
+    here rather than silently halving the prompt."""
+    from repowise.server.mcp_server._answer_context import _MAX_CHARS_PER_HIT_EXCERPT
+    from repowise.server.mcp_server.tool_answer.config import _GATED_EXCERPT_CHARS
+
+    assert _MAX_CHARS_PER_HIT_EXCERPT >= _GATED_EXCERPT_CHARS


### PR DESCRIPTION
## The bug

`get_answer` fetches real page content for the synthesis prompt at `_GATED_EXCERPT_CHARS = 1500` — that constant exists because 600 was measured to be too short, cutting the excerpt off mid-context. The context-block formatter then applied `_MAX_CHARS_PER_HIT_SUMMARY = 800` to the same string.

So every excerpt lost 47% of itself immediately after the database round-trip that produced it, and what it lost was the tail — the part of the page that comes after the opening section.

## Why it survived

The two caps look like the same thing. They are not:

- a hit's **fallback** text is a one-line LLM summary or a 200-char page opener, and 800 chars is already more than either will ever use;
- a real page **excerpt** has had its size decided by the fetch, and the formatter re-deciding it is pure loss.

They also live in different modules (`tool_answer/config.py` and `_answer_context.py`), so nothing ever compared them.

## The change

- the page excerpt gets its own cap, `_MAX_CHARS_PER_HIT_EXCERPT`, applied only to a real excerpt; the summary/snippet fallback keeps the cap it had;
- `tool_answer/answer.py` — the one module that imports both — checks at import time that the format cap is not below the fetch size, and raises if it is. A future edit to either constant fails at boot instead of quietly trimming the prompt again.

## Tests

`tests/unit/server/mcp/test_answer_excerpt_cap.py`, three tests, all failing before this change:

- the whole 1500-char fetched excerpt reaches the synthesis prompt (this is the regression; on `main` only the first 800 chars arrive);
- a hit whose page has no content still formats, falling back to its summary — an empty body is a normal state, not an error;
- the two constants are asserted against each other directly.

Gates: 704 passed in `tests/unit/server/mcp`, ruff check and format clean.