### PR TITLE
docs(architecture): align chat tool registry with the live 7-tool set

### DIFF
--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -1154,9 +1154,10 @@ file, tokens used, estimated cost, estimated time remaining).
 repowise includes an interactive chat interface that lets users ask questions about
 their codebase and receive answers grounded in the wiki, dependency graph, git
 history, and architectural decisions. The chat agent uses whichever LLM provider
-the user has configured and has access to all 11 MCP tools.
+the user has configured and has access to **7 tools** from the MCP surface
+(see [`chat.md`](chat.md) — not the full 11-tool MCP default).
 
-See [`docs/CHAT.md`](CHAT.md) for the full technical reference covering the
+See [`docs/architecture/chat.md`](chat.md) for the full technical reference covering the
 backend agentic loop, SSE streaming protocol, provider abstraction extensions,
 database schema, frontend component architecture, and artifact rendering system.
 
@@ -1165,7 +1166,7 @@ database schema, frontend component architecture, and artifact rendering system.
 - **Provider-agnostic** — the chat agent goes through the same provider abstraction
   as documentation generation. A `ChatProvider` protocol extends `BaseProvider` with
   `stream_chat()` for streaming + tool use without breaking existing callers.
-- **Tool reuse** — the 11 MCP tools are called directly as Python functions (no
+- **Tool reuse** — the 7 chat tools are called directly as Python functions (no
   subprocess round-trip). Tool schemas are defined once in `chat_tools.py` and
   fed to both the LLM and the executor.
 - **SSE streaming** — `POST /api/repos/{repo_id}/chat/messages` runs the agentic

--- a/docs/architecture/chat.md
+++ b/docs/architecture/chat.md
@@ -2,7 +2,8 @@
 
 The codebase chat feature lets users have an interactive conversation with their
 codebase. The agent uses whichever LLM provider the user has configured, has
-access to all 10 MCP tools, and streams responses back to the browser in real time
+access to **7 tools** from the MCP surface (a curated chat subset — not the full
+11-tool MCP default), and streams responses back to the browser in real time
 showing tool calls as they happen and rendering results in an artifact panel.
 
 ---
@@ -158,8 +159,10 @@ class ChatProvider(Protocol):
 
 Defined in `packages/server/src/repowise/server/chat_tools.py`.
 
-Single source of truth for tool schemas and execution. Imports the 10 MCP tool
-functions directly from `repowise.server.mcp_server`.
+Single source of truth for chat tool schemas and execution. Imports **7** MCP
+tool functions from `repowise.server.mcp_server` (the chat agent does not
+advertise the full MCP default surface — no `get_answer`, `get_symbol`,
+`get_health`, or `list_repos` here).
 
 ```python
 TOOL_REGISTRY: dict[str, ToolDef]  # name -> ToolDef(name, description, parameters, function, artifact_type)
@@ -174,18 +177,17 @@ TOOL_REGISTRY: dict[str, ToolDef]  # name -> ToolDef(name, description, paramete
 | `get_artifact_type(name)` | Maps tool name to frontend artifact type |
 | `init_tool_state(...)` | Bridges FastAPI app state to MCP module globals |
 
-**Tool to artifact type mapping:**
+**Tool to artifact type mapping (7 tools):**
 
 | Tool | Artifact Type |
 |------|--------------|
 | `get_overview` | `overview` |
 | `get_context` | `wiki_page` |
 | `get_risk` | `risk_report` |
+| `get_change_risk` | `risk_report` |
 | `get_why` | `decisions` |
 | `search_codebase` | `search_results` |
-| `get_dependency_path` | `graph` |
 | `get_dead_code` | `dead_code` |
-| `get_architecture_diagram` | `diagram` |
 
 ---
 

--- a/packages/server/src/repowise/server/chat_tools.py
+++ b/packages/server/src/repowise/server/chat_tools.py
@@ -188,8 +188,8 @@ _TOOL_SCHEMAS: list[dict[str, Any]] = [
                 },
                 "min_confidence": {
                     "type": "number",
-                    "description": "Minimum confidence threshold (default 0.5).",
-                    "default": 0.5,
+                    "description": "Minimum confidence threshold (default 0.4; matches RISK_CAP_CONFIDENCE).",
+                    "default": 0.4,
                 },
                 "safe_only": {
                     "type": "boolean",

--- a/tests/unit/server/test_chat_tool_registry.py
+++ b/tests/unit/server/test_chat_tool_registry.py
@@ -1,0 +1,26 @@
+"""Drift guard: chat tool registry stays a documented 7-tool subset."""
+
+from __future__ import annotations
+
+from repowise.server.chat_tools import get_tool_registry
+
+
+def test_chat_tool_registry_is_the_documented_seven() -> None:
+    names = set(get_tool_registry())
+    assert names == {
+        "get_overview",
+        "get_context",
+        "get_risk",
+        "get_change_risk",
+        "get_why",
+        "search_codebase",
+        "get_dead_code",
+    }
+
+
+def test_chat_dead_code_schema_default_matches_risk_cap() -> None:
+    from repowise.core.analysis.dead_code.risk_factors import RISK_CAP_CONFIDENCE
+    from repowise.server.chat_tools import get_tool_registry
+
+    params = get_tool_registry()["get_dead_code"].parameters["properties"]["min_confidence"]
+    assert params["default"] == RISK_CAP_CONFIDENCE


### PR DESCRIPTION
## Summary
- Rewrite \`docs/architecture/chat.md\` to the **7** tools actually registered in \`chat_tools.py\` (drop invented \`get_dependency_path\` / \`get_architecture_diagram\`; add \`get_change_risk\`).
- Fix ARCHITECTURE §12 chat counts and the broken \`CHAT.md\` link.
- Align chat \`get_dead_code\` schema default with \`RISK_CAP_CONFIDENCE\` (0.4).
- Add \`tests/unit/server/test_chat_tool_registry.py\` drift guard.

## Why
MCP website/package docs were fixed earlier; chat architecture docs still described a pre-consolidation 10-tool surface. Not tied to any open issue.

## Test plan
- [x] \`pytest tests/unit/server/test_chat_tool_registry.py\`