### PR TITLE
docs(cli): document structurizr export in the package README

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -173,7 +173,8 @@ repowise search "AuthService" --mode symbol
 
 ### `repowise export`
 
-Export all wiki pages to files on disk in Markdown, HTML, or JSON format.
+Export wiki pages to files on disk (Markdown, HTML, or JSON), or emit the
+architecture model as [Structurizr DSL](https://structurizr.com).
 
 ```
 repowise export [PATH] [OPTIONS]
@@ -181,8 +182,12 @@ repowise export [PATH] [OPTIONS]
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `--format` | `markdown` | Output format: `markdown`, `html`, `json` |
-| `--output`, `-o` | `.repowise/export` | Output directory |
+| `--format` | `markdown` | `markdown`, `html`, `json`, or `structurizr` |
+| `--output`, `-o` | `.repowise/export` | Output directory (for `structurizr`, a path ending in `.dsl` names the file) |
+| `--full` | off | JSON only: include decisions, dead code, hotspots, provenance |
+| `--standalone` | off | Structurizr only: emit a complete workspace with default views |
+| `--components` | off | Structurizr only: include the component level (one box per directory) |
+| `--no-externals` | off | Structurizr only: omit third-party dependencies |
 
 ```bash
 # Export as Markdown to .repowise/export/
@@ -193,9 +198,18 @@ repowise export --format json -o ./wiki-export
 
 # Export as HTML
 repowise export --format html -o ./docs/wiki
+
+# Architecture as Structurizr DSL (model fragment by default)
+repowise export --format structurizr
+repowise export --format structurizr --standalone -o arch/
 ```
 
-The JSON output is a single `wiki_pages.json` file with all pages as an array. Markdown and HTML outputs write one file per page.
+Markdown and HTML write one file per page. JSON writes a single
+`wiki_pages.json`. Structurizr writes one `.dsl` file from the existing
+graph (no LLM). See
+[`docs/architecture/structurizr-export.md`](../../docs/architecture/structurizr-export.md)
+and the full flag set in
+[`docs/reference/CLI_REFERENCE.md`](../../docs/reference/CLI_REFERENCE.md).
 
 ---
 


### PR DESCRIPTION
## Summary
- Update \`packages/cli/README.md\` \`repowise export\` to include \`structurizr\` format plus \`--standalone\` / \`--components\` / \`--no-externals\` / \`--full\`.
- Link the deep guide \`docs/architecture/structurizr-export.md\` and \`CLI_REFERENCE.md\`.

## Why
Structurizr export shipped on main; the package README still listed only markdown/html/json. Not tied to any open issue (avoids open #1106 website CLI page).

## Test plan
- [x] Diff flags against \`docs/reference/CLI_REFERENCE.md\` export section
- [x] \`repowise export --help\` lists \`structurizr\`