### PR TITLE
docs(examples): add change-risk CLI walkthrough

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -11,6 +11,7 @@ self-contained README under `examples/<name>/`.
 | [distill/](distill/) | `distill` / `expand` / `saved` — compress command output (no LLM key) |
 | [health-coverage/](health-coverage/) | Code health, coverage ingest, and impacted-tests (no LLM key) |
 | [opencode/](opencode/) | OpenCode as the LLM provider for wiki generation |
+| [risk/](risk/) | `repowise risk` change / PR defect scoring (no LLM key) |
 | [security-scan/](security-scan/) | Working-tree security signals + OSS `security scan --history` (no LLM key) |
 
 ## Conventions
@@ -27,6 +28,7 @@ self-contained README under `examples/<name>/`.
 - [Codex integration](../docs/agent/CODEX.md)
 - [OpenCode integration](../docs/agent/OPENCODE.md)
 - [Code health](../docs/layers/CODE_HEALTH.md)
+- [Change risk](../docs/layers/CHANGE_RISK.md)
 - [Test intelligence](../docs/layers/TEST_INTELLIGENCE.md)
 - [Distill](../docs/agent/DISTILL.md)
 - [CLI: security](../docs/reference/CLI_REFERENCE.md)

--- a/examples/risk/README.md
+++ b/examples/risk/README.md
@@ -1,0 +1,58 @@
+# Change-Risk Example
+
+Score the defect risk of a commit or `base..head` range with
+`repowise risk`. No LLM key required — pure git + calibrated signals.
+Works without `repowise init` (index is optional).
+
+## Prerequisites
+
+1. A git repository with at least one commit.
+2. `repowise` on `PATH` (`uv tool install repowise` or from this repo:
+   `uv sync --all-packages`).
+
+```bash
+cd /path/to/your-repo
+```
+
+## 1. Score HEAD or a range
+
+```bash
+repowise risk                 # score HEAD
+repowise risk main..HEAD      # whole branch / PR as one change
+repowise risk HEAD~5..HEAD    # recent local work
+```
+
+The headline is **repo-relative**: percentile and review priority
+(`Below typical` / `Typical` / `Elevated`) among recent commits. The raw
+0–10 model score is secondary context.
+
+## 2. Narrow what counts
+
+```bash
+# Only certain suffixes
+repowise risk --ext .py
+repowise risk main..HEAD --ext .ts,.tsx
+
+# Omit paths (repeatable); root .riskignore also applies
+repowise risk main..HEAD -x 'tests/' -x '*.spec.ts'
+```
+
+## 3. Machine-readable output
+
+```bash
+repowise risk main..HEAD --format json
+```
+
+## Smoke checklist
+
+| Step | Expected |
+|------|----------|
+| `repowise risk` | Table with score / percentile / review priority for HEAD |
+| `repowise risk main..HEAD` | Same shape for the range (or a clear revspec error) |
+| `repowise risk --format json` | JSON object; no API key needed |
+
+## Related docs
+
+- [Change risk](../../docs/layers/CHANGE_RISK.md)
+- [CLI: `repowise risk`](../../docs/reference/CLI_REFERENCE.md)
+- [Quickstart](../../docs/start/QUICKSTART.md)


### PR DESCRIPTION
## Summary
- Add \`examples/risk/README.md\` for \`repowise risk\` (HEAD / \`base..head\`, \`--ext\`, \`-x\`, \`--format json\`).
- Index it in \`examples/README.md\` and link \`CHANGE_RISK.md\`.

## Why
Risk is a first-class no-LLM CLI surface (QUICKSTART / USER_GUIDE) but \`examples/\` had no walkthrough after health/security/distill. Not tied to any open issue.

## Test plan
- [x] \`repowise risk HEAD\` runs locally
- [x] Skim flags against \`docs/reference/CLI_REFERENCE.md\`