### PR TITLE
fix(cli): generation checks reach a normal run of init and update

### DIFF
--- a/packages/cli/src/repowise/cli/commands/init_cmd/reporting.py
+++ b/packages/cli/src/repowise/cli/commands/init_cmd/reporting.py
@@ -292,6 +292,30 @@ def show_completion(
             console.print(_line)
         console.print()
 
+    _show_generation_checks(result)
+
+
+def _show_generation_checks(result: Any) -> None:
+    """Report the generation quality checks on the pages this run wrote.
+
+    ``init`` built no report at all, so the checks ran on a later ``update``
+    and never on the first index — which is the run that creates a repository's
+    pages, and so the run where duplication first appears.
+
+    Only the checks are shown, not the statistics table: the completion panel
+    above already carries the page count, cost and token totals.
+    """
+    try:
+        from repowise.core.generation.report import GenerationReport, render_generation_checks
+
+        render_generation_checks(GenerationReport.from_pages(result.generated_pages or []), console)
+    except Exception as exc:
+        # A first index that could not check itself must not read like one that
+        # checked itself clean. The run still exits 0; the wiki is written.
+        console.print(
+            f"[bold red]Generation checks did not run:[/bold red] {type(exc).__name__}: {exc}"
+        )
+
 
 def show_workspace_completion(
     *,

--- a/packages/cli/src/repowise/cli/commands/update_cmd/command.py
+++ b/packages/cli/src/repowise/cli/commands/update_cmd/command.py
@@ -1711,6 +1711,7 @@ def run_update(
         elapsed=elapsed,
         degraded=degraded,
     )
-    if verbose:
-        _render_update_report(generated_pages, affected, new_decision_markers, elapsed)
+    _render_update_report(
+        generated_pages, affected, new_decision_markers, elapsed, detail=verbose
+    )
     return UpdateOutcome.REGENERATED

--- a/packages/cli/src/repowise/cli/commands/update_cmd/reporting.py
+++ b/packages/cli/src/repowise/cli/commands/update_cmd/reporting.py
@@ -325,10 +325,22 @@ def _render_update_report(
     affected: Any,
     new_decision_markers: list,
     elapsed: float,
+    detail: bool = False,
 ) -> None:
-    """Render the detailed generation report table (verbose mode / fallback)."""
+    """Render the generation report.
+
+    The quality checks print on every run; ``detail`` adds the page, token and
+    cost statistics on top. Checks used to render only under ``-v``, and since
+    ``repowise.core`` logging is silenced outside verbose mode, that left a
+    flagged page pair with no channel at all — it was measured, reported to
+    nobody, and read as a clean run.
+    """
     try:
-        from repowise.core.generation.report import GenerationReport, render_report
+        from repowise.core.generation.report import (
+            GenerationReport,
+            render_generation_checks,
+            render_report,
+        )
 
         report = GenerationReport.from_pages(
             generated_pages,
@@ -336,9 +348,14 @@ def _render_update_report(
             decisions_count=len(new_decision_markers),
             elapsed=elapsed,
         )
-        render_report(report, console)
-    except Exception:
-        # Fallback to simple message if report fails
+        if detail:
+            render_report(report, console)
+        else:
+            render_generation_checks(report, console)
+    except Exception as exc:
+        # Never fail a completed index over its own summary, but never let the
+        # failure pass for a clean run either. This message is the only signal
+        # that the checks below it are missing rather than empty.
         console.print(
-            f"[bold green]Updated {len(generated_pages)} pages in {elapsed:.1f}s[/bold green]"
+            f"[bold red]Generation checks did not run:[/bold red] {type(exc).__name__}: {exc}"
         )

--- a/packages/core/src/repowise/core/generation/report.py
+++ b/packages/core/src/repowise/core/generation/report.py
@@ -162,31 +162,45 @@ def render_report(report: GenerationReport, console: object) -> None:
     if report.self_repaired_page_count:
         table.add_row("Self-repaired pages", str(report.self_repaired_page_count))
 
-    # Always shown, including when nothing was comparable.  Hiding the row on
-    # a zero would make "the check did not run" look like "the check passed".
+    console.print(table)  # type: ignore[union-attr]
+    render_generation_checks(report, console)
+
+
+def render_generation_checks(report: GenerationReport, console: object) -> None:
+    """Print the run's quality checks, each of them every time.
+
+    Split out of the statistics table so a caller can show the checks without
+    the cost and token detail. Both callers share this one definition: a check
+    that renders in only one of two places is a check that goes silent the
+    moment a run takes the other path.
+
+    Every row prints even at zero. A hidden zero would make "the check did not
+    run" indistinguishable from "the check passed", which is the failure the
+    checks exist to prevent.
+    """
+    from rich.table import Table  # deferred so core has no hard rich dep
+
+    table = Table(title="Generation Checks", show_lines=False)
+    table.add_column("Check", style="cyan")
+    table.add_column("Result", justify="right")
+
     overlap = report.orientation_overlap
     overlap_text = overlap.summary_line()
     if overlap.flagged:
         overlap_text = f"[yellow]{overlap_text}[/yellow]"
     table.add_row("Orientation overlap", overlap_text)
 
-    # Always shown, for the same reason as the row above: a hidden zero would
-    # make "nothing was groupable" read as "everything grouped".
     grouping = report.layer_grouping
     grouping_text = grouping.summary_line()
     if grouping.ungrouped:
         grouping_text = f"[yellow]{grouping_text}[/yellow]"
     table.add_row("Layer grouping", grouping_text)
 
-    # Same reasoning as the overlap row: shown even at zero, because a check
-    # that never ran must not look like a check that passed.
     artifact_text = report.artifact_check_summary()
     if report.artifact_checks.get("rejected"):
         artifact_text = f"[yellow]{artifact_text}[/yellow]"
     table.add_row("Artifact checks", artifact_text)
 
-    # Always shown for the same reason as the two rows above: a budget nobody
-    # sees the reading of is a budget nobody keeps.
     length_text = report.overview_length_summary()
     if report.overview_over_budget:
         length_text = f"[yellow]{length_text}[/yellow]"

--- a/tests/unit/cli/test_init_failure_reporting.py
+++ b/tests/unit/cli/test_init_failure_reporting.py
@@ -286,6 +286,81 @@ def test_show_completion_panel_with_failures(monkeypatch):
     assert metrics_dict.get("Pages generated") == "1 (2 failed)"
 
 
+def _completion_result(pages: list) -> SimpleNamespace:
+    graph_mock = MagicMock()
+    graph_mock.number_of_nodes.return_value = 10
+    graph_mock.number_of_edges.return_value = 5
+    return SimpleNamespace(
+        graph_builder=MagicMock(graph=lambda: graph_mock),
+        dead_code_report=None,
+        decision_report=None,
+        git_summary=None,
+        git_meta_map={},
+        repo_structure=SimpleNamespace(root_language_distribution={"Python": 1.0}),
+        generated_pages=pages,
+        failed_page_ids=[],
+        file_count=3,
+        symbol_count=42,
+    )
+
+
+# Every generation check the report carries.
+_CHECK_ROWS = ("Orientation overlap", "Layer grouping", "Artifact checks", "Overview length")
+
+
+class TestInitRendersGenerationChecks:
+    """`init` writes a repository's first pages, so it must report on them.
+
+    It never built a GenerationReport at all: the checks ran only on a later
+    `update`. The first index is where duplication is created, and it was the
+    one run that said nothing about it.
+    """
+
+    def _output(self, monkeypatch, *, index_only: bool) -> str:
+        import io
+
+        from rich.console import Console
+
+        buf = io.StringIO()
+        monkeypatch.setattr(
+            "repowise.cli.commands.init_cmd.reporting.console",
+            Console(file=buf, width=200, force_terminal=False),
+        )
+        monkeypatch.setattr(
+            "repowise.cli.commands.init_cmd.reporting.build_completion_panel",
+            lambda title, metrics, next_steps=None: "PANEL",
+        )
+        show_completion(
+            repo_path="/fake",
+            result=_completion_result([_page("file_page:a")]),
+            start=0.0,
+            effective_index_only=index_only,
+            run_mode="standard",
+            provider=SimpleNamespace(provider_name="mock", model_name="mock-model"),
+        )
+        return buf.getvalue()
+
+    @pytest.mark.parametrize("index_only", [False, True])
+    def test_checks_render_after_completion(self, monkeypatch, index_only):
+        output = self._output(monkeypatch, index_only=index_only)
+
+        for row in _CHECK_ROWS:
+            assert row in output, f"{row} missing from init's completion output"
+
+    def test_check_failure_is_loud_and_names_the_cause(self, monkeypatch):
+        """A failed check block must not read as a clean first index."""
+
+        def _boom(*_args, **_kwargs):
+            raise RuntimeError("overlap exploded")
+
+        monkeypatch.setattr("repowise.core.generation.report.GenerationReport.from_pages", _boom)
+        output = self._output(monkeypatch, index_only=False)
+
+        assert "overlap exploded" in output
+        assert "RuntimeError" in output
+        assert "checks did not run" in output
+
+
 def test_run_repo_generation_uses_exact_job_id_when_provided(tmp_path, monkeypatch):
     """When result has a job_id attached, run_repo_generation queries that exact job checkpoint."""
     jobs_dir = tmp_path / ".repowise" / "jobs"

--- a/tests/unit/cli/test_update_reporting.py
+++ b/tests/unit/cli/test_update_reporting.py
@@ -43,6 +43,10 @@ def _diffs(n: int, status: str = "modified") -> list:
     return [SimpleNamespace(status=status, path=f"src/file_{i}.py") for i in range(n)]
 
 
+def _affected(decay_only: list | None = None) -> SimpleNamespace:
+    return SimpleNamespace(decay_only=decay_only or [])
+
+
 class TestRenderChangedFiles:
     def test_collapses_to_preview_plus_more_by_default(self, monkeypatch):
         printed = _capture(monkeypatch)
@@ -125,3 +129,57 @@ class TestCompletionPanels:
             elapsed=63.1,
         )
         assert any("workspace update complete" in line for line in printed.lines)
+
+
+# Every generation check the report carries. A check that stops reaching the
+# console is a check nobody acts on, so the names are asserted literally.
+_CHECK_ROWS = ("Orientation overlap", "Layer grouping", "Artifact checks", "Overview length")
+
+
+class TestGenerationReport:
+    """The generation checks must reach a plain run, not only `-v`.
+
+    Warnings from `repowise.core.*` are silenced process-wide outside verbose
+    mode (`cli/_setup.py`), so this console output is the only channel a check
+    has. Rendering it under `if verbose:` left every check invisible by default.
+    """
+
+    def test_checks_render_without_detail(self, monkeypatch):
+        printed = _capture(monkeypatch)
+        reporting._render_update_report([], _affected(), [], 4.2, detail=False)
+
+        for row in _CHECK_ROWS:
+            assert any(row in line for line in printed.lines), f"{row} missing from a plain run"
+
+    def test_detail_adds_the_stats_table_and_keeps_the_checks(self, monkeypatch):
+        printed = _capture(monkeypatch)
+        reporting._render_update_report([], _affected(), [], 4.2, detail=True)
+
+        assert any("Est. cost" in line for line in printed.lines)
+        for row in _CHECK_ROWS:
+            assert any(row in line for line in printed.lines), f"{row} missing from a verbose run"
+
+    def test_plain_run_omits_the_stats_table(self, monkeypatch):
+        printed = _capture(monkeypatch)
+        reporting._render_update_report([], _affected(), [], 4.2, detail=False)
+
+        assert not any("Est. cost" in line for line in printed.lines)
+
+    def test_render_failure_is_loud_and_names_the_cause(self, monkeypatch):
+        """A failed report must not read as a successful one.
+
+        The previous fallback printed a green "Updated N pages", so a report
+        that raised looked exactly like a run with nothing to report.
+        """
+        printed = _capture(monkeypatch)
+
+        def _boom(*_args, **_kwargs):
+            raise RuntimeError("overlap exploded")
+
+        monkeypatch.setattr("repowise.core.generation.report.GenerationReport.from_pages", _boom)
+        reporting._render_update_report([], _affected(), [], 4.2, detail=False)
+
+        text = "\n".join(printed.lines)
+        assert "overlap exploded" in text
+        assert "RuntimeError" in text
+        assert "checks did not run" in text


### PR DESCRIPTION
## The problem

`GenerationReport` renders from exactly one place, and `update` called it only under `if verbose:`. `init` never built a report at all.

That matters more than it looks, because the logger is not a fallback: `cli/_setup.py:29` sets `repowise.core` to `ERROR` process-wide unless `-v` is passed, and every generation check logs under `repowise.core.*`. So in a normal run **both** channels were dark. The orientation-overlap, layer-grouping, artifact and overview-length checks all ran, computed their numbers, and reported them to nobody. A flagged page pair looked exactly like a clean run.

Each of those checks was built on the premise that the console row is what makes a finding visible. That premise was false, so they shipped effectively disabled.

## The change

**One definition of the check rows.** `render_generation_checks` splits the four checks out of the statistics table. Every caller shares it. A row that renders in only one of several paths goes silent the moment a run takes another one, and this is exactly the kind of signal whose absence nobody notices.

**`update` always renders them.** `detail=verbose` decides whether the page/token/cost table prints on top. Verbose output is unchanged apart from the checks moving into their own titled table beneath it.

**`init` renders them too.** It writes a repository's first pages, so it is the run where duplication is created — and it was the one run saying nothing about it. It shows the checks alone, without the statistics table, because its completion panel already carries the page count, cost and token totals.

**A failed report no longer reads as a successful one.** `update`'s bare `except Exception` printed a green `Updated N pages in Xs`, so a report that raised was indistinguishable from a run with nothing to report. Both commands now print the exception type and message in red. The run still exits 0 — a completed index should not fail over its own summary — but that message is the only thing telling a reader the checks are *missing* rather than *empty*, so it is loud and it names the cause.

`init` and `update` are in one PR because the second half calls the function the first half introduces; splitting them would mean stacking a branch that gets no CI.

## Tests

Seven new tests across `test_update_reporting.py` and `test_init_failure_reporting.py`: the checks render without `detail`, `detail` adds the statistics table without losing them, a plain run omits that table, `init` renders the checks in both index-only and full mode, and a raising report prints a red notice naming the cause in each command.

Proven to bite. `update`'s first run failed only on the signature, which is a weak proof, so the old verbose-only branch was restored temporarily and the test failed behaviourally: `AssertionError: Orientation overlap missing from a plain run`. The `init` tests failed behaviourally on first write — the captured output was the completion panel and nothing else.

The tests sit at the reporting-module level rather than driving the CLI. That keeps `update_cmd/command.py` down to a single line — it carries 11 prior bug fixes, 7 of them in `run_update` — and avoids the `CliRunner` flakiness in this suite on macOS.

## Gates

- `tests/unit/cli` + `tests/unit/generation`: 1,991 passed. The remaining failures are the known pre-existing `CliRunner` bucket — each also fails on unmodified `main`, and which of them fail shifts between runs of the same code, which is the signature of that flakiness rather than of a regression.
- `ruff check` and `ruff format` clean on all changed files.