### PR TITLE
docs(generation): record what the overlap thresholds actually measure

### DIFF
--- a/packages/core/src/repowise/core/generation/page_overlap.py
+++ b/packages/core/src/repowise/core/generation/page_overlap.py
@@ -52,14 +52,34 @@ ORIENTATION_PAGE_TYPES: frozenset[str] = frozenset(
     {"onboarding", "layer_page", "repo_overview", "architecture_diagram"}
 )
 
-# Measured across the orientation set of a full index: pairs of *different*
-# page types sit at or below 0.19, except one known duplicate at 0.24.  0.22
-# separates them with margin on both sides.
+# Both thresholds warn; neither fails a run.  The readings below come from a
+# fresh index of this repository over an orientation set of 8 pages (7
+# onboarding plus the overview), measured after the layer and architecture
+# pages stopped being emitted.  They replace readings taken on a 20-page set
+# that no longer exists.
+#
+#   cross-type    7 pairs   max 0.2113   median 0.1473
+#   same-type    21 pairs   max 0.2371   median 0.1453
+#
+# Read that as one sample rather than a distribution: one repository, one
+# model.  Page vocabulary depends on both, so another repository can sit
+# anywhere relative to these numbers.
+#
+# Cross-type: the highest innocent pair is 0.2113 — the overview against the
+# guided tour, two pages that should both exist — and the only duplicate ever
+# measured here scored 0.2431 before it was merged away.  Roughly 0.03
+# separates the two classes, which is why this stays a warning line.  Failing a
+# run on it would fail innocent pages at the same rate it caught duplicates,
+# and this check runs during a user's index, not in CI.
 DEFAULT_CROSS_TYPE_THRESHOLD = 0.22
 
-# Pages of the *same* type share a template and a domain vocabulary, so they
-# run far higher — the layer pages have a median near 0.38 with nothing wrong.
-# 0.45 catches the genuinely interchangeable ones without flagging the rest.
+# Same-type pages share a template and a domain vocabulary, so they used to run
+# much higher: the layer pages had a median near 0.38 with nothing wrong, and
+# 0.45 was chosen against them.  Those pages are gone and the remaining
+# same-type maximum is 0.2371, so nothing approaches this bar now.  Left where
+# it is on purpose rather than re-tuned to fit a single index — a bar nobody
+# approaches is worth revisiting once there is more than one index to set it
+# against.
 DEFAULT_SAME_TYPE_THRESHOLD = 0.45
 
 _TOKEN_RE = re.compile(r"[a-z0-9_]+")


### PR DESCRIPTION
## What

Comment-only. Both threshold comments in `page_overlap.py` describe a corpus that no longer exists, and a reader trusting them would draw the wrong conclusion about how much room either number has.

| | comment said | fresh index measures |
|---|---|---|
| cross-type | different-type pairs "at or below 0.19", one duplicate at 0.24 | **max 0.2113**, median 0.1473 (7 pairs) |
| same-type | justified by a layer-page median "near 0.38" | **max 0.2371**, median 0.1453 (21 pairs) |

The layer and architecture pages are no longer emitted, so the orientation set is 8 pages rather than 20, and the layer-page median the same-type bar was chosen against no longer exists at all.

## Why the values are unchanged

The intent was to promote the cross-type check from warn-only to a gate at 0.22. The measurement is what stopped it: the highest *innocent* pair is 0.2113 — the overview against the guided tour, two pages that should both exist — while the only real duplicate ever measured here scored 0.2431 before it was merged away.

About 0.03 separates the two classes. A gate in that space fails innocent pages at close to the rate it catches duplicates, and this check runs inside `init` and `update` on a user's machine rather than in CI, so a false positive fails their index rather than showing a red tick someone can override. On top of that, these are readings from one repository on one model, and page vocabulary depends on both.

So the numbers get written down and the thresholds keep warning. The comment now says that explicitly, including why the same-type bar sits far above anything that approaches it — deliberately not re-tuned to fit a single index.

## Tests

None, and deliberately so: no behaviour changes, so a test here would assert the thresholds against the same numbers the comment records and pass by construction. `tests/unit/generation` covers the values themselves and is unchanged at **947 passed**.

Verification for the readings is the index they came from: 1,817 pages, 8 orientation pages (7 onboarding + 1 `repo_overview`, zero `layer_page`, zero `architecture_diagram`), scored with the shipped `measure_orientation_overlap` rather than a reimplementation. 0 of 28 pairs flag at current defaults.

## Gates

- `tests/unit/generation`: 947 passed.
- `ruff check` and `ruff format --check` clean on the changed file.