### PR TITLE
feat(docs): the file corpus sits above the layer outline, not under it

### DIFF
--- a/packages/ui/__tests__/docs/docs-tree.test.tsx
+++ b/packages/ui/__tests__/docs/docs-tree.test.tsx
@@ -381,6 +381,47 @@ describe("DocsTree", () => {
     expect(indexOfRow("runtime/engine")).toBeLessThan(indexOfRow("Alpha API"));
   });
 
+  it("puts the file corpus above the layers, so it never sinks under the outline", () => {
+    render(
+      <DocsTree
+        pages={[
+          layeredRoot({ layer_order_ids: SPINE_IDS }),
+          makePage({
+            id: "onboarding:onboarding/getting_started",
+            page_type: "onboarding",
+            title: "Getting Started",
+            target_path: "onboarding/getting_started",
+            parent_page_id: "repo_overview:demo",
+            display_order: 1,
+          }),
+          stampedModule("module_page:runtime/engine", "Module: runtime/engine", {
+            layer_id: "layer:runtime",
+            layer_name: "Zebra Runtime",
+          }),
+          stampedModule("module_page:api/routes", "Module: api/routes", {
+            layer_id: "layer:api",
+            layer_name: "Alpha API",
+          }),
+          makePage({ id: "f1", target_path: "src/foo.ts", title: "foo.ts" }),
+        ]}
+        selectedPageId={null}
+        onSelectPage={() => {}}
+      />,
+    );
+    // Orientation first, then the way into the files, then the layer outline.
+    // The corpus is the largest thing in the wiki and the thing most readers
+    // came for; it cannot sit below a list that grows with the repository.
+    const corpus = indexOfRow("Auto-documented files (1)");
+    expect(indexOfRow("Repository Overview: demo")).toBeLessThan(indexOfRow("Getting Started"));
+    expect(indexOfRow("Getting Started")).toBeLessThan(corpus);
+    expect(corpus).toBeLessThan(indexOfRow("Zebra Runtime"));
+    // The layers keep their own order behind it, so this cannot pass on a
+    // build that merely shuffled the top-level rows.
+    expect(indexOfRow("Zebra Runtime")).toBeLessThan(indexOfRow("Alpha API"));
+    // Still a deliberate drill-in, not opened on load.
+    expect(screen.queryByText("foo.ts")).not.toBeInTheDocument();
+  });
+
   it("labels a layer by its id when no member carries the display name", () => {
     render(
       <DocsTree

--- a/packages/ui/src/docs/docs-tree.tsx
+++ b/packages/ui/src/docs/docs-tree.tsx
@@ -416,6 +416,19 @@ function buildStoredTree(
   const spinePages = visible.filter(isSpinePage);
   const deterministicPages = visible.filter((p) => !isSpinePage(p));
 
+  // Every deterministic page in one collapsed folder, held apart from the
+  // concept outline so the distinction is obvious. Its interior reuses the
+  // filesystem builder, so the files stay navigable by directory.
+  const referenceFolder: TreeNode | null =
+    deterministicPages.length > 0
+      ? {
+          name: `Auto-documented files (${deterministicPages.length})`,
+          path: AUTO_ROOT_KEY,
+          isDir: true,
+          children: buildTree(deterministicPages),
+        }
+      : null;
+
   const byId = new Map(spinePages.map((p) => [p.id, p]));
   const childrenOf = new Map<string, DocPageSummary[]>();
   const claimed = new Set<string>();
@@ -477,6 +490,12 @@ function buildStoredTree(
     // chapters and the architecture diagram sort before any module, and that
     // is the order a reader should meet them in.
     top.push(...grouping.ungrouped.map((child) => toNode(child, root)));
+    // The file corpus sits directly after the orientation chapters, ahead of
+    // the layers. It is the largest thing in the wiki by a wide margin and the
+    // thing most readers arrive wanting, so it cannot be the last row of a list
+    // whose length grows with the repository — one layer opened and it is off
+    // the screen. Collapsed, so it costs a single row to keep it in reach.
+    if (referenceFolder) top.push(referenceFolder);
     for (const group of grouping.groups) {
       top.push({
         name: group.label,
@@ -527,16 +546,10 @@ function buildStoredTree(
     });
   }
 
-  // Every deterministic page in one collapsed folder at the very bottom, held
-  // apart from the concept outline so the distinction is obvious. Its interior
-  // reuses the filesystem builder, so the files stay navigable by directory.
-  if (deterministicPages.length > 0) {
-    top.push({
-      name: `Auto-documented files (${deterministicPages.length})`,
-      path: AUTO_ROOT_KEY,
-      isDir: true,
-      children: buildTree(deterministicPages),
-    });
+  // A store with no concept root has no orientation to sit behind, so the
+  // folder falls to the bottom rather than opening the tree with it.
+  if (referenceFolder && !top.includes(referenceFolder)) {
+    top.push(referenceFolder);
   }
 
   return top;


### PR DESCRIPTION
## What

The `Auto-documented files (N)` folder moves from the very bottom of the docs tree to directly after the orientation chapters, ahead of the layer rows.

## Why

That folder holds every file and symbol page — by a wide margin the largest thing in the wiki, and the thing most readers arrive wanting. It was the last row in the tree, below every layer and every module essay.

That placement was fine while the outline above it was short. It is not fine on a repository of any size: the list ahead of it grows with the codebase, so the one row a reader is looking for is the one row that keeps sliding off the bottom of the panel.

The reading order is now: **what this repository is** (overview + orientation chapters) → **how to look something up** (the file corpus) → **the shape of the code** (the layers).

It stays collapsed, so it costs a single row to keep in reach.

## Edge case kept

A store with no concept root — one whose page tree was never built — has no orientation for the folder to sit behind. There it still falls to the bottom, exactly as before.

## Test

`puts the file corpus above the layers, so it never sinks under the outline` pins the full top-level order: overview → orientation chapter → corpus → layers, with the layers still in spine order behind it. That last assertion means a build which merely shuffled the top-level rows cannot pass.

Verified failing before the change on the ordering assertion itself (`AssertionError: expected 8 to be less than 4`), not on an import or a signature.

Also asserts the folder is still collapsed on load — moving it up must not mean opening it.

## Gates

- `@repowise-dev/ui`: **1023 passed** (142 files)
- `packages/web`: 20 passed
- `tsc --noEmit` clean on ui and web
- `next lint` clean, `lint:shared` clean