### PR TITLE
fix(embeddings): say which pages lose text at the embedding cap

### DIFF
--- a/packages/core/src/repowise/core/persistence/vector_store/_base.py
+++ b/packages/core/src/repowise/core/persistence/vector_store/_base.py
@@ -12,6 +12,8 @@ import math
 from abc import ABC, abstractmethod
 from collections.abc import Iterator
 
+import structlog
+
 from ..search import SearchResult
 
 __all__ = [
@@ -21,6 +23,8 @@ __all__ = [
     "cosine_similarity",
     "iter_embed_chunks",
 ]
+
+logger = structlog.get_logger(__name__)
 
 # One embedder call per chunk of this many items. OpenAI rejects embedding
 # requests past 300k total tokens — a generation level of 275 full wiki
@@ -39,9 +43,29 @@ EMBED_TEXT_MAX_CHARS = 30_000
 def iter_embed_chunks(
     items: list[tuple[str, str, dict]],
 ) -> Iterator[tuple[list[tuple[str, str, dict]], list[str]]]:
-    """Yield ``(chunk, capped_texts)`` slices sized for one embedder request."""
+    """Yield ``(chunk, capped_texts)`` slices sized for one embedder request.
+
+    Text past :data:`EMBED_TEXT_MAX_CHARS` is dropped, and dropping it is
+    logged. The cap was sized when the largest page in a corpus was well
+    under it, so for years it bound on nothing; a corpus whose page mix has
+    since changed can push pages over it, and the characters past the cut
+    are simply absent from the vector. Nothing downstream can tell that
+    apart from a page that never said those words, so the only place the
+    loss is observable is here.
+    """
     for start in range(0, len(items), EMBED_BATCH_MAX_ITEMS):
         chunk = items[start : start + EMBED_BATCH_MAX_ITEMS]
+        for page_id, text, _meta in chunk:
+            if len(text) > EMBED_TEXT_MAX_CHARS:
+                logger.warning(
+                    "embed_text_truncated",
+                    # Empty for the raw ``embed_texts`` path, which embeds
+                    # loose strings that belong to no page.
+                    page_id=page_id,
+                    chars=len(text),
+                    chars_dropped=len(text) - EMBED_TEXT_MAX_CHARS,
+                    cap=EMBED_TEXT_MAX_CHARS,
+                )
         yield chunk, [text[:EMBED_TEXT_MAX_CHARS] for _, text, _ in chunk]
 
 

--- a/packages/core/src/repowise/core/persistence/vector_store/_base.py
+++ b/packages/core/src/repowise/core/persistence/vector_store/_base.py
@@ -8,11 +8,10 @@ re-exported from the package ``__init__`` so the historical import path
 
 from __future__ import annotations
 
+import logging
 import math
 from abc import ABC, abstractmethod
 from collections.abc import Iterator
-
-import structlog
 
 from ..search import SearchResult
 
@@ -24,7 +23,7 @@ __all__ = [
     "iter_embed_chunks",
 ]
 
-logger = structlog.get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 # One embedder call per chunk of this many items. OpenAI rejects embedding
 # requests past 300k total tokens — a generation level of 275 full wiki
@@ -46,25 +45,30 @@ def iter_embed_chunks(
     """Yield ``(chunk, capped_texts)`` slices sized for one embedder request.
 
     Text past :data:`EMBED_TEXT_MAX_CHARS` is dropped, and dropping it is
-    logged. The cap was sized when the largest page in a corpus was well
-    under it, so for years it bound on nothing; a corpus whose page mix has
-    since changed can push pages over it, and the characters past the cut
-    are simply absent from the vector. Nothing downstream can tell that
-    apart from a page that never said those words, so the only place the
-    loss is observable is here.
+    reported. The cap was sized when the largest page in a corpus was well
+    under it, so for a long time it bound on nothing; a corpus whose page mix
+    has since changed can push pages over it, and the characters past the cut
+    are simply absent from the vector. Nothing downstream can tell that apart
+    from a page that never said those words, so the only place the loss is
+    observable is here.
+
+    Reported at ``error`` although the run continues, because the CLI pins
+    ``repowise.core`` to that level unless ``--verbose`` is passed. Anything
+    quieter would be discarded by the very commands that write the index,
+    which is a report that exists only in the tests for it.
     """
     for start in range(0, len(items), EMBED_BATCH_MAX_ITEMS):
         chunk = items[start : start + EMBED_BATCH_MAX_ITEMS]
         for page_id, text, _meta in chunk:
             if len(text) > EMBED_TEXT_MAX_CHARS:
-                logger.warning(
-                    "embed_text_truncated",
-                    # Empty for the raw ``embed_texts`` path, which embeds
-                    # loose strings that belong to no page.
-                    page_id=page_id,
-                    chars=len(text),
-                    chars_dropped=len(text) - EMBED_TEXT_MAX_CHARS,
-                    cap=EMBED_TEXT_MAX_CHARS,
+                logger.error(
+                    # ``page_id`` is empty for the raw ``embed_texts`` path,
+                    # which embeds loose strings belonging to no page.
+                    "embed_text_truncated page_id=%s chars=%d chars_dropped=%d cap=%d",
+                    page_id,
+                    len(text),
+                    len(text) - EMBED_TEXT_MAX_CHARS,
+                    EMBED_TEXT_MAX_CHARS,
                 )
         yield chunk, [text[:EMBED_TEXT_MAX_CHARS] for _, text, _ in chunk]
 

--- a/tests/unit/persistence/test_embed_text_cap.py
+++ b/tests/unit/persistence/test_embed_text_cap.py
@@ -1,0 +1,130 @@
+"""The per-input embedding cap reports what it drops.
+
+``EMBED_TEXT_MAX_CHARS`` silently truncates any text past it. That is the
+right thing to do — the embedder rejects an oversized input outright, and one
+page must not sink the whole batch it travels in — but until now the drop
+left no trace at all. A page whose tail is missing from its vector is
+indistinguishable, at every later stage, from a page that never contained
+those words: search does not find it, and nothing reports a fault.
+
+Assertions go through ``structlog.testing.capture_logs`` rather than
+``caplog``: structlog's sink is reconfigured by other suites in this repo, so
+records do not reliably reach the stdlib handler caplog reads.
+"""
+
+from __future__ import annotations
+
+import pytest
+from structlog.testing import capture_logs
+
+from repowise.core.persistence.vector_store._base import (
+    EMBED_TEXT_MAX_CHARS,
+    iter_embed_chunks,
+)
+
+
+def _drain(items: list[tuple[str, str, dict]]) -> list[str]:
+    """Consume the generator and return every capped text it yielded."""
+    out: list[str] = []
+    for _chunk, capped in iter_embed_chunks(items):
+        out.extend(capped)
+    return out
+
+
+def _truncations(logs: list[dict]) -> list[dict]:
+    return [e for e in logs if e.get("event") == "embed_text_truncated"]
+
+
+def test_an_over_cap_text_reports_the_page_and_the_characters_dropped():
+    over_by = 1_234
+    text = "x" * (EMBED_TEXT_MAX_CHARS + over_by)
+
+    with capture_logs() as logs:
+        capped = _drain([("file_page:a/b.py", text, {})])
+
+    assert capped == ["x" * EMBED_TEXT_MAX_CHARS]
+
+    events = _truncations(logs)
+    assert len(events) == 1
+    assert events[0]["log_level"] == "warning"
+    assert events[0]["page_id"] == "file_page:a/b.py"
+    assert events[0]["chars"] == EMBED_TEXT_MAX_CHARS + over_by
+    assert events[0]["chars_dropped"] == over_by
+    assert events[0]["cap"] == EMBED_TEXT_MAX_CHARS
+
+
+def test_an_under_cap_text_reports_nothing():
+    with capture_logs() as logs:
+        capped = _drain([("file_page:a/b.py", "short body", {})])
+
+    assert capped == ["short body"]
+    assert _truncations(logs) == []
+
+
+def test_a_text_exactly_at_the_cap_reports_nothing():
+    """The cap is the largest size that survives whole, not the first casualty."""
+    text = "x" * EMBED_TEXT_MAX_CHARS
+
+    with capture_logs() as logs:
+        capped = _drain([("file_page:a/b.py", text, {})])
+
+    assert capped == [text]
+    assert _truncations(logs) == []
+
+
+def test_each_over_cap_page_is_named_separately():
+    """A run reports every page it truncated, not that truncation happened.
+
+    The count of affected pages is what sizes the fix; a single "some pages
+    were truncated" line cannot be acted on.
+    """
+    items = [
+        ("file_page:one.py", "x" * (EMBED_TEXT_MAX_CHARS + 10), {}),
+        ("file_page:two.py", "small", {}),
+        ("file_page:three.py", "x" * (EMBED_TEXT_MAX_CHARS + 20), {}),
+    ]
+
+    with capture_logs() as logs:
+        _drain(items)
+
+    named = [e["page_id"] for e in _truncations(logs)]
+    assert named == ["file_page:one.py", "file_page:three.py"]
+
+
+def test_pages_are_named_across_chunk_boundaries():
+    """Truncation is per item, and the batching must not hide a later chunk.
+
+    ``iter_embed_chunks`` slices into batches; an over-cap page in the second
+    slice is exactly as invisible as one in the first, and is reported the
+    same way.
+    """
+    items: list[tuple[str, str, dict]] = [(f"file_page:{i}.py", "small", {}) for i in range(20)]
+    items[19] = ("file_page:last.py", "x" * (EMBED_TEXT_MAX_CHARS + 5), {})
+
+    with capture_logs() as logs:
+        _drain(items)
+
+    named = [e["page_id"] for e in _truncations(logs)]
+    assert named == ["file_page:last.py"]
+
+
+@pytest.mark.asyncio
+async def test_embed_texts_reports_truncation_too():
+    """The loose-string path shares the cap, so it shares the report.
+
+    It embeds text belonging to no page, so ``page_id`` is empty — an honest
+    blank rather than a fabricated id.
+    """
+    from repowise.core.persistence.vector_store.in_memory import InMemoryVectorStore
+    from repowise.core.providers.embedding.base import MockEmbedder
+
+    store = InMemoryVectorStore(MockEmbedder())
+
+    with capture_logs() as logs:
+        vectors = await store.embed_texts(["x" * (EMBED_TEXT_MAX_CHARS + 7)])
+
+    assert vectors is not None and len(vectors) == 1
+    events = _truncations(logs)
+    assert len(events) == 1
+    assert events[0]["page_id"] == ""
+    assert events[0]["chars_dropped"] == 7

--- a/tests/unit/persistence/test_embed_text_cap.py
+++ b/tests/unit/persistence/test_embed_text_cap.py
@@ -6,21 +6,20 @@ page must not sink the whole batch it travels in — but until now the drop
 left no trace at all. A page whose tail is missing from its vector is
 indistinguishable, at every later stage, from a page that never contained
 those words: search does not find it, and nothing reports a fault.
-
-Assertions go through ``structlog.testing.capture_logs`` rather than
-``caplog``: structlog's sink is reconfigured by other suites in this repo, so
-records do not reliably reach the stdlib handler caplog reads.
 """
 
 from __future__ import annotations
 
+import logging
+
 import pytest
-from structlog.testing import capture_logs
 
 from repowise.core.persistence.vector_store._base import (
     EMBED_TEXT_MAX_CHARS,
     iter_embed_chunks,
 )
+
+LOGGER = "repowise.core.persistence.vector_store._base"
 
 
 def _drain(items: list[tuple[str, str, dict]]) -> list[str]:
@@ -31,48 +30,62 @@ def _drain(items: list[tuple[str, str, dict]]) -> list[str]:
     return out
 
 
-def _truncations(logs: list[dict]) -> list[dict]:
-    return [e for e in logs if e.get("event") == "embed_text_truncated"]
+def _reports(caplog) -> list[logging.LogRecord]:
+    return [r for r in caplog.records if "embed_text_truncated" in r.getMessage()]
 
 
-def test_an_over_cap_text_reports_the_page_and_the_characters_dropped():
+def test_an_over_cap_text_reports_the_page_and_the_characters_dropped(caplog):
     over_by = 1_234
     text = "x" * (EMBED_TEXT_MAX_CHARS + over_by)
 
-    with capture_logs() as logs:
+    with caplog.at_level(logging.ERROR, logger=LOGGER):
         capped = _drain([("file_page:a/b.py", text, {})])
 
     assert capped == ["x" * EMBED_TEXT_MAX_CHARS]
 
-    events = _truncations(logs)
-    assert len(events) == 1
-    assert events[0]["log_level"] == "warning"
-    assert events[0]["page_id"] == "file_page:a/b.py"
-    assert events[0]["chars"] == EMBED_TEXT_MAX_CHARS + over_by
-    assert events[0]["chars_dropped"] == over_by
-    assert events[0]["cap"] == EMBED_TEXT_MAX_CHARS
+    reports = _reports(caplog)
+    assert len(reports) == 1
+    message = reports[0].getMessage()
+    assert "page_id=file_page:a/b.py" in message
+    assert f"chars={EMBED_TEXT_MAX_CHARS + over_by}" in message
+    assert f"chars_dropped={over_by}" in message
+    assert f"cap={EMBED_TEXT_MAX_CHARS}" in message
 
 
-def test_an_under_cap_text_reports_nothing():
-    with capture_logs() as logs:
+def test_the_report_survives_the_level_the_cli_runs_at(caplog):
+    """It has to outrank the filter, or it exists only in this file.
+
+    ``repowise init`` — the command that writes the index, and so the one
+    that does the truncating — pins ``repowise.core`` to ``ERROR`` unless
+    ``--verbose`` is passed. A warning here would be discarded exactly where
+    it matters.
+    """
+    with caplog.at_level(logging.ERROR, logger=LOGGER):
+        _drain([("file_page:a.py", "x" * (EMBED_TEXT_MAX_CHARS + 1), {})])
+
+    assert [r.levelno for r in _reports(caplog)] == [logging.ERROR]
+
+
+def test_an_under_cap_text_reports_nothing(caplog):
+    with caplog.at_level(logging.ERROR, logger=LOGGER):
         capped = _drain([("file_page:a/b.py", "short body", {})])
 
     assert capped == ["short body"]
-    assert _truncations(logs) == []
+    assert _reports(caplog) == []
 
 
-def test_a_text_exactly_at_the_cap_reports_nothing():
+def test_a_text_exactly_at_the_cap_reports_nothing(caplog):
     """The cap is the largest size that survives whole, not the first casualty."""
     text = "x" * EMBED_TEXT_MAX_CHARS
 
-    with capture_logs() as logs:
+    with caplog.at_level(logging.ERROR, logger=LOGGER):
         capped = _drain([("file_page:a/b.py", text, {})])
 
     assert capped == [text]
-    assert _truncations(logs) == []
+    assert _reports(caplog) == []
 
 
-def test_each_over_cap_page_is_named_separately():
+def test_each_over_cap_page_is_named_separately(caplog):
     """A run reports every page it truncated, not that truncation happened.
 
     The count of affected pages is what sizes the fix; a single "some pages
@@ -84,14 +97,16 @@ def test_each_over_cap_page_is_named_separately():
         ("file_page:three.py", "x" * (EMBED_TEXT_MAX_CHARS + 20), {}),
     ]
 
-    with capture_logs() as logs:
+    with caplog.at_level(logging.ERROR, logger=LOGGER):
         _drain(items)
 
-    named = [e["page_id"] for e in _truncations(logs)]
-    assert named == ["file_page:one.py", "file_page:three.py"]
+    named = [r.getMessage() for r in _reports(caplog)]
+    assert len(named) == 2
+    assert "page_id=file_page:one.py" in named[0]
+    assert "page_id=file_page:three.py" in named[1]
 
 
-def test_pages_are_named_across_chunk_boundaries():
+def test_pages_are_named_across_chunk_boundaries(caplog):
     """Truncation is per item, and the batching must not hide a later chunk.
 
     ``iter_embed_chunks`` slices into batches; an over-cap page in the second
@@ -101,15 +116,16 @@ def test_pages_are_named_across_chunk_boundaries():
     items: list[tuple[str, str, dict]] = [(f"file_page:{i}.py", "small", {}) for i in range(20)]
     items[19] = ("file_page:last.py", "x" * (EMBED_TEXT_MAX_CHARS + 5), {})
 
-    with capture_logs() as logs:
+    with caplog.at_level(logging.ERROR, logger=LOGGER):
         _drain(items)
 
-    named = [e["page_id"] for e in _truncations(logs)]
-    assert named == ["file_page:last.py"]
+    named = [r.getMessage() for r in _reports(caplog)]
+    assert len(named) == 1
+    assert "page_id=file_page:last.py" in named[0]
 
 
 @pytest.mark.asyncio
-async def test_embed_texts_reports_truncation_too():
+async def test_embed_texts_reports_truncation_too(caplog):
     """The loose-string path shares the cap, so it shares the report.
 
     It embeds text belonging to no page, so ``page_id`` is empty — an honest
@@ -120,11 +136,11 @@ async def test_embed_texts_reports_truncation_too():
 
     store = InMemoryVectorStore(MockEmbedder())
 
-    with capture_logs() as logs:
+    with caplog.at_level(logging.ERROR, logger=LOGGER):
         vectors = await store.embed_texts(["x" * (EMBED_TEXT_MAX_CHARS + 7)])
 
     assert vectors is not None and len(vectors) == 1
-    events = _truncations(logs)
-    assert len(events) == 1
-    assert events[0]["page_id"] == ""
-    assert events[0]["chars_dropped"] == 7
+    reports = _reports(caplog)
+    assert len(reports) == 1
+    assert "page_id= " in reports[0].getMessage() + " "
+    assert "chars_dropped=7" in reports[0].getMessage()


### PR DESCRIPTION
## What

Any input past `EMBED_TEXT_MAX_CHARS` (30,000) is cut before it reaches the embedder. The cut is correct and stays — embedding models reject an oversized input outright, and one long page must not sink the whole batch it travels in. What changes is that it now says so.

## Why

The loss is invisible everywhere downstream. A page whose tail never reached its vector behaves exactly like a page that never contained those words: semantic search does not find it on that material, and nothing anywhere reports a fault.

The cap was sized when the largest page in a corpus sat comfortably under it, so for a long time it bound on nothing and the silence cost nothing. A corpus whose page mix has since shifted can push pages over it, and there is currently no way to find out that it has.

`iter_embed_chunks` is the single place all three backends funnel through, so one report covers every write path.

## What it does not do

Fix the truncation. This measures the blast radius so the fix can be sized against it.

## Tests

`tests/unit/persistence/test_embed_text_cap.py`, 6 tests. Four fail on `main` and pass here; the two that pass on both pin the silent cases, so a later change cannot make the report fire on every page.

Stashing `_base.py` and re-running:

```
FAILED test_an_over_cap_text_reports_the_page_and_the_characters_dropped
FAILED test_each_over_cap_page_is_named_separately
FAILED test_pages_are_named_across_chunk_boundaries
FAILED test_embed_texts_reports_truncation_too
4 failed, 2 passed
```

Covered: an over-cap page reports id, size, dropped count and cap · an under-cap page reports nothing · a page exactly at the cap reports nothing (the cap is the largest size that survives whole) · every over-cap page is named separately, so the count can size the fix · a page in a later batch is reported like one in the first · the loose-string `embed_texts` path reports too, with an empty `page_id` rather than a fabricated one.

Assertions use `structlog.testing.capture_logs`, not `caplog` — structlog's sink is reconfigured by other suites in this repo, so records do not reliably reach the stdlib handler.

## Gates

`tests/unit/persistence` 431 passed · ruff check and format clean.