### PR TITLE
feat(mcp): let get_answer synthesis run its own provider and model

### DIFF
--- a/docs/reference/CONFIG.md
+++ b/docs/reference/CONFIG.md
@@ -41,6 +41,8 @@ flags like `--commit-limit`, `--follow-renames`, or `--wiki-style`.
 ```yaml
 provider: anthropic                  # LLM provider (auto-detected if omitted)
 model: claude-sonnet-4-6             # Model identifier (provider default if omitted)
+answer_provider: anthropic           # Provider for get_answer synthesis (falls back to provider)
+answer_model: claude-haiku-4-5       # Model for get_answer synthesis (falls back to model)
 embedder: mock                       # Embedding provider (mock if no key detected)
 embedding_model: text-embedding-3-small  # Embedding model (provider default if omitted)
 reasoning: auto                      # auto | off | none | minimal | low | medium | high | xhigh | max
@@ -493,7 +495,9 @@ The `.repowise/.env` file is gitignored automatically.
 |----------|-------------|
 | `REPOWISE_PROVIDER` | Override provider (skips auto-detection) |
 | `REPOWISE_MODEL` | Override model |
-| `REPOWISE_DOC_MODEL` | Override the model used for `get_answer` synthesis specifically |
+| `REPOWISE_ANSWER_PROVIDER` | Provider for `get_answer` synthesis. Answering a question (short grounded prose over retrieved excerpts) is a different workload from writing wiki pages, so the answer surface can run its own provider; falls back to the generation provider when unset |
+| `REPOWISE_ANSWER_MODEL` | Model for `get_answer` synthesis; falls back through `REPOWISE_DOC_MODEL` / `REPOWISE_MODEL` to the persisted model. Together with `embedding_model` this makes the three model roles — wiki writer, answerer, embedder — independently configurable |
+| `REPOWISE_DOC_MODEL` | Older name for the `get_answer` model override; still honored, at lower precedence than `REPOWISE_ANSWER_MODEL` |
 | `REPOWISE_REASONING` | Override `reasoning` (see valid values above) |
 | `REPOWISE_ANSWER_TIMEOUT_S` | Seconds `get_answer` waits for synthesis before giving up. Defaults to a per-provider budget: 60s for the remote API providers, 120s for `ollama` and `litellm`, 180s for `codex_cli` and `opencode`. Raise it if your model is slower than its class suggests, lower it if you would rather an agent fail fast than block. Capped at 600s. Note your MCP client enforces its own tool timeout underneath this one, so setting a value above it produces a client-side error instead of repowise's diagnosable "synthesis exceeded its budget" response |
 

--- a/packages/server/src/repowise/server/mcp_server/tool_answer/synthesis.py
+++ b/packages/server/src/repowise/server/mcp_server/tool_answer/synthesis.py
@@ -14,6 +14,7 @@ import logging
 import math
 import os
 from pathlib import Path
+from typing import NamedTuple
 
 from repowise.server.mcp_server.tool_answer.config import (
     _SYNTHESIS_MAX_TOKENS,
@@ -46,9 +47,26 @@ def _hash_question(question: str) -> str:
     return hashlib.sha256(norm.encode("utf-8")).hexdigest()
 
 
+class _RepoProviderConfig(NamedTuple):
+    """Persisted provider intent for one repo, as the resolver consumes it.
+
+    ``provider``/``model`` drive generation and are the historical answer
+    fallback. ``answer_provider``/``answer_model`` are the answer surface's
+    own choice: serving a question is a different workload from writing a
+    wiki (short grounded prose against excerpts vs. long-form synthesis), so
+    the two no longer have to share a model. Any field may be None.
+    """
+
+    provider: str | None
+    model: str | None
+    answer_provider: str | None
+    answer_model: str | None
+    env_overlay: dict[str, str]
+
+
 def _load_repo_provider_config(
     repo_path: Path | None,
-) -> tuple[str | None, str | None, dict[str, str]]:
+) -> _RepoProviderConfig:
     """Read persisted provider config for a repo.
 
     `repowise init` writes the chosen provider + model into
@@ -59,11 +77,11 @@ def _load_repo_provider_config(
     launched Claude Code. This recovers the persisted values so the same
     provider used for init / update is reused for get_answer.
 
-    Returns ``(provider_name, model, env_overlay)``. Any field may be
-    None / empty — callers should fall back to process env when missing.
+    Returns a :class:`_RepoProviderConfig`. Any field may be None / empty —
+    callers should fall back to process env when missing.
     """
     if repo_path is None:
-        return None, None, {}
+        return _RepoProviderConfig(None, None, None, None, {})
 
     config_path = repo_path / ".repowise" / "config.yaml"
     state_path = repo_path / ".repowise" / "state.json"
@@ -71,6 +89,8 @@ def _load_repo_provider_config(
 
     name: str | None = None
     model: str | None = None
+    answer_name: str | None = None
+    answer_model: str | None = None
     overlay: dict[str, str] = {}
 
     # config.yaml first: it is the user-editable intent. state.json only
@@ -86,6 +106,12 @@ def _load_repo_provider_config(
             if isinstance(data, dict):
                 name = data.get("provider") or None
                 model = data.get("model") or None
+                # Answer-surface intent lives in config.yaml only: state.json
+                # records what the last index run used, and no index run ever
+                # uses the answer model, so a state fallback could only serve
+                # stale or meaningless values.
+                answer_name = data.get("answer_provider") or None
+                answer_model = data.get("answer_model") or None
     except Exception:
         _log.debug("Failed to read %s", config_path, exc_info=True)
 
@@ -111,7 +137,7 @@ def _load_repo_provider_config(
     except Exception:
         _log.debug("Failed to read %s", env_path, exc_info=True)
 
-    return name, model, overlay
+    return _RepoProviderConfig(name, model, answer_name, answer_model, overlay)
 
 
 def _resolve_provider_for_answer(repo_path: Path | None = None):
@@ -122,11 +148,18 @@ def _resolve_provider_for_answer(repo_path: Path | None = None):
     the two cannot drift apart. Returns a BaseProvider or None if no API key /
     provider is configured.
 
-    Resolution order: process env vars first, then ``.repowise/config.yaml``
-    / ``state.json`` + ``.repowise/.env`` for the active repo. The persisted
-    values are the same ones ``repowise init`` and ``repowise update`` use, so
-    get_answer follows the user's existing provider choice without a separate
-    config.
+    Resolution order: the answer surface's own settings first —
+    ``REPOWISE_ANSWER_PROVIDER`` / ``REPOWISE_ANSWER_MODEL`` in the process
+    env, then ``answer_provider`` / ``answer_model`` in
+    ``.repowise/config.yaml`` — because answering questions (short grounded
+    prose over excerpts) and writing wiki pages (long-form synthesis) are
+    different workloads that need not share a model. Absent those, the
+    generation chain applies unchanged: process env
+    (``REPOWISE_PROVIDER`` / ``REPOWISE_DOC_MODEL`` / ``REPOWISE_MODEL``),
+    then ``.repowise/config.yaml`` / ``state.json`` + ``.repowise/.env`` for
+    the active repo — the same values ``repowise init`` and ``repowise
+    update`` use, so get_answer follows the existing provider choice without
+    a separate config.
     """
     try:
         from repowise.core.providers.llm.registry import (
@@ -140,17 +173,35 @@ def _resolve_provider_for_answer(repo_path: Path | None = None):
         _log.warning("Provider registry import failed", exc_info=True)
         return None
 
-    persisted_name, persisted_model, env_overlay = _load_repo_provider_config(repo_path)
+    persisted = _load_repo_provider_config(repo_path)
 
     def _env(key: str) -> str | None:
         # Prefer real process env so an explicit shell export still wins;
         # fall back to .repowise/.env only when the process env is empty.
-        return os.environ.get(key) or env_overlay.get(key) or None
+        return os.environ.get(key) or persisted.env_overlay.get(key) or None
 
-    name = os.environ.get("REPOWISE_PROVIDER") or persisted_name
-    model = (
-        os.environ.get("REPOWISE_DOC_MODEL") or os.environ.get("REPOWISE_MODEL") or persisted_model
-    )
+    # Answer-specific intent outranks the generation settings: writing a wiki
+    # and answering a question are different workloads, and a deployment that
+    # names an answer model has said so explicitly. Within each tier, process
+    # env beats persisted config, matching the rest of this function.
+    answer_name = os.environ.get("REPOWISE_ANSWER_PROVIDER") or persisted.answer_provider
+    answer_model = os.environ.get("REPOWISE_ANSWER_MODEL") or persisted.answer_model
+
+    if answer_name:
+        name = answer_name
+        # A generic doc/generation model belongs to the generation provider;
+        # pairing it with a different answer provider would request a model
+        # that provider does not serve. No answer model means the answer
+        # provider's own default.
+        model = answer_model
+    else:
+        name = os.environ.get("REPOWISE_PROVIDER") or persisted.provider
+        model = (
+            answer_model
+            or os.environ.get("REPOWISE_DOC_MODEL")
+            or os.environ.get("REPOWISE_MODEL")
+            or persisted.model
+        )
 
     def _try(provider_name: str, provider_model: str | None):
         kwargs = provider_kwargs(
@@ -182,7 +233,11 @@ def _resolve_provider_for_answer(repo_path: Path | None = None):
             "auto-detection from available API keys.",
             name,
         )
-        if not (os.environ.get("REPOWISE_DOC_MODEL") or os.environ.get("REPOWISE_MODEL")):
+        if not (
+            os.environ.get("REPOWISE_ANSWER_MODEL")
+            or os.environ.get("REPOWISE_DOC_MODEL")
+            or os.environ.get("REPOWISE_MODEL")
+        ):
             model = None  # persisted model was provider-specific
 
     # Auto-detect from whatever credentials the environment carries. Only the

--- a/tests/unit/server/mcp/test_provider_resolution.py
+++ b/tests/unit/server/mcp/test_provider_resolution.py
@@ -25,6 +25,8 @@ def _clean_env(monkeypatch):
         "REPOWISE_PROVIDER",
         "REPOWISE_DOC_MODEL",
         "REPOWISE_MODEL",
+        "REPOWISE_ANSWER_PROVIDER",
+        "REPOWISE_ANSWER_MODEL",
         "OPENAI_API_KEY",
         "ANTHROPIC_API_KEY",
         "GEMINI_API_KEY",
@@ -56,9 +58,9 @@ def test_config_yaml_outranks_state_json(tmp_path):
         config={"provider": "openai", "model": "gpt-5.4-nano"},
         state={"provider": "gemini", "model": "gemini-3.1-flash-lite-preview"},
     )
-    name, model, _ = _load_repo_provider_config(repo)
-    assert name == "openai"
-    assert model == "gpt-5.4-nano"
+    persisted = _load_repo_provider_config(repo)
+    assert persisted.provider == "openai"
+    assert persisted.model == "gpt-5.4-nano"
 
 
 def test_state_json_still_used_when_config_lacks_provider(tmp_path):
@@ -67,9 +69,9 @@ def test_state_json_still_used_when_config_lacks_provider(tmp_path):
         config={"commit_limit": 200},
         state={"provider": "openai", "model": "gpt-5.4-nano"},
     )
-    name, model, _ = _load_repo_provider_config(repo)
-    assert name == "openai"
-    assert model == "gpt-5.4-nano"
+    persisted = _load_repo_provider_config(repo)
+    assert persisted.provider == "openai"
+    assert persisted.model == "gpt-5.4-nano"
 
 
 def test_keyless_persisted_provider_falls_back_to_available_key(tmp_path, monkeypatch):
@@ -179,3 +181,88 @@ def test_openrouter_key_alone_now_resolves(tmp_path, monkeypatch):
 
     assert _resolve_provider_for_answer(repo) is not None
     assert seen["name"] == "openrouter"
+
+
+# ---------------------------------------------------------------------------
+# Dedicated answer model (three-model separation: wiki writer / answerer /
+# embedder). The answer surface may name its own provider and model; absent
+# that, it follows the generation chain exactly as before.
+# ---------------------------------------------------------------------------
+
+
+def test_answer_model_env_swaps_the_model_but_keeps_the_provider(tmp_path, monkeypatch):
+    """Same provider (the common local case), different model for answers."""
+    repo = _write_repo(tmp_path, config={"provider": "openai", "model": "wiki-writer-model"})
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setenv("REPOWISE_ANSWER_MODEL", "answer-writer-model")
+    seen = _record_get_provider(monkeypatch)
+
+    assert _resolve_provider_for_answer(repo) is not None
+    assert seen["name"] == "openai"
+    assert seen["kwargs"]["model"] == "answer-writer-model"
+
+
+def test_answer_provider_env_does_not_inherit_the_generation_model(tmp_path, monkeypatch):
+    """A generation model belongs to the generation provider; the answer
+    provider gets its own default rather than a model it does not serve."""
+    repo = _write_repo(tmp_path, config={"provider": "gemini", "model": "gemini-3.1-flash"})
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setenv("REPOWISE_ANSWER_PROVIDER", "openai")
+    seen = _record_get_provider(monkeypatch)
+
+    assert _resolve_provider_for_answer(repo) is not None
+    assert seen["name"] == "openai"
+    assert seen["kwargs"].get("model") is None
+
+
+def test_config_yaml_answer_keys_are_honored(tmp_path, monkeypatch):
+    repo = _write_repo(
+        tmp_path,
+        config={
+            "provider": "gemini",
+            "model": "gemini-3.1-flash",
+            "answer_provider": "openai",
+            "answer_model": "gpt-5.4-nano",
+        },
+    )
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    seen = _record_get_provider(monkeypatch)
+
+    assert _resolve_provider_for_answer(repo) is not None
+    assert seen["name"] == "openai"
+    assert seen["kwargs"]["model"] == "gpt-5.4-nano"
+
+
+def test_answer_env_outranks_answer_config(tmp_path, monkeypatch):
+    repo = _write_repo(
+        tmp_path,
+        config={"provider": "openai", "answer_model": "from-config"},
+    )
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setenv("REPOWISE_ANSWER_MODEL", "from-env")
+    seen = _record_get_provider(monkeypatch)
+
+    assert _resolve_provider_for_answer(repo) is not None
+    assert seen["kwargs"]["model"] == "from-env"
+
+
+def test_keyless_answer_provider_still_falls_back_to_available_key(tmp_path, monkeypatch):
+    """An answer provider without a usable key must not end resolution."""
+    repo = _write_repo(tmp_path, config={"answer_provider": "gemini", "answer_model": "gemini-x"})
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    provider = _resolve_provider_for_answer(repo)
+    assert provider is not None
+    assert getattr(provider, "provider_name", "") == "openai"
+    # The persisted answer model belongs to gemini and must not leak.
+    assert "gemini" not in (getattr(provider, "model_name", "") or "")
+
+
+def test_state_json_never_supplies_answer_settings(tmp_path):
+    """state.json records the last index run; no index run uses the answer model."""
+    repo = _write_repo(
+        tmp_path,
+        state={"provider": "openai", "answer_provider": "gemini", "answer_model": "gemini-x"},
+    )
+    persisted = _load_repo_provider_config(repo)
+    assert persisted.answer_provider is None
+    assert persisted.answer_model is None

--- a/website/configuration.md
+++ b/website/configuration.md
@@ -45,6 +45,8 @@ The main configuration file. Created after first `init`, updated when you pass `
 ```yaml
 provider: anthropic                  # LLM provider
 model: claude-sonnet-4-6             # Model identifier
+answer_provider: anthropic           # Provider for get_answer synthesis (optional; falls back to provider)
+answer_model: claude-haiku-4-5       # Model for get_answer synthesis (optional; falls back to model)
 embedder: gemini                     # Embedding provider
 reasoning: auto                      # auto | off/none | minimal | low | medium | high | xhigh | max
 max_tokens: 16384                    # Max output tokens per generated documentation page


### PR DESCRIPTION
## Motivation

Repowise has three model roles — the wiki writer (generation), the answer synthesizer (`get_answer`), and the embedder — but only two are configurable today. The embedder has its own axis (`embedder` / `embedding_model`), while `get_answer` synthesis inherits the generation model. The closest thing to a split is `REPOWISE_DOC_MODEL`, which despite its name is read only by the answer path, works only through process env, and cannot name a different provider.

Answering a question is a different workload from writing a wiki page: synthesis produces short grounded prose over retrieved excerpts (well served by a fast instruction-follower, and hurt by hidden thinking draining the shared `max_tokens` budget), while page generation is long-form synthesis. On local single-GPU deployments the two also have very different residency budgets — the answerer must be resident interactively, the wiki writer only during batch generation.

## Change

`_resolve_provider_for_answer` resolves the answer surface's own settings first:

| Precedence | Provider | Model |
|---|---|---|
| 1 (env) | `REPOWISE_ANSWER_PROVIDER` | `REPOWISE_ANSWER_MODEL` |
| 2 (config.yaml) | `answer_provider` | `answer_model` |
| 3 (existing chain, unchanged) | `REPOWISE_PROVIDER` → persisted | `REPOWISE_DOC_MODEL` → `REPOWISE_MODEL` → persisted |

- Absent any answer-specific setting, resolution is byte-for-byte today's behavior.
- When an answer **provider** is named without an answer **model**, the provider's own default is used rather than inheriting the generation model, which belongs to the generation provider (mirrors the existing rule that drops a persisted model on cross-provider fallback).
- An answer provider with no usable key falls through to auto-detection exactly like the generation provider does — it never silently ends resolution.
- `state.json` deliberately supplies no answer settings: it records what the last index run used, and no index run uses the answer model.
- `REPOWISE_DOC_MODEL` stays honored at lower precedence.

## Tests & docs

- `tests/unit/server/mcp/test_provider_resolution.py`: six new cases (env swap keeps provider, answer provider does not inherit the generation model, config.yaml keys, env-over-config, keyless fall-through, state.json exclusion); full `tests/unit/server` suite passes (1542).
- `docs/reference/CONFIG.md` and `website/configuration.md` document the new keys and reframe `REPOWISE_DOC_MODEL` as the older name for the same override.