### PR TITLE
fix(embedding): make the pinned embedding_model operative on every surface

### DIFF
--- a/docs/reference/CONFIG.md
+++ b/docs/reference/CONFIG.md
@@ -74,7 +74,7 @@ You can edit this file directly. Changes take effect on the next `init`,
 | `provider` | auto-detected | `anthropic`, `openai`, `gemini`, `openrouter`, `deepseek`, `kimi`, `ollama`, `litellm`, `opencode` |
 | `model` | provider default | Model identifier passed to the provider |
 | `embedder` | `mock` | `openai`, `gemini`, `ollama`, `openrouter`, `mock` |
-| `embedding_model` | provider default | Embedding model identifier |
+| `embedding_model` | provider default | Embedding model the store was built with. Read wherever an embedder is constructed for this repo (init, update, reindex, search, doctor, and the MCP server's query embedding), so editing it takes effect; `OLLAMA_EMBEDDING_MODEL` / `REPOWISE_EMBEDDING_MODEL` env vars override it |
 | `reasoning` | `auto` | `auto`, `off`, `none`, `minimal`, `low`, `medium`, `high`, `xhigh`, `max` |
 | `max_tokens` | `16384` | Maximum output tokens requested for each model-written documentation page |
 | `commit_limit` | `500` | Max commits per file walked for git analysis, clamped to 1-10000 |
@@ -441,10 +441,14 @@ would match nothing in the narrower stored table.
 next `update` would read the old pin, write vectors at the old width, and the
 store would be rebuilt from scratch, discarding what the reindex just built.
 
-`REPOWISE_EMBEDDING_MODEL` overrides the model for whichever embedder is
-active. `REPOWISE_EMBEDDING_DIMS` and `REPOWISE_EMBEDDING_TIMEOUT` apply the
-same way; the `OLLAMA_EMBEDDING_*` variants below are Ollama-specific
-equivalents.
+The embedding model resolves the same way on every surface (CLI commands and
+the MCP server's query embedding): `OLLAMA_EMBEDDING_MODEL` (for the ollama
+backend), then `REPOWISE_EMBEDDING_MODEL`, then the `embedding_model` pinned
+in `config.yaml`, then the embedder's own default. The pin is what the store
+was embedded with, so a shell without the env vars still queries the table
+with the model that built it. `REPOWISE_EMBEDDING_DIMS` and
+`REPOWISE_EMBEDDING_TIMEOUT` remain env-only operational overrides; the
+`OLLAMA_EMBEDDING_*` variants below are Ollama-specific equivalents.
 
 ---
 

--- a/packages/cli/src/repowise/cli/commands/doctor_cmd/repo_checks.py
+++ b/packages/cli/src/repowise/cli/commands/doctor_cmd/repo_checks.py
@@ -509,7 +509,7 @@ def _run_repo_checks(
                     # combination and returns None, so a repo whose embedder is
                     # unavailable is left alone instead of wrecked.
                     embedder_name = resolve_embedder_for_repo(repo_path)
-                    embedder = build_embedder(embedder_name)
+                    embedder = build_embedder(embedder_name, repo_path)
                     vs = build_vector_store(_DoctorPath(repo_path), embedder)
                     if vs is None:
                         raise RuntimeError(

--- a/packages/cli/src/repowise/cli/commands/generate_cmd/engine.py
+++ b/packages/cli/src/repowise/cli/commands/generate_cmd/engine.py
@@ -183,7 +183,7 @@ async def run_scoped_generation(
         embedder = None
         vector_store = None
         try:
-            embedder = build_embedder(resolve_embedder(embedder_name))
+            embedder = build_embedder(resolve_embedder(embedder_name), repo_path)
             vector_store = build_vector_store(repo_path, embedder)
         except Exception as exc:
             # Null BOTH on any failure. If the embedder built but the store did

--- a/packages/cli/src/repowise/cli/commands/init_cmd/command.py
+++ b/packages/cli/src/repowise/cli/commands/init_cmd/command.py
@@ -1533,7 +1533,7 @@ def init_command(
         # pair: `serve` pins the model from it, and the store-format upgrade
         # check reads it to notice an embedder change. Half the pair is not
         # enough for either.
-        from repowise.cli.providers.embedders import resolve_embedding_model
+        from repowise.core.providers.embedding.registry import resolve_embedding_model
 
         save_config_partial(
             repo_path,
@@ -1541,7 +1541,9 @@ def init_command(
             commit_limit=resolved_commit_limit if commit_limit is not None else None,
             embedder=_index_only_embedder,
             embedding_model=(
-                resolve_embedding_model(_index_only_embedder) if _index_only_embedder else None
+                resolve_embedding_model(_index_only_embedder, repo_path)
+                if _index_only_embedder
+                else None
             ),
         )
         # Fingerprint after config writes so the first update doesn't false-positive.

--- a/packages/cli/src/repowise/cli/commands/init_cmd/generation.py
+++ b/packages/cli/src/repowise/cli/commands/init_cmd/generation.py
@@ -268,7 +268,7 @@ def run_repo_generation(
     if verbose:
         announce_file_page_cap(result.parsed_files, gen_config)
 
-    embedder_impl: Any = build_embedder(embedder_name_resolved)
+    embedder_impl: Any = build_embedder(embedder_name_resolved, repo_path)
     vector_store: Any = build_vector_store(repo_path, embedder_impl)
     result.vector_store = vector_store
 

--- a/packages/cli/src/repowise/cli/commands/init_cmd/persistence.py
+++ b/packages/cli/src/repowise/cli/commands/init_cmd/persistence.py
@@ -349,14 +349,14 @@ def save_full_state_and_config(
     if kg is not None:
         save_knowledge_graph_json(repo_path, kg)
 
-    from repowise.cli.providers.embedders import resolve_embedding_model
+    from repowise.core.providers.embedding.registry import resolve_embedding_model
 
     save_config(
         repo_path,
         provider.provider_name,
         provider.model_name,
         embedder_name_resolved,
-        embedding_model=resolve_embedding_model(embedder_name_resolved),
+        embedding_model=resolve_embedding_model(embedder_name_resolved, repo_path),
         exclude_patterns=exclude_patterns if exclude_patterns else None,
         commit_limit=resolved_commit_limit if commit_limit is not None else None,
         reasoning=resolved_reasoning,

--- a/packages/cli/src/repowise/cli/commands/init_cmd/workspace.py
+++ b/packages/cli/src/repowise/cli/commands/init_cmd/workspace.py
@@ -477,14 +477,14 @@ def _ingest_and_generate_repo(repo: Any, idx: int, total: int, ctx: _WorkspaceCt
 
     # Persist provider/model config per-repo when doing full generation
     if docs_mode == "llm" and provider is not None:
-        from repowise.cli.providers.embedders import resolve_embedding_model
+        from repowise.core.providers.embedding.registry import resolve_embedding_model
 
         save_config(
             repo.path,
             provider.provider_name,
             provider.model_name,
             ctx.embedder_name_resolved,
-            embedding_model=resolve_embedding_model(ctx.embedder_name_resolved),
+            embedding_model=resolve_embedding_model(ctx.embedder_name_resolved, repo.path),
             exclude_patterns=ctx.exclude_patterns if ctx.exclude_patterns else None,
             commit_limit=ctx.resolved_commit_limit,
             reasoning=ctx.resolved_reasoning,
@@ -503,14 +503,14 @@ def _ingest_and_generate_repo(repo: Any, idx: int, total: int, ctx: _WorkspaceCt
         # could re-embed the store at a different width, which the LanceDB
         # writer resolves by dropping the table. Provider/model/style/language
         # only reach a model, so they are intentionally not written here.
-        from repowise.cli.providers.embedders import resolve_embedding_model
+        from repowise.core.providers.embedding.registry import resolve_embedding_model
 
         save_config_partial(
             repo.path,
             exclude_patterns=ctx.exclude_patterns if ctx.exclude_patterns else None,
             commit_limit=ctx.resolved_commit_limit if ctx.resolved_commit_limit else None,
             embedder=det_embedder,
-            embedding_model=(resolve_embedding_model(det_embedder) if det_embedder else None),
+            embedding_model=(resolve_embedding_model(det_embedder, repo.path) if det_embedder else None),
         )
 
     return _RepoOutcome(

--- a/packages/cli/src/repowise/cli/commands/reindex_cmd.py
+++ b/packages/cli/src/repowise/cli/commands/reindex_cmd.py
@@ -60,7 +60,7 @@ async def _reindex(repo_path, embedder_name: str, batch_size: int) -> None:
 
         embedder_name = _resolve_embedder(None)
 
-    embedder_impl = build_embedder(embedder_name)
+    embedder_impl = build_embedder(embedder_name, repo_path)
     if isinstance(embedder_impl, MockEmbedder) and requested_embedder != "mock":
         console.print(
             "[red]No real embedder available. Set a real embedder key, configure Ollama, or pass --embedder mock for test vectors.[/red]"

--- a/packages/cli/src/repowise/cli/commands/search_cmd.py
+++ b/packages/cli/src/repowise/cli/commands/search_cmd.py
@@ -159,7 +159,7 @@ def _search_semantic(repo_path, query: str, limit: int) -> None:
                 )
                 from repowise.core.persistence.vector_store import LanceDBVectorStore
 
-                embedder = build_embedder(resolve_embedder_for_repo(repo_path))
+                embedder = build_embedder(resolve_embedder_for_repo(repo_path), repo_path)
                 store = LanceDBVectorStore(str(lance_dir), embedder=embedder)
                 results = await store.search(query, limit=limit)
                 await store.close()
@@ -279,7 +279,7 @@ def _collect_semantic(repo_path, query: str, limit: int):
                 )
                 from repowise.core.persistence.vector_store import LanceDBVectorStore
 
-                embedder = build_embedder(resolve_embedder_for_repo(repo_path))
+                embedder = build_embedder(resolve_embedder_for_repo(repo_path), repo_path)
                 store = LanceDBVectorStore(str(lance_dir), embedder=embedder)
                 results = await store.search(query, limit=limit)
                 await store.close()

--- a/packages/cli/src/repowise/cli/commands/update_cmd/deterministic.py
+++ b/packages/cli/src/repowise/cli/commands/update_cmd/deterministic.py
@@ -171,7 +171,7 @@ def _render_pages(
             from repowise.cli.providers import build_embedder, build_vector_store
 
             try:
-                vector_store = build_vector_store(repo_path, build_embedder(embedder_name))
+                vector_store = build_vector_store(repo_path, build_embedder(embedder_name, repo_path))
             except Exception as exc:  # embedding is optional; FTS still indexes
                 degraded.append(f"Page embedding: {exc}")
 

--- a/packages/cli/src/repowise/cli/commands/update_cmd/incremental.py
+++ b/packages/cli/src/repowise/cli/commands/update_cmd/incremental.py
@@ -26,7 +26,7 @@ def _build_update_vector_store(repo_path: Any, cfg: dict) -> Any | None:
     try:
         from repowise.cli.providers import build_embedder, build_vector_store, resolve_embedder
 
-        embedder = build_embedder(resolve_embedder(cfg.get("embedder")))
+        embedder = build_embedder(resolve_embedder(cfg.get("embedder")), repo_path)
         return build_vector_store(repo_path, embedder)
     except Exception:
         return None

--- a/packages/cli/src/repowise/cli/commands/upgrade_flow.py
+++ b/packages/cli/src/repowise/cli/commands/upgrade_flow.py
@@ -258,7 +258,7 @@ async def _run_upgrade(
     embedder = None
     vector_store = None
     try:
-        embedder = build_embedder(resolve_embedder(embedder_name))
+        embedder = build_embedder(resolve_embedder(embedder_name), repo_path)
         vector_store = build_vector_store(repo_path, embedder)
     except Exception as exc:
         console.print(f"[yellow]Embedding skipped: {exc}[/yellow]")

--- a/packages/cli/src/repowise/cli/providers/embedders.py
+++ b/packages/cli/src/repowise/cli/providers/embedders.py
@@ -6,11 +6,12 @@ import os
 from typing import Any
 
 
-def _embedder_kwargs(embedder_name: str) -> dict[str, Any]:
+def _embedder_kwargs(embedder_name: str, repo_path: Any = None) -> dict[str, Any]:
+    from repowise.core.providers.embedding.registry import resolve_embedding_model
+
     kwargs: dict[str, Any] = {}
-    model = os.environ.get("REPOWISE_EMBEDDING_MODEL")
+    model = resolve_embedding_model(embedder_name, repo_path)
     if embedder_name == "ollama":
-        model = os.environ.get("OLLAMA_EMBEDDING_MODEL") or model
         base_url = os.environ.get("OLLAMA_BASE_URL")
         dimensions = os.environ.get("OLLAMA_EMBEDDING_DIMS") or os.environ.get(
             "REPOWISE_EMBEDDING_DIMS"
@@ -31,21 +32,6 @@ def _embedder_kwargs(embedder_name: str) -> dict[str, Any]:
     if model:
         kwargs["model"] = model
     return kwargs
-
-
-def resolve_embedding_model(embedder_name: str) -> str | None:
-    """Return the configured embedding model for *embedder_name*, if any.
-
-    Mirrors the precedence in :func:`_embedder_kwargs` so the value persisted
-    to ``config.yaml`` at init time is exactly what the embedder would build
-    with. Returns ``None`` when no model is configured (the embedder then uses
-    its own default), which keeps ``config.yaml`` free of empty keys.
-    """
-    if embedder_name == "ollama":
-        return os.environ.get("OLLAMA_EMBEDDING_MODEL") or os.environ.get(
-            "REPOWISE_EMBEDDING_MODEL"
-        )
-    return os.environ.get("REPOWISE_EMBEDDING_MODEL")
 
 
 def resolve_embedder(embedder_flag: str | None) -> str:
@@ -126,12 +112,16 @@ def resolve_embedder_for_repo(repo_path: Any) -> str:
     return str(pinned) if pinned else resolve_embedder(None)
 
 
-def build_embedder(embedder_name_resolved: str) -> Any:
+def build_embedder(embedder_name_resolved: str, repo_path: Any = None) -> Any:
     """Construct the configured embedder, falling back to MockEmbedder.
 
     Shared by the generation flows and the decision semantic-dedup wiring so
     the same backend selection logic isn't duplicated. Real providers fall
     back to the deterministic mock when their SDK/credentials are unavailable.
+
+    *repo_path* lets the model resolution read the ``embedding_model`` pinned
+    in that repo's ``config.yaml`` when no env var overrides it; without it,
+    resolution is env-only and the embedder's own default fills the gap.
     """
     from repowise.core.providers.embedding.base import MockEmbedder
     from repowise.core.providers.embedding.registry import get_embedder
@@ -139,6 +129,8 @@ def build_embedder(embedder_name_resolved: str) -> Any:
     if embedder_name_resolved == "mock":
         return MockEmbedder()
     try:
-        return get_embedder(embedder_name_resolved, **_embedder_kwargs(embedder_name_resolved))
+        return get_embedder(
+            embedder_name_resolved, **_embedder_kwargs(embedder_name_resolved, repo_path)
+        )
     except Exception:
         return MockEmbedder()

--- a/packages/cli/src/repowise/cli/upgrade.py
+++ b/packages/cli/src/repowise/cli/upgrade.py
@@ -95,7 +95,9 @@ class _CliUpgradeContext:
 def _current_embedding_model() -> str | None:
     """The embedding model the running build would resolve right now."""
     try:
-        from .providers.embedders import resolve_embedder, resolve_embedding_model
+        from repowise.core.providers.embedding.registry import resolve_embedding_model
+
+        from .providers.embedders import resolve_embedder
 
         return resolve_embedding_model(resolve_embedder(None))
     except Exception:
@@ -134,7 +136,7 @@ def _vector_dims(repo_path: Path) -> tuple[int | None, int | None]:
     if stored != MockEmbedder.dimensions:
         return None, None
     try:
-        embedder = build_embedder(resolve_embedder_for_repo(repo_path))
+        embedder = build_embedder(resolve_embedder_for_repo(repo_path), repo_path)
     except Exception:
         return None, None
     if isinstance(embedder, MockEmbedder):

--- a/packages/core/src/repowise/core/providers/embedding/registry.py
+++ b/packages/core/src/repowise/core/providers/embedding/registry.py
@@ -18,10 +18,14 @@ Custom embedder registration:
 from __future__ import annotations
 
 import importlib
+import logging
 from collections.abc import Callable
+from pathlib import Path
 from typing import Any
 
 from repowise.core.providers.embedding.base import Embedder
+
+_log = logging.getLogger(__name__)
 
 _BUILTIN_EMBEDDERS: dict[str, tuple[str, str]] = {
     "openai": ("repowise.core.providers.embedding.openai", "OpenAIEmbedder"),
@@ -98,3 +102,48 @@ def get_embedder(name: str, **kwargs: Any) -> Embedder:
 def list_embedders() -> list[str]:
     """Return a sorted list of all available embedder names."""
     return sorted(set(_BUILTIN_EMBEDDERS) | set(_custom_embedders))
+
+
+def resolve_embedding_model(embedder_name: str, repo_path: Path | None = None) -> str | None:
+    """The embedding model *embedder_name* should build with, or None for its default.
+
+    Process env wins, so a shell override still beats persisted intent —
+    ``OLLAMA_EMBEDDING_MODEL`` ahead of the generic ``REPOWISE_EMBEDDING_MODEL``
+    for the ollama backend, matching that constructor's own fallback chain.
+    Below env sits the ``embedding_model`` pinned in ``.repowise/config.yaml``.
+    The pin used to be write-only — recorded at init as the model the store was
+    embedded with, read by nothing — so editing it changed nothing, and a shell
+    without the env vars silently fell to the embedder's default, which can be
+    a different vector width than the table it queries.
+
+    Without *repo_path* the resolution is env-only: callers that measure what
+    the environment alone would resolve (embedder-drift detection) depend on
+    the pin not answering for itself.
+
+    Shared by the CLI build path and the MCP server so the same repo cannot
+    resolve two different ways depending on which surface asks.
+    """
+    import os
+
+    model: str | None = None
+    if embedder_name == "ollama":
+        model = os.environ.get("OLLAMA_EMBEDDING_MODEL") or None
+    model = model or os.environ.get("REPOWISE_EMBEDDING_MODEL") or None
+    if model:
+        return model
+    if repo_path is None:
+        return None
+
+    config_path = Path(repo_path) / ".repowise" / "config.yaml"
+    try:
+        if config_path.is_file():
+            import yaml
+
+            data = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+            if isinstance(data, dict):
+                pinned = data.get("embedding_model")
+                if pinned:
+                    return str(pinned)
+    except Exception:
+        _log.debug("Failed to read embedding_model from %s", config_path, exc_info=True)
+    return None

--- a/packages/server/src/repowise/server/mcp_server/_server.py
+++ b/packages/server/src/repowise/server/mcp_server/_server.py
@@ -66,15 +66,24 @@ def _configured_embedder_name() -> str:
 
 
 def _embedder_kwargs(name: str) -> dict[str, Any]:
-    """Map repowise embedding env vars onto an embedder's constructor kwargs.
+    """Map embedding model config + env onto an embedder's constructor kwargs.
 
-    Kept backend-agnostic: ``REPOWISE_EMBEDDING_MODEL`` applies to any embedder
-    that accepts a ``model`` arg; ``REPOWISE_EMBEDDING_DIMS`` is gemini-specific
-    (its constructor exposes ``output_dimensionality``). Anything not set here
-    falls through to the embedder's own defaults.
+    The model comes from the shared resolver (env first, then the
+    ``embedding_model`` pinned in the repo's ``config.yaml``), the same one
+    the CLI build path uses — the server used to read only the generic env
+    var, so the same repo could embed queries with a different model than the
+    one that built its table, depending on which surface asked.
+    ``REPOWISE_EMBEDDING_DIMS`` stays gemini-specific (its constructor
+    exposes ``output_dimensionality``). Anything not set here falls through
+    to the embedder's own defaults.
     """
+    from pathlib import Path
+
+    from repowise.core.providers.embedding.registry import resolve_embedding_model
+
+    repo_path = Path(_state._repo_path) if _state._repo_path else None
     kwargs: dict[str, Any] = {}
-    model = os.environ.get("REPOWISE_EMBEDDING_MODEL")
+    model = resolve_embedding_model(name, repo_path)
     if model:
         kwargs["model"] = model
     if name == "gemini":

--- a/tests/unit/cli/test_embedder_resolution.py
+++ b/tests/unit/cli/test_embedder_resolution.py
@@ -145,7 +145,7 @@ def test_semantic_search_reads_through_the_repo_resolver(
 
     seen: list[str] = []
 
-    def _record(name: str):
+    def _record(name: str, repo_path: Path | None = None):
         seen.append(name)
         return MockEmbedder()
 
@@ -250,7 +250,7 @@ async def test_reindex_persists_its_resolved_embedder(
     # _reindex imports build_embedder from this module inside the function, so
     # the module attribute is the one that takes effect.
     monkeypatch.setattr(
-        "repowise.cli.providers.embedders.build_embedder", lambda _n: _WideEmbedder()
+        "repowise.cli.providers.embedders.build_embedder", lambda _n, _repo=None: _WideEmbedder()
     )
 
     await reindex_cmd._reindex(tmp_path, "openai", batch_size=8)
@@ -299,7 +299,7 @@ async def test_reindex_does_not_pin_an_embedder_that_wrote_nothing(
         "sqlalchemy.ext.asyncio.async_sessionmaker", lambda *a, **k: lambda: _Session()
     )
     monkeypatch.setattr(
-        "repowise.cli.providers.embedders.build_embedder", lambda _n: _WideEmbedder()
+        "repowise.cli.providers.embedders.build_embedder", lambda _n, _repo=None: _WideEmbedder()
     )
 
     await reindex_cmd._reindex(tmp_path, "openai", batch_size=8)
@@ -417,7 +417,7 @@ def test_mock_width_with_a_real_pin_proposes_a_re_embed(
     monkeypatch.delenv("REPOWISE_EMBEDDER", raising=False)
     _patch_stored_dim(monkeypatch, 8)
     monkeypatch.setattr(
-        "repowise.cli.providers.embedders.build_embedder", lambda _n: _WideEmbedder()
+        "repowise.cli.providers.embedders.build_embedder", lambda _n, _repo=None: _WideEmbedder()
     )
 
     assert _vector_dims(tmp_path) == (8, 1536)
@@ -447,7 +447,8 @@ def test_two_real_widths_are_never_compared(
             return [[0.0] * 1024 for _ in texts]
 
     monkeypatch.setattr(
-        "repowise.cli.providers.embedders.build_embedder", lambda _n: _MisreportingEmbedder()
+        "repowise.cli.providers.embedders.build_embedder",
+        lambda _n, _repo=None: _MisreportingEmbedder(),
     )
 
     assert _vector_dims(tmp_path) == (None, None)
@@ -538,3 +539,52 @@ def test_duplicate_reembed_actions_run_once() -> None:
     )
     asyncio.run(apply_auto(verdict, _Ctx()))
     assert calls == 1
+
+
+# --- the model pin: config.yaml embedding_model must be operative ------------
+#
+# The pin used to be write-only: recorded at init as the model the store was
+# embedded with, read by nothing. A shell without the embedding env vars then
+# silently built the embedder at its own default — a different model, and
+# potentially a different vector width, than the table it queries.
+
+
+def test_pinned_embedding_model_reaches_the_resolver(tmp_path: Path, monkeypatch) -> None:
+    from repowise.core.providers.embedding.registry import resolve_embedding_model
+
+    monkeypatch.delenv("REPOWISE_EMBEDDING_MODEL", raising=False)
+    monkeypatch.delenv("OLLAMA_EMBEDDING_MODEL", raising=False)
+    _write_config(tmp_path, embedder="ollama", embedding_model="qwen3-embedding:8b")
+    assert resolve_embedding_model("ollama", tmp_path) == "qwen3-embedding:8b"
+
+
+def test_env_still_overrides_the_pinned_embedding_model(tmp_path: Path, monkeypatch) -> None:
+    from repowise.core.providers.embedding.registry import resolve_embedding_model
+
+    _write_config(tmp_path, embedder="ollama", embedding_model="pinned-model")
+    monkeypatch.setenv("REPOWISE_EMBEDDING_MODEL", "generic-env-model")
+    assert resolve_embedding_model("ollama", tmp_path) == "generic-env-model"
+    # The ollama-specific variable outranks the generic one, matching the
+    # OllamaEmbedder constructor's own fallback chain.
+    monkeypatch.setenv("OLLAMA_EMBEDDING_MODEL", "ollama-env-model")
+    assert resolve_embedding_model("ollama", tmp_path) == "ollama-env-model"
+
+
+def test_no_repo_path_means_env_only(tmp_path: Path, monkeypatch) -> None:
+    """Embedder-drift detection measures what the environment alone resolves;
+    the pin must not answer for itself there."""
+    from repowise.core.providers.embedding.registry import resolve_embedding_model
+
+    monkeypatch.delenv("REPOWISE_EMBEDDING_MODEL", raising=False)
+    monkeypatch.delenv("OLLAMA_EMBEDDING_MODEL", raising=False)
+    _write_config(tmp_path, embedder="ollama", embedding_model="pinned-model")
+    assert resolve_embedding_model("ollama", None) is None
+
+
+def test_build_embedder_builds_with_the_pinned_model(tmp_path: Path, monkeypatch) -> None:
+    """End to end through the shared constructor: the pin, not the default."""
+    monkeypatch.delenv("REPOWISE_EMBEDDING_MODEL", raising=False)
+    monkeypatch.delenv("OLLAMA_EMBEDDING_MODEL", raising=False)
+    _write_config(tmp_path, embedder="ollama", embedding_model="qwen3-embedding:8b")
+    embedder = providers.build_embedder("ollama", tmp_path)
+    assert getattr(embedder, "_model", None) == "qwen3-embedding:8b"

--- a/tests/unit/server/mcp/test_embedder_resolution.py
+++ b/tests/unit/server/mcp/test_embedder_resolution.py
@@ -188,3 +188,34 @@ def test_build_meta_clean_when_healthy(monkeypatch):
     # And when nothing has been resolved at all.
     monkeypatch.setattr(_state, "_embedder_status", None)
     assert "embedder_degraded" not in build_meta(timing_ms=1.0)
+
+
+def test_pinned_embedding_model_reaches_the_server_embedder(monkeypatch, tmp_path):
+    """The `embedding_model` pinned in config.yaml must drive query embedding.
+
+    The server read only the generic env var, so the same repo could embed
+    queries with a different model than the one that built its table,
+    depending on which surface asked.
+    """
+    repowise_dir = tmp_path / ".repowise"
+    repowise_dir.mkdir(parents=True)
+    (repowise_dir / "config.yaml").write_text(
+        "embedder: ollama\nembedding_model: qwen3-embedding:8b\n", encoding="utf-8"
+    )
+    monkeypatch.setattr(_state, "_repo_path", str(tmp_path), raising=False)
+
+    kwargs = _server._embedder_kwargs("ollama")
+    assert kwargs.get("model") == "qwen3-embedding:8b"
+
+
+def test_env_model_still_outranks_the_pin_on_the_server(monkeypatch, tmp_path):
+    repowise_dir = tmp_path / ".repowise"
+    repowise_dir.mkdir(parents=True)
+    (repowise_dir / "config.yaml").write_text(
+        "embedder: ollama\nembedding_model: pinned-model\n", encoding="utf-8"
+    )
+    monkeypatch.setattr(_state, "_repo_path", str(tmp_path), raising=False)
+    monkeypatch.setenv("OLLAMA_EMBEDDING_MODEL", "env-model")
+
+    kwargs = _server._embedder_kwargs("ollama")
+    assert kwargs.get("model") == "env-model"


### PR DESCRIPTION
## The defect

`config.yaml`'s `embedding_model` is write-only today: `repowise init` records the model the store was embedded with, and nothing ever reads it back. Editing the pin changes nothing, and a shell without the embedding env vars silently builds the embedder at its own default — potentially a different vector width than the table it queries (the same failure class the `embedder`-pin work fixed for the backend *name*; the *model* field never got the same plumbing).

Separately, the CLI and the MCP server resolve the model through divergent env chains — the server's `_embedder_kwargs` ignores `OLLAMA_EMBEDDING_MODEL` while the CLI honors it — so the same repo can embed queries with a different model than the one that built its table, depending on which surface asks.

## The fix

One shared resolver in the embedding registry (`resolve_embedding_model(embedder_name, repo_path)`):

1. `OLLAMA_EMBEDDING_MODEL` (ollama backend only, matching that constructor's own fallback chain)
2. `REPOWISE_EMBEDDING_MODEL`
3. the `embedding_model` pinned in `.repowise/config.yaml`
4. `None` → the embedder's own default

- The CLI build path threads `repo_path` through `build_embedder` at every command site (init, generate, update, reindex, search, doctor, upgrade).
- The MCP server's query-embedding `_embedder_kwargs` uses the same resolver, closing the CLI/server divergence.
- Init-time persistence records the same value the build resolves, so a config-only model survives re-init instead of being clobbered.
- Embedder-drift detection (`_current_embedding_model`) deliberately stays env-only via `repo_path=None`: it measures what the environment alone would resolve, and the pin must not answer for itself.
- The hosted multi-repo server (`server/app.py`) is intentionally untouched: one shared embedder across many repos is env-configured by design.

## Tests & docs

- CLI: pin-reaches-resolver, env-beats-pin (both variables), env-only mode for drift detection, and end-to-end through `build_embedder`.
- Server: pin reaches `_embedder_kwargs`; env still outranks it.
- `tests/unit/cli` + `tests/unit/server` + `tests/unit/upgrade`: 1,847 passed.
- `docs/reference/CONFIG.md`: the `embedding_model` row and the Embeddings section now document the precedence.

Together with #1194 this makes all three model roles — wiki writer (`provider`/`model`), answerer (`answer_provider`/`answer_model`), and embedder (`embedder`/`embedding_model`) — independently configurable as config values with env overrides.