### PR TITLE
refactor(persist): one stale-page UPDATE instead of two copies

### DIFF
--- a/packages/core/src/repowise/core/pipeline/persist.py
+++ b/packages/core/src/repowise/core/pipeline/persist.py
@@ -189,7 +189,7 @@ async def tombstone_absent_file_pages(
     return marked
 
 
-async def mark_stale_pages(session: Any, repo_id: str, paths: list[str]) -> int:
+async def mark_stale_pages(session: Any, repo_id: str, paths: Iterable[str]) -> int:
     """Decay weakly-affected file pages to ``freshness_status='stale'``.
 
     ``ChangeDetector.get_affected_pages`` returns ``decay_only`` — pages hit
@@ -201,28 +201,21 @@ async def mark_stale_pages(session: Any, repo_id: str, paths: list[str]) -> int:
     already-stale pages keep their stronger status, and pages regenerated in
     this run are never in ``decay_only`` by construction.
 
+    Maps each path to its ``file_page:<path>`` id and hands off to
+    :func:`mark_page_ids_stale`, so both entry points share one UPDATE.
+
+    The two were separate copies of the same statement, and only the sibling
+    was chunked against ``SQLITE_MAX_VARIABLE_NUMBER``. That is not a crash
+    anyone is hitting today: SQLite has defaulted to 32766 bind variables since
+    3.32, and a ``decay_only`` set that large would take an enormous cascade.
+    It is reachable on the 999-variable builds older interpreters still ship,
+    but the reason to collapse the two is narrower than that. They answered the
+    same question differently, in the file with the most bug fixes in this repo,
+    and now there is one place to answer it.
+
     Returns the number of pages marked.
     """
-    if not paths:
-        return 0
-    from sqlalchemy import update
-
-    from repowise.core.persistence.models import Page
-
-    page_ids = [f"file_page:{path}" for path in paths]
-    res = await session.execute(
-        update(Page)
-        .where(
-            Page.repository_id == repo_id,
-            Page.id.in_(page_ids),
-            Page.freshness_status == "fresh",
-        )
-        .values(freshness_status="stale")
-    )
-    marked = int(res.rowcount or 0)
-    if marked:
-        logger.info("pages_decayed_stale", repo_id=repo_id, count=marked)
-    return marked
+    return await mark_page_ids_stale(session, repo_id, (f"file_page:{path}" for path in paths))
 
 
 async def mark_page_ids_stale(session: Any, repo_id: str, page_ids: Iterable[str]) -> int:

--- a/tests/unit/persistence/test_mark_stale_pages.py
+++ b/tests/unit/persistence/test_mark_stale_pages.py
@@ -65,3 +65,43 @@ async def test_missing_pages_and_empty_input_are_noops(async_session):
 
     assert await mark_stale_pages(async_session, repo.id, []) == 0
     assert await mark_stale_pages(async_session, repo.id, ["src/never_indexed.py"]) == 0
+
+
+@pytest.mark.asyncio
+async def test_a_cascade_spanning_several_chunks_counts_them_all(async_session):
+    """More paths than one chunk, so the batched UPDATE has to accumulate.
+
+    This does not reproduce the bind-variable cap. SQLite has allowed 32766
+    variables since 3.32, so the unchunked version passed it too. What it pins
+    is the arithmetic the shared path introduces: three batches of 500, with a
+    rowcount summed across them rather than taken from the last one.
+    """
+    repo = await insert_repo(async_session)
+    paths = [f"src/mod{i}.py" for i in range(1200)]  # > _STALE_ID_CHUNK (500)
+    for path in paths:
+        await _seed_page(async_session, repo.id, path)
+
+    marked = await mark_stale_pages(async_session, repo.id, paths)
+    await async_session.commit()
+
+    assert marked == len(paths)
+    assert len(await get_stale_pages(async_session, repo.id)) == len(paths)
+
+
+@pytest.mark.asyncio
+async def test_a_generator_of_paths_is_accepted(async_session):
+    """The signature takes any iterable, matching ``mark_page_ids_stale``.
+
+    The old ``if not paths`` early-return would have been wrong for a lazy
+    iterable, since a generator is always truthy. Widening the annotation
+    without moving that check would have traded one inconsistency for a subtler
+    one. The shared path materializes before it tests.
+    """
+    repo = await insert_repo(async_session)
+    await _seed_page(async_session, repo.id, "src/a.py")
+
+    marked = await mark_stale_pages(async_session, repo.id, (p for p in ["src/a.py"]))
+    await async_session.commit()
+
+    assert marked == 1
+    assert await mark_stale_pages(async_session, repo.id, (p for p in [])) == 0


### PR DESCRIPTION
`mark_stale_pages` and `mark_page_ids_stale` ran the same statement: set `freshness_status` to `stale` for a set of page ids belonging to one repo, and only where the page is still `fresh`. They differ in the id shape they accept, which is a real distinction, and in one substantive way nobody wrote down.

`mark_page_ids_stale` chunks its `IN` list at 500, with a comment explaining that SQLite binds one variable per id and caps at `SQLITE_MAX_VARIABLE_NUMBER`. `mark_stale_pages` bound every id in a single statement.

### How much that matters

Less than the comment implies. SQLite has defaulted to 32766 bind variables since 3.32 (2020), and a `decay_only` set large enough to exceed that would take an enormous cascade. It is reachable on the 999-variable builds that older interpreters still ship, so it is worth closing, but nobody is hitting it today and this is not a bug report.

The reason to collapse them is narrower. `persist.py` has been bug-fixed fifteen times in six months, the last one four days ago. Two functions answering the same question two different ways, one of them hardened and one not, for no stated reason, is the shape a sixteenth fix grows out of.

### The change

`mark_stale_pages` maps its paths to `file_page:<path>` ids and delegates to `mark_page_ids_stale`. The path-shaped entry point keeps its name, its callers and its return value. 21 lines of duplicated UPDATE go away, and the chunk size has one definition.

The annotation widens from `list[str]` to `Iterable[str]` to match the sibling. Both production callers pass lists and need no change.

One thing that did not survive the move: the old `if not paths` early-return. A generator is always truthy, so carrying that guard across while widening the annotation would have traded a visible inconsistency for an invisible one. The shared path materializes before testing for empty, and there is a test for it now.

### Tests

Two added. Neither reproduces the bind-variable cap, and the docstrings say so rather than implying a fix that is not there:

- 1200 paths across three chunks, pinning that the rowcount is summed across batches instead of taken from the last one.
- A generator and an empty generator, covering the guard that moved.

436 tests pass in `tests/unit/persistence` plus the stub-fallback suite that also calls into this module. `ruff check` clean. `ruff format` reports two pre-existing deviations elsewhere in `persist.py`, left alone to keep the diff to the change.
