### PR TITLE
fix(generation): refuse a structurally-keyed page that has no key

### DIFF
--- a/packages/core/src/repowise/core/generation/page_generator/orchestrate.py
+++ b/packages/core/src/repowise/core/generation/page_generator/orchestrate.py
@@ -873,6 +873,20 @@ def _stamp_structural_keys(pages: list[GeneratedPage]) -> None:
             # curated id is the best identity available and is stable for a
             # layer; for the others this is a fallback, not the design.
             page.structural_key = page.target_path
+        if not page.structural_key:
+            # The fallback above is a target_path, and a page whose members are
+            # unknown *and* whose target_path is empty comes out of it with no
+            # identity at all. That page is not merely unkeyed: the stale-page
+            # sweep matches these three types by structural key, so an empty one
+            # is a page the sweep can neither find nor retire, and it strands as
+            # a duplicate on every later run. Nothing downstream can tell that
+            # from a type that is not keyed on purpose, which is why this raises
+            # here rather than being logged and carried.
+            raise ValueError(
+                f"structural key missing for {page.page_id!r} (type "
+                f"{page.page_type!r}): it has no member list and no target "
+                f"path, so there is nothing to identify it by."
+            )
 
 
 def _compute_kg_file_scores(kg_ctx: Any) -> dict[str, float]:

--- a/tests/unit/generation/test_structural_key_required.py
+++ b/tests/unit/generation/test_structural_key_required.py
@@ -1,0 +1,115 @@
+"""A structurally-keyed page must leave generation with a structural key.
+
+Three page types are keyed on what they group rather than on a path —
+``module_page``, ``layer_page`` and ``scc_page`` — and the stale-page sweep
+finds them by that key. A keyed page that lands without one is invisible to
+the sweep: it can never be retired, so every later run strands it as a
+duplicate alongside its replacement.
+
+Nothing downstream can tell that page apart from one of the many types that
+carry no key on purpose, which is why the check lives here, at the moment the
+key is assigned, and raises.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from repowise.core.generation.models import GeneratedPage
+from repowise.core.generation.page_generator.orchestrate import _stamp_structural_keys
+
+
+def _page(page_id: str, page_type: str, *, target_path: str = "", **metadata) -> GeneratedPage:
+    return GeneratedPage(
+        page_id=page_id,
+        page_type=page_type,
+        title=page_id,
+        content="Body.",
+        source_hash="",
+        model_name="mock",
+        provider_name="mock",
+        input_tokens=0,
+        output_tokens=0,
+        cached_tokens=0,
+        generation_level=1,
+        target_path=target_path,
+        created_at="2026-01-01T00:00:00Z",
+        updated_at="2026-01-01T00:00:00Z",
+        summary="",
+        metadata=dict(metadata),
+    )
+
+
+def test_a_keyed_page_with_neither_members_nor_a_path_raises():
+    """The gap the fallback leaves open.
+
+    The stamp keys a module page on its member list and falls back to the
+    target_path. A page with an empty member list *and* an empty target_path
+    comes out of both branches with an empty string, which reads downstream as
+    "this type is not keyed" — the one thing it is not.
+    """
+    page = _page("module_page:orphan", "module_page")
+
+    with pytest.raises(ValueError, match="structural key missing"):
+        _stamp_structural_keys([page])
+
+
+def test_the_raise_names_the_page_and_why():
+    """A run that stops has to say which page stopped it.
+
+    The page id alone is not enough to act on — the fix differs depending on
+    whether the producer lost the member list or the target path.
+    """
+    page = _page("scc_page:orphan", "scc_page")
+
+    with pytest.raises(ValueError) as exc:
+        _stamp_structural_keys([page])
+
+    assert "scc_page:orphan" in str(exc.value)
+    assert "scc_page" in str(exc.value)
+    assert "no member list" in str(exc.value)
+
+
+def test_a_member_keyed_page_is_still_keyed_from_its_members():
+    page = _page("module_page:one", "module_page", file_paths=["pkg/a.py", "pkg/b.py"])
+
+    _stamp_structural_keys([page])
+
+    assert page.structural_key
+    assert page.structural_key.startswith("module-")
+
+
+def test_a_layer_is_still_keyed_from_its_target_path():
+    """Layers have no member list and are keyed by their curated id."""
+    page = _page("layer_page:presentation", "layer_page", target_path="presentation")
+
+    _stamp_structural_keys([page])
+
+    assert page.structural_key == "presentation"
+
+
+def test_a_key_set_by_the_producer_is_kept():
+    page = _page("module_page:planned", "module_page", file_paths=["pkg/a.py"])
+    page.structural_key = "concept-abc123"
+
+    _stamp_structural_keys([page])
+
+    assert page.structural_key == "concept-abc123"
+
+
+def test_an_unkeyed_type_is_left_alone_and_does_not_raise():
+    """The check must not become an argument for keying everything.
+
+    A file page's identity *is* its path, so a key would be a duplicate
+    identity rather than an identity. The sweep deletes by this column, so a
+    file page carrying one is a file page the sweep can delete.
+    """
+    pages = [
+        _page("file_page:a.py", "file_page", target_path="a.py"),
+        _page("symbol_spotlight:a.py::F", "symbol_spotlight", target_path="a.py"),
+        _page("repo_overview:repowise", "repo_overview"),
+    ]
+
+    _stamp_structural_keys(pages)
+
+    assert [p.structural_key for p in pages] == [None, None, None]


### PR DESCRIPTION
## Background — the premise this started from was wrong, and that is the useful part

The finding that opened this was *"`structural_key` is null on 3,562 of 3,678 rows, so the cleanup mechanism is inert — backfill it."* **That is correct by design, not a bug, and the backfill would have been damaging.**

Only three page types are structurally keyed — `STRUCTURALLY_KEYED_PAGE_TYPES = ("module_page", "layer_page", "scc_page")` (`generation/models.py:352`) — and the corpus holds 88 module pages, 17 SCC pages and 11 layer pages. 88 + 17 + 11 = 116, which is exactly the 3,678 − 3,562 non-null rows. `_sweep_stale_generated_pages` sweeps only those same three types and **imports the identical tuple**, so the two cannot drift. The mechanism is matching 100% of what it is supposed to match.

A file page's identity *is* its path, so copying the path into the column would be a duplicate identity rather than an identity — and the sweep **deletes** by that column, so a backfilled file page is a file page the sweep can delete. No backfill here.

## The real gap

`_stamp_structural_keys` keys a member-grouped page on its member list and falls back to `page.target_path`. A keyed page with an **empty member list and an empty target_path** falls through both branches and lands with `structural_key = ''`:

```
main leaves structural_key = ''
```

Empty reads downstream exactly like the 3,562 legitimately-unkeyed rows, so nothing can tell the two apart. The consequence is specific: the sweep matches these three types by key, so a page with an empty one can never be found and never be retired — every later run strands it as a duplicate beside its replacement, which is the precise failure the sweep exists to prevent.

## The change

`_stamp_structural_keys` raises when a page of a keyed type finishes the stamp with no key, naming the page, its type, and which half is missing — the fix differs depending on whether the producer lost the member list or the target path. It raises rather than logs because a warning here is indistinguishable from the normal case for every consumer downstream.

Nothing else changes. The three keyed types are keyed as before; the other types are still left alone.

## Tests

`tests/unit/generation/test_structural_key_required.py`, 6 tests. **2 fail on `main`** — as a behaviour difference, not an import or a missing attribute: the function exists, runs to completion, and silently produces `structural_key = ''` where it now refuses.

```
E  Failed: DID NOT RAISE <class 'ValueError'>   test_a_keyed_page_with_neither_members_nor_a_path_raises
E  Failed: DID NOT RAISE <class 'ValueError'>   test_the_raise_names_the_page_and_why
2 failed, 4 passed
```

The other four are the regression guard, and one of them is the point of the PR: `test_an_unkeyed_type_is_left_alone_and_does_not_raise` pins that a file page, a symbol spotlight and the repo overview all still come out with `structural_key is None`. That test is what stops this check from later being read as an argument for keying everything.

Covered: a keyed page with neither members nor a path raises · the message names the page and the reason · a member-keyed page is still keyed from its members · a layer is still keyed from its target path · a key set by the producer is kept · the unkeyed types are untouched.

## Gates

`tests/unit/generation` + `tests/unit/persistence` 1402 passed · `tests/unit/cli` + `tests/unit/pipeline` 1123 passed · ruff check and format clean.