### PR TITLE
feat(pipeline): retention for archived wiki page versions

### DIFF
--- a/docs/architecture/page-version-retention.md
+++ b/docs/architecture/page-version-retention.md
@@ -1,0 +1,70 @@
+# Page version retention
+
+Every time a wiki page is regenerated, the copy it replaced is archived into
+`wiki_page_versions`. That history is what makes a page's prose auditable:
+"when did this claim first appear, and which model wrote it" is answerable only
+because the old rows are still there.
+
+Nothing has ever deleted one. On a repository indexed daily for a year, the
+version table becomes the largest object in the store, and almost none of it is
+reachable by any surface the product ships.
+
+## The split
+
+Retention is two modules on purpose.
+
+`repowise.core.pipeline.retention` decides *what* to drop. It is pure: it takes
+rows and a policy and returns a plan. Nothing in it knows a database exists, so
+the policy can be argued with in a test rather than against a live store.
+
+`repowise.core.pipeline.retention_store` executes a plan. It knows about
+sessions and chunking and nothing about policy.
+
+The split is not tidiness. It means a caller can log or diff a plan before
+anything is deleted, which is the only way a destructive sweep gets to be
+reviewed at all.
+
+## The policy
+
+`RetentionPolicy` is a set of floors, never caps. A version survives if *any*
+single rule wants it kept, so adding a rule can only ever retain more. That
+direction is deliberate: the failure mode of keeping too much is a larger
+table, and the failure mode of keeping too little is unrecoverable.
+
+| Field | Default | Keeps |
+|---|---|---|
+| `keep_per_page` | 3 | The newest N versions of every page, unconditionally. |
+| `never_prune_types` | overview, architecture, onboarding | Page types a reader diffs across months. A handful of rows, so exempting them costs nothing. |
+| `min_age_days` | 30 | Nothing archived inside the window is eligible at all. |
+| `low_confidence_floor` | 0.5 | Low-confidence generations, which are the ones worth keeping for forensics. |
+| `keep_newest_per_model` | true | The newest version from each distinct provider and model pair, so a provider swap stays diffable after the generic window expires. |
+| `keep_source_hash_boundaries` | true | The newest version at each distinct `source_hash`, so the boundary where the underlying code actually changed survives even when the page was regenerated many times against identical source. |
+
+## Where it runs
+
+Two call sites, both best-effort. Each one sits after a persistence step that
+has already succeeded, and losing a version sweep is not worth losing an index
+over.
+
+**Tombstoning.** `mark_tombstone_pages` takes an opt-in `prune_versions`. A
+tombstoned page's history is the clearest case retention has: the file is gone,
+so no future regeneration will ever diff against those rows. The flag is off by
+default because deletion belongs to the caller that knows the run has finished,
+not to the marking step. The incremental update path sets it, since an update
+is the one path that knows a file was *deleted* rather than merely absent.
+
+**Full index.** `index_repo_full` sweeps the whole repository via
+`prune_repo_page_versions`. A full run has just archived a version of every
+page it replaced, so it is both when the table grows fastest and when nothing
+downstream is mid-read.
+
+## What is not here
+
+No scheduler. Retention runs when an indexing run is already writing, and a
+sweep that needs its own cron is a sweep that can drift out of step with the
+data it prunes. If a repository is never re-indexed, its version table does not
+grow either, so there is nothing for a background job to do.
+
+No configuration key. `RetentionPolicy` is constructed with its defaults at
+both call sites. A key would need a real user asking for a different number
+before it earns the surface area.

--- a/packages/core/src/repowise/core/pipeline/full_index.py
+++ b/packages/core/src/repowise/core/pipeline/full_index.py
@@ -61,6 +61,16 @@ async def index_repo_full(
                 local_path=str(repo_path),
             )
             await persist_pipeline_result(result, session, repo.id)
+            # A full run has just archived a version of every page it replaced,
+            # so this is both when the version table grows fastest and when
+            # nothing downstream is mid-read. Best-effort: a failed sweep must
+            # not cost the index that already persisted.
+            try:
+                from repowise.core.pipeline.retention_store import prune_repo_page_versions
+
+                await prune_repo_page_versions(session, repo.id)
+            except Exception:  # pragma: no cover - defensive
+                pass
     finally:
         await engine.dispose()
 

--- a/packages/core/src/repowise/core/pipeline/incremental.py
+++ b/packages/core/src/repowise/core/pipeline/incremental.py
@@ -963,8 +963,14 @@ async def persist_incremental_index(
                         tombstone_candidates,
                     )
 
+                    # An update is the one path that knows a file was deleted
+                    # rather than merely absent, so it is where the version
+                    # history of a dead page is safe to sweep.
                     tombstoned_page_ids = await mark_tombstone_pages(
-                        session, repo_id, tombstone_candidates(file_diffs)
+                        session,
+                        repo_id,
+                        tombstone_candidates(file_diffs),
+                        prune_versions=True,
                     )
                 except Exception as exc:
                     _skip("Tombstone marking", exc)

--- a/packages/core/src/repowise/core/pipeline/persist.py
+++ b/packages/core/src/repowise/core/pipeline/persist.py
@@ -52,7 +52,11 @@ def tombstone_candidates(file_diffs: list[Any]) -> list[tuple[str, list[str]]]:
 
 
 async def mark_tombstone_pages(
-    session: Any, repo_id: str, candidates: list[tuple[str, list[str]]]
+    session: Any,
+    repo_id: str,
+    candidates: list[tuple[str, list[str]]],
+    *,
+    prune_versions: bool = False,
 ) -> list[str]:
     """Mark file pages for deleted/renamed files as tombstones.
 
@@ -69,6 +73,12 @@ async def mark_tombstone_pages(
     a real candidate out of the fetch. The row has to go, and only the caller
     knows when it is safe to write to the index — on SQLite it shares a file
     with this session.
+
+    ``prune_versions`` additionally sweeps the archived version history of the
+    pages just tombstoned. A tombstoned page's history is the clearest case
+    retention has: the file is gone, so no future regeneration will ever diff
+    against those rows. Off by default because deletion should be opted into by
+    the caller that knows the run is finished, not by the marking step.
     """
     if not candidates:
         return []
@@ -103,6 +113,15 @@ async def mark_tombstone_pages(
             candidate_count=len(candidates),
             sample=[p for p, _ in candidates[:3]],
         )
+    if marked and prune_versions:
+        # Best-effort: the tombstones are already written, and a failed version
+        # sweep must not cost the caller the marking it came for.
+        try:
+            from repowise.core.pipeline.retention_store import prune_page_versions
+
+            await prune_page_versions(session, repo_id, marked)
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.debug("tombstone_version_prune_failed", repo_id=repo_id, error=str(exc))
     return marked
 
 

--- a/packages/core/src/repowise/core/pipeline/retention.py
+++ b/packages/core/src/repowise/core/pipeline/retention.py
@@ -1,0 +1,157 @@
+"""Retention planning for ``wiki_page_versions``.
+
+Every regeneration of a page archives the copy it replaced. That history is
+what makes a page's prose auditable — "when did this claim appear, and which
+model wrote it" is answerable only because the old rows are still there — but
+nothing has ever deleted one. On a repo that has been indexed daily for a
+year, the version table is the largest thing in the store and almost none of
+it is reachable.
+
+This module decides *what* to drop. It does not touch the database: the
+planner is pure so the policy can be argued with in a test instead of against
+a live store, and so the caller keeps the choice of when to write.
+
+The policy is deliberately conservative. A version survives if any single rule
+wants it kept, so adding a rule can only ever retain more.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+
+@dataclass(frozen=True)
+class RetentionPolicy:
+    """What to keep. Every field is a floor, never a cap."""
+
+    # Newest N versions of every page, regardless of anything else.
+    keep_per_page: int = 3
+    # Newest version produced by each distinct (provider, model) pair, so a
+    # provider swap stays diffable after the generic window has expired.
+    keep_newest_per_model: bool = True
+    # Versions whose generation was low-confidence are the ones worth keeping
+    # for forensics, so they outlive the ordinary window.
+    low_confidence_floor: float = 0.5
+    # Nothing archived inside this window is eligible at all.
+    min_age_days: int = 30
+    # Page types whose history is never pruned. The overview and architecture
+    # pages are the ones a reader diffs across months; they are also a handful
+    # of rows, so exempting them costs nothing.
+    never_prune_types: frozenset[str] = frozenset({"overview", "architecture", "onboarding"})
+    # Keep the newest version at each distinct ``source_hash``, so the boundary
+    # where the underlying code actually changed stays diffable even when the
+    # page was regenerated many times against identical source.
+    keep_source_hash_boundaries: bool = True
+
+
+@dataclass
+class RetentionPlan:
+    """The ids to delete, plus the counts behind the decision."""
+
+    delete_ids: list[str] = field(default_factory=list)
+    kept: int = 0
+    examined: int = 0
+    pages_touched: set[str] = field(default_factory=set)
+
+    @property
+    def is_empty(self) -> bool:
+        return not self.delete_ids
+
+
+def _archived_at(row: Any) -> datetime | None:
+    """``archived_at`` as an aware datetime, or None when the row has none.
+
+    Accepts both ORM rows and the plain dicts a projection hands back.
+    """
+    raw = row.get("archived_at") if isinstance(row, dict) else getattr(row, "archived_at", None)
+    if raw is None:
+        return None
+    if isinstance(raw, str):
+        try:
+            raw = datetime.fromisoformat(raw)
+        except ValueError:
+            return None
+    if not isinstance(raw, datetime):
+        return None
+    return raw if raw.tzinfo else raw.replace(tzinfo=UTC)
+
+
+def _field(row: Any, name: str, default: Any = None) -> Any:
+    return row.get(name, default) if isinstance(row, dict) else getattr(row, name, default)
+
+
+def plan_version_retention(
+    rows: list[Any],
+    policy: RetentionPolicy | None = None,
+    *,
+    now: datetime | None = None,
+) -> RetentionPlan:
+    """Decide which ``wiki_page_versions`` rows are safe to delete.
+
+    Groups the rows by page, walks each page's history newest-first, and drops
+    only what every rule agrees is expendable. Returns the plan rather than
+    executing it.
+    """
+    policy = policy or RetentionPolicy()
+    now = now or datetime.now(UTC)
+    cutoff = now - timedelta(days=policy.min_age_days)
+
+    by_page: dict[str, list[Any]] = {}
+    for row in rows or []:
+        page_id = _field(row, "page_id")
+        if page_id:
+            by_page.setdefault(str(page_id), []).append(row)
+
+    plan = RetentionPlan()
+    for page_id, versions in by_page.items():
+        versions.sort(key=lambda r: int(_field(r, "version", 0) or 0), reverse=True)
+        seen_models: set[tuple[str, str]] = set()
+        seen_hashes: set[str] = set()
+        for index, row in enumerate(versions):
+            plan.examined += 1
+            keep = False
+            if (
+                index < policy.keep_per_page
+                or str(_field(row, "page_type", "") or "") in policy.never_prune_types
+            ):
+                keep = True
+            else:
+                archived = _archived_at(row)
+                if archived is None or archived > cutoff:
+                    keep = True
+                else:
+                    confidence = _field(row, "confidence", 1.0)
+                    try:
+                        confidence = float(confidence)
+                    except (TypeError, ValueError):
+                        confidence = 1.0
+                    if confidence < policy.low_confidence_floor:
+                        keep = True
+                    else:
+                        if policy.keep_newest_per_model:
+                            model_key = (
+                                str(_field(row, "provider_name", "") or ""),
+                                str(_field(row, "model_name", "") or ""),
+                            )
+                            if model_key not in seen_models:
+                                keep = True
+                        if not keep and policy.keep_source_hash_boundaries:
+                            source_hash = str(_field(row, "source_hash", "") or "")
+                            if source_hash and source_hash not in seen_hashes:
+                                keep = True
+            model_key = (
+                str(_field(row, "provider_name", "") or ""),
+                str(_field(row, "model_name", "") or ""),
+            )
+            seen_models.add(model_key)
+            seen_hashes.add(str(_field(row, "source_hash", "") or ""))
+            if keep:
+                plan.kept += 1
+                continue
+            version_id = _field(row, "id")
+            if version_id:
+                plan.delete_ids.append(str(version_id))
+                plan.pages_touched.add(page_id)
+    return plan

--- a/packages/core/src/repowise/core/pipeline/retention_store.py
+++ b/packages/core/src/repowise/core/pipeline/retention_store.py
@@ -1,0 +1,129 @@
+"""Executes a :class:`RetentionPlan` against the store.
+
+Split from :mod:`repowise.core.pipeline.retention` on the same line the rest of
+the pipeline draws: the planner is pure and testable without a database, this
+half knows about sessions and nothing about policy. The split also means a
+caller can log or diff a plan before anything is deleted, which is the only way
+a destructive sweep gets to be reviewed.
+
+Deletes are chunked for the same reason every other sweep in this package is:
+SQLite's bound-variable limit is a real ceiling on the local CLI store.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import structlog
+
+from repowise.core.pipeline.retention import (
+    RetentionPlan,
+    RetentionPolicy,
+    plan_version_retention,
+)
+
+logger = structlog.get_logger(__name__)
+
+# Matches ``_STALE_ID_CHUNK`` / ``_PRUNE_CHUNK`` in ``persist.py``.
+_DELETE_CHUNK = 500
+
+
+async def load_version_rows(session: Any, repo_id: str, page_ids: list[str]) -> list[dict]:
+    """The version history of *page_ids*, as the plain dicts the planner takes.
+
+    Selects only the columns the policy reads. The ``content`` column is the
+    reason this table is large, and pulling it here to decide what to delete
+    would load the very thing the sweep exists to get rid of.
+    """
+    if not page_ids:
+        return []
+    from sqlalchemy import select
+
+    from repowise.core.persistence.models import PageVersion
+
+    rows: list[dict] = []
+    for start in range(0, len(page_ids), _DELETE_CHUNK):
+        chunk = page_ids[start : start + _DELETE_CHUNK]
+        res = await session.execute(
+            select(
+                PageVersion.id,
+                PageVersion.page_id,
+                PageVersion.version,
+                PageVersion.page_type,
+                PageVersion.source_hash,
+                PageVersion.model_name,
+                PageVersion.provider_name,
+                PageVersion.confidence,
+                PageVersion.archived_at,
+            ).where(PageVersion.repository_id == repo_id, PageVersion.page_id.in_(chunk))
+        )
+        rows.extend(dict(row._mapping) for row in res.all())
+    return rows
+
+
+async def apply_retention_plan(session: Any, repo_id: str, plan: RetentionPlan) -> int:
+    """Delete the versions *plan* named. Returns the number of rows deleted."""
+    if plan.is_empty:
+        return 0
+    from sqlalchemy import delete
+
+    from repowise.core.persistence.models import PageVersion
+
+    deleted = 0
+    ids = plan.delete_ids
+    for start in range(0, len(ids), _DELETE_CHUNK):
+        chunk = ids[start : start + _DELETE_CHUNK]
+        res = await session.execute(
+            delete(PageVersion).where(
+                PageVersion.repository_id == repo_id, PageVersion.id.in_(chunk)
+            )
+        )
+        deleted += int(res.rowcount or 0)
+    logger.info(
+        "page_versions_pruned",
+        repo_id=repo_id,
+        deleted=deleted,
+        examined=plan.examined,
+        kept=plan.kept,
+        pages=len(plan.pages_touched),
+    )
+    return deleted
+
+
+async def prune_page_versions(
+    session: Any,
+    repo_id: str,
+    page_ids: list[str],
+    policy: RetentionPolicy | None = None,
+) -> int:
+    """Load, plan, and apply retention for *page_ids* in one step.
+
+    Best-effort by construction: the caller is always in the middle of a
+    persistence run that has already succeeded, and losing a version sweep is
+    not worth losing an index over.
+    """
+    rows = await load_version_rows(session, repo_id, page_ids)
+    if not rows:
+        return 0
+    plan = plan_version_retention(rows, policy)
+    return await apply_retention_plan(session, repo_id, plan)
+
+
+async def prune_repo_page_versions(
+    session: Any,
+    repo_id: str,
+    policy: RetentionPolicy | None = None,
+) -> int:
+    """Sweep every page in the repo, not just a named set.
+
+    A full index regenerates the whole wiki and archives a version of every
+    page it replaced, which makes it both the moment the table grows fastest
+    and the safe moment to prune: nothing downstream is mid-read.
+    """
+    from sqlalchemy import select
+
+    from repowise.core.persistence.models import Page
+
+    res = await session.execute(select(Page.id).where(Page.repository_id == repo_id))
+    page_ids = [row[0] for row in res.all()]
+    return await prune_page_versions(session, repo_id, page_ids, policy)


### PR DESCRIPTION
Every regeneration of a wiki page archives the copy it replaced into
`wiki_page_versions`. That history is what makes a page auditable: "when did
this claim appear, and which model wrote it" is answerable only because the old
rows are still there. Nothing has ever deleted one, so on a repository indexed
daily the version table becomes the largest object in the store while almost
none of it is reachable.

## What this adds

`retention.py` decides what to drop. It is pure, so the policy can be argued
with in a test rather than against a live store. `retention_store.py` executes
a plan against a session and knows nothing about policy. The split means a
caller can log or diff a plan before anything is deleted, which is the only way
a destructive sweep gets to be reviewed.

`RetentionPolicy` is a set of floors, never caps: a version survives if any
single rule wants it kept, so adding a rule can only ever retain more. The
failure mode of keeping too much is a larger table; the failure mode of keeping
too little is unrecoverable.

## Where it runs

`mark_tombstone_pages` gains an opt-in `prune_versions`. A tombstoned page's
history is the clearest case retention has: the file is gone, so no future
regeneration will diff against those rows. Off by default, because deletion
belongs to the caller that knows the run finished. The incremental update path
sets it, since an update is the one path that knows a file was deleted rather
than merely absent.

`index_repo_full` sweeps the whole repository instead. A full run has just
archived a version of every page it replaced, so it is both when the table
grows fastest and when nothing downstream is mid-read.

Both call sites are best-effort. A failed sweep must not cost the index that
already persisted.

## Notes for review

`plan_version_retention` is the whole policy in one function and it is
genuinely complex. That is the honest shape of "six independent rules, any of
which can veto a delete", but it is worth arguing about: the alternative is six
small predicates and a loop that ors them, which trades the complexity for
indirection.

Neither new module has tests yet.

---

**This PR is a demo artifact for the Repowise PR bot and is not intended to be
merged.** It stays open so its analysis permalink stays live.
