### PR TITLE
fix(generation): a file page drops the sections it cannot fill

### DIFF
--- a/packages/core/src/repowise/core/generation/templates/file_page.j2
+++ b/packages/core/src/repowise/core/generation/templates/file_page.j2
@@ -9,6 +9,14 @@
     symbols, its neighbours' file paths and its layer in full, because those
     are the identifiers a question embeds near. Nobody reads a file page end
     to end, so where readability and retrieval disagree, retrieval wins.
+
+    Every section below the Overview is conditional. A heading with nothing
+    under it costs a reader a stop and puts the same stock sentence into the
+    search index on thousands of pages, where it matches every query and
+    distinguishes none of them. The Overview is the one exception: it is
+    generated rather than looked up, so it always has something to say, and
+    ``_extract_summary`` reads it back as the summary shown in search results
+    and the wiki list.
 -#}
 {%- set public_syms = ctx.symbols | selectattr("visibility", "equalto", "public") | list -%}
 # {{ ctx.file_path }}
@@ -16,35 +24,51 @@
 ## Overview
 
 {% if ctx.docstring %}{{ ctx.docstring | as_markdown }}{% else %}`{{ ctx.file_path }}` is a {{ ctx.language }} {% if ctx.is_entry_point %}entry-point {% endif %}{% if ctx.is_test %}test {% endif %}source file{% if ctx.kg_layer_name %} in the {{ ctx.kg_layer_name }} layer{% endif %}{% if ctx.community_label %}, part of the {{ ctx.community_label }} module cluster{% endif %}.{% endif %}
+{%- if public_syms %}
 
-{% if public_syms %}It exposes {{ public_syms | length }} public symbol{{ "s" if public_syms | length != 1 else "" }}{% if ctx.dependencies %} and depends on {{ ctx.dependencies | length }} other file{{ "s" if ctx.dependencies | length != 1 else "" }}{% endif %}.{% endif %}
+It exposes {{ public_syms | length }} public symbol{{ "s" if public_syms | length != 1 else "" }}{% if ctx.dependencies %} and depends on {{ ctx.dependencies | length }} other file{{ "s" if ctx.dependencies | length != 1 else "" }}{% endif %}.
 
 ## Public API
 
-{% if public_syms %}| Symbol | Kind | Signature |
+| Symbol | Kind | Signature |
 | --- | --- | --- |
-{% for s in public_syms %}| `{{ s.name }}` | {{ s.kind }} | {{ (s.signature or "") | signature | replace("|", "\\|") }} |
-{% endfor %}{% else %}_No public symbols were extracted from this file._
-{% endif %}
-## Depends on
+{%- for s in public_syms %}
+| `{{ s.name }}` | {{ s.kind }} | {{ (s.signature or "") | signature | replace("|", "\\|") }} |
+{%- endfor %}
+{%- endif %}
+{%- if ctx.dependencies %}
 
-{% if ctx.dependencies %}{% for dep in ctx.dependencies[:25] %}- `{{ dep }}`
-{% endfor %}{% if ctx.dependencies | length > 25 %}
+## Depends on
+{% for dep in ctx.dependencies[:25] %}
+- `{{ dep }}`
+{%- endfor %}
+{%- if ctx.dependencies | length > 25 %}
+
 _and {{ ctx.dependencies | length - 25 }} more._
-{% endif %}{% else %}_No internal dependencies resolved._
-{% endif %}
+{%- endif %}
+{%- endif %}
+{%- if ctx.dependents %}
+
 ## Used by
 
-{% if ctx.dependents %}Imported by {{ ctx.dependents | length }} file{{ "s" if ctx.dependents | length != 1 else "" }} in this repository.
+Imported by {{ ctx.dependents | length }} file{{ "s" if ctx.dependents | length != 1 else "" }} in this repository.
+{% for dep in ctx.dependents[:25] %}
+- `{{ dep }}`
+{%- endfor %}
+{%- if ctx.dependents | length > 25 %}
 
-{% for dep in ctx.dependents[:25] %}- `{{ dep }}`
-{% endfor %}{% if ctx.dependents | length > 25 %}
 _and {{ ctx.dependents | length - 25 }} more._
-{% endif %}{% else %}_No internal callers were resolved for this file._
-{% endif %}
-{% if ctx.community_label or ctx.kg_layer_name %}## Usage Notes
+{%- endif %}
+{%- endif %}
+{%- if ctx.community_label or ctx.kg_layer_name %}
 
-{% if ctx.community_label %}Part of the **{{ ctx.community_label }}** module cluster.
-{% endif %}{% if ctx.kg_layer_name %}**Layer:** {{ ctx.kg_layer_name }}{% if ctx.kg_layer_role %} | **Role:** {{ ctx.kg_layer_role }}{% endif %}
-{% endif %}
-{% endif %}{% include "_footer.j2" %}
+## Usage Notes
+{% if ctx.community_label %}
+Part of the **{{ ctx.community_label }}** module cluster.
+{%- endif %}
+{%- if ctx.kg_layer_name %}
+**Layer:** {{ ctx.kg_layer_name }}{% if ctx.kg_layer_role %} | **Role:** {{ ctx.kg_layer_role }}{% endif %}
+{%- endif %}
+{%- endif %}
+
+{% include "_footer.j2" %}

--- a/tests/unit/generation/test_templates.py
+++ b/tests/unit/generation/test_templates.py
@@ -118,6 +118,85 @@ def test_file_page_contains_file_path(jinja_env, file_page_ctx):
     assert file_page_ctx.file_path in result
 
 
+@pytest.fixture(scope="module")
+def bare_file_page_ctx() -> FilePageContext:
+    """A file the graph knows nothing about: no symbols, no edges, no docstring.
+
+    Config files, data files and the unparsed tail of a large repo all land
+    here, so this is not a corner case — it is a large share of the file pages
+    a real wiki contains.
+    """
+    return FilePageContext(
+        file_path="python_pkg/settings.py",
+        language="python",
+        docstring=None,
+        symbols=[],
+        imports=[],
+        exports=[],
+        file_source_snippet="DEBUG = False",
+        pagerank_score=0.0,
+        betweenness_score=0.0,
+        community_id=0,
+        dependents=[],
+        dependencies=[],
+        is_api_contract=False,
+        is_entry_point=False,
+        is_test=False,
+        parse_errors=[],
+        estimated_tokens=10,
+    )
+
+
+def test_file_page_omits_a_section_it_cannot_fill(jinja_env, bare_file_page_ctx):
+    """A heading with nothing under it is worse than no heading.
+
+    An empty section still costs a reader a stop and still puts its words into
+    the search index, where the same four sentences repeated across thousands
+    of pages are noise that matches everything and distinguishes nothing.
+    """
+    result = render(jinja_env, "file_page.j2", bare_file_page_ctx)
+    assert "## Public API" not in result
+    assert "## Depends on" not in result
+    assert "## Used by" not in result
+
+
+def test_file_page_keeps_the_sections_it_can_fill(jinja_env, file_page_ctx):
+    """The other half of the rule: a populated file still renders everything."""
+    result = render(jinja_env, "file_page.j2", file_page_ctx)
+    assert "## Overview" in result
+    assert "## Public API" in result
+    assert "## Depends on" in result
+    assert "## Used by" in result
+
+
+def test_file_page_leaves_no_gap_where_a_section_was_dropped(
+    jinja_env, file_page_ctx, bare_file_page_ctx
+):
+    """Dropping a section must not leave the blank lines that framed it.
+
+    Every section is conditional, so the run of blank lines between two of them
+    depends on which ones rendered. Asserting the invariant here is what stops
+    a later edit from silently reintroducing the gaps.
+    """
+    for ctx in (file_page_ctx, bare_file_page_ctx):
+        result = render(jinja_env, "file_page.j2", ctx)
+        assert "\n\n\n" not in result
+        assert not result.startswith("\n")
+
+
+def test_file_page_always_says_what_the_file_is(jinja_env, bare_file_page_ctx):
+    """Overview stays unconditional — it is generated, so it is never empty.
+
+    It is also what ``_extract_summary`` reads back as the page summary shown
+    in search results and the wiki list, so a file page without it would be a
+    blank row there.
+    """
+    result = render(jinja_env, "file_page.j2", bare_file_page_ctx)
+    assert "## Overview" in result
+    assert bare_file_page_ctx.file_path in result
+    assert "_No " not in result
+
+
 # ---------------------------------------------------------------------------
 # module_page.j2
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Every file page rendered the same five headings whether or not there was anything to put under them. A file with no symbols and no resolved import edges still got `## Public API`, `## Depends on` and `## Used by`, each followed by a stock sentence apologising for being empty:

- `_No public symbols were extracted from this file._`
- `_No internal dependencies resolved._`
- `_No internal callers were resolved for this file._`

Each section below the Overview is now conditional, and those three sentences are deleted.

## Why

Two costs, and the second is the larger one.

A heading with nothing under it costs a reader a stop. But the same three sentences repeated across thousands of file pages also go into the search index, where they match every query and distinguish none of them. Config files, data files and the unparsed tail of a large repo all render in that shape, so this is a large share of the file pages a real wiki contains, not a corner case.

The Overview stays unconditional on purpose. It is generated from the parse rather than looked up, so it always has something to say, and `_extract_summary` reads it back as the page summary shown in search results, the wiki list and `get_context`. Making it conditional would blank that row.

## Page count is unchanged

Which pages exist is decided by selection, not by what a template renders. Nothing here can add or remove a page. Worth stating explicitly because content-length thresholds do exist elsewhere in indexing — `meets_information_floor` returns `True` at its default of `0`, so it is inert, but a run with a non-default floor set will now see these pages as slightly shorter than before.

## Whitespace

The blank lines that framed a dropped section had to go with it, or a page with two of five sections rendered with runs of three and four blank lines. The strip rule is now uniform across the sections rather than depending on which combination happened to render, and `test_file_page_leaves_no_gap_where_a_section_was_dropped` holds it there.

## Tests

Four new tests in `tests/unit/generation/test_templates.py`, on rendered output rather than on template internals, with a new `bare_file_page_ctx` fixture for the no-symbols-no-edges shape:

- `test_file_page_omits_a_section_it_cannot_fill` — the three headings are absent
- `test_file_page_keeps_the_sections_it_can_fill` — a populated file still renders all of them
- `test_file_page_leaves_no_gap_where_a_section_was_dropped` — no run of three newlines, no leading newline
- `test_file_page_always_says_what_the_file_is` — Overview survives, no `_No ` line anywhere

Before this change the first fails with:

```
E   AssertionError: assert '## Public API' not in '# python_pk...n about it.*'
E     '## Public API' is contained here:
E        file.
E       ## Public API...
```

and the fourth with:

```
E   AssertionError: assert '_No ' not in '# python_pk...n about it.*'
E     '_No ' is contained here:
E       blic API
E       _No public symbols were extracted from this file._
```

`tests/unit/generation` and `tests/unit/cli`: 2019 passed. Also rendered the four real page shapes (full, bare, symbols-only, edges-only) plus the >25 truncation and layer/community cases and checked the markdown by eye.

## Reaching existing wikis

`structural_fingerprint` hashes the template source, so this change marks stored file pages stale and `repowise update` re-renders them. No version constant to bump.

## Note for reviewers

One visible consequence outside this diff: `packages/ui/src/docs/reader-persona.ts` hides `## Public API` for the overview persona, and that heading is the only one persona filtering touches on a file page. On a file page with no public symbols there is now no hidden heading, so `personaFilteringApplies()` returns `false` and the reader-level control stops rendering on those pages. Cosmetic, and nothing depends on it, but it is a real change.