### PR TITLE
fix(generation): a symbol spotlight drops the importers section when empty

### DIFF
--- a/packages/core/src/repowise/core/generation/templates/symbol_spotlight.j2
+++ b/packages/core/src/repowise/core/generation/templates/symbol_spotlight.j2
@@ -4,47 +4,53 @@
     the containing module, not verified call sites. The LLM template hedges
     the same way; a template that claimed otherwise would over-state what the
     graph actually knows.
+
+    Every section but the Overview is conditional: a heading with nothing
+    under it costs a reader a stop and repeats a stock sentence across
+    thousands of pages, where it matches every query and distinguishes none.
+
+    The Overview is the exception, and its no-docstring sentence stays even
+    though it reads like a placeholder. It is what ``_extract_summary`` reads
+    back as the page summary, and it names the symbol, its kind and its file —
+    the identifiers this page exists to carry. Deleting it would blank the
+    summary for every undocumented symbol.
 -#}
 # {{ ctx.qualified_name }}
 
 **Kind:** {{ ctx.kind }}{% if ctx.is_async %} (async){% endif %} | **Defined in:** `{{ ctx.file_path }}`{% if ctx.complexity_estimate %} | **Estimated complexity:** {{ ctx.complexity_estimate }}{% endif %}
+{%- if ctx.signature %}
 
-{% if ctx.signature %}
 ```
 {{ ctx.signature }}
 ```
-{% endif %}
+{%- endif %}
 
 ## Overview
 
-{% if ctx.docstring %}{{ ctx.docstring | as_markdown }}
-{% else %}`{{ ctx.symbol_name }}` is {{ "an" if ctx.kind and ctx.kind[0] in "aeiou" else "a" }} {{ ctx.kind or "symbol" }} defined in `{{ ctx.file_path }}`. It carries no docstring.{% endif %}
+{% if ctx.docstring %}{{ ctx.docstring | as_markdown }}{% else %}`{{ ctx.symbol_name }}` is {{ "an" if ctx.kind and ctx.kind[0] in "aeiou" else "a" }} {{ ctx.kind or "symbol" }} defined in `{{ ctx.file_path }}`. It carries no docstring.{% endif %}
+{%- if ctx.decorators %}
 
-{% if ctx.decorators %}
 ## Decorators
 {% for d in ctx.decorators %}
 - `{{ d }}`
-{% endfor %}
-{% endif %}
+{%- endfor %}
+{%- endif %}
+{%- if ctx.callers %}
 
-{% if ctx.callers %}
 ## Where it is used
 
-{{ ctx.callers | length }} file{{ "s" if ctx.callers | length != 1 else "" }} import the module that defines it. These are import-level references, not confirmed call sites.
+{{ ctx.callers | length }} file{{ "s" if ctx.callers | length != 1 else "" }} import{{ "" if ctx.callers | length != 1 else "s" }} the module that defines it. These are import-level references, not confirmed call sites.
 {% for c in ctx.callers %}
 - `{{ c }}`
-{% endfor %}
-{% else %}
-## Where it is used
+{%- endfor %}
+{%- endif %}
+{%- if ctx.source_body %}
 
-No importers of the defining module were resolved.
-{% endif %}
-
-{% if ctx.source_body %}
 ## Implementation
 
 ```
 {{ ctx.source_body }}
 ```
-{% endif %}
+{%- endif %}
+
 {% include "_footer.j2" %}

--- a/tests/unit/generation/test_templates.py
+++ b/tests/unit/generation/test_templates.py
@@ -239,6 +239,78 @@ def test_symbol_spotlight_contains_symbol_name(jinja_env, symbol_spotlight_ctx):
     assert symbol_spotlight_ctx.symbol_name in result
 
 
+@pytest.fixture(scope="module")
+def unimported_spotlight_ctx() -> SymbolSpotlightContext:
+    """A symbol nothing in the repository imports, and with no docstring.
+
+    Both halves matter: the importer list is what the dropped section was
+    reporting on, and the missing docstring is what the Overview has to cover
+    for on its own.
+    """
+    return SymbolSpotlightContext(
+        symbol_name="_normalise",
+        qualified_name="python_pkg.calculator._normalise",
+        kind="function",
+        signature="def _normalise(value: str) -> str:",
+        docstring=None,
+        file_path="python_pkg/calculator.py",
+        decorators=[],
+        is_async=False,
+        complexity_estimate=1,
+        callers=[],
+    )
+
+
+def test_spotlight_omits_the_importers_section_when_nothing_imports_it(
+    jinja_env, unimported_spotlight_ctx
+):
+    """No importers is not a fact worth a heading of its own."""
+    result = render(jinja_env, "symbol_spotlight.j2", unimported_spotlight_ctx)
+    assert "## Where it is used" not in result
+    assert "No importers" not in result
+
+
+def test_spotlight_keeps_the_importers_section_when_it_has_importers(
+    jinja_env, symbol_spotlight_ctx
+):
+    """The other half: a symbol with importers still lists them, still hedged.
+
+    The hedge is load-bearing. ``callers`` holds files importing the defining
+    module, not verified call sites, and the sentence has to keep saying so.
+    """
+    result = render(jinja_env, "symbol_spotlight.j2", symbol_spotlight_ctx)
+    assert "## Where it is used" in result
+    assert "`main.py`" in result
+    assert "not confirmed call sites" in result
+    # The count and its verb have to agree; one importer is the common case.
+    assert "1 file imports the module" in result
+
+
+def test_spotlight_still_describes_a_symbol_that_has_no_docstring(
+    jinja_env, unimported_spotlight_ctx
+):
+    """The Overview sentence stays even though it reads like a placeholder.
+
+    It is the page summary — ``_extract_summary`` skips the metadata line and
+    the signature fence and lands on it — and it names the symbol, its kind and
+    its file, which is the identifier-bearing text the page exists to carry.
+    Deleting it would blank the summary for every undocumented symbol.
+    """
+    result = render(jinja_env, "symbol_spotlight.j2", unimported_spotlight_ctx)
+    assert "## Overview" in result
+    assert "_normalise" in result
+    assert "python_pkg/calculator.py" in result
+
+
+def test_spotlight_leaves_no_gap_where_a_section_was_dropped(
+    jinja_env, symbol_spotlight_ctx, unimported_spotlight_ctx
+):
+    for ctx in (symbol_spotlight_ctx, unimported_spotlight_ctx):
+        result = render(jinja_env, "symbol_spotlight.j2", ctx)
+        assert "\n\n\n" not in result
+        assert not result.startswith("\n")
+
+
 # ---------------------------------------------------------------------------
 # architecture_diagram.j2
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

`## Where it is used` was emitted in **both** branches of its conditional, so a symbol that nothing in the repository imports still rendered the heading, above:

> No importers of the defining module were resolved.

The section is now conditional on there actually being importers, and that sentence is deleted.

## Why

Most symbols in a repository are imported by nothing, so this placeholder was on a large share of spotlight pages. Beyond costing a reader a stop, the identical sentence repeated across thousands of pages goes into the search index, where it matches every query and distinguishes none of them.

## What deliberately stays

The Overview's no-docstring sentence:

> `_normalise` is a function defined in `python_pkg/calculator.py`. It carries no docstring.

This reads like the same kind of placeholder and is not one, for two reasons:

1. It is the **page summary**. `_extract_summary` is called with `skip_metadata=True` for this page type, so it skips the `**Kind:** …` line and the signature fence and lands on exactly this sentence. That summary is what search results, the wiki list and `get_context` display. Deleting it blanks that row for every undocumented symbol.
2. It names the symbol, its kind and its file — the identifier-bearing text the page exists to carry.

So this PR drops one section, not two, and the asymmetry with the file page is intentional.

## Also in this diff

One-word grammar fix in the sentence being made conditional: one importer rendered as *"1 file import the module"*. The count and its verb now agree. Asserted, because it is the common case.

The hedge is untouched and still load-bearing — `ctx.callers` holds files importing the defining module, not verified call sites, and the sentence still says so.

## Tests

Four new tests in `tests/unit/generation/test_templates.py`, on rendered output, with a new `unimported_spotlight_ctx` fixture (no importers, no docstring):

- `test_spotlight_omits_the_importers_section_when_nothing_imports_it`
- `test_spotlight_keeps_the_importers_section_when_it_has_importers` — including the hedge and the count/verb agreement
- `test_spotlight_still_describes_a_symbol_that_has_no_docstring` — the Overview sentence survives
- `test_spotlight_leaves_no_gap_where_a_section_was_dropped`

Before this change the first fails with:

```
E   AssertionError: assert '## Where it is used' not in '# python_pk...n about it.*'
E     '## Where it is used' is contained here:
E       ring.
E       ...
```

`tests/unit/generation` and `tests/unit/cli`: 2019 passed. Also rendered three real page shapes (full with decorators and a body, no-importers-no-docstring, and minimal) and checked the markdown by eye.

## Reaching existing wikis — read before merging

**This change does not reach an existing wiki through `repowise update`, and that is not fixed here.** Three separate reasons, all on `main` today:

1. `pertype.py:115` calls the spotlight renderer without `subject_hash`, so `structural_content_hash` returns `""` and `_structural_page` stamps no `render_key`. Every stored spotlight page has no render key at all, so there is nothing for a new fingerprint to disagree with.
2. The staleness sweep queries `WHERE page_type == 'file_page'` (`update_cmd/deterministic.py:352`).
3. The "already up to date" gate fingerprints `FILE_PAGE_TEMPLATE` alone (`update_cmd/command.py:437-459`), so a run with only this template changed returns before doing anything.

So this lands via `repowise init`, `generate --all` and `restyle`, and not otherwise. A follow-up PR fixes the render key and generalises the sweep; this one is correct on its own and does not depend on it.