### PR TITLE
fix(generation): add the questions block the tests already assert

### DIFF
--- a/packages/core/src/repowise/core/generation/templates/file_page.j2
+++ b/packages/core/src/repowise/core/generation/templates/file_page.j2
@@ -70,5 +70,40 @@ Part of the **{{ ctx.community_label }}** module cluster.
 **Layer:** {{ ctx.kg_layer_name }}{% if ctx.kg_layer_role %} | **Role:** {{ ctx.kg_layer_role }}{% endif %}
 {%- endif %}
 {%- endif %}
+{#- Question-shaped text, built from structure rather than prose.
+
+    Every search query is a question and this page is a declarative reference,
+    so the two share almost no vocabulary. The identifiers are the whole point:
+    thousands of file pages asking the same question differ only in the file
+    and symbol they name, and without those they would be one sentence
+    repeated across the corpus, matching everything and distinguishing nothing.
+
+    A question is emitted only where the page can answer it. A question whose
+    answer is not below it puts the words of a promise into the index and then
+    breaks it, which is the failure this block exists to avoid. Last on the
+    page so it cannot become the summary ``_extract_summary`` reads back.
+
+    Built as a list and capped, because a fully-connected file qualifies for
+    more of them than are worth carrying: past three the block stops being
+    question-shaped text and starts being padding on every page in the corpus.
+-#}
+{%- set questions = [] -%}
+{%- if public_syms -%}
+{%- set _ = questions.append("What does `" ~ ctx.file_path ~ "` export?") -%}
+{%- set _ = questions.append("Where is `" ~ public_syms[0].name ~ "` defined?") -%}
+{%- endif -%}
+{%- if ctx.dependents -%}
+{%- set _ = questions.append("What imports `" ~ ctx.file_path ~ "`?") -%}
+{%- endif -%}
+{%- if ctx.dependencies -%}
+{%- set _ = questions.append("What does `" ~ ctx.file_path ~ "` depend on?") -%}
+{%- endif -%}
+{%- if questions %}
+
+## Questions this page answers
+{% for q in questions[:3] %}
+- {{ q }}
+{%- endfor %}
+{%- endif %}
 
 {% include "_footer.j2" %}

--- a/packages/core/src/repowise/core/generation/templates/symbol_spotlight.j2
+++ b/packages/core/src/repowise/core/generation/templates/symbol_spotlight.j2
@@ -52,5 +52,23 @@
 {{ ctx.source_body }}
 ```
 {%- endif %}
+{#- Question-shaped text, built from structure rather than prose. The file
+    page carries the same block; the identifiers are what make it worth
+    anything, since otherwise it is one sentence repeated across the corpus.
+
+    This context is thinner than the file page's: no layer, no dependents, no
+    dependencies. And ``callers`` holds files importing the defining module,
+    not verified call sites, so "what calls this?" is a question this page
+    cannot honestly ask. Two it can always answer, plus one when there are
+    importers — fewer than the file page, and honest rather than padded.
+#}
+
+## Questions this page answers
+
+- Where is `{{ ctx.symbol_name }}` defined?
+- What is `{{ ctx.qualified_name }}`?
+{%- if ctx.callers %}
+- Which files import the module that defines `{{ ctx.symbol_name }}`?
+{%- endif %}
 
 {% include "_footer.j2" %}


### PR DESCRIPTION
## main is red, and this is the missing half

#1209 landed its tests, its report counter, and **neither of the two templates**. Eight tests on `main` currently assert a block that nothing renders:

```
FAILED test_templates.py::test_file_page_questions_carry_the_real_identifiers
FAILED test_templates.py::test_file_page_asks_at_most_three_questions
FAILED test_templates.py::test_file_page_asks_about_importers_only_when_it_has_them
FAILED test_templates.py::test_spotlight_questions_carry_the_symbol_and_its_file
FAILED test_templates.py::test_spotlight_asks_about_importers_only_when_it_has_them
FAILED test_question_text_reaches_search.py::test_a_file_pages_questions_are_searchable
FAILED test_question_text_reaches_search.py::test_a_spotlights_questions_are_searchable
FAILED test_question_text_reaches_search.py::test_the_block_is_not_what_the_page_summary_reads
```

This PR adds `file_page.j2` and `symbol_spotlight.j2` and nothing else. Everything else from that change is already on `main` and untouched here.

## How it happened

My fault, and worth writing down because the mechanism is not obvious.

Proving the failing-then-passing test meant stashing the two templates, running the suite to capture the failures, then restoring:

```
git stash -- packages/.../templates/
pytest ...                                 # 8 failures, pasted into the PR
git stash pop
git commit
```

**`git stash pop` restores the working tree but not the index.** The templates had been staged before the stash; they came back *unstaged*. `git commit` then took only what was staged — four files where there should have been six.

I verified the commit with `git log`, which shows the message and looks correct, instead of `git diff --stat`, which would have shown the missing files immediately. The PR body I wrote listed six files because that is what I had staged before the stash, not what I committed.

The rebase onto the merged PRs did not catch it either: the templates were still modified in the working tree the whole time, so everything I rendered and every test I ran locally passed against files that were never in the commit.

## What actually caught it

Not CI, and not review. Installing the merged build into the eval venv and checking it before spending a measurement run on it:

```
file_page  questions block: False
file_page  _No placeholder : False      <- #1206 present
spotlight  questions block: False
spotlight  No-importers text: False     <- #1207 present
has SYMBOL_SPOTLIGHT_TEMPLATE: True     <- #1208 present
```

Three of four merges were in the build and the fourth was not. Without that check the measurement would have compared a pre-S3 index against an index built by the same templates, reported "flat", and the conclusion would have been that question-shaped text does not help — from a run where it was never rendered.

## Verification, done properly this time

```
$ git diff --cached --stat
 .../core/generation/templates/file_page.j2         | 35 ++++++++++++++++++++++
 .../core/generation/templates/symbol_spotlight.j2  | 18 +++++++++++
 2 files changed, 53 insertions(+)
```

`tests/unit/generation` + `tests/unit/cli`: **2050 passed** with these two files present, against 8 failures without them.

The rendered output was re-checked by eye on both templates across the full, bare, symbols-only, edges-only, importers and no-importers shapes.