### PR TITLE
feat(generation): a page says how far it can be trusted

### DIFF
--- a/packages/core/src/repowise/core/generation/models.py
+++ b/packages/core/src/repowise/core/generation/models.py
@@ -249,6 +249,33 @@ class GenerationConfig:
 # GeneratedPage
 # ---------------------------------------------------------------------------
 
+# What a page's ``confidence`` says, and why there are exactly three values.
+#
+# The column stood at a constant 1.0 on every page a run produced. A constant
+# cannot gate anything: retrieval could not weight by it, the reader UI's
+# low-confidence banner had never once rendered, and a wiki where a provider
+# outage left hundreds of stubs looked exactly as trustworthy as a complete
+# one. These three values are the distinctions that are actually available at
+# the moment a page is written, and no more than that — a finer scale would be
+# a number with nothing behind it.
+
+#: A page whose only renderer is a template: file pages, symbol spotlights.
+#: Every statement on it came from the parse, the import graph or git history,
+#: and no model saw it. There is nothing on the page to be unsure about.
+TEMPLATE_PAGE_CONFIDENCE = 1.0
+
+#: A page a model wrote from assembled material. It is grounded in that
+#: material and checked against it, but it is a summary of the code rather
+#: than an extraction from it, so it is not the same claim a template page
+#: makes. Above the reader UI's banner threshold: worth reading normally.
+MODEL_PAGE_CONFIDENCE = 0.8
+
+#: The structural stub standing in for a page a model was meant to write —
+#: because the provider call failed, or because no key was configured. It is
+#: real material with the prose missing, which is the one case a reader has to
+#: be told about, so it sits below the banner threshold.
+STUB_PAGE_CONFIDENCE = 0.3
+
 
 @dataclass
 class GeneratedPage:
@@ -269,7 +296,9 @@ class GeneratedPage:
         target_path:      File/module/SCC this page documents.
         created_at:       ISO-8601 UTC timestamp.
         updated_at:       ISO-8601 UTC timestamp.
-        confidence:       Decay score (1.0 = fresh, 0.0 = expired).
+        confidence:       How far this page's statements can be trusted, set
+                          at generation from how the page was written.  See
+                          the three constants below.
         freshness_status: Current freshness state.
         metadata:         Provider-specific or page-type-specific extras.
     """

--- a/packages/core/src/repowise/core/generation/page_generator/core.py
+++ b/packages/core/src/repowise/core/generation/page_generator/core.py
@@ -27,6 +27,7 @@ from repowise.core.providers.llm.base import BaseProvider, CacheHint, GeneratedR
 
 from ..context_assembler import ContextAssembler, FilePageContext
 from ..models import (
+    MODEL_PAGE_CONFIDENCE,
     GeneratedPage,
     GenerationConfig,
     compute_page_id,
@@ -450,6 +451,10 @@ class PageGenerator(PerTypeGenerationMixin, StructuralRenderMixin):
             created_at=now,
             updated_at=now,
             content_hash=content_hash,
+            # A model wrote this from assembled material: grounded in it and
+            # checked against it, but a summary of the code rather than an
+            # extraction from it. Not the claim a template page makes.
+            confidence=MODEL_PAGE_CONFIDENCE,
         )
         # Record the effective style as page provenance (D10). Only for active
         # styles, so default ("comprehensive") pages keep byte-identical metadata.

--- a/packages/core/src/repowise/core/generation/page_generator/structural.py
+++ b/packages/core/src/repowise/core/generation/page_generator/structural.py
@@ -30,7 +30,14 @@ from typing import Any
 
 import structlog
 
-from ..models import GENERATION_LEVELS, GeneratedPage, compute_page_id, compute_source_hash
+from ..models import (
+    GENERATION_LEVELS,
+    STUB_PAGE_CONFIDENCE,
+    TEMPLATE_PAGE_CONFIDENCE,
+    GeneratedPage,
+    compute_page_id,
+    compute_source_hash,
+)
 from .helpers import _extract_summary, _now_iso
 
 log = structlog.get_logger(__name__)
@@ -338,12 +345,18 @@ class StructuralRenderMixin:
         target_path: str,
         title: str,
         template: str,
+        confidence: float = TEMPLATE_PAGE_CONFIDENCE,
         **render_kwargs: Any,
     ) -> GeneratedPage:
         """Render one template page and wrap it as a GeneratedPage.
 
         The mirror of ``_build_generated_page`` for the no-model path: same
         fields, zero tokens, ``provider_name="template"``.
+
+        ``confidence`` is a parameter rather than a constant because the two
+        callers make different claims. A sole renderer's page is everything the
+        page is meant to be; a stub is the same material with the prose
+        missing, and a reader has to be told which one they are looking at.
         """
         content = self._render(template, style_prefix=False, **render_kwargs)
         now = _now_iso()
@@ -363,6 +376,7 @@ class StructuralRenderMixin:
             target_path=target_path,
             created_at=now,
             updated_at=now,
+            confidence=confidence,
         )
 
     def _structural_page(
@@ -417,6 +431,7 @@ class StructuralRenderMixin:
             target_path=target_path,
             title=title,
             template=f"{_STUB_PREFIX}/{template}",
+            confidence=STUB_PAGE_CONFIDENCE,
             **render_kwargs,
         )
 

--- a/packages/ui/__tests__/docs/docs-reader-confidence.test.tsx
+++ b/packages/ui/__tests__/docs/docs-reader-confidence.test.tsx
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { DocsReader } from "../../src/docs/docs-reader.js";
+import type { DocPage } from "@repowise-dev/types/docs";
+
+/**
+ * The low-confidence warning had never rendered for anyone.
+ *
+ * Generation wrote a constant 1.0 into every page's `confidence`, so the
+ * condition guarding this banner could not be true on any real wiki. It was
+ * shipped, styled, and unreachable — and untested, because a test would have
+ * had to construct the value no page ever had.
+ *
+ * Generation now writes three values, and the lowest of them — a structural
+ * stub standing in for a page a model was meant to write — falls under this
+ * threshold. These assert the banner at values on both sides of it.
+ */
+
+const WARNING = /generated with low confidence/i;
+
+// The reader scrolls its pane back to the top on every page change, and jsdom
+// implements no scrolling. Stubbed here rather than in the shared setup: it is
+// this component's requirement, not the suite's.
+beforeAll(() => {
+  Element.prototype.scrollTo = () => {};
+});
+
+function makePage(overrides: Partial<DocPage> = {}): DocPage {
+  return {
+    id: "p1",
+    repository_id: "r1",
+    page_type: "module_page",
+    title: "Resolution Layer",
+    content: "The layer turns references into edges.",
+    target_path: "core/resolvers",
+    source_hash: "h",
+    model_name: "m",
+    provider_name: "template",
+    input_tokens: 0,
+    output_tokens: 0,
+    cached_tokens: 0,
+    generation_level: 3,
+    version: 1,
+    confidence: 1,
+    freshness_status: "fresh",
+    metadata: {},
+    created_at: "2026-08-01T00:00:00Z",
+    updated_at: "2026-08-01T00:00:00Z",
+    ...overrides,
+  } as DocPage;
+}
+
+function renderReader(page: DocPage) {
+  return render(
+    <DocsReader
+      page={page}
+      repoId="r1"
+      persona="contributor"
+      sidebarOpen={false}
+      buildPageHref={(id) => `?page=${id}`}
+      LinkComponent={({ href, children, ...rest }) => (
+        <a href={href} {...rest}>
+          {children}
+        </a>
+      )}
+    />,
+  );
+}
+
+describe("DocsReader low-confidence warning", () => {
+  it("warns on a page written with low confidence", () => {
+    // 0.3 is what generation stamps on a structural stub: real material with
+    // the prose missing, standing in for a page a model never wrote.
+    renderReader(makePage({ confidence: 0.3 }));
+
+    expect(screen.getByText(WARNING)).toBeTruthy();
+  });
+
+  it("stays quiet on a model-written page", () => {
+    // 0.8. A model page is grounded and checked — normal to read, not suspect.
+    renderReader(makePage({ confidence: 0.8 }));
+
+    expect(screen.queryByText(WARNING)).toBeNull();
+  });
+
+  it("stays quiet on a template-rendered page", () => {
+    renderReader(makePage({ confidence: 1 }));
+
+    expect(screen.queryByText(WARNING)).toBeNull();
+  });
+
+  it("stays quiet when confidence is absent rather than low", () => {
+    // Zero is the "nobody measured this" value the column carries before a
+    // page has been through generation. Warning on it would put the flag on
+    // every page of an older wiki, which is the opposite of a trust signal.
+    renderReader(makePage({ confidence: 0 }));
+
+    expect(screen.queryByText(WARNING)).toBeNull();
+  });
+});

--- a/tests/unit/generation/test_page_confidence.py
+++ b/tests/unit/generation/test_page_confidence.py
@@ -1,0 +1,155 @@
+"""A page says how far it can be trusted, and the three answers are different.
+
+``confidence`` stood at a constant 1.0 on every page a run produced. A constant
+column cannot gate anything: retrieval cannot weight by it, the reader's
+low-confidence banner had never once rendered, and — the case that matters — a
+wiki where a provider outage left hundreds of stubs looked exactly as
+trustworthy as a complete one.
+
+Three values, because three distinctions are actually available when a page is
+written:
+
+* a template page is everything the parse, the graph and git history know, with
+  no model in the loop;
+* a model page is grounded in that material and checked against it, but it is a
+  summary of the code rather than an extraction from it;
+* a stub is that same material with the prose missing, standing in for a page a
+  model was meant to write. That is the one a reader has to be warned about, so
+  it is the one that sits below the banner threshold.
+"""
+
+from __future__ import annotations
+
+import networkx as nx
+import pytest
+
+from repowise.core.generation.context_assembler import ContextAssembler
+from repowise.core.generation.models import (
+    MODEL_PAGE_CONFIDENCE,
+    STUB_FALLBACK_ERROR,
+    STUB_PAGE_CONFIDENCE,
+    TEMPLATE_PAGE_CONFIDENCE,
+    GenerationConfig,
+)
+from repowise.core.generation.page_generator import PageGenerator
+from repowise.core.providers.llm.mock import MockProvider
+
+# The reader UI shows its warning below this. Duplicated from the component on
+# purpose: the point of the values above is where they sit relative to it, and
+# a test that imported the threshold would move with it and stop asserting the
+# relationship.
+BANNER_THRESHOLD = 0.5
+
+
+class _OutageProvider(MockProvider):
+    """Fails the way a real provider outage does: every call raises."""
+
+    async def generate(self, *args, **kwargs):
+        raise RuntimeError("upstream 529 overloaded")
+
+
+@pytest.fixture
+def config() -> GenerationConfig:
+    return GenerationConfig(max_tokens=1024, token_budget=2000, max_concurrency=2)
+
+
+@pytest.fixture
+def generator(config) -> PageGenerator:
+    return PageGenerator(MockProvider(), ContextAssembler(config), config)
+
+
+@pytest.fixture
+def outage_generator(config) -> PageGenerator:
+    return PageGenerator(_OutageProvider(), ContextAssembler(config), config)
+
+
+async def test_a_template_page_is_fully_confident(
+    generator, sample_parsed_file, sample_graph, graph_metrics, sample_source_bytes
+):
+    """Nothing on it came from a model, so there is nothing to be unsure about."""
+    page = await generator.generate_file_page(
+        sample_parsed_file,
+        sample_graph,
+        graph_metrics["pagerank"],
+        graph_metrics["betweenness"],
+        graph_metrics["community"],
+        sample_source_bytes,
+    )
+
+    assert page.confidence == TEMPLATE_PAGE_CONFIDENCE
+    assert page.confidence > BANNER_THRESHOLD
+
+
+async def test_a_model_written_page_is_confident_but_not_certain(generator):
+    page = await generator.generate_module_page(
+        "Resolution Layer", "python", [], nx.DiGraph(), target_path="core/resolvers"
+    )
+
+    assert page.confidence == MODEL_PAGE_CONFIDENCE
+    assert page.confidence < TEMPLATE_PAGE_CONFIDENCE
+    # A model page is normal, not suspect: it must not raise the reader's flag.
+    assert page.confidence > BANNER_THRESHOLD
+
+
+async def test_a_page_lost_to_a_provider_outage_says_so(outage_generator):
+    """The failure this exists to make visible.
+
+    The stub is real material with the prose missing. Before this it claimed
+    the same confidence as a page that was actually written, so a wiki with
+    hundreds of them read as complete.
+    """
+    page = await outage_generator.generate_module_page(
+        "Resolution Layer", "python", [], nx.DiGraph(), target_path="core/resolvers"
+    )
+
+    assert page.metadata[STUB_FALLBACK_ERROR]
+    assert page.confidence == STUB_PAGE_CONFIDENCE
+    assert page.confidence < BANNER_THRESHOLD
+
+
+async def test_a_keyless_stub_is_marked_the_same_way(config):
+    """No provider is configured at all, so nothing wrote the prose either."""
+    deterministic = GenerationConfig(
+        max_tokens=1024, token_budget=2000, max_concurrency=2, deterministic=True
+    )
+    generator = PageGenerator(MockProvider(), ContextAssembler(deterministic), deterministic)
+
+    page = await generator.generate_module_page(
+        "Resolution Layer", "python", [], nx.DiGraph(), target_path="core/resolvers"
+    )
+
+    assert page.confidence == STUB_PAGE_CONFIDENCE
+    assert page.confidence < BANNER_THRESHOLD
+
+
+async def test_the_run_produces_more_than_one_value(
+    generator,
+    outage_generator,
+    sample_parsed_file,
+    sample_graph,
+    graph_metrics,
+    sample_source_bytes,
+):
+    """The whole point: a column with a distribution, not a constant.
+
+    Asserted as a set rather than page by page, because the failure being
+    prevented is every page agreeing — which each individual assertion above
+    would still pass under, if they all agreed on the wrong value.
+    """
+    pages = [
+        await generator.generate_file_page(
+            sample_parsed_file,
+            sample_graph,
+            graph_metrics["pagerank"],
+            graph_metrics["betweenness"],
+            graph_metrics["community"],
+            sample_source_bytes,
+        ),
+        await generator.generate_module_page("A", "python", [], nx.DiGraph(), target_path="a"),
+        await outage_generator.generate_module_page(
+            "B", "python", [], nx.DiGraph(), target_path="b"
+        ),
+    ]
+
+    assert len({p.confidence for p in pages}) == 3
+    assert min(p.confidence for p in pages) < BANNER_THRESHOLD


### PR DESCRIPTION
## What was wrong

`confidence` was a constant **1.0 on every page** a run produced — the dataclass default, never written by anything.

A constant column gates nothing. Retrieval cannot weight by it, and the reader's low-confidence banner in `docs-reader.tsx`, which fires below 0.5, **had never once rendered for anyone**. It was shipped, styled, and unreachable.

The case that matters: a wiki where a provider outage left hundreds of structural stubs standing in for pages a model was meant to write looked exactly as trustworthy as a complete one, on every surface.

## Three values

| Value | Page | Why |
|---|---|---|
| **1.0** | template page (file pages, spotlights) | Every statement came from the parse, the import graph or git history. No model saw it. Nothing to be unsure about. |
| **0.8** | model page | Grounded in assembled material and checked against it, but a *summary* of the code rather than an extraction from it. Above the banner threshold — normal to read, not suspect. |
| **0.3** | stub | The same material with the prose missing: the provider call failed, or no key was configured. Below the threshold, so the reader is told. |

No finer scale, because a finer scale would be a number with nothing behind it. These are the distinctions actually available at the moment a page is written.

`_render_page` takes the value as a parameter rather than a constant: its two callers make different claims, and a stub must not inherit the claim a sole renderer makes.

## The banner's first test

Four cases, on both sides of the threshold. Including **confidence 0**, which means "nobody measured this" rather than "this is bad" — warning on it would put the flag on every page of an older wiki, which is the opposite of a trust signal.

## Failing-then-passing

With only the two page builders reverted and the tests in place:

```
FAILED test_page_confidence.py::test_a_model_written_page_is_confident_but_not_certain
FAILED test_page_confidence.py::test_a_page_lost_to_a_provider_outage_says_so
FAILED test_page_confidence.py::test_a_keyless_stub_is_marked_the_same_way
FAILED test_page_confidence.py::test_the_run_produces_more_than_one_value
E   assert 1 == 3
E    +  where 1 = len({1.0})
4 failed, 1 passed
```

`len({1.0}) == 1` is the constant column, stated by the suite.

## Gates

- `tests/unit`: **9377 passed, 6 skipped**
- `packages/ui` vitest: **1035 passed, 143 files**
- `tsc --noEmit`: clean
- `ruff format` / `ruff check`: clean, edited files only