### PR TITLE
fix(ingestion): extract unparenthesized single-parameter arrow functions in JS/TS

### DIFF
--- a/packages/core/src/repowise/core/ingestion/extractors/signatures.py
+++ b/packages/core/src/repowise/core/ingestion/extractors/signatures.py
@@ -68,5 +68,12 @@ def build_signature(node_type: str, name: str, params_text: str, def_node: Node,
         if len(first_line) > 160:
             first_line = first_line[:157] + "..."
         return first_line
+    if node_type == "lexical_declaration":
+        # Arrow function assigned to const/let.
+        # params_text is either "(a, b)" (formal_parameters) or a bare
+        # identifier "x" (unparenthesized single-param arrow: x => ...).
+        if params_text and not params_text.startswith("("):
+            return f"{name}({params_text})"
+        return f"{name}{params_text}"
     # Fallback
     return f"{name}{params_text}"

--- a/packages/core/src/repowise/core/ingestion/queries/javascript.scm
+++ b/packages/core/src/repowise/core/ingestion/queries/javascript.scm
@@ -26,12 +26,22 @@
   parameters: (formal_parameters) @symbol.params
 ) @symbol.def
 
-; Arrow function assigned to const/let
+; Arrow function assigned to const/let (parenthesized)
 (lexical_declaration
   (variable_declarator
     name: (identifier) @symbol.name
     value: (arrow_function
       parameters: (formal_parameters) @symbol.params
+    )
+  )
+) @symbol.def
+
+; Arrow function assigned to const/let (unparenthesized single parameter)
+(lexical_declaration
+  (variable_declarator
+    name: (identifier) @symbol.name
+    value: (arrow_function
+      parameter: (identifier) @symbol.params
     )
   )
 ) @symbol.def

--- a/packages/core/src/repowise/core/ingestion/queries/typescript.scm
+++ b/packages/core/src/repowise/core/ingestion/queries/typescript.scm
@@ -60,6 +60,16 @@
   )
 ) @symbol.def
 
+; Arrow function assigned to const/let (unparenthesized single parameter): const foo = x => { }
+(lexical_declaration
+  (variable_declarator
+    name: (identifier) @symbol.name
+    value: (arrow_function
+      parameter: (identifier) @symbol.params
+    )
+  )
+) @symbol.def
+
 ; Public method accessor modifier capture
 (method_definition
   (accessibility_modifier) @symbol.modifiers

--- a/tests/unit/ingestion/parser/test_typescript.py
+++ b/tests/unit/ingestion/parser/test_typescript.py
@@ -282,6 +282,41 @@ export class Service {
         method_names = {s.name for s in result.symbols if s.kind == "method"}
         assert {"run", "helper"} <= method_names
 
+    def test_unparenthesized_arrow_functions_extracted(self, parser: ASTParser) -> None:
+        # Single-parameter unparenthesized arrow functions (x => x * 2) must be
+        # extracted as function symbols just like parenthesized ones ((x) => x * 2).
+        src = b"""
+export const double = x => x * 2;
+export const identity = (x: number) => x;
+export const square = n => n * n;
+export const add = (a: number, b: number) => a + b;
+const priv = x => x;
+"""
+        fi = _make_file_info("src/math.ts", "typescript")
+        result = parser.parse_file(fi, src)
+        fn_symbols = {s.name: s for s in result.symbols if s.kind == "function"}
+        # All four must be present — no unparenthesized arrow silently dropped.
+        assert {"double", "identity", "square", "add", "priv"} <= set(fn_symbols.keys())
+        # Unparenthesized single param is normalised to name(param) form.
+        assert fn_symbols["double"].signature == "double(x)"
+        # Exported symbols are public; unexported are private.
+        assert fn_symbols["double"].visibility == "public"
+        assert fn_symbols["priv"].visibility == "private"
+
+    def test_unparenthesized_arrow_functions_extracted_javascript(
+        self, parser: ASTParser
+    ) -> None:
+        # javascript.scm was also patched — verify the same fix works for .js files.
+        src = b"""
+export const double = x => x * 2;
+export const add = (a, b) => a + b;
+"""
+        fi = _make_file_info("src/math.js", "javascript")
+        result = parser.parse_file(fi, src)
+        fn_symbols = {s.name: s for s in result.symbols if s.kind == "function"}
+        assert {"double", "add"} <= set(fn_symbols.keys())
+        assert fn_symbols["double"].signature == "double(x)"
+
 
 def test_mts_file_uses_typescript_parser(parser: ASTParser) -> None:
     fi = _make_file_info("src/module.mts", "typescript")


### PR DESCRIPTION
## Summary

- Added Tree-sitter SCM query rules matching `parameter: (identifier)` in `javascript.scm` and `typescript.scm` to prevent single-parameter unparenthesized arrow functions (`x => ...`) from being omitted during AST parsing.
- Added explicit `lexical_declaration` signature handling in `signatures.py` to format unparenthesized arrow signatures cleanly (`double(x)`).
- Added comprehensive unit tests in `test_typescript.py` covering `.ts` and `.js` files, verifying symbol extraction, parameter signatures, and public/private visibility.

## Related Issues

fixes #1214 

## Test Plan

- [x] Tests pass (`pytest`) — Verified via `uv run pytest tests/unit/ingestion/parser/` (148/148 passed cleanly).
- [x] Lint passes (`ruff check .`)
- [ ] Web build passes (`npm run build`) *(N/A - backend ingestion changes only)*

## Checklist

- [x] My code follows the project's code style
- [x] I have added tests for new functionality
- [x] All existing tests still pass
- [ ] I have updated documentation if needed

***