### PR TITLE
docs(readme): cite the 21-repo health validation, drop the PR comment screenshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,9 +180,7 @@ Install the [GitHub App](https://github.com/apps/repowise-bot) and the index sho
 where the decision actually gets made. One comment per pull request, edited in place on
 every push rather than reposted, and **a green PR gets no comment at all**.
 
-<img src=".github/assets/pr-bot/pr-comment.jpg" alt="The Repowise PR bot comment on a real pull request: repository health and change risk, an at-a-glance line, a before-you-merge checklist of missing tests and co-change partners, the symbol-level blast radius listing nine callers outside the PR, and AI versus human authorship of the changed files" width="100%" />
-
-<sub>A real comment on a real PR, not a mockup:
+<sub>See a real comment on a real PR, not a mockup:
 [repowise-dev/repowise#1204](https://github.com/repowise-dev/repowise/pull/1204).</sub>
 
 What decides a review is inline. What is context sits behind one fold, so the comment
@@ -260,6 +258,12 @@ repowise health --trend                # snapshots plus declining-health alerts
 The dashboard renders each plan as a card with a copy-to-agent button. An optional LLM
 step, never in the indexing path and only on request, expands any plan into generated
 code and a unified diff.
+
+<sub>Validated on <strong>21 open-source repos across 9 languages</strong> (2,826 files,
+scored at a fixed point and checked against the following 6 months of bug fixes,
+keyword-labelled): <strong>ROC AUC 0.737</strong> [0.683, 0.787]. The signal is
+correlated with file size and weakens sharply within a fixed size band, which we report
+rather than bury. Independently recomputed from the raw data.</sub>
 
 <sub>Against <strong>CodeScene</strong>, the leading commercial code-health tool, on the
 same 2,770 files and the same defect labels, ranking by repowise health surfaces


### PR DESCRIPTION
The health section proved itself only against CodeScene and the per-repo self-check. It now also carries the cross-language defect-prediction result that already existed but had never been surfaced on the README: **21 open-source repos across 9 languages, 2,826 files, ROC AUC 0.737 [0.683, 0.787]**, scored at a fixed point and checked against the following 6 months of bug fixes.

Two deliberate choices in how it is worded:

- **The size confound sits next to the number, not in a subfolder.** The signal correlates with file size and weakens sharply within a fixed size band. A reader who takes the headline away should take that away with it.
- **The label is named.** The figure is keyword-labelled, which is the default and the weakest of the three labelling strategies available. SZZ labelling moves some per-repo AUCs materially in both directions, so quoting the number without the label would be misleading.

The number was independently recomputed from the raw cached data with a separate implementation before being published here, and reproduced the existing headline to three decimals.

Also drops the PR bot comment screenshot. The link to the live comment on #1204 conveys the same thing, and the analysis-page screenshot that follows it is the one showing what a markdown comment cannot. The asset file is left in place since it may still be used elsewhere.

No other README claims were touched.
