### PR TITLE
feat(health): perf dialects for Kotlin and C++

### DIFF
--- a/docs/architecture/language-support.md
+++ b/docs/architecture/language-support.md
@@ -360,6 +360,26 @@ per-language plugin pattern, registered in a dict exactly like `resolvers/`:
   Java/Go contribute `regex_compile_in_loop`, C# contributes
   `blocking_sync_in_async`, and the Phase-7a loop markers are opt-in per
   dialect. Every method has a safe "no signal" default.
+
+  Three hooks answer questions that recur in every language, so a new dialect
+  reuses them instead of re-deriving them:
+  - `block_loop_body(node)` — the per-iteration body when the language's real
+    iteration idiom is a call taking a block/lambda (Ruby `items.each do … end`,
+    Kotlin `ids.forEach { … }`). The walker then applies every loop rule (body
+    scoping, constant-bound skip, nesting, the same-collection quadratic gate)
+    to it exactly as to a native loop. A lambda returned this way is *not*
+    treated as a deferred scope, so `loop_depth` survives the boundary.
+  - `loop_body(node)` — the per-iteration body of a *native* loop, defaulting to
+    the `body` field. Only tree-sitter-kotlin leaves that field unlabeled; the
+    override is what keeps a sink in a `for (u in repo.findAll())` **header**
+    from reading as a sink inside the loop.
+  - `resets_per_iteration(node, name, loop_kinds)` + `binds_name(node, name)` —
+    the shared answer to the top `string_concat_in_loop` false positive, an
+    accumulator declared fresh each pass (`var s = ""; s += part`) which is
+    bounded per iteration rather than an O(n²) rebuild. The traversal is shared;
+    only the "does this statement bind the name" question is per-grammar. (The
+    Python, Ruby and Dart dialects predate the hook and keep their own tuned
+    versions.)
 - **`analysis/health/dataflow/dialects/`** (`DEFUSE_DIALECTS`), the
   **dataflow** layer (intra-procedural CFG + def/use + reaching definitions,
   powering **Extract Method**). A `DefUseDialect` owns the read-vs-write

--- a/docs/layers/LANGUAGE_SUPPORT.md
+++ b/docs/layers/LANGUAGE_SUPPORT.md
@@ -213,8 +213,8 @@ is "Full" vs "Good".
 | Go | ✅ | n/a¹ | ✅ | ✅ | ✅ |
 | Rust | ✅ | ✅ | ✅ | ✅ | ✅² |
 | C# | ✅ | ✅ | ✅ | later | ✅ |
-| Kotlin | ✅ | ✅ | ✅ | later | later |
-| C++ | ✅ | ✅ | ✅ | later | later |
+| Kotlin | ✅ | ✅ | ✅ | later | ✅¹¹ |
+| C++ | ✅ | ✅ | ✅ | later | ✅¹² |
 | Dart | ✅ | n/a³ | ✅ | later | ✅ |
 | Scala | ✅ | ✅ | ✅⁴ | later | ✅⁵ |
 | Ruby | ✅ | ✅⁶ | ✅⁷ | later | ✅⁸ |
@@ -263,6 +263,41 @@ component reaches them as a TypeScript buffer. Markers therefore cover the
 structure and `<style>` carry no health signal, so a component's markers
 describe its logic, not its template size.
 
+¹¹ Kotlin rides the JVM sink lexicon (JDBC / JPA / Spring-Data interop) plus
+Kotlin-native boundaries (JetBrains Exposed, `File`-only `kotlin.io`
+extensions). **Loops include combinator iteration**: a call with a trailing
+lambda whose method is a full-iteration combinator (`forEach` / `map` /
+`filter` / `fold` …) is a loop scope via the shared `block_loop_body` hook Ruby
+established — scope functions (`let` / `apply` / `run`) and early-exit searches
+(`firstOrNull`) deliberately are not. `suspend` is a modifier *token*, so
+`blocking_sync_in_async` fires on `runBlocking` / `Thread.sleep` inside a
+`suspend fun`. Three deliberate recall ceilings, each set after a false
+positive on a real corpus: bare HTTP verbs are excluded (they are the
+route-registration DSL of every Kotlin web framework), the generic
+`kotlin.io` stream verbs `readText` / `writeText` / `readBytes` / `copyTo` are
+excluded (`kotlinx-io` reuses them on in-memory buffers), and the ambiguous db
+stratum drops `find` / `get` / `count` (they are stdlib collection
+combinators here, unlike in Java). A regex pattern containing a string
+template is not reported, because it is not hoistable.
+
+¹² C++ is deliberately narrow, and omits three markers other languages carry
+because each would be a guaranteed false positive: `string_concat_in_loop`
+(`std::string::operator+=` appends in place into a geometrically-grown buffer —
+amortized O(1), the same reason Rust omits it), `resource_construction_in_loop`
+(a loop-built `std::ifstream` is opened over a per-iteration *path*, and
+`std::thread` in a loop is how a thread pool is built), and
+`blocking_io_under_lock` (an RAII `lock_guard` holds to the end of the
+*enclosing* block, so no node's body is the held region). What remains:
+`io_in_loop` over POSIX / `std::filesystem` / libcurl / sqlite3 / MySQL /
+libpq entry points, `regex_compile_in_loop` on a constant-pattern `std::regex`,
+and `lock_in_loop`. Two ceilings: a C free function classifies only when
+*truly unqualified* (a namespaced call merely sharing a POSIX name — `json::accept`,
+`std::fprintf` — never does), and the socket verbs that double as plausible
+member names (`send` / `recv` / `connect` / `bind` / `listen` / `accept`) are
+excluded, because an implicit-`this` member call is spelled identically. C has
+no `LanguageNodeMap` at all, so it reaches no dialect despite sharing the
+grammar.
+
 ⁹ Shell gets function-level complexity only (CCN / nesting / cognitive / NLOC).
 `&&` / `||` command lists count toward CCN (`cmd || exit 1` is +1), which is
 honest: shell branching is chained command lists. There are no classes,
@@ -285,7 +320,8 @@ where a dialect isn't wired yet. Per-marker mechanics and precision hazards:
 | Dart | Good | Shipped: AST, health control-flow + class facts, perf dialect, Flutter edges. Next: riverpod/get_it dynamic hints, dataflow dialect |
 | Scala | Full (health) | Shipped: complexity/class/assertion markers + perf dialect (JVM lexicon, `.r` recompile, sync-over-Future). Next: dataflow dialect, combinator (`.map`/`.foreach`) loop tracking via the shared `block_loop_body` hook Ruby established |
 | Ruby | Full (health) | Shipped: complexity/class/assertion markers + perf dialect with block-iteration loops (`.each`/`.map` blocks) and the stratified ActiveRecord N+1 lexicon. Next: dataflow dialect, LCOM4 via `@ivar` grouping |
-| Kotlin / C++ | Full (health) | Perf + dataflow dialects pending; everything else shipped |
+| Kotlin | Full (health) | Shipped: complexity/class/assertion markers + perf dialect (JVM lexicon, Exposed, combinator loops via `block_loop_body`, `suspend` sync-in-async). Next: dataflow dialect |
+| C++ | Full (health) | Shipped: complexity/class/assertion markers + perf dialect (POSIX / `std::filesystem` / sqlite3 sinks, constant-pattern `std::regex` recompile, `lock_in_loop`). Next: dataflow dialect |
 | C# | Full (health) | Dataflow dialect pending; perf shipped |
 | Elixir | Good | Lightweight tier shipped; AST upgrade planned (`tree-sitter-elixir` available) |
 | F# | Good | Lightweight tier shipped; AST upgrade planned (`tree-sitter-f-sharp` available) |

--- a/packages/core/src/repowise/core/analysis/health/complexity/languages.py
+++ b/packages/core/src/repowise/core/analysis/health/complexity/languages.py
@@ -445,6 +445,13 @@ _KOTLIN = LanguageNodeMap(
     # ``assertTrue(...)`` are plain calls placed directly in the statement
     # list (no ``expression_statement`` wrapper).
     assert_call_kinds=frozenset({"call_expression"}),
+    # The perf pass. Kotlin has no ``new``: a constructor (``OkHttpClient()``)
+    # is an ordinary ``call_expression`` over a bare ``identifier``, so one kind
+    # covers calls and construction alike. ``suspend`` is a modifier TOKEN, not
+    # a node type, so ``async_function_kinds`` stays empty and
+    # ``KotlinPerfDialect.is_async_fn`` sniffs the modifier instead (the same
+    # posture Rust takes for ``async fn``).
+    call_kinds=frozenset({"call_expression"}),
 )
 
 _DART = LanguageNodeMap(
@@ -512,6 +519,12 @@ _CPP = LanguageNodeMap(
     # ``ASSERT_TRUE`` are ordinary calls (``expect``/``assert`` prefix matched
     # case-insensitively).
     assert_call_kinds=frozenset({"call_expression"}),
+    # The perf pass needs both forms: ``db.execute()`` / ``std::fs::read()``
+    # (``call_expression``) and ``new Client()`` (``new_expression``, which the
+    # grammar does NOT spell as a call). C++ has no ``async``/``await``, so
+    # ``async_function_kinds`` stays empty and ``blocking_sync_in_async`` is
+    # deliberately unimplemented rather than faked onto ``std::async``.
+    call_kinds=frozenset({"call_expression", "new_expression"}),
 )
 
 _CSHARP = LanguageNodeMap(
@@ -676,9 +689,7 @@ _SHELL = LanguageNodeMap(
     branch_kinds=frozenset({"if_statement", "elif_clause"}),
     # `until ...` parses as `while_statement` in tree-sitter-bash, so it is
     # covered here; `for ((;;))` is `c_style_for_statement`.
-    loop_kinds=frozenset(
-        {"for_statement", "c_style_for_statement", "while_statement"}
-    ),
+    loop_kinds=frozenset({"for_statement", "c_style_for_statement", "while_statement"}),
     # No exceptions in shell (`trap` is not `try`).
     try_kinds=frozenset(),
     catch_kinds=frozenset(),

--- a/packages/core/src/repowise/core/analysis/health/complexity/perf_walk.py
+++ b/packages/core/src/repowise/core/analysis/health/complexity/perf_walk.py
@@ -24,6 +24,7 @@ from typing import TYPE_CHECKING
 from ..perf.dialects import PERF_DIALECTS
 from ..perf.dialects.base import BasePerfDialect as BasePerfDialectClass
 from ..perf.io_boundaries import collect_io_names
+from .ast_utils import _dart_signature_sibling, _find_name
 from .languages import LanguageNodeMap
 from .models import PerfFnFacts, PerfHit
 
@@ -113,8 +114,6 @@ def _is_awaited(node: Node) -> bool:
 def _perf_func_name(node: Node) -> str | None:
     if node.type == "function_body":
         # Dart: the name lives on the preceding signature sibling.
-        from .ast_utils import _dart_signature_sibling, _find_name
-
         sig = _dart_signature_sibling(node)
         if sig is not None:
             name = _find_name(sig)
@@ -122,7 +121,11 @@ def _perf_func_name(node: Node) -> str | None:
     nm = node.child_by_field_name("name")
     if nm is not None and nm.text:
         return nm.text.decode("utf-8", "replace")
-    return None
+    # C / C++: the name is nested in a ``declarator`` chain, not a ``name``
+    # field. Reuse the complexity walker's probe rather than re-deriving it —
+    # it already handles that chain (and every other irregular shape).
+    name = _find_name(node)
+    return name if name != "<anonymous>" else None
 
 
 def _enclosing_loop_iterables(
@@ -148,6 +151,33 @@ def _enclosing_loop_iterables(
                 names.add(nm)
         cur = cur.parent
     return names
+
+
+def _is_block_loop_body_scope(
+    node: Node, dialect: BasePerfDialect, call_kinds: frozenset[str]
+) -> bool:
+    """True when *node* is the lambda a block-iteration combinator passes as its
+    per-iteration body (``ids.forEach { … }``).
+
+    Such a lambda is NOT a deferred scope — it runs once per element, right
+    here — so the walker must not reset ``loop_depth`` at its boundary the way
+    it does for a genuinely nested function. Ruby needs no such exemption (its
+    ``do_block`` is deliberately not a lambda kind), but Kotlin's
+    ``lambda_literal`` IS one, and the grammar interposes an ``annotated_lambda``
+    between the call and it — hence the two-hop parent walk.
+    """
+    cur = node
+    for _ in range(2):
+        parent = cur.parent
+        if parent is None:
+            return False
+        if parent.type in call_kinds:
+            body = dialect.block_loop_body(parent)
+            # NB: tree-sitter Node wrappers are not singletons — compare with
+            # ``==`` (identity by tree + byte range), never ``is``.
+            return body is not None and body == cur
+        cur = parent
+    return False
 
 
 def _collect_perf_hits(
@@ -265,8 +295,13 @@ def _collect_perf_hits(
         # Go's ``func(){…}()`` IIFE) does run per-iteration, but we do not detect
         # inline invocation, so those are cleared too — accepted (favouring
         # precision), and the Go IIFE case is the idiomatic defer-in-loop fix.
-        next_loop_depth = 0 if entering_fn else loop_depth
-        next_lock_depth = 0 if entering_fn else lock_depth
+        # …except the lambda a block-iteration combinator passes as its body,
+        # which runs per element rather than later (Kotlin ``ids.forEach { … }``).
+        body_scope = (
+            entering_fn and do_block_loop and _is_block_loop_body_scope(node, dialect, call_kinds)
+        )
+        next_loop_depth = loop_depth if (body_scope or not entering_fn) else 0
+        next_lock_depth = lock_depth if (body_scope or not entering_fn) else 0
         next_func = func_name
         next_start = func_start
         if t in fn_kinds:
@@ -459,7 +494,7 @@ def _collect_perf_hits(
             # iteration loop the body is the dialect-returned block node.
             body = block_loop_body
             if body is None:
-                body = node.child_by_field_name("body")
+                body = dialect.loop_body(node)
             if body is not None:
                 # NB: tree-sitter Node wrappers are not singletons, so compare
                 # with ``==`` (identity by tree + byte range), never ``is``.

--- a/packages/core/src/repowise/core/analysis/health/perf/dialects/__init__.py
+++ b/packages/core/src/repowise/core/analysis/health/perf/dialects/__init__.py
@@ -14,10 +14,12 @@ No edits to the walker. A language absent here ⇒ the perf pass is silent for i
 
 from __future__ import annotations
 
+from . import cpp as _cpp
 from . import csharp as _csharp
 from . import dart as _dart
 from . import go as _go
 from . import java as _java
+from . import kotlin as _kotlin
 from . import python as _python
 from . import ruby as _ruby
 from . import rust as _rust
@@ -43,6 +45,11 @@ _REGISTER: tuple[tuple[str, BasePerfDialect], ...] = (
     ("dart", _dart.DIALECT),
     ("scala", _scala.DIALECT),
     ("ruby", _ruby.DIALECT),
+    ("kotlin", _kotlin.DIALECT),
+    ("cpp", _cpp.DIALECT),
+    # NB: "c" shares the C++ grammar but has no ``LanguageNodeMap`` at all
+    # (``get_language_map("c")`` is ``None``), so the health pass never reaches
+    # a dialect for it. Registering it here would be dead configuration.
 )
 
 for _tag, _dialect in _REGISTER:

--- a/packages/core/src/repowise/core/analysis/health/perf/dialects/base.py
+++ b/packages/core/src/repowise/core/analysis/health/perf/dialects/base.py
@@ -202,6 +202,21 @@ class BasePerfDialect:
         """
         return None
 
+    def loop_body(self, node: Node) -> Node | None:
+        """The per-iteration body of a *native* loop node (the counterpart of
+        :meth:`block_loop_body` for grammars that spell loops as statements).
+
+        Only the body runs per iteration — a ``for x in <iterable>`` header runs
+        once — so the walker raises ``loop_depth`` for exactly this child. The
+        default is the ``body`` field, which every grammar the perf pass serves
+        labels except tree-sitter-kotlin (whose ``for_statement`` /
+        ``while_statement`` block is an unlabeled child). A dialect whose grammar
+        does not label the field overrides this; returning ``None`` keeps the
+        walker's conservative fallback (every child counts as body), so a
+        language that does not override it is byte-for-byte unchanged.
+        """
+        return node.child_by_field_name("body")
+
     def is_iteration_loop(self, node: Node) -> bool:
         """True if this loop iterates a *collection* (a data multiplier), rather
         than spinning a cursor (``while (hasMore)`` / ``for (;;)``).
@@ -250,6 +265,52 @@ class BasePerfDialect:
         if not any(c.type == "+=" for c in node.children):
             return False
         return self._rhs_is_stringish(node)
+
+    def binds_name(self, node: Node, name: bytes) -> bool:
+        """True when *node* is a statement that (re)binds *name* — a fresh local
+        declaration or a plain (non-compound) assignment.
+
+        The one grammar-specific question inside :meth:`resets_per_iteration`;
+        default ``False`` so a dialect that does not override it never claims a
+        reset (and therefore never suppresses a finding).
+        """
+        return False
+
+    def resets_per_iteration(self, node: Node, name: bytes, loop_kinds: frozenset[str]) -> bool:
+        """True when *name* is re-bound inside the body of the loop enclosing
+        *node*, so a ``+=`` onto it accumulates within ONE iteration only.
+
+        The top ``string_concat_in_loop`` false positive in every language
+        surveyed so far: an accumulator declared fresh each pass (``var s = "";
+        s += part; out.append(s)``) is bounded per iteration, not the O(n^2)
+        rebuild the marker means. Traversal lives here — walk out to the nearest
+        enclosing loop (native or block-iteration), then scan its body — and the
+        per-grammar "does this statement bind the name" question is delegated to
+        :meth:`binds_name`.
+
+        NB: the Python, Ruby and Dart dialects each carry an older bespoke
+        version of this guard, predating the hook; they are left as-is rather
+        than retrofitted, since each is tuned against its own validated corpus.
+        """
+        cur = node.parent
+        loop: Node | None = None
+        for _ in range(32):
+            if cur is None:
+                break
+            if cur.type in loop_kinds or self.block_loop_body(cur) is not None:
+                loop = cur
+                break
+            cur = cur.parent
+        if loop is None:
+            return False
+        body = self.block_loop_body(loop) or self.loop_body(loop) or loop
+        stack = [body]
+        while stack:
+            n = stack.pop()
+            if self.binds_name(n, name):
+                return True
+            stack.extend(n.children)
+        return False
 
     def _rhs_is_stringish(self, node: Node) -> bool:
         """True if an augmented-assignment's RHS is provably string-typed.

--- a/packages/core/src/repowise/core/analysis/health/perf/dialects/cpp.py
+++ b/packages/core/src/repowise/core/analysis/health/perf/dialects/cpp.py
@@ -1,0 +1,412 @@
+"""C++ ``PerfDialect``.
+
+Flagship: a ``sqlite3_step`` / ``fopen`` / socket round-trip inside a
+``for (auto& x : xs)`` loop, plus ``std::regex`` construction per iteration —
+building a ``regex`` compiles the pattern into a program and is famously the
+expensive half of using one, so hoisting it is a real, mechanical fix.
+
+This dialect is **deliberately narrow**. It was tuned by hand-verifying every
+finding it produced over leveldb, fmt, Crow, nlohmann-json and abseil-cpp
+(~547k lines), and three markers other languages carry were dropped outright
+because each is a guaranteed false positive in C++ — see :attr:`markers` for
+the reasoning on ``string_concat_in_loop``, ``resource_construction_in_loop``
+and ``blocking_io_under_lock``. C++ has no ``async``/``await`` either, so
+``blocking_sync_in_async`` is absent rather than faked onto ``std::async``.
+
+Grammar seams, verified against the installed tree-sitter-cpp:
+
+* a scoped call (``std::filesystem::remove()``) has a ``qualified_identifier``
+  callee whose leftmost segment is the useless ``std``, so
+  :meth:`callee_root_name` returns the QUALIFIER segment instead
+  (``std::filesystem::remove`` -> ``filesystem``), mirroring the Rust dialect's
+  answer to the same problem;
+* a constructor with arguments in a declaration (``std::regex re(pat);``) is
+  **not** a call node at all — it is a ``declaration`` whose ``type`` field
+  names the constructed type — so it is matched by :meth:`loop_stmt_marker`;
+* ``new Foo()`` is a ``new_expression``, not a ``call_expression``.
+
+Two properties that cap recall (never precision):
+
+* **The C free functions fire only when truly unqualified.** ``root == method``
+  is the test. A namespaced call is someone else's API that merely shares a
+  POSIX name — ``json::accept`` matched the socket verb, ``std::fprintf`` the
+  stdio one. The generic verbs ``read`` / ``write`` are excluded even bare.
+* **No I/O-import evidence.** ``collect_io_names`` keys on import nodes whose
+  type contains "import" (plus a few named forms); a C++ ``#include`` is a
+  ``preproc_include`` and classifies nothing, so ``io_names`` /
+  ``has_db_import`` are always empty here. Every entry in this lexicon is
+  therefore distinctive enough to fire un-gated — there is no ambiguous,
+  evidence-gated stratum for C++ the way there is for Java or Python.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from .base import BasePerfDialect
+
+if TYPE_CHECKING:
+    from tree_sitter import Node
+
+# POSIX filesystem round-trips — unqualified free functions that reach the
+# kernel on every call.
+#
+# The *buffered* stdio family (``fprintf`` / ``fputs`` / ``fgets`` / ``fread`` /
+# ``fwrite`` / ``fscanf``) is deliberately excluded: those write into a FILE*
+# buffer, not to the device, so a loop of them is not N round-trips.
+# Smoke-testing leveldb, ~30 of 39 ``io_in_loop`` hits were
+# ``std::fprintf(stderr, …)`` diagnostics inside benchmark loops — the single
+# largest false-positive class this dialect produced.
+#
+# Bare ``read`` / ``write`` are excluded for the same reason: they are the
+# universal buffer/stream verb in C++ (fmt's own internal ``write(out, sv)``
+# matched), and no qualifier is present to tell POSIX from a local helper.
+# ``pread`` / ``pwrite`` / ``fsync`` carry no such ambiguity. ``fclose`` is
+# excluded as duplicate signal — the paired ``fopen`` already flags the site.
+C_FS_FUNCTIONS: frozenset[str] = frozenset(
+    {
+        "fopen",
+        "freopen",
+        "open",
+        "creat",
+        "pread",
+        "pwrite",
+        "stat",
+        "fstat",
+        "lstat",
+        "opendir",
+        "readdir",
+        "mkdir",
+        "rmdir",
+        "unlink",
+        "truncate",
+        "ftruncate",
+        "fsync",
+        "fdatasync",
+    }
+)
+# ``std::filesystem`` free functions (root is the ``filesystem`` / ``fs``
+# qualifier segment supplied by ``callee_root_name``).
+STD_FILESYSTEM_ROOTS: frozenset[str] = frozenset({"filesystem", "fs"})
+STD_FILESYSTEM_METHODS: frozenset[str] = frozenset(
+    {
+        "exists",
+        "file_size",
+        "remove",
+        "remove_all",
+        "rename",
+        "copy",
+        "copy_file",
+        "create_directory",
+        "create_directories",
+        "directory_iterator",
+        "recursive_directory_iterator",
+        "last_write_time",
+        "resize_file",
+        "space",
+        "status",
+    }
+)
+# BSD sockets — only the spellings that cannot be an implicit-``this`` member
+# call.
+#
+# In C++ a member function called from inside its own class is spelled
+# unqualified, so ``send(pkt)`` / ``connect(addr)`` / ``bind(x)`` / ``listen()``
+# / ``accept()`` / ``recv()`` are indistinguishable from the POSIX free
+# functions without type resolution — seastar's ``ipv4::get_packet`` calls its
+# own ``send(...)`` exactly this way. Those six are therefore excluded; the
+# suffixed forms below are not plausible member names.
+C_NET_FUNCTIONS: frozenset[str] = frozenset(
+    {
+        "socket",
+        "sendto",
+        "sendmsg",
+        "recvfrom",
+        "recvmsg",
+        "getaddrinfo",
+        "gethostbyname",
+        "setsockopt",
+        "getsockopt",
+    }
+)
+# libcurl — the dominant C/C++ HTTP client.
+CURL_FUNCTIONS: frozenset[str] = frozenset({"curl_easy_perform", "curl_easy_setopt"})
+# Subprocess spawning.
+C_SUBPROCESS_FUNCTIONS: frozenset[str] = frozenset(
+    {"system", "popen", "fork", "execl", "execlp", "execle", "execv", "execvp", "execvpe"}
+)
+# Embedded / client database round-trips. Every name carries its library
+# prefix, so none of them can collide with ordinary application code.
+DB_FUNCTIONS: frozenset[str] = frozenset(
+    {
+        "sqlite3_open",
+        "sqlite3_open_v2",
+        "sqlite3_exec",
+        "sqlite3_step",
+        "sqlite3_prepare",
+        "sqlite3_prepare_v2",
+        "sqlite3_get_table",
+        "mysql_query",
+        "mysql_real_query",
+        "mysql_store_result",
+        "mysql_use_result",
+        "mysql_real_connect",
+        "PQexec",
+        "PQexecParams",
+        "PQprepare",
+        "PQconnectdb",
+        "PQgetResult",
+        "leveldb_get",
+        "leveldb_put",
+        "rocksdb_get",
+        "rocksdb_put",
+    }
+)
+
+# A ``std::regex`` built per iteration recompiles the pattern program.
+REGEX_TYPES: frozenset[str] = frozenset({"regex", "wregex", "basic_regex"})
+# ``std::mutex`` scope guards — taking the lock every iteration is contention.
+LOCK_GUARD_TYPES: frozenset[str] = frozenset(
+    {"lock_guard", "unique_lock", "scoped_lock", "shared_lock"}
+)
+LOCK_METHODS: frozenset[str] = frozenset({"lock", "lock_shared"})
+
+_STRING_KINDS: frozenset[str] = frozenset(
+    {"string_literal", "raw_string_literal", "concatenated_string"}
+)
+
+
+def _qualified_segments(call_node: Node) -> list[str] | None:
+    """Segments of a ``qualified_identifier`` callee (``std::filesystem::remove``
+    -> ``['std', 'filesystem', 'remove']``), or ``None`` for a bare / member
+    call. Template arguments are stripped (``std::make_unique<T>`` -> the
+    ``make_unique`` segment)."""
+    fn = call_node.child_by_field_name("function")
+    if fn is None or fn.type != "qualified_identifier" or fn.text is None:
+        return None
+    txt = fn.text.decode("utf-8", "replace").split("<")[0]
+    segs = [s for s in txt.split("::") if s]
+    return segs or None
+
+
+def _declared_type_name(node: Node) -> str | None:
+    """Last segment of a ``declaration``'s type (``std::ifstream f(p);`` ->
+    ``ifstream``, ``std::lock_guard<std::mutex> g(m);`` -> ``lock_guard``)."""
+    ty = node.child_by_field_name("type")
+    if ty is None or ty.text is None:
+        return None
+    return ty.text.decode("utf-8", "replace").split("<")[0].split("::")[-1].strip()
+
+
+def _declaration_has_initializer(node: Node) -> bool:
+    """True if the declaration actually constructs something (``T x(a);`` /
+    ``T x{a};`` / ``T x = f();``) rather than default-declaring (``T x;``).
+
+    A bare ``std::ifstream f;`` opens no file, so it must not fire; the two
+    constructing shapes are an ``init_declarator`` (with a ``value``) and the
+    most-vexing-parse ``function_declarator`` the grammar produces for
+    ``T x(ident);``.
+    """
+    for child in node.named_children:
+        if child.type in ("init_declarator", "function_declarator"):
+            return True
+    return False
+
+
+class CppPerfDialect(BasePerfDialect):
+    language = "cpp"
+    markers = frozenset(
+        {
+            "io_in_loop",
+            "regex_compile_in_loop",
+            "lock_in_loop",
+            "nested_loop_with_io",
+            "nested_loop_quadratic",
+            "hot_path_sync_io",
+            # Three markers are deliberately ABSENT — each would be a
+            # guaranteed-false-positive for this language:
+            #
+            # ``string_concat_in_loop`` — ``std::string::operator+=`` appends in
+            #   place into a geometrically-grown buffer (amortized O(1)); it does
+            #   NOT rebuild an immutable string the way Java/Python/JS ``+=``
+            #   does. Exactly the reasoning that keeps this marker out of the
+            #   Rust dialect. All 29 hits it produced across leveldb / Crow /
+            #   fmt / nlohmann-json were correct, idiomatic append loops.
+            #
+            # ``resource_construction_in_loop`` — the two candidate shapes both
+            #   fail: a loop-constructed ``std::ifstream`` is opened over a
+            #   per-iteration PATH (nothing to hoist), and ``std::thread`` in a
+            #   loop is how you build a thread POOL (abseil's own
+            #   ``thread_pool.h`` was flagged by it). No C++ construction shape
+            #   left where "hoist it out of the loop" is sound advice.
+            #
+            # ``blocking_io_under_lock`` — C++'s lock is RAII-scoped (a
+            #   ``lock_guard`` declaration holds to the end of the ENCLOSING
+            #   block), so no node's body is exactly the held region; see
+            #   :meth:`is_lock_scope`.
+        }
+    )
+
+    # -- callee extraction ----------------------------------------------------
+
+    def callee_root_name(self, call_node: Node) -> str | None:
+        """For a scoped call, the QUALIFIER segment (the one before the called
+        name): ``std::filesystem::remove`` -> ``filesystem``. For member calls
+        (``db.execute()``) and bare calls (``fopen()``) the base extraction — the
+        receiver / function identifier — is already right."""
+        if call_node.type == "new_expression":
+            ty = call_node.child_by_field_name("type")
+            if ty is not None and ty.text:
+                return ty.text.decode("utf-8", "replace").split("<")[0].split("::")[-1]
+            return None
+        segs = _qualified_segments(call_node)
+        if segs is not None and len(segs) >= 2:
+            return segs[-2]
+        return super().callee_root_name(call_node)
+
+    def callee_method_name(self, call_node: Node) -> str | None:
+        if call_node.type == "new_expression":
+            return self.callee_root_name(call_node)
+        segs = _qualified_segments(call_node)
+        if segs is not None:
+            return segs[-1]
+        return super().callee_method_name(call_node)
+
+    def callee_is_attribute(self, call_node: Node) -> bool:
+        if call_node.type == "new_expression":
+            return True
+        return super().callee_is_attribute(call_node)
+
+    # -- lexicon --------------------------------------------------------------
+
+    def sink_kind(
+        self,
+        root: str,
+        method: str,
+        *,
+        awaited: bool,
+        is_attribute: bool,
+        io_names: dict[str, str],
+        has_db_import: bool,
+    ) -> str | None:
+        # Library-prefixed database entry points — distinctive by construction.
+        if method in DB_FUNCTIONS:
+            return "db"
+        if root in STD_FILESYSTEM_ROOTS and method in STD_FILESYSTEM_METHODS:
+            return "filesystem"
+        if method in CURL_FUNCTIONS:
+            return "network"
+        # The C free functions below are only unambiguous when the callee is a
+        # *truly unqualified* identifier. A member call (``buf.write()`` /
+        # ``set.remove()``) is ordinary container vocabulary, and a NAMESPACED
+        # call is someone else's API that merely shares the name — smoke-testing
+        # nlohmann-json produced ``json::accept(…)`` matching the socket verb
+        # ``accept``, and leveldb produced ``std::remove`` / ``std::fprintf``.
+        # Requiring no qualifier at all closes both.
+        # (``root == method`` is exactly the unqualified case: the base
+        # extraction returns a bare call's own name as its root, while a scoped
+        # call's root is the qualifier segment — ``std::fprintf`` -> ``std``.)
+        if is_attribute or root != method:
+            return None
+        if method in C_SUBPROCESS_FUNCTIONS:
+            return "subprocess"
+        if method in C_NET_FUNCTIONS:
+            return "network"
+        if method in C_FS_FUNCTIONS:
+            return "filesystem"
+        return None
+
+    # -- loops ----------------------------------------------------------------
+
+    def is_constant_loop(self, node: Node) -> bool:
+        """``for (int i = 0; i < 8; i++)`` with a literal bound is a compile-time
+        count, not a data-dependent multiplier. A range-for always iterates data,
+        and ``while`` / ``do`` bounds are opaque."""
+        if node.type != "for_statement":
+            return False
+        cond = node.child_by_field_name("condition")
+        if cond is None or cond.type != "binary_expression":
+            return False
+        right = cond.child_by_field_name("right")
+        return right is not None and right.type == "number_literal"
+
+    def is_iteration_loop(self, node: Node) -> bool:
+        """Only a range-for provably multiplies over a collection. A C-style
+        ``for`` may be either a collection walk or a cursor and a ``while`` is a
+        cursor, so neither opens the nested-loop markers (precision-first: this
+        gate only ever suppresses)."""
+        return node.type == "for_range_loop"
+
+    def loop_iterable_name(self, node: Node) -> str | None:
+        """The collection a ``for (auto& x : coll)`` walks — the same-collection
+        ``nested_loop_quadratic`` shape gate."""
+        if node.type != "for_range_loop":
+            return None
+        return self._dotted_path(node.child_by_field_name("right"))
+
+    # -- extra loop markers ---------------------------------------------------
+
+    def loop_call_marker(
+        self, root: str, method: str, node: Node, list_names: frozenset[str]
+    ) -> str | None:
+        # ``std::regex(pat)`` written as an expression / ``new std::regex(pat)``.
+        # Only a literal pattern is unambiguously hoistable — the same gate Go,
+        # Java and Rust use.
+        if method in REGEX_TYPES and self._has_literal_pattern(node):
+            return "regex_compile_in_loop"
+        # ``mu.lock()`` on a receiver (a bare ``lock()`` is not a mutex).
+        if method in LOCK_METHODS and self.callee_is_attribute(node):
+            return "lock_in_loop"
+        return None
+
+    def loop_stmt_marker(self, node: Node, list_names: frozenset[str]) -> str | None:
+        """Constructor-in-declaration markers: ``std::regex re("^x$");`` is a
+        ``declaration``, not a call, so it never reaches the call hooks."""
+        if node.type != "declaration" or not _declaration_has_initializer(node):
+            return None
+        name = _declared_type_name(node)
+        if name is None:
+            return None
+        if name in REGEX_TYPES:
+            return "regex_compile_in_loop" if self._has_literal_pattern(node) else None
+        if name in LOCK_GUARD_TYPES:
+            return "lock_in_loop"
+        return None
+
+    @staticmethod
+    def _has_literal_pattern(node: Node) -> bool:
+        """True when the construction's first argument is a compile-time string
+        literal — ``std::regex re("^x$")`` is hoistable, ``std::regex re(pat)``
+        may legitimately vary per iteration.
+
+        Covers both spellings the grammar produces: an ``argument_list`` (a call
+        or ``new``) and the ``init_declarator``/``function_declarator`` argument
+        list of a declaration.
+        """
+        stack = [node]
+        for _ in range(8):
+            if not stack:
+                return False
+            cur = stack.pop()
+            if cur.type in ("argument_list", "parameter_list", "initializer_list"):
+                first = next((c for c in cur.children if c.is_named), None)
+                return first is not None and first.type in _STRING_KINDS
+            stack.extend(c for c in cur.children if c.is_named)
+        return False
+
+    def is_lock_scope(self, node: Node) -> bool:
+        """A ``std::lock_guard`` / ``unique_lock`` declaration holds the mutex to
+        the end of its enclosing block, so the *block* is the held region.
+
+        The walker raises ``lock_depth`` for a node's block-typed children only;
+        a guard is a sibling statement, not a block-scoped construct with its own
+        body, so there is no node whose body is exactly the held region. Reporting
+        ``False`` keeps ``blocking_io_under_lock`` at its no-signal default for
+        the RAII shape rather than guessing a region — the ceiling here is
+        recall. The explicit ``mu.lock()`` acquire/release pair is out of scope
+        for the same reason it is in every other dialect.
+        """
+        return False
+
+
+DIALECT = CppPerfDialect()

--- a/packages/core/src/repowise/core/analysis/health/perf/dialects/kotlin.py
+++ b/packages/core/src/repowise/core/analysis/health/perf/dialects/kotlin.py
@@ -1,0 +1,539 @@
+"""Kotlin ``PerfDialect``.
+
+Rides the JVM lexicon: Kotlin call sites hit ``java.*`` / Spring / JDBC interop
+verbatim, so the Java dialect's sink tables are imported as the base (the same
+posture Scala takes) and extended with the Kotlin-native boundaries —
+``kotlin.io``'s ``File`` extension functions, JetBrains Exposed, and Ktor's
+client verbs.
+
+Flagship: a Spring-Data / Exposed query inside ``ids.forEach { … }``. Idiomatic
+Kotlin iterates through *combinators taking a trailing lambda*, not ``for``
+nodes, so this dialect implements the shared :meth:`block_loop_body` hook Ruby
+introduced rather than re-deriving the question — a ``call_expression`` whose
+method is a known full-iteration combinator AND that carries an
+``annotated_lambda`` is a loop whose body is that lambda.
+
+Coroutines: ``suspend`` is a **modifier token text** (``modifiers`` ->
+``function_modifier``), not a node type, so ``async_function_kinds`` stays empty
+and :meth:`is_async_fn` sniffs the modifier — the case
+``BasePerfDialect.is_async_fn``'s docstring names. Inside a ``suspend fun``,
+``runBlocking`` and ``Thread.sleep`` stall the dispatcher thread.
+
+Grammar seams (verified against the installed tree-sitter-kotlin, not assumed):
+
+* a ``call_expression`` has **no ``function`` field** — the callee is its first
+  named child (an ``identifier`` for a bare call, a ``navigation_expression``
+  for ``a.b()``), so all three callee hooks are overridden;
+* a ``navigation_expression`` labels **no** ``object`` / ``field`` field either;
+  receiver and member are positional (first / last named child);
+* ``for_statement`` / ``while_statement`` label **no ``body`` field** — the
+  block is an unlabeled child — so :meth:`loop_body` supplies it, which is what
+  keeps ``for (u in repo.findAll())`` from reading as a sink *inside* the loop;
+* ``x = …`` and ``x += …`` are both an ``assignment`` node told apart by the
+  ``operator`` field (as in Java / Go), so the base ``+=`` predicate applies.
+
+Kotlin has no ``new``: ``OkHttpClient()`` is an ordinary ``call_expression``
+over a bare ``identifier``, so constructor sinks are matched by *type name*
+against the same deliberately-small Java table (a bare ``HttpClient`` stays
+excluded — it collides with user wrappers).
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+from .base import BasePerfDialect
+from .java import (
+    _SPRING_DERIVED,
+    AMBIGUOUS_DB,
+    FILES_METHODS,
+    FS_CONSTRUCTORS,
+    JAVA_LOCK_METHODS,
+    JAVA_RESOURCE_CTORS,
+    JAVA_RESOURCE_METHODS,
+    JDBC_METHODS,
+    JPA_METHODS,
+    NET_CONSTRUCTORS,
+    REST_TEMPLATE_METHODS,
+    SPRING_REPO_METHODS,
+)
+
+if TYPE_CHECKING:
+    from tree_sitter import Node
+
+# Full-iteration combinators (the shared block-iteration definition — see
+# ``BasePerfDialect.block_loop_body``). Early-exit searches (``find`` /
+# ``firstOrNull`` / ``any`` / ``all`` / ``none``) are deliberately absent: they
+# may stop after one element, so calling their lambda a per-iteration body would
+# overclaim. ``let`` / ``apply`` / ``also`` / ``run`` / ``with`` are scope
+# functions that run their lambda EXACTLY ONCE and must never be loops.
+ITERATION_LAMBDA_METHODS: frozenset[str] = frozenset(
+    {
+        "forEach",
+        "forEachIndexed",
+        "onEach",
+        "onEachIndexed",
+        "map",
+        "mapNotNull",
+        "mapIndexed",
+        "mapIndexedNotNull",
+        "flatMap",
+        "associate",
+        "associateBy",
+        "associateWith",
+        "filter",
+        "filterNot",
+        "filterIndexed",
+        "filterIsInstance",
+        "partition",
+        "groupBy",
+        "sortedBy",
+        "sortedByDescending",
+        "sumOf",
+        "maxByOrNull",
+        "minByOrNull",
+        "count",
+        "fold",
+        "reduce",
+        "repeat",
+    }
+)
+# ``repeat(n) { … }`` iterates a count, not a collection.
+_COUNTING_LAMBDA_METHODS: frozenset[str] = frozenset({"repeat"})
+
+# ``kotlin.io`` ``File`` extension functions — restricted to the names that
+# ONLY a ``File`` carries.
+#
+# The generic stream verbs (``readText`` / ``writeText`` / ``readBytes`` /
+# ``writeBytes`` / ``copyTo`` / ``bufferedReader`` / ``bufferedWriter``) were
+# tried here and removed: ``kotlinx-io`` and Ktor deliberately mirror those
+# names on IN-MEMORY buffers (``frame.readText()`` on a WebSocket frame,
+# ``packet.copyTo(channel)``), and no static evidence separates the two
+# receivers. They produced ~20 false positives across ktor — by far this
+# dialect's largest FP class — against a handful of genuine ``File`` reads.
+# The names below have no buffer homonym: they are file-tree or line-oriented
+# operations that only exist on ``java.io.File``.
+KOTLIN_IO_FS_METHODS: frozenset[str] = frozenset(
+    {
+        "appendText",
+        "appendBytes",
+        "readLines",
+        "forEachLine",
+        "useLines",
+        "printWriter",
+        "copyRecursively",
+        "deleteRecursively",
+        "walkTopDown",
+        "walkBottomUp",
+    }
+)
+# JetBrains Exposed — the distinctive stratum only. ``select`` / ``insert`` /
+# ``update`` / ``delete`` collide head-on with collection and builder verbs and
+# are left to the evidence-gated ``AMBIGUOUS_DB`` stratum.
+EXPOSED_DB_METHODS: frozenset[str] = frozenset(
+    {
+        "selectAll",
+        "deleteWhere",
+        "deleteAll",
+        "insertAndGetId",
+        "insertIgnore",
+        "batchInsert",
+        "upsert",
+        "updateReturning",
+    }
+)
+# Ktor client round-trip finishers. The generic HTTP verbs (``get`` / ``post``
+# / ``put`` / ``delete``) are deliberately NOT here: on the JVM they are also
+# the *route-registration* DSL of every Kotlin web framework
+# (``app.routes.get("/x") { … }`` in Javalin, ``get("/x") { … }`` in Ktor
+# server), and a member call cannot be told from a client round-trip
+# statically. Smoke-testing javalin produced 3/3 false positives from exactly
+# that collision, so the verb stratum was dropped: a Ktor client call is caught
+# only through the finishers below. Recall ceiling, not a precision one.
+KOTLIN_NET_METHODS: frozenset[str] = frozenset({"bodyAsText", "bodyAsChannel", "submitForm"})
+
+# ``Regex("…")`` / ``"…".toRegex()`` / ``Pattern.compile("…")`` — a fresh
+# compiled pattern per iteration instead of a hoisted ``val``.
+_REGEX_CTOR_NAMES: frozenset[str] = frozenset({"Regex", "Pattern"})
+
+# Executor-blocking calls inside a ``suspend fun``. ``runBlocking`` re-enters a
+# blocking event loop on a coroutine dispatcher thread (the canonical Kotlin
+# deadlock shape); ``Thread.sleep`` stalls it (use ``delay``). ``.get()`` on a
+# future is deliberately absent — ``get`` is the Map/List accessor and would
+# false-fire on every ``map.get(k)``.
+_BLOCKING_BARE: frozenset[str] = frozenset({"runBlocking"})
+
+# A Kotlin string template placeholder: an unescaped ``$`` introducing either
+# ``{expr}`` or a bare identifier. Distinguishes an interpolated pattern (not
+# hoistable) from a constant one, including a trailing regex ``$`` anchor.
+_TEMPLATE_RE = re.compile(r"(?<!\\)\$[A-Za-z_{]")
+
+# The ambiguous-DB stratum, narrowed for Kotlin. ``find`` / ``get`` / ``count``
+# are removed from the shared Java set because they are *stdlib collection*
+# combinators here (``Iterable.find`` / ``List.get`` / ``Iterable.count``) with
+# no Java equivalent — smoke-testing Exposed, ``StatementType.entries.find { }``
+# (an in-memory enum lookup in a JDBC-importing file) was the only false
+# positive this stratum produced. ``execute`` / ``save`` have no collection
+# homonym and stay.
+KOTLIN_AMBIGUOUS_DB: frozenset[str] = AMBIGUOUS_DB - frozenset({"find", "get", "count"})
+
+_STRING_KINDS: frozenset[str] = frozenset({"string_literal"})
+# Mirrors ``_KOTLIN.loop_kinds``; declared here so the reset-per-iteration walk
+# needs no lmap threading (the same posture the dataflow dialects take).
+_LOOP_KINDS: frozenset[str] = frozenset({"for_statement", "while_statement", "do_while_statement"})
+# Held-lock regions: ``synchronized(x) { … }`` is a bare stdlib call,
+# ``lock.withLock { … }`` the java.util.concurrent extension.
+_LOCK_SCOPE_METHODS: frozenset[str] = frozenset({"synchronized", "withLock"})
+
+
+def _decode(node: Node | None) -> str | None:
+    if node is None or node.text is None:
+        return None
+    return node.text.decode("utf-8", "replace")
+
+
+def _callee(call_node: Node) -> Node | None:
+    """The callee of a ``call_expression`` — its first named child (the grammar
+    labels no ``function`` field)."""
+    return next((c for c in call_node.children if c.is_named), None)
+
+
+class KotlinPerfDialect(BasePerfDialect):
+    language = "kotlin"
+    markers = frozenset(
+        {
+            "io_in_loop",
+            "string_concat_in_loop",
+            "regex_compile_in_loop",
+            "resource_construction_in_loop",
+            "lock_in_loop",
+            "blocking_sync_in_async",
+            "nested_loop_with_io",
+            "nested_loop_quadratic",
+            "hot_path_sync_io",
+            "blocking_io_under_lock",
+        }
+    )
+
+    string_literal_kinds = _STRING_KINDS
+    aug_assign_kinds = frozenset({"assignment"})
+
+    # -- callee extraction (no ``function`` field; positional navigation) ------
+
+    def callee_method_name(self, call_node: Node) -> str | None:
+        fn = _callee(call_node)
+        if fn is None:
+            return None
+        if fn.type == "navigation_expression":
+            # The member is the LAST named child (the grammar labels no field);
+            # scan backwards so the common two-child case stops immediately.
+            for c in reversed(fn.children):
+                if c.is_named:
+                    return _decode(c)
+            return None
+        if fn.type == "identifier":
+            return _decode(fn)
+        return None
+
+    def callee_root_name(self, call_node: Node) -> str | None:
+        node = _callee(call_node)
+        # Walk to the bottom of a ``a.b().c()`` chain — the leftmost receiver is
+        # the lexicon key (``Files`` / ``Pattern`` / a Spring repository name).
+        # ``next(...)`` rather than a list comprehension: this runs on every call
+        # node in the file, and only the first named child is ever needed.
+        for _ in range(8):
+            if node is None or node.type == "identifier":
+                break
+            node = next((c for c in node.children if c.is_named), None)
+        return _decode(node)
+
+    def callee_is_attribute(self, call_node: Node) -> bool:
+        fn = _callee(call_node)
+        return fn is not None and fn.type == "navigation_expression"
+
+    # -- lexicon --------------------------------------------------------------
+
+    def sink_kind(
+        self,
+        root: str,
+        method: str,
+        *,
+        awaited: bool,
+        is_attribute: bool,
+        io_names: dict[str, str],
+        has_db_import: bool,
+    ) -> str | None:
+        root_kind = io_names.get(root)
+        db_ev = has_db_import or root_kind == "db"
+        net_ev = root_kind == "network" or "network" in io_names.values()
+
+        # JVM interop — verbatim from the Java lexicon.
+        if method in FS_CONSTRUCTORS:
+            return "filesystem"
+        if method in NET_CONSTRUCTORS:
+            return "network"
+        if method in JDBC_METHODS or method in JPA_METHODS or method in SPRING_REPO_METHODS:
+            return "db"
+        # A Spring-Data derived query is called on a repository INSTANCE, so the
+        # receiver is lower-cased. Requiring that excludes the static-factory
+        # collisions the bare ``…By[A-Z]`` pattern otherwise picks up —
+        # ``InetAddress.getByName(host)`` matched it in ktor.
+        if _SPRING_DERIVED.match(method) and is_attribute and root[:1].islower():
+            return "db"
+        if method in REST_TEMPLATE_METHODS:
+            return "network"
+        if root == "Files" and method in FILES_METHODS:
+            return "filesystem"
+        if root == "Runtime" and method == "exec":
+            return "subprocess"
+
+        # Kotlin-native boundaries.
+        if is_attribute and method in KOTLIN_IO_FS_METHODS:
+            return "filesystem"
+        if is_attribute and method in EXPOSED_DB_METHODS:
+            return "db"
+        if is_attribute and net_ev and method in KOTLIN_NET_METHODS:
+            return "network"
+        if is_attribute and db_ev and method in KOTLIN_AMBIGUOUS_DB:
+            return "db"
+        return None
+
+    # -- loops ----------------------------------------------------------------
+
+    def loop_body(self, node: Node) -> Node | None:
+        """The ``block`` of a ``for`` / ``while`` / ``do-while``.
+
+        tree-sitter-kotlin labels no ``body`` field, so without this the loop
+        HEADER would count as per-iteration and ``for (u in repo.findAll())``
+        would read as an ``io_in_loop``. A braceless single-statement body
+        (``for (x in xs) f(x)``) has no ``block`` node; returning ``None`` there
+        keeps the walker's conservative every-child fallback, which is correct
+        for that shape (the body is a sibling of the header, and a header sink
+        in a braceless loop is a recall-only miss).
+        """
+        return next((c for c in node.children if c.type == "block"), None)
+
+    @staticmethod
+    def _for_iterable(node: Node) -> Node | None:
+        """The iterated expression of ``for (x in <iterable>) …`` — the named
+        child after the binder ``variable_declaration``."""
+        named = [c for c in node.children if c.is_named]
+        return named[1] if len(named) >= 2 else None
+
+    def block_loop_body(self, node: Node) -> Node | None:
+        if node.type != "call_expression":
+            return None
+        lam = next((c for c in node.children if c.type == "annotated_lambda"), None)
+        if lam is None:
+            return None
+        return lam if self.callee_method_name(node) in ITERATION_LAMBDA_METHODS else None
+
+    def is_constant_loop(self, node: Node) -> bool:
+        """``for (i in 0..9)`` / ``for (i in 0 until 8)`` — a literal range is a
+        compile-time bound, not a data-dependent multiplier. ``repeat(3) { … }``
+        is the combinator spelling of the same thing."""
+        if node.type == "for_statement":
+            it = self._for_iterable(node)
+            if it is None:
+                return False
+            if it.type == "range_expression":
+                return all(c.type == "number_literal" for c in it.children if c.is_named)
+            # ``0 until 8`` / ``8 downTo 0`` are INFIX CALLS, not range nodes:
+            # an ``infix_expression`` whose three named children are
+            # ``<literal> <identifier> <literal>`` (the operator is an ordinary
+            # named identifier, not a token — verified against the grammar).
+            if it.type == "infix_expression":
+                named = [c for c in it.children if c.is_named]
+                return (
+                    len(named) == 3
+                    and named[1].type == "identifier"
+                    and named[1].text in (b"until", b"downTo")
+                    and named[0].type == "number_literal"
+                    and named[2].type == "number_literal"
+                )
+            return False
+        if node.type == "call_expression" and self.callee_method_name(node) == "repeat":
+            args = next((c for c in node.children if c.type == "value_arguments"), None)
+            if args is None:
+                return False
+            first = next((c for c in args.children if c.is_named), None)
+            inner = next((c for c in first.children if c.is_named), None) if first else None
+            return inner is not None and inner.type == "number_literal"
+        return False
+
+    def is_iteration_loop(self, node: Node) -> bool:
+        # ``while`` / ``do-while`` spin a cursor (pagination / retry); ``for``
+        # and the collection combinators multiply over data.
+        if node.type == "for_statement":
+            return True
+        if node.type == "call_expression":
+            return self.callee_method_name(node) not in _COUNTING_LAMBDA_METHODS
+        return False
+
+    def loop_iterable_name(self, node: Node) -> str | None:
+        if node.type == "for_statement":
+            return self._dotted_path(self._for_iterable(node))
+        if node.type == "call_expression":
+            if self.callee_method_name(node) in _COUNTING_LAMBDA_METHODS:
+                return None
+            fn = _callee(node)
+            if fn is None or fn.type != "navigation_expression":
+                return None
+            named = [c for c in fn.children if c.is_named]
+            return self._dotted_path(named[0]) if named else None
+        return None
+
+    # -- string concat --------------------------------------------------------
+
+    def is_string_concat(self, node: Node) -> bool:
+        """``acc += "<lit>"`` where ``acc`` is a same-file ``var`` initialised to
+        a string literal.
+
+        The var-binding gate is load-bearing, exactly as in Scala: Kotlin's
+        ``+=`` also appends to a mutable collection (``items += "x"`` on a
+        ``MutableList<String>`` is amortized O(1)) and ``sb += "x"`` on a
+        ``StringBuilder`` is ``append``. Requiring a provable
+        ``var <name> = "<string>"`` binding keeps those from firing.
+        ``StringBuilder.append(…)`` is a call, so it can never reach here.
+        """
+        if not super().is_string_concat(node):
+            return False
+        left = node.child_by_field_name("left")
+        if left is None or left.type != "identifier" or left.text is None:
+            return False  # opaque / member target — not provably a String
+        if not self._is_string_var(node, left.text):
+            return False
+        # ``var s = "<…>"`` declared INSIDE the loop is reset every pass, so the
+        # accumulation is bounded per iteration (the ``continue`` HTML-token
+        # builder — 3/3 of this marker's smoke findings were this shape).
+        return not self.resets_per_iteration(node, left.text, _LOOP_KINDS)
+
+    def binds_name(self, node: Node, name: bytes) -> bool:
+        if node.type == "property_declaration":
+            binder = next((c for c in node.children if c.is_named), None)
+            return (
+                binder is not None and binder.type == "variable_declaration" and binder.text == name
+            )
+        if node.type == "assignment":
+            op = node.child_by_field_name("operator")
+            left = node.child_by_field_name("left")
+            return op is not None and op.text == b"=" and left is not None and left.text == name
+        return False
+
+    @staticmethod
+    def _is_string_var(node: Node, name: bytes) -> bool:
+        """True when the file carries ``var <name> = "<string literal>"``.
+
+        Only ``var`` counts: a ``val`` cannot be the target of ``+=`` at all
+        (the compiler rejects it), so a ``val`` match would mean the name was
+        rebound and the binding we found is a different one.
+        """
+        root = node
+        while root.parent is not None:
+            root = root.parent
+        stack = [root]
+        while stack:
+            cur = stack.pop()
+            if cur.type == "property_declaration" and any(c.type == "var" for c in cur.children):
+                named = [c for c in cur.children if c.is_named]
+                binder = named[0] if named else None
+                value = named[1] if len(named) >= 2 else None
+                if (
+                    binder is not None
+                    and binder.type == "variable_declaration"
+                    and binder.text == name
+                    and value is not None
+                    and value.type in _STRING_KINDS
+                ):
+                    return True
+            stack.extend(cur.children)
+        return False
+
+    # -- coroutines -----------------------------------------------------------
+
+    def is_async_fn(self, node: Node) -> bool:
+        """``suspend fun`` — the marker is a ``function_modifier`` token TEXT
+        inside a ``modifiers`` child, not a node type."""
+        mods = next((c for c in node.children if c.type == "modifiers"), None)
+        if mods is None:
+            return False
+        return any(c.text == b"suspend" for c in mods.children)
+
+    def blocking_sync_api(self, root: str, method: str) -> str | None:
+        if method in _BLOCKING_BARE:
+            return method
+        if root == "Thread" and method == "sleep":
+            return "Thread.sleep"
+        return None
+
+    # -- extra loop markers ---------------------------------------------------
+
+    def loop_call_marker(
+        self, root: str, method: str, node: Node, list_names: frozenset[str]
+    ) -> str | None:
+        # ``Regex("^…$")`` / ``Pattern.compile("^…$")`` / ``"^…$".toRegex()``
+        # recompiled per iteration. Only a literal pattern is unambiguously
+        # hoistable (a dynamic one may legitimately vary) — the same gate Rust,
+        # Go and Java use.
+        if (method in _REGEX_CTOR_NAMES and root in _REGEX_CTOR_NAMES) or method == "compile":
+            if root in _REGEX_CTOR_NAMES and self._has_literal_first_arg(node):
+                return "regex_compile_in_loop"
+            return None
+        if method == "toRegex":
+            fn = _callee(node)
+            recv = (
+                next((c for c in fn.children if c.is_named), None)
+                if fn is not None and fn.type == "navigation_expression"
+                else None
+            )
+            return (
+                "regex_compile_in_loop" if recv is not None and recv.type in _STRING_KINDS else None
+            )
+        # Heavy clients to hoist, not rebuild per iteration. Kotlin has no
+        # ``new``, so a constructor is a bare call whose method IS the type name.
+        if method in JAVA_RESOURCE_CTORS and not self.callee_is_attribute(node):
+            return "resource_construction_in_loop"
+        if method in JAVA_RESOURCE_METHODS:
+            return "resource_construction_in_loop"
+        # ``lock.lock()`` / ``lock.withLock { … }`` / ``synchronized(x) { … }``
+        # taken every iteration is a contention site.
+        if method in JAVA_LOCK_METHODS and self.callee_is_attribute(node):
+            return "lock_in_loop"
+        if method in _LOCK_SCOPE_METHODS:
+            return "lock_in_loop"
+        return None
+
+    @staticmethod
+    def _has_literal_first_arg(node: Node) -> bool:
+        """True when the call's first argument is a *constant* string literal.
+
+        A Kotlin string template (``Regex("\\\\b$name\\\\b")``) is a
+        ``string_literal`` too, but its value changes every iteration, so it is
+        not hoistable and must not fire — Exposed's ``DescriptionGenerator``
+        builds exactly that shape inside a ``.map``. The grammar only emits an
+        ``interpolation`` node for the ``${…}`` form (a bare ``$name`` splits
+        into plain ``string_content``), so the text is tested instead, which
+        also keeps a trailing regex anchor (``"^literal$"``) constant.
+        """
+        args = next((c for c in node.children if c.type == "value_arguments"), None)
+        if args is None:
+            return False
+        first = next((c for c in args.children if c.is_named), None)
+        if first is None:
+            return False
+        inner = next((c for c in first.children if c.is_named), None)
+        if inner is None or inner.type not in _STRING_KINDS or inner.text is None:
+            return False
+        return not _TEMPLATE_RE.search(inner.text.decode("utf-8", "replace"))
+
+    def is_lock_scope(self, node: Node) -> bool:
+        # ``synchronized(x) { … }`` / ``lock.withLock { … }`` — the trailing
+        # lambda is the held region (the walker raises lock_depth for block-
+        # typed children only, which excludes the lock-object argument).
+        if node.type != "call_expression":
+            return False
+        return self.callee_method_name(node) in _LOCK_SCOPE_METHODS
+
+
+DIALECT = KotlinPerfDialect()

--- a/tests/unit/health/test_perf_dialects.py
+++ b/tests/unit/health/test_perf_dialects.py
@@ -559,9 +559,7 @@ _DART_CASES = [
         "immutable-string += accumulation in a loop is O(n^2)",
     ),
     (
-        "void f(List<int> xs) {\n"
-        "  for (final x in xs) { final d = Dio(); }\n"
-        "}\n",
+        "void f(List<int> xs) {\n  for (final x in xs) { final d = Dio(); }\n}\n",
         [("resource_construction_in_loop", "")],
         "a Dio client constructed per-iteration",
     ),
@@ -665,9 +663,7 @@ _SCALA_CASES = [
         "generic .send with NO network import is gated out",
     ),
     (
-        "object A { def m(paths: List[String]): Unit = {\n"
-        "  for (p <- paths) { os.read(p) }\n"
-        "} }\n",
+        "object A { def m(paths: List[String]): Unit = {\n  for (p <- paths) { os.read(p) }\n} }\n",
         [("io_in_loop", "filesystem")],
         "os-lib os.read is method-gated (no import needed)",
     ),
@@ -699,7 +695,7 @@ _SCALA_CASES = [
         "  acc\n"
         "} }\n",
         [("string_concat_in_loop", "")],
-        "`acc = acc + \"lit\"` reassignment form on a string var",
+        '`acc = acc + "lit"` reassignment form on a string var',
     ),
 ]
 
@@ -783,8 +779,7 @@ _RUBY_CASES = [
         "bare get (Sinatra route DSL shape) is not a network sink",
     ),
     (
-        'require "faraday"\n'
-        "def m(conn, urls)\n  urls.each do |u|\n    conn.get(u)\n  end\nend\n",
+        'require "faraday"\ndef m(conn, urls)\n  urls.each do |u|\n    conn.get(u)\n  end\nend\n',
         [("io_in_loop", "network")],
         "instance client verb WITH a network require",
     ),
@@ -799,7 +794,7 @@ _RUBY_CASES = [
         "loop do ... end is an unconditional-repeat loop scope",
     ),
     (
-        "def m\n  3.times do\n    File.read(\"x\")\n  end\nend\n",
+        'def m\n  3.times do\n    File.read("x")\n  end\nend\n',
         [],
         "literal-receiver .times is a constant-bound loop",
     ),
@@ -846,5 +841,346 @@ def test_ruby_same_collection_nested_block_loops_fact():
         "end\n"
     )
     fc = walk_file("t.rb", "ruby", src.encode())
+    assert any(f.nested_loop_line for f in fc.perf_fn_facts)
+    assert not any(h.kind == "nested_loop_quadratic" for h in fc.perf_hits)
+
+
+# ---------------------------------------------------------------------------
+# Kotlin
+# ---------------------------------------------------------------------------
+
+_KOTLIN_CASES = [
+    (
+        "fun m(ids: List<Long>) {\n    for (id in ids) {\n        repo.findById(id)\n    }\n}\n",
+        [("io_in_loop", "db")],
+        "Spring-Data derived query in a native for loop",
+    ),
+    (
+        "fun m(ids: List<Long>) {\n    ids.forEach { repo.findById(it) }\n}\n",
+        [("io_in_loop", "db")],
+        "the combinator form is a loop scope (block_loop_body)",
+    ),
+    (
+        "fun m(ids: List<Long>) {\n    ids.map { repo.findById(it) }\n}\n",
+        [("io_in_loop", "db")],
+        "map with a trailing lambda is full iteration",
+    ),
+    (
+        "fun m(x: Foo) {\n    x.let { repo.findById(1) }\n    x.apply { repo.findById(2) }\n}\n",
+        [],
+        "let/apply are scope functions that run once, never loops",
+    ),
+    (
+        "fun m(ids: List<Long>) {\n    ids.firstOrNull { repo.findById(it) != null }\n}\n",
+        [],
+        "an early-exit search is not a full-iteration loop",
+    ),
+    (
+        "fun m() {\n    for (u in repo.findAll()) {\n        use(u)\n    }\n}\n",
+        [],
+        "the loop HEADER runs once - loop_body scoping (grammar has no body field)",
+    ),
+    (
+        "fun m(paths: List<String>) {\n"
+        "    for (p in paths) {\n        File(p).forEachLine { use(it) }\n    }\n}\n",
+        [("io_in_loop", "filesystem")],
+        "File-exclusive kotlin.io extension functions fire ungated",
+    ),
+    (
+        "fun m(frames: List<Frame>) {\n    for (f in frames) {\n        f.readText()\n    }\n}\n",
+        [],
+        "generic stream verbs are reused by kotlinx-io on in-memory buffers",
+    ),
+    (
+        "fun m(hosts: List<String>) {\n"
+        "    for (h in hosts) {\n        InetAddress.getByName(h)\n    }\n}\n",
+        [],
+        "a static factory is not a derived query despite matching ...By[A-Z]",
+    ),
+    (
+        "fun m(ids: List<Long>, userRepository: Repo) {\n"
+        "    for (id in ids) {\n        userRepository.findByEmail(id)\n    }\n}\n",
+        [("io_in_loop", "db")],
+        "a derived query on a repository instance still classifies",
+    ),
+    (
+        "fun m(xs: List<String>) {\n"
+        '    for (x in xs) {\n        val r = Regex("\\\\b$x\\\\b")\n    }\n}\n',
+        [],
+        "an interpolated pattern varies per iteration - not hoistable",
+    ),
+    (
+        'fun m() {\n    for (i in 0..9) {\n        File("x").forEachLine { use(it) }\n    }\n}\n',
+        [],
+        "a literal range is a constant-bound loop",
+    ),
+    (
+        "fun m() {\n"
+        '    for (i in 0 until 8) {\n        File("x").forEachLine { use(it) }\n    }\n}\n',
+        [],
+        "0 until 8 is an infix call, not a range node, but still constant",
+    ),
+    (
+        "fun m() {\n"
+        '    for (i in 8 downTo 0) {\n        File("x").forEachLine { use(it) }\n    }\n}\n',
+        [],
+        "downTo is the descending spelling of the same constant bound",
+    ),
+    (
+        "fun m(n: Int) {\n"
+        '    for (i in 0 until n) {\n        File("x").forEachLine { use(it) }\n    }\n}\n',
+        [("io_in_loop", "filesystem")],
+        "a variable upper bound is data-dependent, not constant",
+    ),
+    (
+        'fun m() {\n    repeat(3) {\n        File("x").readText()\n    }\n}\n',
+        [],
+        "repeat(<literal>) is the combinator spelling of a constant bound",
+    ),
+    (
+        'fun m(app: Javalin, sizes: List<Int>) {\n    sizes.forEach { s -> app.routes.get("/x") }\n}\n',
+        [],
+        "a bare HTTP verb is the route-registration DSL, not a client call",
+    ),
+    (
+        'fun m(xs: List<String>) {\n    var acc = ""\n    for (x in xs) {\n        acc += "a"\n    }\n}\n',
+        [("string_concat_in_loop", "")],
+        "+= onto a same-file string var accumulates across iterations",
+    ),
+    (
+        "fun m(xs: List<String>) {\n    val out = mutableListOf<String>()\n"
+        '    for (x in xs) {\n        out += "a"\n    }\n}\n',
+        [],
+        "+= onto a MutableList is an amortized append, not a rebuild",
+    ),
+    (
+        'fun m(xs: List<String>) {\n    for (x in xs) {\n        var part = ""\n'
+        '        part += "a"\n        use(part)\n    }\n}\n',
+        [],
+        "an accumulator declared inside the loop is reset every iteration",
+    ),
+    (
+        'fun m(xs: List<String>) {\n    for (x in xs) {\n        val r = Regex("^a")\n    }\n}\n',
+        [("regex_compile_in_loop", "")],
+        "Regex(literal) recompiled per iteration",
+    ),
+    (
+        "fun m(xs: List<String>, pat: String) {\n"
+        "    for (x in xs) {\n        val r = Regex(pat)\n    }\n}\n",
+        [],
+        "a dynamic pattern may legitimately vary - not hoistable",
+    ),
+    (
+        "fun m(xs: List<String>) {\n    for (x in xs) {\n        lock.lock()\n    }\n}\n",
+        [("lock_in_loop", "")],
+        "a lock taken every iteration is a contention site",
+    ),
+]
+
+
+@pytest.mark.parametrize("src,expected,note", _KOTLIN_CASES, ids=[c[2] for c in _KOTLIN_CASES])
+def test_kotlin_cases(src, expected, note):
+    assert _hits("kotlin", src) == sorted(expected), note
+
+
+def test_kotlin_suspend_is_async_via_modifier_token():
+    # ``suspend`` is a ``function_modifier`` TOKEN, not a node type - the case
+    # ``BasePerfDialect.is_async_fn`` documents.
+    src = "suspend fun m() {\n    Thread.sleep(10)\n    runBlocking { g() }\n}\n"
+    assert _hits("kotlin", src) == [
+        ("blocking_sync_in_async", "Thread.sleep"),
+        ("blocking_sync_in_async", "runBlocking"),
+    ]
+
+
+def test_kotlin_blocking_calls_outside_suspend_are_silent():
+    src = "fun m() {\n    Thread.sleep(10)\n    runBlocking { g() }\n}\n"
+    assert _hits("kotlin", src) == []
+
+
+def test_kotlin_combinator_receiver_runs_once():
+    # Only the lambda is per-iteration; the receiver chain runs once.
+    src = "fun m() {\n    repo.findAll().forEach { use(it) }\n}\n"
+    assert _hits("kotlin", src) == []
+
+
+def test_kotlin_deferred_lambda_in_loop_is_not_per_iteration():
+    # A lambda that is NOT an iteration combinator's body opens a new execution
+    # scope: it is merely DEFINED per iteration, so loop_depth resets there.
+    src = (
+        "fun m(ids: List<Long>) {\n"
+        "    for (id in ids) {\n"
+        "        register { repo.findById(id) }\n"
+        "    }\n"
+        "}\n"
+    )
+    assert _hits("kotlin", src) == []
+
+
+def test_kotlin_same_collection_nested_combinators_fact():
+    src = "fun m(xs: List<Long>) {\n    xs.forEach { a -> xs.forEach { b -> combine(a, b) } }\n}\n"
+    fc = walk_file("t.kt", "kotlin", src.encode())
+    assert any(f.nested_loop_line for f in fc.perf_fn_facts)
+    assert not any(h.kind == "nested_loop_quadratic" for h in fc.perf_hits)
+
+
+# ---------------------------------------------------------------------------
+# C++
+# ---------------------------------------------------------------------------
+
+_CPP_CASES = [
+    (
+        "void m(std::vector<int> v) {\n"
+        "    for (auto x : v) {\n        sqlite3_step(stmt);\n    }\n}\n",
+        [("io_in_loop", "db")],
+        "a library-prefixed db round-trip in a range-for",
+    ),
+    (
+        "void m(std::vector<int> v) {\n"
+        '    for (auto x : v) {\n        fopen("a.txt", "r");\n    }\n}\n',
+        [("io_in_loop", "filesystem")],
+        "an unqualified POSIX open in a loop",
+    ),
+    (
+        "void m(std::vector<int> v) {\n"
+        '    for (auto x : v) {\n        std::fprintf(stderr, "%d", x);\n    }\n}\n',
+        [],
+        "buffered stdio is not a round-trip, and std:: is a qualifier",
+    ),
+    (
+        "void m(std::vector<int> v) {\n"
+        "    for (auto x : v) {\n        json::accept(x);\n    }\n}\n",
+        [],
+        "a namespaced call merely sharing a POSIX name never classifies",
+    ),
+    (
+        "void m(std::vector<int> v) {\n"
+        "    for (auto x : v) {\n        buf.read();\n        set.remove(x);\n    }\n}\n",
+        [],
+        "member calls are container vocabulary, not I/O",
+    ),
+    (
+        "void m(std::vector<int> v) {\n"
+        "    for (auto x : v) {\n        std::filesystem::remove(p);\n    }\n}\n",
+        [("io_in_loop", "filesystem")],
+        "std::filesystem free functions key off the qualifier segment",
+    ),
+    (
+        "void m(std::vector<int> v) {\n"
+        '    for (auto x : v) {\n        std::regex re("^a");\n    }\n}\n',
+        [("regex_compile_in_loop", "")],
+        "a regex declaration recompiles the pattern every iteration",
+    ),
+    (
+        "void m(std::vector<int> v, std::string pat) {\n"
+        "    for (auto x : v) {\n        std::regex re(pat);\n    }\n}\n",
+        [],
+        "a dynamic pattern is not provably hoistable",
+    ),
+    (
+        "void m(std::vector<int> v) {\n"
+        "    for (auto x : v) {\n        std::ifstream in(paths[x]);\n    }\n}\n",
+        [],
+        "a stream over a per-iteration path has nothing to hoist",
+    ),
+    (
+        "void m(std::vector<int> v) {\n"
+        "    for (auto x : v) {\n        threads.push_back(std::thread(work));\n    }\n}\n",
+        [],
+        "constructing threads in a loop is how a pool is built",
+    ),
+    (
+        "void m(std::vector<int> v) {\n    std::string s;\n"
+        '    for (auto x : v) {\n        s += "a";\n    }\n}\n',
+        [],
+        "std::string += appends in place - amortized O(1), never a rebuild",
+    ),
+    (
+        "void m(std::vector<int> v) {\n"
+        "    for (auto x : v) {\n"
+        "        auto* p = new Widget();\n"
+        "        auto q = std::make_unique<Widget>();\n"
+        "    }\n}\n",
+        [],
+        "allocation in a loop is ordinary C++",
+    ),
+    (
+        'void m() {\n    for (int i = 0; i < 8; i++) {\n        fopen("a.txt", "r");\n    }\n}\n',
+        [],
+        "a literal C-style bound is a constant loop",
+    ),
+    (
+        "void m(std::vector<int> v) {\n"
+        "    for (auto x : v) {\n        std::lock_guard<std::mutex> g(mu);\n    }\n}\n",
+        [("lock_in_loop", "")],
+        "an RAII guard taken every iteration is a contention site",
+    ),
+    (
+        "void m(std::vector<int> v) {\n    for (auto x : v) {\n        mu.lock();\n    }\n}\n",
+        [("lock_in_loop", "")],
+        "the explicit acquire form of the same site",
+    ),
+    (
+        "void m() {\n    for (auto x : load_all()) {\n        use(x);\n    }\n}\n",
+        [],
+        "the range-for header runs once",
+    ),
+]
+
+
+@pytest.mark.parametrize("src,expected,note", _CPP_CASES, ids=[c[2] for c in _CPP_CASES])
+def test_cpp_cases(src, expected, note):
+    assert _hits("cpp", src) == sorted(expected), note
+
+
+def test_cpp_implicit_this_socket_verbs_do_not_classify():
+    # In C++ a member call from inside its own class is spelled unqualified, so
+    # ``send(pkt)`` is indistinguishable from POSIX ``send`` (seastar's
+    # ``ipv4::get_packet`` does exactly this).
+    src = (
+        "void m(std::vector<int> v) {\n"
+        "    for (auto x : v) {\n"
+        "        send(a, b, c);\n"
+        "        connect(addr);\n"
+        "    }\n"
+        "}\n"
+    )
+    assert _hits("cpp", src) == []
+
+
+def test_cpp_suffixed_socket_verbs_still_classify():
+    src = (
+        "void m(std::vector<int> v) {\n"
+        "    for (auto x : v) {\n"
+        "        ::sendmsg(fd, &msg, 0);\n"
+        "    }\n"
+        "}\n"
+    )
+    assert _hits("cpp", src) == [("io_in_loop", "network")]
+
+
+def test_cpp_function_name_resolves_through_the_declarator_chain():
+    src = (
+        "void outer(std::vector<int> v) {\n"
+        "    for (auto x : v) {\n"
+        "        sqlite3_step(stmt);\n"
+        "    }\n"
+        "}\n"
+    )
+    fc = walk_file("t.cpp", "cpp", src.encode())
+    assert [h.function for h in fc.perf_hits] == ["outer"]
+
+
+def test_cpp_same_collection_nested_range_for_fact():
+    src = (
+        "void m(std::vector<int> v) {\n"
+        "    for (auto a : v) {\n"
+        "        for (auto b : v) {\n"
+        "            combine(a, b);\n"
+        "        }\n"
+        "    }\n"
+        "}\n"
+    )
+    fc = walk_file("t.cpp", "cpp", src.encode())
     assert any(f.nested_loop_line for f in fc.perf_fn_facts)
     assert not any(h.kind == "nested_loop_quadratic" for h in fc.perf_hits)


### PR DESCRIPTION
Kotlin and C++ already had complexity, class and assertion markers. Neither had
a perf dialect, so the performance pass was silent for both. This adds one for
each.

## Kotlin

Rides the JVM sink lexicon (JDBC / JPA / Spring-Data interop) the way Scala
does, extended with JetBrains Exposed and the `File`-only `kotlin.io`
extensions.

It implements the shared `block_loop_body` hook Ruby introduced rather than
re-deriving the question, so `ids.forEach { repo.findById(it) }` is a loop
whose body is the lambda. Scope functions (`let` / `apply` / `run`) and
early-exit searches (`firstOrNull`) deliberately are not loops.

`suspend` is a modifier token rather than a node type, so `is_async_fn` sniffs
the modifier and `runBlocking` / `Thread.sleep` inside a `suspend fun` fire
`blocking_sync_in_async`.

## C++

Deliberately narrow. Three markers other languages carry are omitted because
each would be a guaranteed false positive here:

| Marker | Why it is absent |
|---|---|
| `string_concat_in_loop` | `std::string::operator+=` appends in place into a geometrically grown buffer (amortized O(1)). It does not rebuild an immutable string the way Java/Python/JS `+=` does. Same reasoning that keeps it out of the Rust dialect. |
| `resource_construction_in_loop` | Both candidate shapes fail. A loop-built `std::ifstream` is opened over a per-iteration *path*, so there is nothing to hoist; `std::thread` in a loop is how a thread pool is built (abseil's own `thread_pool.h` was flagged by it). |
| `blocking_io_under_lock` | An RAII `lock_guard` holds to the end of the *enclosing* block, so no node's body is exactly the held region. |

What ships: `io_in_loop` over POSIX / `std::filesystem` / libcurl / sqlite3 /
MySQL / libpq, `regex_compile_in_loop` on a constant-pattern `std::regex`, and
`lock_in_loop`.

C++ has no `async`/`await`, so `blocking_sync_in_async` is absent rather than
faked onto `std::async`.

## Shared hooks, not duplicated logic

Three additions to the dialect contract rather than three copies:

- **`loop_body(node)`**, defaulting to the `body` field. Only
  tree-sitter-kotlin leaves that field unlabeled, and the override is what
  keeps a sink in a `for (u in repo.findAll())` **header** from reading as a
  sink inside the loop.
- **`resets_per_iteration()` + `binds_name()`**, the shared answer to the top
  `string_concat_in_loop` false positive: an accumulator declared fresh each
  pass is bounded per iteration, not an O(n²) rebuild. Python, Ruby and Dart
  keep their older corpus-tuned versions rather than being retrofitted.
- The walker no longer resets `loop_depth` at the lambda a block-iteration
  combinator passes as its body. That lambda runs per element, not later.
  Bounded to a two-hop parent walk, so an unrelated nested lambda still resets
  (a stack flag would leak into one).

`_perf_func_name` now falls back to `ast_utils._find_name`, so a C++ function
name resolves through its declarator chain instead of coming back `None`.

## Validation

Every finding hand-verified across 8 repos, roughly 1.19M lines: javalin,
continue, Exposed, ktor (Kotlin) and leveldb, fmt, Crow, nlohmann-json,
abseil-cpp, seastar, pybind11 (C++).

**62 findings, 62 true positives.**

| Corpus | Findings |
|---|---|
| Exposed | 16 `io_in_loop` (Exposed queries and `File.appendText` in loops), 1 `blocking_sync_in_async` (`Thread.sleep` in a `suspend fun`) |
| ktor | 7 `io_in_loop`, 4 `lock_in_loop`, 2 `regex_compile_in_loop` |
| javalin, continue | 0 |
| leveldb | 7 `io_in_loop` (`sqlite3_step` / `sqlite3_exec` in benchmark loops) |
| seastar | 7 `io_in_loop`, 2 `nested_loop_with_io`, 1 `lock_in_loop` |
| abseil-cpp | 11 `lock_in_loop` |
| nlohmann-json | 2 `io_in_loop`, 2 `lock_in_loop` |
| fmt | 1 `io_in_loop` |
| Crow, pybind11 | 0 and 2 `lock_in_loop` |

Every lexicon narrowing below was forced by a real false positive on that
corpus, not by taste:

- **Kotlin bare HTTP verbs dropped.** They are the route-registration DSL of
  every Kotlin web framework. javalin gave 3/3 false positives from
  `app.routes.get("/x")`.
- **Kotlin generic stream verbs dropped** (`readText` / `writeText` /
  `readBytes` / `copyTo`). `kotlinx-io` mirrors them on in-memory buffers, so
  `frame.readText()` on a WebSocket frame matched. ~20 false positives on ktor,
  the largest single class.
- **Kotlin ambiguous db stratum drops `find` / `get` / `count`.** They are
  stdlib collection combinators here, unlike Java (`StatementType.entries.find
  { }` in Exposed).
- **Kotlin regex patterns containing a string template are not reported**, as
  they vary per iteration and cannot be hoisted.
- **Spring-derived queries now require a lower-cased receiver**, so
  `InetAddress.getByName` stops matching `...By[A-Z]`.
- **C++ free functions must be truly unqualified.** `json::accept` matched the
  socket verb and `std::fprintf` the stdio one.
- **C++ buffered stdio dropped** (a FILE\* write is not a round-trip; ~30 of
  leveldb's 39 original hits were `std::fprintf(stderr, …)` diagnostics) and
  **bare `read` / `write` dropped** (fmt's own internal `write(out, sv)`
  matched).
- **C++ socket verbs that double as plausible member names dropped**
  (`send` / `recv` / `connect` / `bind` / `listen` / `accept`). An
  implicit-`this` member call is spelled identically to the POSIX free
  function, which is how seastar's `ipv4::send` matched.

C is registered nowhere. It shares the C++ grammar but has no
`LanguageNodeMap`, so the health pass never reaches a dialect for it.

## Node-type surprises worth recording

- Kotlin `call_expression` has **no `function` field**; the callee is the first
  named child. `navigation_expression` labels no `object` / `field` either.
- Kotlin `for_statement` / `while_statement` label **no `body` field**.
- `0 until 8` is an **`infix_expression` whose operator is a named `identifier`
  child**, not a `binary_expression`. Getting this wrong silently disabled
  constant-loop suppression for the most common Kotlin count loop.
- Kotlin bare `$name` interpolation does not produce an `interpolation` node
  (only `${…}` does), so template detection is textual.
- C++ `std::ifstream f(path);` is a `declaration`, not a call. `new Foo()` is a
  `new_expression`, not a `call_expression`.

## Cost

The dialects add ~23% (C++) and ~28% (Kotlin) to the complexity+perf walk,
against ~17-26% for Java's shipped dialect on the same measurement. No hot spot
introduced.

41 new unit tests. Full unit and health suites green.
