### PR TITLE
fix(docker): copy monorepo workspace packages to resolve internal dep…

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,12 +13,15 @@ FROM node:20-alpine AS frontend-builder
 
 WORKDIR /app
 
-# Install dependencies first (cached layer)
-COPY packages/web/package.json packages/web/package-lock.json* ./
+# Copy root manifest/lockfile and all packages for monorepo resolution
+COPY package.json package-lock.json* ./
+COPY packages/ ./packages/
+
+# Change directory to web package and install dependencies
+WORKDIR /app/packages/web
 RUN npm install --production=false
 
-# Copy source and build
-COPY packages/web/ ./
+# Build Next.js frontend
 ENV NEXT_TELEMETRY_DISABLED=1
 ENV NEXT_PUBLIC_REPOWISE_API_URL=http://localhost:7337
 RUN npm run build
@@ -48,9 +51,9 @@ COPY packages/server/ packages/server/
 RUN pip install --no-cache-dir ".[all]"
 
 # Copy built Next.js standalone output
-COPY --from=frontend-builder /app/.next/standalone /app/web
-COPY --from=frontend-builder /app/.next/static /app/web/.next/static
-COPY --from=frontend-builder /app/public /app/web/public
+COPY --from=frontend-builder /app/packages/web/.next/standalone /app/web
+COPY --from=frontend-builder /app/packages/web/.next/static /app/web/.next/static
+COPY --from=frontend-builder /app/packages/web/public /app/web/public
 
 # Data volume for .repowise directory
 VOLUME /data


### PR DESCRIPTION
## Summary

- Resolves Docker build failure during the frontend build phase by copying all monorepo workspace package manifests before `npm install`.
- Ensures internal dependency `@repowise-dev/api-client` is properly found and linked in the build environment.

## Related Issues

Fixes #1148

## Test Plan

- [x] Web build passes (`npm run build`) *(if frontend changes)*

## Checklist

- [x] My code follows the project's code style
- [ ] I have added tests for new functionality
- [x] All existing tests still pass
- [ ] I have updated documentation if needed