### PR TITLE
fix(tests): restore structlog's global config after every test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,6 +34,33 @@ def _no_telemetry_network():
     mp.undo()
 
 
+@pytest.fixture(autouse=True)
+def _isolate_structlog_config():
+    """Restore structlog's global configuration after every test.
+
+    ``configure_cli_logging`` / ``silence_logs_for_machine_output`` install a
+    filtering bound logger at ERROR process-wide and never undo it, so the
+    first test to exercise a CLI command silences every ``info`` and
+    ``warning`` for the rest of the session.
+
+    That is invisible until a test asserts on a log record.
+    ``structlog.testing.capture_logs`` swaps the *processor chain*, not the
+    *wrapper class*, so a filtering logger drops the event before ``LogCapture``
+    ever runs and the test reads an empty list. Tests collected after
+    ``tests/unit/cli`` therefore pass alone and fail in a full run.
+
+    Snapshot and restore rather than reset to defaults: a test that configures
+    structlog on purpose keeps working, and the next test still starts clean.
+    """
+    import structlog
+
+    saved = structlog.get_config()
+    try:
+        yield
+    finally:
+        structlog.configure(**saved)
+
+
 @pytest.fixture(scope="session")
 def repo_root() -> Path:
     """Absolute path to the repository root."""

--- a/tests/unit/test_structlog_isolation.py
+++ b/tests/unit/test_structlog_isolation.py
@@ -1,0 +1,31 @@
+"""The global structlog config does not leak from one test into the next.
+
+``silence_logs_for_machine_output`` and ``configure_cli_logging`` install a
+filtering bound logger at ERROR for the whole process. Without the autouse
+fixture in ``tests/conftest.py`` that setting outlives the test that made it,
+and every later ``capture_logs`` assertion on an ``info`` or ``warning`` reads
+an empty list. Such a test passes in isolation and fails in a full run.
+
+The two tests below must stay in this order: the first one does the damage,
+the second one proves it was undone.
+"""
+
+from __future__ import annotations
+
+import structlog
+from structlog.testing import capture_logs
+
+from repowise.cli.helpers import silence_logs_for_machine_output
+
+
+def test_a_cli_command_silences_logs_process_wide() -> None:
+    silence_logs_for_machine_output()
+    with capture_logs() as logs:
+        structlog.get_logger(__name__).warning("silenced_here")
+    assert logs == []
+
+
+def test_b_the_next_test_can_still_capture_a_warning() -> None:
+    with capture_logs() as logs:
+        structlog.get_logger(__name__).warning("visible_again")
+    assert [entry["event"] for entry in logs] == ["visible_again"]


### PR DESCRIPTION
## What

`structlog`'s configuration is process-global. `configure_cli_logging` (`_setup.py`) and `silence_logs_for_machine_output` (`helpers.py`) both install a filtering bound logger at `ERROR` so a progress bar is not interleaved with log lines, and neither ever puts it back. Roughly ten CLI commands call one of them.

Under pytest that means the first test to exercise a CLI command silences every `info` and `warning` for the rest of the session.

That is invisible right up until a test asserts on a log record. `structlog.testing.capture_logs` swaps the **processor chain**, not the **wrapper class**, so a filtering logger discards the event before `LogCapture` ever runs and the assertion reads an empty list. Since pytest collects `tests/unit/cli` before `tests/unit/generation`, a log assertion written anywhere after it passes on its own and fails in a full run, with an assertion message that points at the code under test rather than at the real cause.

This adds an autouse fixture to `tests/conftest.py` that snapshots `structlog.get_config()` and restores it after every test.

## Why snapshot and restore, not reset

`structlog.reset_defaults()` would also work, but it discards any configuration a test set up on purpose partway through. Snapshot and restore leaves a deliberate reconfiguration working inside its own test and still hands the next test a clean slate.

## Test

`tests/unit/test_structlog_isolation.py` pins it with two tests that must stay in order: the first calls `silence_logs_for_machine_output` and asserts the silencing works, the second asserts a later test can still capture a `warning`. The second fails on `main` and passes here.

```
tests/unit/test_structlog_isolation.py::test_b_the_next_test_can_still_capture_a_warning
E   AssertionError: assert [] == ['visible_again']
```

## Scope

No production code changes. The CLI still silences its own logs exactly as before; only the test session stops inheriting it.
