### PR TITLE
fix(stats): the punch card's UTC footnote describes, it does not prescribe

### DIFF
--- a/packages/ui/src/stats/punch-card.tsx
+++ b/packages/ui/src/stats/punch-card.tsx
@@ -316,7 +316,14 @@ export function PunchCard({
             title={
               isLocal
                 ? "Each commit is placed at its author's own local time, using the UTC offset git recorded with it."
-                : "This index predates the commit-offset capture, so hours fall back to UTC. Run `repowise update` to switch to author-local time."
+                : // Describes the state, prescribes nothing. This renders in the
+                  // CLI's web UI and in the hosted app, where a viewer of someone
+                  // else's public snapshot can act on neither a shell command nor
+                  // a re-index. Also says what the rule actually is: the branch
+                  // is coverage-based (_LOCAL_TIME_COVERAGE), so an index whose
+                  // offsets are merely patchy lands here too, and any promised
+                  // remedy would be false for it.
+                  "Too few commits carry the UTC offset git records with them, so hours fall back to UTC rather than mixing two clocks in one matrix."
             }
             className="cursor-help font-mono uppercase tracking-[0.1em]"
           >


### PR DESCRIPTION
## What

The punch card's footer tooltip, on the `utc` branch, told the reader to run `repowise update`. It now states the condition instead.

## Why

The old copy was wrong about its own rule. `timezone_mode` is coverage-based: it falls back to `utc` whenever fewer than `_LOCAL_TIME_COVERAGE` of dated commits carry an offset, not only when the column was never captured at all. On an index whose offsets are merely patchy, nothing the reader runs will flip it, so the tooltip promised an outcome it could not deliver.

It also addressed a reader who may have no way to act. `PunchCard` is a shared component and renders for people looking at snapshots they do not own, who have no shell and no ability to rebuild the index. An instruction to someone with no means to follow it reads worse than a plain statement of what happened.

## Behavior

Copy only, on one tooltip branch. The `author_local` branch is unchanged, as is the visible "Hours in UTC" label and every figure on the chart. The new sentence names the condition and the reason the matrix does not mix two clocks, which is the part a reader can actually use.

Remedies stay on the surfaces that know whether their reader has one. The People tab already carries that guidance for the empty-offset case.

## Verification

`type-check` clean, `packages/ui` stats tests 31 passing. No test, snapshot or doc asserted the old string.