### PR TITLE
fix(python): capture correct module path for aliased imports

### DIFF
--- a/packages/core/src/repowise/core/ingestion/queries/python.scm
+++ b/packages/core/src/repowise/core/ingestion/queries/python.scm
@@ -66,7 +66,10 @@
 
 ; import x.y.z
 (import_statement
-  name: (_) @import.module
+  name: [
+    (dotted_name) @import.module
+    (aliased_import name: (_) @import.module)
+  ]
 ) @import.statement
 
 ; ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #1219.

**The Bug:**
When using an aliased import in Python (e.g., `import module as alias`), the tree-sitter AST encapsulates the module path inside an `aliased_import` node. The previous tree-sitter query used a wildcard capture (`(_) @import.module`) that captured the entire `aliased_import` node rather than just the `dotted_name`. 

Because the module path was malformed, the call resolver couldn't process the imports correctly. This caused the target module to incorrectly register as having 0 importers, leading to severe false-positive deletions in the `repowise dead-code` analyzer.

**The Fix:**
Updated `python.scm` to explicitly target and capture the `dotted_name` node whether it sits bare inside the `import_statement` or wrapped within an `aliased_import`. Aliased imports now resolve correctly to their backing files.
