### PR TITLE
refactor(generation): shrink the frozen evidence-files mapping

### DIFF
--- a/packages/core/src/repowise/core/generation/models.py
+++ b/packages/core/src/repowise/core/generation/models.py
@@ -14,6 +14,7 @@ from collections.abc import Iterable, Iterator, Mapping
 from copy import deepcopy
 from dataclasses import dataclass, field, fields
 from datetime import UTC, datetime
+from types import MappingProxyType
 from typing import Any, Literal
 
 from repowise.core.reasoning import ReasoningMode, normalize_reasoning
@@ -68,28 +69,33 @@ def _source_evidence_page_keys() -> set[str]:
 
 
 class _FrozenEvidenceFiles(Mapping[str, tuple[str, ...]]):
-    """Small immutable mapping that preserves the frozen config contract."""
+    """Small immutable mapping that preserves the frozen config contract.
 
-    __slots__ = ("_items",)
+    The config is ``frozen=True`` and hash-tested, so the stored value must be
+    hashable and read-only. Backed by a ``MappingProxyType`` over a plain dict:
+    O(1) lookup and no in-place mutation, still hashable because ``__hash__``
+    runs over ``frozenset(items())`` rather than the proxy. The ``__setattr__``
+    guard blocks rebinding ``_items``. ``__reduce__`` stays because a
+    ``mappingproxy`` is not picklable on its own; it rebuilds from a plain dict,
+    which also serves ``copy``/``deepcopy``. ``__slots__`` and the explicit
+    ``__copy__``/``__deepcopy__`` are gone — ``__reduce__`` covers all three.
+    """
 
     def __init__(self, values: Mapping[str, tuple[str, ...]] | None = None) -> None:
         object.__setattr__(
             self,
             "_items",
-            tuple((key, tuple(paths)) for key, paths in (values or {}).items()),
+            MappingProxyType({key: tuple(paths) for key, paths in (values or {}).items()}),
         )
 
     def __setattr__(self, name: str, value: object) -> None:
         raise TypeError("source_evidence_files is immutable")
 
     def __getitem__(self, key: str) -> tuple[str, ...]:
-        for candidate, paths in self._items:
-            if candidate == key:
-                return paths
-        raise KeyError(key)
+        return self._items[key]
 
     def __iter__(self) -> Iterator[str]:
-        return (key for key, _ in self._items)
+        return iter(self._items)
 
     def __len__(self) -> int:
         return len(self._items)
@@ -101,13 +107,6 @@ class _FrozenEvidenceFiles(Mapping[str, tuple[str, ...]]):
 
     def __hash__(self) -> int:
         return hash(frozenset(self.items()))
-
-    def __copy__(self) -> _FrozenEvidenceFiles:
-        return self
-
-    def __deepcopy__(self, memo: dict[int, object]) -> _FrozenEvidenceFiles:
-        memo[id(self)] = self
-        return self
 
     def __reduce__(self) -> tuple[type[_FrozenEvidenceFiles], tuple[dict[str, tuple[str, ...]]]]:
         return type(self), (dict(self),)

--- a/tests/unit/generation/test_models.py
+++ b/tests/unit/generation/test_models.py
@@ -184,6 +184,10 @@ def test_generation_config_remains_hashable_and_evidence_mapping_is_immutable():
         dict.__setitem__(config.source_evidence_files, "repo_overview", ("other.md",))  # type: ignore[arg-type]
     with pytest.raises((AttributeError, TypeError)):
         config.source_evidence_files._items = ()  # type: ignore[attr-defined]
+    # The backing store itself is read-only, so a reachable private handle
+    # cannot mutate it in place and corrupt the cached hash.
+    with pytest.raises(TypeError):
+        config.source_evidence_files._items["repo_overview"] = ("other.md",)  # type: ignore[index]
 
     reordered = GenerationConfig(
         source_evidence_files={


### PR DESCRIPTION
## Summary

- Back `_FrozenEvidenceFiles` with a `MappingProxyType` over a plain dict — O(1) `__getitem__` (was a linear scan over tuple pairs) and no in-place mutation, so the deep immutability the old tuple-of-tuples gave for free is preserved.
- Drop `__slots__`, `__copy__`, `__deepcopy__`. The one-line `__reduce__` stays (a `mappingproxy` is not picklable on its own) and rebuilds from a plain dict — covering copy/deepcopy/pickle alike.
- Two load-bearing contracts hold: the config stays **hashable** (`__hash__` over `frozenset(items())`, order-independent) and the mapping stays **read-only** (`__setattr__` blocks rebinding `_items`; the proxy blocks item assignment *and* in-place mutation of the backing store).

The `job_system` `to_dict` duck-check cleanup floated in the #1227 comment is **deliberately deferred**: `create_job` is called with a non-`GenerationConfig` `SimpleNamespace` in `test_init_failure_reporting.py`, so the `getattr` + `dataclasses.asdict` fallback is load-bearing, not dead.

Follow-up promised in https://github.com/repowise-dev/repowise/pull/1227#issuecomment-5158149047 (note 2).

## Related Issues

Follow-up to #1227.

## Test Plan

- [x] `pytest tests/unit/generation/` — 1163 passed (Python 3.13)
- [x] Contract tests green: hashable + order-independent hash; `copy`/`deepcopy`/**`pickle`** round-trip to an equal object; `to_dict` shape; positional constructor order
- [x] Added assertion: a reachable private handle (`._items[...] = ...`) can't mutate the store and corrupt the cached hash
- [x] `ruff check` / `ruff format --check` clean

## Checklist

- [x] My code follows the project's code style
- [x] I have added tests for new functionality
- [x] All existing tests still pass
- [ ] I have updated documentation if needed — n/a