### PR TITLE
refactor(generation): validate evidence files in one place

### DIFF
--- a/packages/core/src/repowise/core/generation/models.py
+++ b/packages/core/src/repowise/core/generation/models.py
@@ -67,6 +67,40 @@ def _source_evidence_page_keys() -> set[str]:
     }
 
 
+def _normalize_evidence_files(
+    raw_files: Mapping[str, Any], *, label: str
+) -> dict[str, tuple[str, ...]]:
+    """Validate a page-key -> paths mapping, framing errors with *label*.
+
+    Shared by ``from_repo_config`` (label ``generation_context.files``, the key
+    the user wrote) and ``__post_init__`` (label ``source_evidence_files``, the
+    internal field for direct construction). The two labels are the whole point
+    of the parameter: the same rules, reported against the surface the caller
+    touched.
+
+    Sharing one validator also unifies key normalization: both paths now
+    ``str(...).strip()`` a key before the membership check. ``from_repo_config``
+    always did; direct construction did not, so a padded key like
+    ``" repo_overview "`` is now trimmed and accepted where it used to raise.
+    """
+    valid_page_keys = _source_evidence_page_keys()
+    result: dict[str, tuple[str, ...]] = {}
+    for raw_page_key, raw_paths in raw_files.items():
+        page_key = str(raw_page_key).strip()
+        if page_key not in valid_page_keys:
+            raise ValueError(
+                f"{label} keys must name repo_overview or a "
+                "model-written onboarding slot; project_overview is configured "
+                "as repo_overview"
+            )
+        if not isinstance(raw_paths, (list, tuple)) or not all(
+            isinstance(path, str) and path.strip() for path in raw_paths
+        ):
+            raise ValueError(f"{label}.{page_key} must be a list of file paths")
+        result[page_key] = tuple(path.strip() for path in raw_paths)
+    return result
+
+
 class _FrozenEvidenceFiles(Mapping[str, tuple[str, ...]]):
     """Small immutable mapping that preserves the frozen config contract."""
 
@@ -323,24 +357,9 @@ class GenerationConfig:
             raw_files = raw_evidence.get("files", {})
             if not isinstance(raw_files, Mapping):
                 raise ValueError("generation_context.files must be a mapping")
-            valid_page_keys = _source_evidence_page_keys()
-            evidence_files: dict[str, tuple[str, ...]] = {}
-            for raw_page_key, raw_paths in raw_files.items():
-                page_key = str(raw_page_key).strip()
-                if page_key not in valid_page_keys:
-                    raise ValueError(
-                        "generation_context.files keys must name repo_overview or a "
-                        "model-written onboarding slot; project_overview is configured "
-                        "as repo_overview"
-                    )
-                if not isinstance(raw_paths, (list, tuple)) or not all(
-                    isinstance(path, str) and path.strip() for path in raw_paths
-                ):
-                    raise ValueError(
-                        f"generation_context.files.{page_key} must be a list of file paths"
-                    )
-                evidence_files[page_key] = tuple(path.strip() for path in raw_paths)
-            values["source_evidence_files"] = evidence_files
+            values["source_evidence_files"] = _normalize_evidence_files(
+                raw_files, label="generation_context.files"
+            )
 
         values.update(overrides)
         return cls(**values)
@@ -362,20 +381,9 @@ class GenerationConfig:
             raise ValueError("source_evidence_token_budget must be a non-negative integer")
         if not isinstance(self.source_evidence_files, Mapping):
             raise ValueError("source_evidence_files must be a mapping")
-        valid_page_keys = _source_evidence_page_keys()
-        evidence_files: dict[str, tuple[str, ...]] = {}
-        for page_key, paths in self.source_evidence_files.items():
-            if page_key not in valid_page_keys:
-                raise ValueError(
-                    "source_evidence_files keys must name repo_overview or a "
-                    "model-written onboarding slot; project_overview is configured "
-                    "as repo_overview"
-                )
-            if not isinstance(paths, (list, tuple)) or not all(
-                isinstance(path, str) and path.strip() for path in paths
-            ):
-                raise ValueError(f"source_evidence_files.{page_key} must be a list of file paths")
-            evidence_files[page_key] = tuple(path.strip() for path in paths)
+        evidence_files = _normalize_evidence_files(
+            self.source_evidence_files, label="source_evidence_files"
+        )
         object.__setattr__(
             self,
             "source_evidence_files",

--- a/tests/unit/generation/test_models.py
+++ b/tests/unit/generation/test_models.py
@@ -275,6 +275,24 @@ def test_direct_generation_config_rejects_an_unconsumed_evidence_key() -> None:
         )
 
 
+def test_direct_generation_config_frames_evidence_errors_with_the_field_name() -> None:
+    # Direct construction reports against the internal field, not the config
+    # key from_repo_config uses -- the two framings are deliberate, so pin both.
+    with pytest.raises(ValueError, match=r"^source_evidence_files keys must name"):
+        GenerationConfig(source_evidence_files={"module_page": ("README.md",)})
+    with pytest.raises(ValueError, match=r"^source_evidence_files\.repo_overview must be a list"):
+        GenerationConfig(source_evidence_files={"repo_overview": "README.md"})
+
+
+def test_direct_generation_config_normalizes_evidence_keys_like_the_config_loader() -> None:
+    # Sharing one validator also aligns key normalization: direct construction
+    # now strips keys before the membership check, as from_repo_config always
+    # did. A padded key is accepted and stored trimmed, not rejected.
+    config = GenerationConfig(source_evidence_files={" repo_overview ": ("README.md",)})
+
+    assert config.source_evidence_files == {"repo_overview": ("README.md",)}
+
+
 @pytest.mark.parametrize("value", [0, -1, True, 1.5, "not-a-number"])
 def test_generation_config_rejects_invalid_repo_max_tokens(value):
     with pytest.raises(ValueError, match="positive integer"):


### PR DESCRIPTION
## Summary

- The page-key/path-list checks for `source_evidence_files` were written twice — in `GenerationConfig.from_repo_config` and again in `__post_init__` (because `from_repo_config` ends in `cls(**values)`). Lift both into one `_normalize_evidence_files(raw_files, *, label)` helper.

Two behaviours are kept on purpose and now pinned by tests:

- **Error framings differ** (the reason for the `label` parameter): `from_repo_config` reports against `generation_context.files` (the key the user wrote); `__post_init__` against `source_evidence_files` (the internal field). A new test pins the field-framed direct path so the divergence can't silently collapse.
- **Key normalization is unified.** `from_repo_config` always `str().strip()`'d keys before the membership check; `__post_init__` did not. Both now do — so direct construction with a padded key (`" repo_overview "`) is trimmed and accepted where it previously raised. This is a deliberate alignment (direct construction should not be stricter than config parsing), covered by a new test. Flagged explicitly because it is the one observable behavior change.

Follow-up promised in https://github.com/repowise-dev/repowise/pull/1227#issuecomment-5158149047 (note 3).

## Related Issues

Follow-up to #1227.

## Test Plan

- [x] `pytest tests/unit/generation/` — 1164 passed (Python 3.13)
- [x] Both message framings survive; the field-framed direct path is newly pinned (verified non-vacuous: collapsing the label fails the test)
- [x] Key-normalization alignment pinned by `test_direct_generation_config_normalizes_evidence_keys_like_the_config_loader`
- [x] `ruff check` / `ruff format --check` clean

## Checklist

- [x] My code follows the project's code style
- [x] I have added tests for new functionality
- [x] All existing tests still pass
- [ ] I have updated documentation if needed — n/a