### PR TITLE
fix(python): resolve attribute calls on python submodules

### DIFF
--- a/packages/core/src/repowise/core/ingestion/resolvers/python.py
+++ b/packages/core/src/repowise/core/ingestion/resolvers/python.py
@@ -121,7 +121,7 @@ def resolve_python_import_all(
                 # (#1193). Without this the binding's source_file stays the
                 # package init, which declares nothing, and the call is missed.
                 for binding in imp.bindings:
-                    if binding.local_name == name:
+                    if (binding.exported_name or binding.local_name) == name:
                         binding.source_file = hit
                         break
     return tuple(dict.fromkeys(targets))

--- a/tests/unit/ingestion/test_python_resolver_fanout.py
+++ b/tests/unit/ingestion/test_python_resolver_fanout.py
@@ -156,3 +156,45 @@ def test_non_submodule_binding_keeps_package_init() -> None:
     assert len(imp.bindings) == 1
     assert imp.bindings[0].local_name == "some_function"
     assert imp.bindings[0].source_file is None
+
+
+def test_submodule_aliased_binding_points_at_submodule_file() -> None:
+    """``from pkg import submodule as alias`` binds ``alias`` to the submodule file."""
+    paths = {
+        "sensors/__init__.py",
+        "sensors/foo.py",
+        "caller.py",
+    }
+    imp = _imp(
+        "sensors",
+        ["foo"],
+        bindings=[NamedBinding(local_name="f", exported_name="foo", source_file=None)],
+    )
+    targets = resolve_python_import_all(imp, "caller.py", _ctx(paths))
+    assert targets == ("sensors/__init__.py", "sensors/foo.py")
+    assert len(imp.bindings) == 1
+    assert imp.bindings[0].local_name == "f"
+    assert imp.bindings[0].source_file == "sensors/foo.py"
+
+
+def test_non_submodule_aliased_binding_keeps_package_init() -> None:
+    """An aliased name that is not a submodule file keeps the package init as its source."""
+    paths = {
+        "sensors/__init__.py",
+        "sensors/foo.py",
+        "caller.py",
+    }
+    imp = _imp(
+        "sensors",
+        ["some_function"],
+        bindings=[
+            NamedBinding(
+                local_name="sf", exported_name="some_function", source_file=None
+            )
+        ],
+    )
+    targets = resolve_python_import_all(imp, "caller.py", _ctx(paths))
+    assert targets == ("sensors/__init__.py",)
+    assert len(imp.bindings) == 1
+    assert imp.bindings[0].local_name == "sf"
+    assert imp.bindings[0].source_file is None


### PR DESCRIPTION
### Summary
This PR fixes an issue where Python attribute calls on submodules imported from a package would fail to resolve. 

### Changes
- Adds a Python-specific fallback in `CallResolver` to check the `receiver_name.py` or `receiver_name/__init__.py` submodule file when the receiver is tracked back to a package's `__init__.py` and the method is not found there.
