### PR TITLE
fix(ts): allow Node.js package exports wildcard to cross directory boundaries

### DIFF
--- a/packages/core/src/repowise/core/ingestion/resolvers/ts_workspace.py
+++ b/packages/core/src/repowise/core/ingestion/resolvers/ts_workspace.py
@@ -458,12 +458,9 @@ def _expand_exports_wildcard(
             continue
         if suffix and not candidate.endswith(suffix):
             continue
-        # Reject paths whose captured segment crosses a directory boundary
-        # unless the pattern itself spans dirs (``**`` is not part of the
-        # spec; ``*`` matches a single segment).
-        captured = candidate[len(base_prefix) : len(candidate) - len(suffix) if suffix else len(candidate)]
-        if "/" in captured and exports_pattern.endswith("/*"):
-            continue
+        # Node.js package exports spec explicitly allows the `*` wildcard
+        # to match any string including `/` (directory boundaries).
+        # We previously incorrectly rejected paths spanning directories.
         matches.add(candidate)
     return matches
 

--- a/tests/unit/ingestion/test_ts_workspace_index.py
+++ b/tests/unit/ingestion/test_ts_workspace_index.py
@@ -61,6 +61,18 @@ class TestExportsWildcardEntries:
         for p in paths:
             assert p in index.exports_entry_paths, p
 
+    def test_wildcard_export_crosses_directory_boundaries(self, tmp_path: Path) -> None:
+        _write(tmp_path, "package.json", '{"workspaces":["packages/*"]}')
+        _write(
+            tmp_path,
+            "packages/zod/package.json",
+            '{"name":"@org/zod","exports":{"./*":"./src/*"}}',
+        )
+        _write(tmp_path, "packages/zod/src/a/b/c.ts", "export {};\n")
+        ctx = _ctx(tmp_path, ["packages/zod/src/a/b/c.ts"])
+        index = build_ts_workspace_index(ctx)
+        assert "packages/zod/src/a/b/c.ts" in index.exports_entry_paths
+
     def test_main_field_marked_as_entry(self, tmp_path: Path) -> None:
         _write(tmp_path, "package.json", '{"workspaces":["packages/*"]}')
         _write(


### PR DESCRIPTION
### Summary
This PR fixes a bug where Node.js package exports using wildcards (`*`) were incorrectly rejected if they resolved across directory boundaries (e.g., checking for `/` in the resolved path). 

According to the [Node.js Subpath Patterns specification](https://nodejs.org/api/packages.html#subpath-patterns), wildcards are purely string replacements and can validly map to nested directory structures.

### Verification
The TS Workspace indexing and merged index resolution tests run flawlessly with this change:
```text
tests/unit/ingestion/test_resolver_merged_index.py::TestTier2bFreeCall::test_resolves_via_import_targets PASSED
tests/unit/ingestion/test_ts_workspace_index.py::TestExportsWildcardEntries::test_wildcard_export_crosses_directory_boundaries PASSED
... (30 passed in 1.82s)
```
