### PR TITLE
fix(dead-code): confidence_summary low bucket always 0 due to filter order

### DIFF
--- a/packages/core/src/repowise/core/analysis/dead_code/analyzer.py
+++ b/packages/core/src/repowise/core/analysis/dead_code/analyzer.py
@@ -623,15 +623,21 @@ class DeadCodeAnalyzer:
             if on_step:
                 on_step("zombie_packages")
 
+        # Count confidence buckets over all detected findings before applying
+        # the min_confidence filter. Counting after the filter makes `low`
+        # (confidence < 0.4) structurally always 0 when min_confidence >= 0.4
+        # (the default), because those findings are removed before counting.
+        # This matches how get_dead_code_summary() computes the same buckets
+        # from the persisted DB rows (no confidence pre-filter there).
+        high = sum(1 for f in findings if f.confidence >= 0.7)
+        medium = sum(1 for f in findings if 0.4 <= f.confidence < 0.7)
+        low = sum(1 for f in findings if f.confidence < 0.4)
+
         min_conf = cfg.get("min_confidence", 0.4)
         findings = [f for f in findings if f.confidence >= min_conf]
 
         now = datetime.now(UTC)
         deletable = sum(f.lines for f in findings if f.safe_to_delete)
-
-        high = sum(1 for f in findings if f.confidence >= 0.7)
-        medium = sum(1 for f in findings if 0.4 <= f.confidence < 0.7)
-        low = sum(1 for f in findings if f.confidence < 0.4)
 
         return DeadCodeReport(
             repo_id="",
@@ -653,6 +659,10 @@ class DeadCodeAnalyzer:
         """
         affected_set = set(affected_files)
         full = self.analyze(config)
+        # full.findings is already filtered by min_confidence from analyze(), so
+        # the per-file subset inherits the same filter — low will be 0 here by
+        # construction (no findings below min_confidence survive to this point).
+        # The summary is provided for interface consistency with analyze().
         findings = [f for f in full.findings if f.file_path in affected_set]
 
         deletable = sum(f.lines for f in findings if f.safe_to_delete)

--- a/tests/unit/dead_code/test_confidence.py
+++ b/tests/unit/dead_code/test_confidence.py
@@ -1,4 +1,7 @@
 """Unit tests for DeadCodeAnalyzer."""
+# NOTE: test_confidence_summary_low_count_not_always_zero is a regression
+# test for a bug where confidence_summary["low"] was permanently 0 because
+# the bucket counters ran *after* the min_confidence filter instead of before.
 
 from __future__ import annotations
 
@@ -83,3 +86,67 @@ def test_confidence_high_for_stale_unreachable():
     findings = [f for f in report.findings if f.file_path == "pkg/stale.py"]
     assert len(findings) == 1
     assert findings[0].confidence == pytest.approx(1.0)
+
+
+def test_confidence_summary_low_count_not_always_zero():
+    """confidence_summary['low'] must reflect deprecated findings even when
+    min_confidence (default 0.4) filters them out of the returned findings list.
+
+    Regression: the bucket counters previously ran *after* the min_confidence
+    filter, making low permanently 0 on default analyze() calls.
+    """
+    # A deprecated public symbol in a file that has an importer gets
+    # confidence = 0.3 (< 0.4) from _detect_unused_exports. With the default
+    # min_confidence=0.4 it is stripped from report.findings, but it should
+    # still appear in confidence_summary["low"].
+    g = _build_graph(
+        nodes={
+            "pkg/importer.py": {
+                "is_entry_point": False,
+                "is_test": False,
+                "is_api_contract": False,
+                "symbol_count": 0,
+                "symbols": [],
+            },
+            "pkg/utils.py": {
+                "is_entry_point": False,
+                "is_test": False,
+                "is_api_contract": False,
+                "symbol_count": 1,
+                "symbols": [
+                    {
+                        "name": "process_data_DEPRECATED",
+                        "kind": "function",
+                        "visibility": "public",
+                        "language": "python",
+                        "start_line": 1,
+                        "end_line": 5,
+                    }
+                ],
+            },
+        },
+        # importer.py imports utils.py as a module but NOT the deprecated
+        # symbol by name, so has_importers for the symbol is False.
+        edges=[
+            ("pkg/importer.py", "pkg/utils.py", {"edge_type": "imports", "imported_names": []}),
+        ],
+    )
+
+    analyzer = DeadCodeAnalyzer(g, git_meta_map={})
+
+    # Default call: min_confidence=0.4 filters out the 0.3-confidence finding.
+    report = analyzer.analyze({"detect_unreachable_files": False, "detect_zombie_packages": False})
+
+    # The finding must NOT appear in the returned findings list (filtered out).
+    deprecated_findings = [
+        f for f in report.findings if f.symbol_name == "process_data_DEPRECATED"
+    ]
+    assert deprecated_findings == [], (
+        "Deprecated finding should be filtered from report.findings at default min_confidence=0.4"
+    )
+
+    # But it MUST be counted in the low bucket of the summary.
+    assert report.confidence_summary["low"] >= 1, (
+        "confidence_summary['low'] was 0 — bucket counters ran after the min_confidence "
+        "filter and the deprecated finding was silently dropped from the summary"
+    )


### PR DESCRIPTION
## Summary

- Fixed execution order in `DeadCodeAnalyzer.analyze()` so confidence bucket metrics are aggregated prior to applying the `min_confidence` threshold filter.
- Resolved bug where `report.confidence_summary["low"]` was permanently `0` on default analysis runs.
- Added regression test `test_confidence_summary_low_count_not_always_zero` in `tests/unit/dead_code/test_confidence.py`.

## Related Issues

fixes #1260 

## Test Plan

- [x] Tests pass (`pytest tests/unit/dead_code/`)
- [x] Lint passes (`ruff check .`)
- [x] Web build passes (`npm run build`) *(no frontend changes)*

## Checklist

- [x] My code follows the project's code style
- [x] I have added tests for new functionality
- [x] All existing tests still pass
- [x] I have updated documentation if needed```