### PR TITLE
fix(docker): create /data directory before chown (Blocker 1)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -53,6 +53,11 @@ COPY --from=frontend-builder /app/.next/static /app/web/.next/static
 COPY --from=frontend-builder /app/public /app/web/public
 
 # Data volume for .repowise directory
+# mkdir is required: VOLUME only registers metadata and does not create the
+# directory on the image filesystem at build time. Without it, the subsequent
+# `chown -R repowise:repowise /data` (run at build time) fails with
+# "cannot access '/data': No such file or directory".
+RUN mkdir -p /data
 VOLUME /data
 
 # Environment defaults


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Keep it to 1-3 bullet points. -->

- Fixes Blocker 1 in `docker/Dockerfile` where `docker build` fails with `chown: cannot access '/data': No such file or directory`.
- Adds `RUN mkdir -p /data` immediately before `VOLUME /data` in the runtime stage so the physical directory exists at build time when `chown -R repowise:repowise /app /data` executes.

## Related Issues

<!-- Link any related issues: Fixes #123, Closes #456 -->
fixes #1264 

- Follow-up fix for Blocker 1 in `docker/Dockerfile` (identified after #1236).

## Test Plan

<!-- How did you verify this works? -->

- [x] Web build passes (`npm run build`) *(if frontend changes)*
- [x] Local Docker Build Verification:
  1. Fetched the PR #1236 branch (`fix/docker-monorepo-build` by `Shivang9983`) locally to resolve Stage 1 npm workspace dependency resolution.
  2. Merged PR #1236 locally with this branch to allow Stage 1 (`frontend-builder`) to complete successfully.
  3. Ran `docker build -t repowise -f docker/Dockerfile .` and verified Stage 2 step 15/18 (`RUN mkdir -p /data` - `DONE 0.7s`) and step 18/18 (`chown -R repowise:repowise /app /data` - `DONE 23.1s`) passed without error.
  4. Verified layer history in Docker Desktop shows `RUN /bin/sh -c mkdir -p /data # buildkit` as a valid image layer.
  5. Reset branch back to `main` so this PR cleanly contains **only** the `mkdir -p /data` fix.

### Docker Desktop Verification Screenshot

<!-- Drag and drop your Docker Desktop screenshot here -->
![Docker Desktop Layer Verification]<img width="955" height="540" alt="image" src="https://github.com/user-attachments/assets/3ce86962-6766-4b57-b0d0-8326c13a162c" />

## Checklist

- [x] My code follows the project's code style
- [ ] I have added tests for new functionality
- [x] All existing tests still pass
- [x] I have updated documentation if needed
