### PR TITLE
fix(tests): stop two update-lock tests asserting the old staleness contract

### DIFF
--- a/tests/unit/cli/test_augment_staleness.py
+++ b/tests/unit/cli/test_augment_staleness.py
@@ -175,9 +175,12 @@ class TestUpdateLockSuppression:
         _state(repo_path, last_sync_commit=head, docs_enabled=True)
         _commit(repo_path)
 
-        # Lock from 2 hours ago — beyond the 30-min stale window
+        # Lock from 2 hours ago, beyond the 30-min stale window, and carrying no
+        # PID so the wall clock is what decides. No `pid` deliberately: since the
+        # lock rework a live owner outranks the clock, so naming a PID that
+        # happens to exist would make this assert the opposite of the contract.
         (repo_path / ".repowise" / ".update.lock").write_text(
-            json.dumps({"pid": 1, "target_commit": "x", "started_at": 0}),
+            json.dumps({"target_commit": "x", "started_at": 0}),
             encoding="utf-8",
         )
 

--- a/tests/unit/cli/test_helpers.py
+++ b/tests/unit/cli/test_helpers.py
@@ -302,12 +302,44 @@ class TestUpdateLock:
 
         ensure_repowise_dir(tmp_path)
         lock_path = tmp_path / ".repowise" / UPDATE_LOCK_FILENAME
-        # Stale: started 2 hours ago
+        # Old, and carrying no PID, so the wall clock is what decides. Written
+        # without a `pid` deliberately: since the lock rework, a lock whose
+        # owner is alive is not stale however old it is, so naming any live PID
+        # here would assert the opposite of the contract.
         lock_path.write_text(
-            json.dumps({"pid": 1, "target_commit": "x", "started_at": 0}),
+            json.dumps({"target_commit": "x", "started_at": 0}),
             encoding="utf-8",
         )
         assert read_update_lock(tmp_path) is None
+
+    def test_a_live_owner_outranks_the_clock(self, tmp_path):
+        """An ancient lock is NOT stale while the process holding it is alive.
+
+        The other half of the contract, and the half nothing asserted. Without
+        it, a test could name a PID that merely happens to be dead on the
+        machine running it and read as if it were testing age — which is
+        exactly what `pid: 1` did: absent on Windows, always alive on Linux, so
+        the same assertion meant opposite things on the two platforms.
+
+        Uses this process's own PID, which is alive everywhere by definition.
+        """
+        import json
+        import os
+
+        from repowise.cli.helpers import (
+            UPDATE_LOCK_FILENAME,
+            ensure_repowise_dir,
+            read_update_lock,
+        )
+
+        ensure_repowise_dir(tmp_path)
+        (tmp_path / ".repowise" / UPDATE_LOCK_FILENAME).write_text(
+            json.dumps({"pid": os.getpid(), "target_commit": "x", "started_at": 0}),
+            encoding="utf-8",
+        )
+        payload = read_update_lock(tmp_path)
+        assert payload is not None
+        assert payload["target_commit"] == "x"
 
     def test_read_handles_corrupt_payload(self, tmp_path):
         from repowise.cli.helpers import (


### PR DESCRIPTION
`main` has been red on Python 3.11, 3.12 and 3.13 since #1262 (`7d55cfe6`), and again at `6e4001b0`, `5ca428f5` and `c710ea04`. Two tests fail. Both predate #1262 and neither was updated by it.

```
FAILED tests/unit/cli/test_augment_staleness.py::TestUpdateLockSuppression::test_stale_lock_does_not_suppress
FAILED tests/unit/cli/test_helpers.py::TestUpdateLock::test_read_returns_none_when_stale
```

## What actually broke

#1262 changed what makes a lock stale. It used to be the wall clock. It is now the owning process, with the clock consulted only when liveness cannot be established:

```python
if isinstance(pid, int) and pid > 0:
    alive = pid_alive(pid)
    if alive is True:
        ...
        return payload          # returned regardless of age

# Liveness unknown: fall back to the wall clock.
if age > UPDATE_LOCK_STALE_AFTER_SECONDS:
    return None
```

That is the behaviour #1262 wanted, and it is right: a hung-but-alive update should not have its lock stolen just for being slow.

Both failing tests write `{"pid": 1, "target_commit": "x", "started_at": 0}` and assert the lock reads as stale — the pre-#1262 contract. **PID 1 is `init` on Linux and always alive**, so CI correctly reports the lock as live and the assertion fails. On Windows PID 1 does not exist, the probe says dead, and the same tests pass. That is why they were green when written and why the breakage was invisible to anyone developing on Windows.

So the tests are wrong; the lock is not.

## The change

Both tests now omit `pid` entirely, which puts them on the "liveness unknown → wall clock" branch they were always meant to exercise. No product code is touched.

One test is added — `test_a_live_owner_outranks_the_clock` — asserting the half of the contract that nothing covered: **an ancient lock is not stale while its owner is alive.** It uses `os.getpid()`, alive on every platform by definition, so it cannot quietly mean different things on different runners the way `pid: 1` did. Had it existed, #1262 would have had to confront the two stale tests directly.

## Verification

A green Windows run proves nothing here, since Windows is the platform where the bug hides. So the CI condition was reproduced locally by forcing `repowise.core.procutils.pid_alive` to return `True` for every PID:

- under that patch, all three tests pass
- unpatched, `test_helpers.py` + `test_augment_staleness.py` + `test_update_lock.py` are **99 passed**
- `ruff check .` passes

The scaffolding used for the simulation is not part of the diff.
