### PR TITLE
fix(docker): use node:20-bookworm-slim builder for glibc compatibility (Blocker 2)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,10 +6,9 @@
 #   docker run -p 7337:7337 -p 3000:3000 -v /path/to/repo/.repowise:/data -e GEMINI_API_KEY=... repowise
 # =============================================================================
 
-# ---------------------------------------------------------------------------
-# Stage 1: Build the Next.js frontend
-# ---------------------------------------------------------------------------
-FROM node:20-alpine AS frontend-builder
+# Use Debian-based Node builder (glibc) to match python:3.12-slim runtime.
+# Alpine (musl) builds produce a node binary that fails to execute in Debian slim with exit code 127.
+FROM node:20-bookworm-slim AS frontend-builder
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary

- Fixes Blocker 2 in `docker/Dockerfile` where copying the `node` binary from `node:20-alpine` (`musl`) into `python:3.12-slim` (`glibc`) causes runtime failure with `sh: 1: /usr/local/bin/node: not found` (exit code 127).
- Changes Stage 1 builder base image from `node:20-alpine` to `node:20-bookworm-slim` so the pre-built `node` binary is dynamically linked against `glibc`.

## Related Issues

- Follow-up fix for Blocker 2 in `docker/Dockerfile`.
- fixes #1264 

## Test Plan

- [x] Web build passes (`npm run build`)
- [x] Local Docker Build Verification:
  1. Merged PR #1236 locally to resolve Stage 1 workspace dependencies.
  2. Built container image with `FROM node:20-bookworm-slim AS frontend-builder`.
  3. Ran `docker run --rm --entrypoint /usr/local/bin/node repowise-b2-test --version`.
  4. Verified output prints `v20.20.2` cleanly (no exit code 127).
  5. Reset branch back to `main` so this PR cleanly contains **only** the `node:20-bookworm-slim` change.

## Checklist

- [x] My code follows the project's code style
- [ ] I have added tests for new functionality
- [x] All existing tests still pass
- [x] I have updated documentation if needed
