### PR TITLE
fix(docker): add .gitattributes to enforce LF line endings for shell scripts (Blocker 3)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Ensure shell scripts always use LF line endings in the repo and on checkout.
+# Without this, git on Windows converts .sh files to CRLF, producing a
+# "#!/bin/bash\r" shebang that Linux cannot resolve, causing:
+#   exec /app/entrypoint.sh: no such file or directory
+*.sh text eol=lf


### PR DESCRIPTION



## Summary

- Fixes Blocker 3 where checkouts on Windows convert `docker/entrypoint.sh` to CRLF line endings, producing a `#!/bin/bash\r` shebang that causes Linux container startup failure:
  ```text
  exec /app/entrypoint.sh: no such file or directory
  ```
- Adds `.gitattributes` to enforce `*.sh text eol=lf` repo-wide so shell scripts always maintain LF line endings regardless of host OS checkout.

## Related Issues

- fixes #1264 

## Test Plan

- [x] Verified `.gitattributes` enforces LF line endings for `*.sh` files.
- [x] Local Docker Verification:
  1. Ran container image built from Windows checkout.
  2. Executed `docker run --name repowise-b3-demo -p 7337:7337 -p 3000:3000 repowise-full-test`.
  3. Verified `/app/entrypoint.sh` executes cleanly without `exec /app/entrypoint.sh: no such file or directory`.
  4. Observed container startup logs in Docker Desktop:
 <img width="955" height="540" alt="image" src="https://github.com/user-attachments/assets/565297e6-97a1-4fa8-bb5f-f5dbac78b353" />
(the error below is of blocker 4 on it !)

## Checklist

- [x] My code follows the project's code style
- [ ] I have added tests for new functionality
- [x] All existing tests still pass
- [x] I have updated documentation if needed
```