### PR TITLE
fix(docker): update entrypoint.sh server.js path for monorepo standalone output (Blocker 4)

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -9,8 +9,10 @@ uvicorn repowise.server.app:create_app \
   --port "${PORT_BACKEND}" &
 
 # Start the Next.js frontend
+# After PR #1236 moves the lockfile to workspace root, Next.js standalone output
+# nests server.js under packages/web/ relative to the standalone root directory.
 echo "Starting repowise Web UI on port ${PORT_FRONTEND}..."
-cd /app/web
+cd /app/web/packages/web
 REPOWISE_API_URL="http://localhost:${PORT_BACKEND}" \
 HOSTNAME="0.0.0.0" \
 PORT="${PORT_FRONTEND}" \


### PR DESCRIPTION
## Summary

- Fixes Blocker 4 where Next.js standalone build in monorepos nests `server.js` at `packages/web/server.js` relative to the standalone output directory (following #1236 lockfile relocation to workspace root).
- Updates `docker/entrypoint.sh` to `cd /app/web/packages/web` before executing `node server.js`.

## Related Issues

-fixes #1264 
-stacked on #1236 
## Test Plan

- [x] Web build passes (`npm run build`)
- [x] Local End-to-End Docker Verification:
  1. Built full container image with PR #1236 and Blockers 1, 2, 3 & 4.
  2. Executed `docker run --name repowise-b4-demo -p 7337:7337 -p 3000:3000 repowise-full-test`.
  3. Verified both services start cleanly in container logs:
  <img width="955" height="540" alt="image" src="https://github.com/user-attachments/assets/2cfb6bb6-cfd7-4881-921b-16aea2326d97" />

## Checklist

- [x] My code follows the project's code style
- [ ] I have added tests for new functionality
- [x] All existing tests still pass
- [x] I have updated documentation if needed
