### PR TITLE
fix(mcp): hand back the ranked pool the early returns already hold

### DIFF
--- a/packages/server/src/repowise/server/mcp_server/tool_answer/answer.py
+++ b/packages/server/src/repowise/server/mcp_server/tool_answer/answer.py
@@ -587,6 +587,37 @@ def _build_data_shape_payload(grounded: dict, t0: float, repository) -> dict:
     return payload
 
 
+def _with_candidates(payload: dict, resolved_pool: list[dict]) -> dict:
+    """Attach the ranked shortlist to a payload that is about to be returned.
+
+    ``get_answer`` has several early returns that fire *after* retrieval has
+    run: the qualified-miss guard, answer-by-union, the value-extraction fast
+    path, the legacy abstain, and both degraded paths. Each was written as a
+    complete reply in its own terms — the union hands back every definition of
+    the named symbol, the extractor hands back the literal assignment line —
+    and each set ``retrieval`` to ``[]`` and returned.
+
+    That is right about ``retrieval``, which is re-read evidence for a synthesised
+    answer, and wrong about what the caller is left holding. ``resolved_pool``
+    already exists at every one of these sites: the full ranked file list, built
+    before the 5-hit synthesis cap, at no further cost. Discarding it means a
+    caller whose question tripped one of these gates gets a narrower reply than
+    one whose question did not, and gets it *because* we recognised their question
+    more precisely. Measured on the 70 ContextBench dev instances, the gates that
+    fire after retrieval account for 20 firings and 15 answers that named no gold
+    file, every one of them with a ranked pool in hand.
+
+    So the shortlist travels with every reply. This adds to a payload and takes
+    nothing away: no gate stops firing, no predicate moves, and the special reply
+    each gate exists to give is returned unchanged. It is deliberately NOT the
+    fix of loosening a gate — finding A11 measured that at -6.4 recall@5.
+    """
+    candidates = _serialize_candidates(resolved_pool)
+    if candidates:
+        payload["candidates"] = candidates
+    return payload
+
+
 def _degraded_payload(
     *,
     reason: str,
@@ -595,6 +626,7 @@ def _degraded_payload(
     fallback_targets: list[str],
     repository,
     t0: float,
+    resolved_pool: list[dict] | None = None,
 ) -> dict:
     """Shape a synthesis-less get_answer response.
 
@@ -605,24 +637,27 @@ def _degraded_payload(
     set only the top-level key, so a caller watching ``_meta`` saw a normal
     empty answer.
     """
-    return {
-        "answer": "",
-        "citations": [],
-        "confidence": "low",
-        "degraded": reason,
-        "fallback_targets": fallback_targets,
-        "retrieval": _serialize_hits(hits),
-        "note": note,
-        "_meta": {
-            **_build_meta(
-                timing_ms=(time.perf_counter() - t0) * 1000,
-                hint=_answer_hint("low", len(hits)),
-                repository=repository,
-                targets=fallback_targets,
-            ),
+    return _with_candidates(
+        {
+            "answer": "",
+            "citations": [],
+            "confidence": "low",
             "degraded": reason,
+            "fallback_targets": fallback_targets,
+            "retrieval": _serialize_hits(hits),
+            "note": note,
+            "_meta": {
+                **_build_meta(
+                    timing_ms=(time.perf_counter() - t0) * 1000,
+                    hint=_answer_hint("low", len(hits)),
+                    repository=repository,
+                    targets=fallback_targets,
+                ),
+                "degraded": reason,
+            },
         },
-    }
+        resolved_pool if resolved_pool is not None else hits,
+    )
 
 
 @mcp.tool()
@@ -918,27 +953,31 @@ async def get_answer(
     # never degrade to a confidently-wrong answer (CodeGraph #173).
     if homonyms.get("qualified_miss"):
         missed = homonyms["qualified_miss"]
-        return {
-            "answer": "",
-            "citations": [],
-            "confidence": "low",
-            "note": (
-                f"No indexed definition matches the qualified name(s) {missed}. "
-                "The base name is defined elsewhere, but not under the "
-                "class/module you named, so this is not returning a same-named "
-                "symbol from another file, to avoid a confidently-wrong answer. "
-                'Re-check the qualifier, or call search_codebase mode="symbol" '
-                "on the base name to see every definition."
-            ),
-            "fallback_targets": [],
-            "retrieval": [],
-            "_meta": _build_meta(
-                timing_ms=(time.perf_counter() - t0) * 1000,
-                hint=_answer_hint("low", 0),
-                repository=repository,
-                targets=[],
-            ),
-        }
+        return _with_candidates(
+            {
+                "answer": "",
+                "citations": [],
+                "confidence": "low",
+                "note": (
+                    f"No indexed definition matches the qualified name(s) {missed}. "
+                    "The base name is defined elsewhere, but not under the "
+                    "class/module you named, so this is not returning a same-named "
+                    "symbol from another file, to avoid a confidently-wrong answer. "
+                    'Re-check the qualifier, or call search_codebase mode="symbol" '
+                    "on the base name to see every definition. The files retrieval "
+                    "ranked for this question are in candidates."
+                ),
+                "fallback_targets": [],
+                "retrieval": [],
+                "_meta": _build_meta(
+                    timing_ms=(time.perf_counter() - t0) * 1000,
+                    hint=_answer_hint("low", 0),
+                    repository=repository,
+                    targets=[],
+                ),
+            },
+            resolved_pool,
+        )
 
     # --- Answer-by-union (homonym exact-name lookup) -----------------------
     # The question named a symbol with N>=2 defs no qualifier disambiguates
@@ -983,6 +1022,10 @@ async def get_answer(
                     f" {len(more_defs)} more are in more_definitions; call "
                     "get_symbol with the listed id, do NOT Read."
                 )
+            note += (
+                " If the question was about something other than these definitions, "
+                "candidates holds the files retrieval ranked for it."
+            )
             payload: dict = {
                 "answer": (
                     f"`{', '.join(names)}` has {total} definition(s) in this repo; "
@@ -1005,7 +1048,7 @@ async def get_answer(
             }
             if more_defs:
                 payload["more_definitions"] = more_defs
-            return payload
+            return _with_candidates(payload, resolved_pool)
         # Bodies unreadable (no repo root / files gone) — fall through to the
         # normal retrieval/gate path rather than returning an empty union.
 
@@ -1016,26 +1059,34 @@ async def get_answer(
     ]
 
     if not hits:
-        return {
-            "answer": "",
-            "citations": [],
-            "confidence": "low",
-            "fallback_targets": [],
-            "retrieval": [],
-            "note": (
-                "No wiki hits for this question. Rephrase around the code "
-                'concept, or use search_codebase (mode="symbol" for an '
-                'identifier, mode="path" for a file name); if the question '
-                "names a file, call get_context on it directly. Grep only "
-                "if those come back empty too."
-            ),
-            "_meta": _build_meta(
-                timing_ms=(time.perf_counter() - t0) * 1000,
-                hint=_answer_hint("low", 0),
-                repository=repository,
-                targets=[],
-            ),
-        }
+        # Wrapped like every other post-retrieval return even though the pool is
+        # necessarily empty here (``resolved_pool`` is ``hits`` before the cap, so
+        # no hits means no pool). Keeping the invariant "every return after
+        # retrieval goes through ``_with_candidates``" is what stops the next
+        # reordering of this function quietly re-opening the hole.
+        return _with_candidates(
+            {
+                "answer": "",
+                "citations": [],
+                "confidence": "low",
+                "fallback_targets": [],
+                "retrieval": [],
+                "note": (
+                    "No wiki hits for this question. Rephrase around the code "
+                    'concept, or use search_codebase (mode="symbol" for an '
+                    'identifier, mode="path" for a file name); if the question '
+                    "names a file, call get_context on it directly. Grep only "
+                    "if those come back empty too."
+                ),
+                "_meta": _build_meta(
+                    timing_ms=(time.perf_counter() - t0) * 1000,
+                    hint=_answer_hint("low", 0),
+                    repository=repository,
+                    targets=[],
+                ),
+            },
+            resolved_pool,
+        )
 
     # Attach real page content to the top hits, once, for every retrieval —
     # before anything downstream branches on how good the retrieval looks.
@@ -1148,7 +1199,7 @@ async def get_answer(
             repository=repository,
             targets=fallback_targets,
         )
-        return gated
+        return _with_candidates(gated, resolved_pool)
 
     # Confidence is the only axis we gate on. We deliberately do NOT add a
     # second gate keyed on question shape (e.g. relational questions
@@ -1173,28 +1224,32 @@ async def get_answer(
             answer_text = extraction["answer"]
             if extraction.get("value_source"):
                 answer_text += "\n\n" + extraction["value_source"]
-            return {
-                "answer": answer_text,
-                "citations": [extraction["file"]],
-                "confidence": "high",
-                "retrieval_quality": (
-                    "high" if top_score_fp >= _HIGH_CONFIDENCE_SCORE_FLOOR else "partial"
-                ),
-                "grounding": "extracted",
-                "fallback_targets": fallback_targets,
-                "retrieval": [],
-                "note": (
-                    "Extracted verbatim from the live source line — no LLM "
-                    "synthesis involved. Cite directly; no verification "
-                    "Read needed."
-                ),
-                "_meta": _build_meta(
-                    timing_ms=(time.perf_counter() - t0) * 1000,
-                    hint=_answer_hint("high", len(hits)),
-                    repository=repository,
-                    targets=[extraction["file"], *fallback_targets],
-                ),
-            }
+            return _with_candidates(
+                {
+                    "answer": answer_text,
+                    "citations": [extraction["file"]],
+                    "confidence": "high",
+                    "retrieval_quality": (
+                        "high" if top_score_fp >= _HIGH_CONFIDENCE_SCORE_FLOOR else "partial"
+                    ),
+                    "grounding": "extracted",
+                    "fallback_targets": fallback_targets,
+                    "retrieval": [],
+                    "note": (
+                        "Extracted verbatim from the live source line — no LLM "
+                        "synthesis involved. Cite directly; no verification "
+                        "Read needed. candidates holds the files retrieval ranked, "
+                        "for the wider question the value sits inside."
+                    ),
+                    "_meta": _build_meta(
+                        timing_ms=(time.perf_counter() - t0) * 1000,
+                        hint=_answer_hint("high", len(hits)),
+                        repository=repository,
+                        targets=[extraction["file"], *fallback_targets],
+                    ),
+                },
+                resolved_pool,
+            )
 
     # --- Synthesis (LLM) ---------------------------------------------------
     provider = _resolve_provider_for_answer(getattr(ctx, "path", None))
@@ -1218,6 +1273,7 @@ async def get_answer(
             fallback_targets=fallback_targets,
             repository=repository,
             t0=t0,
+            resolved_pool=resolved_pool,
         )
 
     # Decision fusion (why-shaped questions only) + structured prelude. Both
@@ -1258,6 +1314,7 @@ async def get_answer(
             fallback_targets=fallback_targets,
             repository=repository,
             t0=t0,
+            resolved_pool=resolved_pool,
         )
 
     citations = [

--- a/tests/unit/server/mcp/test_answer_early_return_candidates.py
+++ b/tests/unit/server/mcp/test_answer_early_return_candidates.py
@@ -1,0 +1,152 @@
+"""Every ``get_answer`` return that happens after retrieval carries ``candidates``.
+
+``get_answer`` has several early returns that fire once retrieval has already
+run: the qualified-miss guard, answer-by-union, the no-hits reply, the legacy
+abstain, the value-extraction fast path, and both degraded paths. Each is a
+complete reply in its own terms and each used to set ``retrieval`` to ``[]`` and
+return, discarding ``resolved_pool`` -- the full ranked file list, already built,
+already paid for.
+
+Measured on the 70 ContextBench dev instances: the gates that fire after
+retrieval account for 20 firings and 15 replies that named no gold file, every
+one of them with a ranked pool in hand (finding A25's census).
+
+The structural test below is the one that matters. A behavioural test can only
+cover the branches it can reach, and the defect here is a branch nobody thought
+about, so the invariant is asserted over the source: **no ``return`` inside
+``get_answer`` positioned after ``resolved_pool`` is assigned may bypass
+``_with_candidates``.** A future reordering of a 1,800-line function cannot
+quietly re-open the hole.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+from pathlib import Path
+
+from repowise.server.mcp_server.tool_answer import answer as answer_mod
+from repowise.server.mcp_server.tool_answer.answer import _with_candidates
+
+# Returns that route through this are covered: the helper attaches the block
+# itself. ``_degraded_payload`` is the shared shape for both synthesis-less
+# paths and calls ``_with_candidates`` internally.
+_COVERING_CALLS = {"_with_candidates", "_degraded_payload"}
+
+# The mainline return. It attaches ``candidates`` a few lines above itself
+# rather than through the helper, because it also has to build the block after
+# synthesis has run. Named explicitly so the exemption is a decision on the
+# record rather than a hole the test cannot see.
+_MAINLINE_RETURN = "payload"
+
+
+def _get_answer_ast() -> tuple[ast.AsyncFunctionDef, str]:
+    src = Path(inspect.getfile(answer_mod)).read_text(encoding="utf-8")
+    tree = ast.parse(src)
+    fn = next(
+        n
+        for n in ast.walk(tree)
+        if isinstance(n, ast.AsyncFunctionDef) and n.name == "get_answer"
+    )
+    return fn, src
+
+
+def _resolved_pool_line(fn: ast.AsyncFunctionDef) -> int:
+    return next(
+        n.lineno
+        for n in ast.walk(fn)
+        if isinstance(n, ast.Assign)
+        and any(getattr(t, "id", "") == "resolved_pool" for t in n.targets)
+    )
+
+
+def test_no_post_retrieval_return_bypasses_the_candidates_helper():
+    fn, src = _get_answer_ast()
+    pool_line = _resolved_pool_line(fn)
+
+    offenders: list[str] = []
+    for node in ast.walk(fn):
+        if not isinstance(node, ast.Return) or node.value is None:
+            continue
+        if node.lineno <= pool_line:
+            continue  # fires before retrieval; there is no pool to hand over
+        value = node.value
+        if isinstance(value, ast.Name) and value.id == _MAINLINE_RETURN:
+            continue
+        covered = (
+            isinstance(value, ast.Call)
+            and isinstance(value.func, ast.Name)
+            and value.func.id in _COVERING_CALLS
+        )
+        if not covered:
+            snippet = (ast.get_source_segment(src, value) or "").splitlines()[:1]
+            offenders.append(f"line {node.lineno}: {snippet}")
+
+    assert not offenders, (
+        "these returns fire after retrieval and hand back none of the ranked "
+        f"pool they already hold: {offenders}"
+    )
+
+
+def test_the_mainline_return_is_still_the_only_exemption():
+    """Guards the exemption above from widening by accident.
+
+    If someone renames the mainline payload variable or adds a second bare-name
+    return, the test above would silently stop covering it. This pins the count.
+    """
+    fn, _ = _get_answer_ast()
+    pool_line = _resolved_pool_line(fn)
+    bare = [
+        n
+        for n in ast.walk(fn)
+        if isinstance(n, ast.Return)
+        and n.lineno > pool_line
+        and isinstance(n.value, ast.Name)
+    ]
+    assert len(bare) == 1, f"expected exactly one bare-name return, found {len(bare)}"
+    assert bare[0].value.id == _MAINLINE_RETURN
+
+
+def test_helper_attaches_the_shortlist():
+    payload = {"answer": "", "retrieval": []}
+    out = _with_candidates(payload, [{"target_path": "a.py"}, {"target_path": "b.py"}])
+    assert out["candidates"] == [{"path": "a.py"}, {"path": "b.py"}]
+
+
+def test_helper_adds_nothing_when_the_pool_is_empty():
+    """An empty block is worse than none: it reads as "retrieval found nothing"."""
+    payload = {"answer": "", "retrieval": []}
+    assert "candidates" not in _with_candidates(payload, [])
+
+
+def test_helper_takes_nothing_away():
+    """The point of the fix is that each gate's own reply is returned unchanged."""
+    payload = {
+        "answer": "x",
+        "citations": ["a.py"],
+        "confidence": "high",
+        "grounding": "exact_symbol",
+        "symbol_bodies": [{"path": "a.py"}],
+        "retrieval": [],
+    }
+    before = dict(payload)
+    out = _with_candidates(payload, [{"target_path": "z.py"}])
+    for key, value in before.items():
+        assert out[key] == value
+
+
+def test_a_page_that_names_no_file_never_becomes_a_candidate_here_either():
+    """Finding A15 holds on the early-return path too.
+
+    The helper delegates to ``serialize_candidates``, so this is a wiring
+    assertion rather than a re-test of the resolver: the fix must not have
+    introduced a second, laxer path to the same field.
+    """
+    out = _with_candidates(
+        {},
+        [
+            {"page_type": "onboarding", "target_path": "onboarding/guided_tour"},
+            {"page_type": "file_page", "target_path": "pkg/list.go"},
+        ],
+    )
+    assert out["candidates"] == [{"path": "pkg/list.go"}]

--- a/tests/unit/server/mcp/test_answer_synthesis_timeout.py
+++ b/tests/unit/server/mcp/test_answer_synthesis_timeout.py
@@ -398,6 +398,7 @@ def test_both_failure_modes_return_the_same_payload_shape(reason):
         "degraded",
         "fallback_targets",
         "retrieval",
+        "candidates",
         "note",
         "_meta",
     }


### PR DESCRIPTION
`get_answer` has several returns that fire *after* retrieval has already run: the
qualified-miss guard, answer-by-union, the no-hits reply, the legacy abstain, the
value-extraction fast path, and both degraded paths. Each was written as a
complete reply in its own terms, and each set `retrieval` to `[]` and returned,
leaving `resolved_pool` unread.

That is right about `retrieval`, which is re-read evidence for a synthesised
answer and should shrink as confidence rises. It is wrong about what the caller
is left holding. The ranked file list already exists at every one of those sites,
built before the 5-hit synthesis cap, at no further cost.

So a caller whose question tripped one of these gates got a narrower reply than
one whose question did not, and got it *because* we recognised their question
more precisely. Ask "what fields does X have" and you got a field set with
nowhere to go next; ask something vaguer and you got the shortlist.

## The fix

`_with_candidates` attaches the shortlist to every post-retrieval return.

**No gate stops firing and no predicate moves.** Loosening a retrieval gate was
tried before and measured at -6.4 recall@5, because ungated neighbour injection
evicts the module page that is the answer. This only adds a field, so the special
reply each gate exists to give is returned unchanged.

## The test is over the source, not over the branches

The defect here is a branch nobody thought about in a long function, and a
behavioural test only covers branches its author already knows about. So the
invariant is asserted by walking the AST: **no `return` inside `get_answer`
positioned after `resolved_pool` is assigned may bypass `_with_candidates`**, with
the mainline return named as the single exemption and a second test pinning that
the exemption stays single. A future reordering cannot quietly re-open the hole.

## Measured

Three independent readings, none of which lost anything.

| set | n | replies naming a gold file, before | after | lost |
|---|---:|---:|---:|---:|
| ContextBench dev, gates that fire after retrieval | 16 | 5 | **15** | **0** |
| mui, held out, whole set | 45 | 7 | **15** | **0** |
| mui, held out, gate cells only | 22 | 0 | **5** | **0** |

The comparison is one payload read two ways rather than two runs of two binaries.
The change is additive at the payload, so the "before" set is the same reply with
one key ignored, which is exact and cannot flatter it: anything the after side
scores came from the block being added.

Cost of the block, over 70 instances: **+902 bytes median, +1,095 worst case**,
never negative. It is capped at 20 entries. On a reply that was previously near
empty that is a large relative addition, and it is the reply that was serving
nothing at all.

Not claimed: an end-to-end quality number. The local retrieval gate does not read
`candidates` at all, so it cannot speak to this change in either direction, and
saying it passed a regression check it is blind to would be worth nothing.

`ruff check .` clean, `tests/unit/server` green.
