### PR TITLE
fix(mcp): let the data-shape fast path read the question, not the whole paste

### DIFF
--- a/packages/server/src/repowise/server/mcp_server/tool_answer/data_shape.py
+++ b/packages/server/src/repowise/server/mcp_server/tool_answer/data_shape.py
@@ -63,20 +63,65 @@ _CONTAINMENT_VERBS = ("contain", "consist", "comprise", "hold", "look like", "ma
 
 _WORD = re.compile(r"[a-z_]+")
 
+# A body this long is not a question, it is a report that may contain one. The
+# bound is deliberately generous: the longest genuine one-line data-shape
+# question anyone writes is well under it, and the bug reports this exists to
+# exclude run to a median of about 1200 characters.
+_BARE_QUESTION_MAX_CHARS = 400
+
+# Sentence-ish split. Only `?` actually matters below; `.`/`!`/newline are here
+# so a question sentence is bounded by the prose around it rather than swallowing
+# it. Fenced code and tracebacks are full of `.` and newlines, which is fine:
+# splitting them finer only makes it harder for a stray cue to land in a clause
+# that also ends in `?`.
+_SENTENCE_SPLIT = re.compile(r"(?<=[.?!])\s+|\n+")
+
+
+def _interrogative_clauses(question: str) -> list[str]:
+    """The parts of ``question`` that are actually asking something.
+
+    A sentence ending in `?` is a question. If the whole input is short and asks
+    nothing explicitly, the input *is* the question — "what keys are in the
+    blame_record blob" and "describe the schema of GitCommitMeta" are how people
+    type, and demanding punctuation of them would break the short-question case
+    this fast path exists for. Anything longer with no `?` in it is a report, and
+    reports get no clauses.
+    """
+    clauses = [s.strip() for s in _SENTENCE_SPLIT.split(question) if s.strip().endswith("?")]
+    if clauses:
+        return clauses
+    if len(question) <= _BARE_QUESTION_MAX_CHARS:
+        return [question]
+    return []
+
 
 def _is_data_shape_question(question: str, question_ids: set[str]) -> bool:
     """Whether ``question`` asks for the field set of a named data blob.
 
-    Requires (a) a named identifier (something to ground on) and (b) a lexical
-    data-shape cue: a shape noun (field/key/column/schema/...), or a container
-    noun (entry/record/element/...) paired with a containment verb. Mechanism
-    questions ("how does X work") carry neither and fall through. The cue is a
-    cheap gate only; the miner is the real precision gate (it returns nothing
-    unless the fields are grounded in source), so a false-positive cue is safe.
+    Requires (a) a named identifier anywhere in the text, something to ground on,
+    and (b) a lexical data-shape cue **inside an interrogative clause**: a shape
+    noun (field/key/column/schema/...), or a container noun
+    (entry/record/element/...) paired with a containment verb. Mechanism
+    questions ("how does X work") carry neither and fall through.
+
+    The cue itself is still cheap, and the miner is still the real precision
+    gate. What the clause restriction adds is a precondition on *where* the cue
+    may sit. "A false-positive cue is safe" holds for a question someone typed
+    and fails for a body someone pasted: across a bug-report corpus a shape noun
+    like `field` or `key` appears incidentally in nearly every ticket, the
+    identifier extractor always finds something to ground on, and the miner then
+    answers a question nobody asked — returning a field list to a caller who
+    pasted a stack trace, before retrieval has run at all. Requiring the cue to
+    sit in the question's own interrogative clause keeps the short-question case
+    intact and stops an arbitrarily long body from being mined by accident.
     """
     if not question or not question_ids:
         return False
-    low = question.lower()
+    return any(_clause_carries_shape_cue(c) for c in _interrogative_clauses(question))
+
+
+def _clause_carries_shape_cue(clause: str) -> bool:
+    low = clause.lower()
     words = set(_WORD.findall(low))
     if words & _SHAPE_NOUNS:
         return True

--- a/tests/unit/server/mcp/test_answer_data_shape.py
+++ b/tests/unit/server/mcp/test_answer_data_shape.py
@@ -59,6 +59,71 @@ def test_detection(question, ids, expected):
     assert _is_data_shape_question(question, ids) is expected
 
 
+# --- Where the cue is allowed to sit --------------------------------------
+#
+# The cue is a cheap gate and the miner is the precision gate, which holds for a
+# question someone typed and fails for a body someone pasted. A bug report or a
+# stack trace mentions `field` or `key` in passing, the identifier extractor
+# always finds something to ground on, and the caller who wanted files gets a
+# field list back before retrieval has run at all. So the cue has to sit in the
+# question's own interrogative clause.
+
+_TICKET = (
+    "AuthenticationForm's username field doesn't set maxlength HTML attribute.\n"
+    "Description\n"
+    "AuthenticationForm's username field doesn't render with maxlength anymore.\n"
+    "Regression introduced in #27515 and 5ceaf14686ce626404afb6a5fbd3d8286410bf13.\n"
+    "The widget_attrs() call no longer passes the max_length through, so the\n"
+    "rendered input element is missing the attribute it used to carry, and every\n"
+    "template that relied on it now renders an unbounded text box instead.\n"
+)
+
+
+@pytest.mark.parametrize(
+    "question,ids,expected",
+    [
+        # A long report whose shape noun is incidental. The old cue fired here.
+        (_TICKET, {"AuthenticationForm", "widget_attrs"}, False),
+        # Same report, with a real data-shape question appended. The question is
+        # the question, however much prose precedes it.
+        (
+            _TICKET + "\nWhat fields does each entry in widget_attrs contain?",
+            {"AuthenticationForm", "widget_attrs"},
+            True,
+        ),
+        # Same report, with a question that is not about shape. The shape nouns
+        # in the body must not be borrowed by an unrelated interrogative.
+        (
+            _TICKET + "\nWas this deliberate?",
+            {"AuthenticationForm", "widget_attrs"},
+            False,
+        ),
+        # A short unpunctuated body IS the question: people type this way, and
+        # demanding a `?` of them would break the case the fast path is for.
+        ("what keys does session_payload carry", {"session_payload"}, True),
+    ],
+)
+def test_cue_must_sit_in_an_interrogative_clause(question, ids, expected):
+    assert _is_data_shape_question(question, ids) is expected
+
+
+def test_long_pasted_body_with_no_question_never_fires():
+    """The product argument, independent of any benchmark.
+
+    An agent pasting a stack trace into `get_answer` wants the files. Gate 2
+    returns before the cache and before retrieval, so firing here is the
+    thinnest possible answer to the broadest possible ask.
+    """
+    trace = (
+        'Traceback (most recent call last):\n'
+        '  File "app/models.py", line 88, in save\n'
+        '    self.full_clean()\n'
+        'ValidationError: {"schema": ["This field is required."]}\n'
+    ) * 8
+    assert len(trace) > 400
+    assert _is_data_shape_question(trace, {"full_clean", "ValidationError"}) is False
+
+
 # --- Documented shape (authoritative -> high) -----------------------------
 
 


### PR DESCRIPTION
`get_answer` has a fast path for "what fields does each entry in X contain": mine the field set straight from source rather than hand back a pointer list. Its cue is one shape noun (`field`, `key`, `column`, `schema`, ...) appearing anywhere in the text. The module argues that is safe because the miner behind it refuses to ground unless the fields are really in source, so a false-positive cue costs nothing.

That holds for a question someone typed. It fails for a body someone pasted.

A bug report mentions `field` or `key` in passing, the identifier extractor always finds something to ground on, and the miner then answers a question nobody asked. The caller who pasted a traceback and wanted files gets a field list instead, and gets it from the earliest return in the function: before the cache, before any retrieval runs at all. The thinnest payload the tool can produce, handed to the broadest ask.

It reproduces on this repo. Asking the server how the data-shape fast path works returns the field names of a test fixture, at `confidence: high`, with `retrieval: []`, and never answers the question.

## The change

The cue now has to sit inside the question's own interrogative clause. A sentence ending in `?` is a question. A short body with no `?` is itself the question, because "what keys are in the blame_record blob" is how people type and demanding punctuation would break the case the fast path exists for. A long body with nothing interrogative in it is a report, and a report is not asking for a field set.

No predicate is widened, no gate is removed, and the fast path is otherwise untouched. On a real short question it does exactly what it did before.

## Measurements

Predicate re-run over 70 third-party bug reports, and over short typed questions as a control:

| | before | after |
|---|---:|---:|
| typed data-shape questions (must keep firing) | 6/6 | **6/6** |
| mechanism questions (must not fire) | 0/3 | 0/3 |
| pasted bug reports, python | 23/50 | **3/50** |
| pasted bug reports, Go | 1/20 | 1/20 |

End-to-end through `get_answer` against one fixed index, 50 python bug reports, same index both arms:

| | before | after |
|---|---:|---:|
| returns via the fast path | 13/50 | **0/50** |
| replies naming a known-relevant file | 34/50 | **46/50** |
| mean paths served | 15.0 | 19.7 |

Twelve recovered, **zero broken**. The single case not recovered is one where no retrieval approach tried reaches the file at all.

## Regression

- `tests/unit/server`: 1,610 passed
- `ruff check .`: clean
- 99-question retrieval eval, before and after on the same staged index, answer cache disabled: recall@5 and recall@10 **identical** (0.8485 / 0.8485). 93 of 99 questions unchanged; the 6 that moved moved by one rank and none crossed the hit/miss line, which is that eval's known run-to-run noise.
- That eval contains 2 questions that legitimately trip the cue (`E11_data_shape_mining`, `E62_demand_attributes_citations`). **Both still take the fast path, in both arms.** Its questions average 82 characters, so it has almost no exposure to this change, and saying "the eval is green" without that number would be overstating what it can see.