### PR TITLE
feat(hooks): rank the files the search actually matched, not the index's guess

### DIFF
--- a/packages/cli/src/repowise/cli/commands/augment_cmd/search.py
+++ b/packages/cli/src/repowise/cli/commands/augment_cmd/search.py
@@ -1,4 +1,23 @@
-"""PostToolUse Grep/Glob smart enrichment: rescue, triage, flood digest."""
+"""PostToolUse Grep/Glob smart enrichment: rescue, triage, flood digest.
+
+Every surface here answers a question **about the agent's own results**, so
+each one starts by reading them: :func:`_matched_files` parses the grep output
+into ``node id -> match count`` and nothing downstream may speak without it.
+That is the correction plan items 8 and 10 exist for. Triage used to build its
+candidates from a ``WikiSymbol`` ILIKE and rank them by PageRank without ever
+looking at the output, which let a confident three-line answer name a file the
+search had not matched; rescue used to be reachable only at exactly zero
+results, which is the cheapest possible proxy for "the agent is missing
+something".
+
+The digest is the exception and stays index-free by design: it summarizes the
+flood rather than reasoning about it, so it works on an unindexed repo.
+
+Rescue, triage and the appended digest are **advisory**: they add context
+next to the tool output, they do not replace it. They therefore spend tokens
+and are not billed to the savings ledger; only the *served* digest
+(:mod:`search_digest`) replaces bytes and records a saving.
+"""
 
 from __future__ import annotations
 
@@ -20,6 +39,19 @@ from ._shared import HookResult, _extract_output_text, _find_repo_root
 _TRIAGE_THRESHOLD = 15  # grep result lines before we surface a ranking
 _TRIAGE_TOP_N = 3
 _RESCUE_TOP_N = 2
+# Exact-name rows the widened rescue fetches before ranking. Its gate asks
+# about the *top* match's file, so an arbitrary two-of-many would make the
+# answer depend on row order; this is small enough to stay one indexed lookup
+# and large enough that the ranking, not the LIMIT, picks the winner.
+_RESCUE_EXACT_FETCH = 8
+# Files the triage ranker considers. Ranking is over the grep's own matches,
+# so this only bites on floods wider than 200 files, where the tail is taken
+# by match count, the one signal available before any index lookup.
+_TRIAGE_MAX_CANDIDATES = 200
+# Reciprocal Rank Fusion constant, k=60 from the original RRF paper. Same
+# value as ``_fused_retrieve`` in the MCP search tool, which fuses the same
+# way over a different set of legs.
+_RRF_K = 60
 _DIGEST_THRESHOLD = 50  # grep result lines before the full compact digest
 _DIGEST_TOP_FILES = 10
 
@@ -83,12 +115,37 @@ def _handle_search_post(
         mode = "rescue"
     elif result_count >= _TRIAGE_THRESHOLD:
         mode = "triage"
-    else:
+    elif _looks_like_regex(pattern) or _targets_single_non_code_file(tool_input):
+        # Same two guards as the zero-result rescue, for the same reasons.
         return HookResult()
+    elif len(_pattern_terms(pattern)) < 2:
+        # A third guard the zero-result rescue does not need. Replayed over
+        # this machine's real greps, every false positive the widened rescue
+        # produced came from a single-token pattern (`coverage`, `score`,
+        # `provider`) where "a symbol by that name is defined elsewhere" is
+        # true of half the repo and interesting nowhere. Under zero results
+        # even a generic name is the only lead going; under real results it
+        # competes with evidence. Free to check, and it runs before the
+        # query, so it also keeps the cost off the common path.
+        return HookResult()
+    else:
+        mode = "rescue_wide"
+
+    # Both surviving modes are answers *about the agent's own results*, so
+    # neither may run without them. Triage ranks the matched files and rescue
+    # fires only on a file that is absent from them; a mode that cannot see
+    # the result set has no honest question to answer and stays silent.
+    matched = None
+    if mode != "rescue":
+        matched = _matched_files(repo_path, tool_output, output_text)
+        if not matched:
+            return HookResult()
 
     import asyncio
 
-    enrichment = asyncio.run(_search_enrich(repo_path, pattern, mode, result_count))
+    enrichment = asyncio.run(
+        _search_enrich(repo_path, pattern, mode, result_count, matched)
+    )
     if enrichment:
         _log_search_firing(repo_path, session_id, mode, enrichment)
     return HookResult(context=enrichment or None)
@@ -248,6 +305,57 @@ def _grep_flood_digest(repo_path: Path, output_text: str) -> str | None:
     return f"[repowise] Search flood — compact digest (files ordered by {order_note}):\n{digest}"
 
 
+def _as_node_ids(repo_path: Path, paths: list[str]) -> dict[str, str]:
+    """Map each grep-spelled path to its graph-node id, keeping the original.
+
+    Grep output paths may be absolute or OS-native; graph node ids and
+    ``WikiSymbol.file_path`` are repo-relative POSIX. Every index lookup in
+    this module goes through here so the two spellings only have to be
+    reconciled once.
+    """
+    normalized: dict[str, str] = {}
+    repo_posix = repo_path.as_posix().rstrip("/") + "/"
+    for p in paths:
+        norm = p.replace("\\", "/").removeprefix("./")
+        if norm.startswith(repo_posix):
+            norm = norm[len(repo_posix) :]
+        normalized[norm] = p
+    return normalized
+
+
+def _matched_files(repo_path: Path, tool_output: object, output_text: str) -> dict[str, int] | None:
+    """Files the search actually matched, as node id → match count.
+
+    ``None`` means "unknowable", which is different from "none matched": a
+    single-file context grep (``-C``/``-A``/``-B``) is rendered with no path
+    prefix and a ``files_with_matches`` payload carries no line data, so the
+    two shapes have to be read differently and a third shape has to be
+    refused outright rather than guessed at.
+
+    This is the whole point of items 8 and 10: everything downstream ranks or
+    gates against the agent's *real* results instead of against the index's
+    opinion of what the pattern means.
+    """
+    from repowise.core.distill.filters.search_results import group_search_matches
+
+    groups = group_search_matches(output_text)
+    if groups:
+        ids = _as_node_ids(repo_path, list(groups))
+        return {node_id: len(groups[original]) for node_id, original in ids.items()}
+
+    # ``filenames`` rides along on content-mode payloads too, so it is the
+    # fallback rather than the first look: parsing the matches keeps the
+    # per-file counts, and this branch is what serves the modes that have no
+    # match text at all (``files_with_matches``, Glob) plus the context greps
+    # the parser declines. No counts here, so one apiece leaves the grep leg
+    # in ripgrep's own order, which is the only evidence that shape carries.
+    filenames = tool_output.get("filenames") if isinstance(tool_output, dict) else None
+    if not isinstance(filenames, list):
+        return None
+    names = [f for f in filenames if isinstance(f, str)]
+    return dict.fromkeys(_as_node_ids(repo_path, names), 1) or None
+
+
 async def _pagerank_file_order(repo_path: Path, paths: list[str]) -> list[str] | None:
     """Order *paths* by indexed PageRank, or None when the graph can't help."""
     db_path = repo_path / ".repowise" / "wiki.db"
@@ -264,15 +372,7 @@ async def _pagerank_file_order(repo_path: Path, paths: list[str]) -> list[str] |
     from repowise.core.persistence.crud import get_repository_by_path
     from repowise.core.persistence.database import resolve_db_url
 
-    # Grep output paths may be absolute or OS-native; graph node ids are
-    # repo-relative POSIX. Normalize both ways and keep the original spelling.
-    normalized: dict[str, str] = {}
-    repo_posix = repo_path.as_posix().rstrip("/") + "/"
-    for p in paths:
-        norm = p.replace("\\", "/").removeprefix("./")
-        if norm.startswith(repo_posix):
-            norm = norm[len(repo_posix) :]
-        normalized[norm] = p
+    normalized = _as_node_ids(repo_path, paths)
 
     engine = create_engine(resolve_db_url(repo_path))
     try:
@@ -473,6 +573,7 @@ async def _search_enrich(
     pattern: str,
     mode: str,
     result_count: int,
+    matched: dict[str, int] | None = None,
 ) -> str | None:
     """Run the rescue or triage query against the wiki and format output."""
     import re
@@ -505,8 +606,10 @@ async def _search_enrich(
 
             if mode == "rescue":
                 return await _rescue(session, engine, repo_id, pattern, clean)
-            if mode == "triage":
-                return await _triage(session, repo_id, pattern, clean, result_count)
+            if mode == "rescue_wide" and matched:
+                return await _rescue(session, engine, repo_id, pattern, clean, matched)
+            if mode == "triage" and matched:
+                return await _triage(session, repo_id, pattern, clean, result_count, matched)
             return None
     finally:
         await engine.dispose()
@@ -518,6 +621,7 @@ async def _rescue(
     repo_id: int,
     pattern: str,
     clean: str,
+    matched: dict[str, int] | None = None,
 ) -> str | None:
     """Zero-result rescue: grep missed but the wiki has a semantic hit.
 
@@ -532,6 +636,21 @@ async def _rescue(
       3. Skip — if neither signal hits, we have nothing useful to add.
 
     Output is a single line so it can't be confused with a real result.
+
+    Passing *matched* runs the **widened** variant (plan item 10): the grep
+    returned a handful of results rather than none, and the rescue is allowed
+    to speak only when the best symbol hit lives in a file that is **not**
+    among them. This is a set difference, deliberately not a count threshold.
+    Rescue's 44% action rate is the highest in the system and it comes from
+    firing only when it has genuinely new information; a count threshold
+    ("few results, so say something") would turn it into a general suggester
+    and spend that rate. Two extra narrowings hold the same bar:
+
+    * only an **exact** name-variant match qualifies. Under a real result set
+      a fuzzy neighbour is a guess competing against evidence the agent
+      already has, where under zero results it was the only candidate going.
+    * **no FTS fallback.** "The wiki suggests this page" answers a question
+      the agent is no longer asking once grep has handed it real files.
     """
     from sqlalchemy import or_, select
 
@@ -548,13 +667,24 @@ async def _rescue(
     # Build a small set of token variants. Cheap; helps catch case-style
     # drift without a heavy similarity index.
     variants = _name_variants(clean)
-    like_clauses = [
-        WikiSymbol.name.ilike(f"%{escape_like(v)}%", escape=LIKE_ESCAPE) for v in variants
-    ]
+    lowered = {v.lower() for v in variants}
+    if matched is None:
+        name_clause = or_(
+            *[
+                WikiSymbol.name.ilike(f"%{escape_like(v)}%", escape=LIKE_ESCAPE)
+                for v in variants
+            ]
+        )
+    else:
+        # Exactness enforced in SQL, not by filtering the fetched page. The
+        # substring query is unordered under a LIMIT, so an exact match can
+        # sit well outside the first two rows, and post-filtering them would
+        # have made the widened rescue almost never fire, silently.
+        name_clause = WikiSymbol.name.in_(sorted(variants))
     sym_stmt = (
         select(WikiSymbol.name, WikiSymbol.kind, WikiSymbol.file_path, WikiSymbol.start_line)
-        .where(WikiSymbol.repository_id == repo_id, or_(*like_clauses))
-        .limit(_RESCUE_TOP_N)
+        .where(WikiSymbol.repository_id == repo_id, name_clause)
+        .limit(_RESCUE_TOP_N if matched is None else _RESCUE_EXACT_FETCH)
     )
     rows = (await session.execute(sym_stmt)).all()
     if rows:
@@ -562,12 +692,20 @@ async def _rescue(
         # specific). All ties broken by file path lex order for stability.
         def _rank(row):
             name = (row[0] or "").lower()
-            exact = name in {v.lower() for v in variants}
-            return (not exact, len(name), row[2] or "")
+            return (name not in lowered, len(name), row[2] or "")
 
         rows = sorted(rows, key=_rank)[:_RESCUE_TOP_N]
         first = rows[0]
         line = f":{first[3]}" if first[3] else ""
+        if matched is not None:
+            if (first[2] or "") in matched:
+                # The agent already has this file. Nothing new to say.
+                return None
+            return (
+                f"[repowise] `{pattern}` matched {len(matched)} "
+                f"file{'s' if len(matched) != 1 else ''}, but not {first[2]}{line}, "
+                f"where indexed {first[1]} `{first[0]}` is defined."
+            )
         extras = ""
         if len(rows) > 1:
             extras = f" (+{len(rows) - 1} more)"
@@ -575,6 +713,9 @@ async def _rescue(
             f"[repowise] No literal match for `{pattern}`. Closest indexed symbol: "
             f"{first[1]} `{first[0]}` in {first[2]}{line}{extras}"
         )
+
+    if matched is not None:
+        return None
 
     # Fall back to FTS on wiki content. Only return if the FTS row actually
     # points at a code page (file/module/api), not a generic doc page.
@@ -608,68 +749,165 @@ async def _triage(
     pattern: str,
     clean: str,
     result_count: int,
+    matched: dict[str, int],
 ) -> str | None:
-    """Big-result triage: surface top files by PageRank.
+    """Big-result triage: rank the files the search matched, best first.
 
-    The grep result set has too many lines for the agent to scan
-    efficiently. Without overriding the agent's literal results, we
-    point at the top _TRIAGE_TOP_N files (by structural centrality)
-    that contain the pattern in either symbol or path.
+    *matched* is the grep's own output, parsed (see :func:`_matched_files`),
+    and it is the whole candidate set. The previous version built candidates
+    from a ``WikiSymbol`` ILIKE plus a path ILIKE and ranked those by bare
+    PageRank, never reading the grep output at all, so a confident,
+    well-formatted answer could name a file the agent's search had not
+    matched. The index now orders the agent's results; it no longer proposes
+    its own.
 
-    Output is one line plus an enumerated list. Three lines max.
+    Three ranked lists are fused by Reciprocal Rank Fusion (``1/(rank + k)``,
+    k=60), the same arithmetic ``_fused_retrieve`` uses in the MCP search
+    tool. RRF is pure rank arithmetic, so it ports into a hook unchanged,
+    unlike the embedding leg it fuses there, which needs a network call and is
+    out of scope for a hook by the phase-3 retrieval ceiling.
+
+      * **grep evidence**: every matched file, by match count. The only leg
+        that is not an opinion, and the only one that is always populated.
+      * **name coverage**: the fraction of the pattern's subtokens present
+        in a file's path or in the names of its matching indexed symbols.
+        Formula ported from ``_rerank_by_coverage`` in the MCP answer
+        pipeline (see :func:`_coverage_order`). This is what makes the
+        ranking query-aware rather than a fixed importance order: it is the
+        leg that separates the file that *defines* the thing from the twenty
+        that merely mention it.
+      * **PageRank**: structural centrality, the previous sole signal, kept
+        as a tiebreak-weight leg rather than as the verdict.
+
+    A file present in two legs beats a file present in one, which is exactly
+    the property that makes RRF the right fusion here.
+
+    Output is one header line plus at most :data:`_TRIAGE_TOP_N` files.
     """
     from sqlalchemy import select
 
     from repowise.core.persistence import GraphNode, WikiSymbol
     from repowise.core.persistence.sql import LIKE_ESCAPE, escape_like
 
-    if not clean:
+    if not clean or len(matched) < 2:
+        # One matched file needs no ranking; the agent is already looking at
+        # it. Emitting there would be pure cost.
         return None
 
-    # Files that contain a symbol whose name matches, or whose own path
-    # matches. Either way we can rank by PageRank from graph_nodes.
-    sym_files_stmt = (
-        select(WikiSymbol.file_path)
-        .where(
-            WikiSymbol.repository_id == repo_id,
-            WikiSymbol.name.ilike(f"%{escape_like(clean)}%", escape=LIKE_ESCAPE),
-        )
-        .distinct()
-        .limit(50)
-    )
-    sym_files = {r[0] for r in (await session.execute(sym_files_stmt)).all() if r[0]}
+    # Widest floods first-cut by match count. See _TRIAGE_MAX_CANDIDATES.
+    paths = sorted(matched, key=lambda p: (-matched[p], p))[:_TRIAGE_MAX_CANDIDATES]
 
-    path_stmt = (
-        select(GraphNode.node_id)
-        .where(
-            GraphNode.repository_id == repo_id,
-            GraphNode.node_type == "file",
-            GraphNode.node_id.ilike(f"%{escape_like(clean)}%", escape=LIKE_ESCAPE),
-        )
-        .limit(50)
+    sym_stmt = select(WikiSymbol.file_path, WikiSymbol.name).where(
+        WikiSymbol.repository_id == repo_id,
+        WikiSymbol.file_path.in_(paths),
+        WikiSymbol.name.ilike(f"%{escape_like(clean)}%", escape=LIKE_ESCAPE),
     )
-    path_files = {r[0] for r in (await session.execute(path_stmt)).all() if r[0]}
-
-    candidates = sym_files | path_files
-    if not candidates:
-        return None
+    symbol_names: dict[str, list[str]] = {}
+    for file_path, name in (await session.execute(sym_stmt)).all():
+        if file_path and name:
+            symbol_names.setdefault(file_path, []).append(name)
 
     pr_stmt = select(GraphNode.node_id, GraphNode.pagerank).where(
         GraphNode.repository_id == repo_id,
         GraphNode.node_type == "file",
-        GraphNode.node_id.in_(candidates),
+        GraphNode.node_id.in_(paths),
     )
-    pr_rows = (await session.execute(pr_stmt)).all()
-    if not pr_rows:
+    pagerank = {
+        node_id: pr or 0.0
+        for node_id, pr in (await session.execute(pr_stmt)).all()
+        if node_id
+    }
+    if not symbol_names and not pagerank:
+        # The index knows nothing about any matched file. Re-listing the
+        # grep's own top files back at it is not worth the tokens.
         return None
 
-    ranked = sorted(pr_rows, key=lambda r: r[1] or 0.0, reverse=True)[:_TRIAGE_TOP_N]
-    if not ranked:
-        return None
+    legs = [
+        paths,
+        _coverage_order(pattern, paths, symbol_names),
+        sorted(
+            (p for p in paths if p in pagerank),
+            key=lambda p: (-pagerank[p], p),
+        ),
+    ]
+    fused = _rrf(legs)
+    ranked = sorted(paths, key=lambda p: (-fused.get(p, 0.0), p))[:_TRIAGE_TOP_N]
 
-    header = f"[repowise] {result_count}+ matches for `{pattern}`. Top files by graph centrality:"
-    lines = [header] + [f"  {row[0]}" for row in ranked]
+    header = (
+        f"[repowise] {result_count}+ matches for `{pattern}` across {len(matched)} "
+        f"files. Most likely relevant, ranked over the files your search matched:"
+    )
+    lines = [header] + [f"  {p}  ({matched[p]} matches)" for p in ranked]
     return "\n".join(lines)
+
+
+def _rrf(legs: list[list[str]]) -> dict[str, float]:
+    """Reciprocal Rank Fusion over ranked lists: ``sum(1/(rank + k))``.
+
+    Ported verbatim in behaviour from ``_fused_retrieve``; no score scaling,
+    because nothing downstream compares these numbers against a tuned
+    threshold; they only order three files.
+    """
+    scores: dict[str, float] = {}
+    for leg in legs:
+        for rank, key in enumerate(leg):
+            scores[key] = scores.get(key, 0.0) + 1.0 / (rank + _RRF_K)
+    return scores
+
+
+def _coverage_order(
+    pattern: str, paths: list[str], symbol_names: dict[str, list[str]]
+) -> list[str]:
+    """Matched files ordered by how much of *pattern* their names cover.
+
+    Term coverage, ported from ``_rerank_by_coverage`` in
+    ``tool_answer/retrieval.py``: the fraction of the query's distinct terms
+    present in the candidate's text. What did not port is that function's
+    ``raw * (FLOOR + (1-FLOOR)*coverage)`` blend. The floor exists to keep a
+    BM25 score dominant while coverage modulates it, and there is no BM25
+    score on this path. Here coverage produces a *rank*, and RRF does the
+    blending the floor was standing in for.
+
+    Nor does the stopword list port: it lives in the MCP answer pipeline, and
+    importing that package into a hook would pull the server stack in at hook
+    startup for a set of English words a grep pattern does not contain.
+
+    Files covering nothing are dropped rather than ranked last: an empty leg
+    is an honest "no signal", where a full one would inject noise into the
+    fusion.
+    """
+    terms = _pattern_terms(pattern)
+    if not terms:
+        return []
+    scored: list[tuple[float, str]] = []
+    for p in paths:
+        haystack = " ".join([p, *symbol_names.get(p, [])]).lower()
+        coverage = sum(1 for t in terms if t in haystack) / len(terms)
+        if coverage:
+            scored.append((coverage, p))
+    scored.sort(key=lambda item: (-item[0], item[1]))
+    return [p for _, p in scored]
+
+
+def _pattern_terms(pattern: str) -> list[str]:
+    """Distinct content subtokens of a search pattern, lowercased.
+
+    Splits on non-word characters *and* on snake/camel boundaries, so
+    ``record_saving`` covers ``record`` and ``saving`` independently and a
+    file named ``savings.py`` scores against the half it actually carries.
+    Terms shorter than three characters are dropped as noise, matching
+    ``_question_terms``.
+    """
+    import re
+
+    parts = re.split(r"[^\w]+", pattern)
+    terms: list[str] = []
+    for part in parts:
+        for token in re.split(r"_+|(?<=[a-z0-9])(?=[A-Z])", part):
+            token = token.lower()
+            if len(token) >= 3 and token not in terms:
+                terms.append(token)
+    return terms
 
 
 def _name_variants(token: str) -> list[str]:

--- a/packages/core/src/repowise/core/sessions/efficacy.py
+++ b/packages/core/src/repowise/core/sessions/efficacy.py
@@ -33,10 +33,18 @@ read          skeleton_served n/a — the hook already did it (see below)
 read          stale_read      n/a — a warning, not a pointer
 search        triage          a named file is touched
 search        rescue          the named file or symbol is touched
+search        rescue_wide     same, scored apart (see below)
 search        digest          a file the digest ranked is touched
 search        digest_served   n/a, the hook already did it (see below)
 fix_history   edit_notice     a test is run, or the file's history is inspected
 ============= =============== ==================================================
+
+``rescue_wide`` is the same emitter under a different precondition (grep
+returned a few results and the best indexed symbol is in a file none of them
+name), and it is a **separate category** on purpose. ``rescue``'s 44% is the
+highest action rate in the system and it was measured on the zero-result
+population only; pooling a new population under the same key would move that
+number without anything having changed about the surface it describes.
 
 A ranged Read after a skeleton nudge is deliberately **not** acting: reading a
 range of a file you just read in full is ordinary edit-prep and cannot be
@@ -177,6 +185,24 @@ _PATTERNS: tuple[tuple[str, str, re.Pattern[str]], ...] = (
     ),
     (
         "search",
+        "rescue_wide",
+        re.compile(
+            r"^\[repowise\] `(?P<pattern>[^`]+)` matched \d+ files?, but not "
+            r"(?P<target>[^\s:]+)(?::\d+)?, where indexed \S+ `(?P<symbol>[^`]+)`"
+        ),
+    ),
+    (
+        "search",
+        "triage",
+        re.compile(
+            r"^\[repowise\] \d+\+ matches for `(?P<pattern>[^`]+)` across \d+ files\. "
+            r"Most likely relevant"
+        ),
+    ),
+    # The pre-#1292 triage header. Kept so `hook backfill` still settles the
+    # 111 firings already in the corpus; nothing new lands here.
+    (
+        "search",
         "triage",
         re.compile(r"^\[repowise\] \d+\+ matches for `(?P<pattern>[^`]+)`\. Top files by"),
     ),
@@ -306,6 +332,7 @@ def classify(firing: Firing, following: list[tuple[str, str]]) -> Firing:
         ("read", "skeleton_nudge"): _acted_skeleton,
         ("search", "triage"): _acted_target,
         ("search", "rescue"): _acted_rescue,
+        ("search", "rescue_wide"): _acted_rescue,
         ("search", "digest"): _acted_target,
         ("fix_history", "edit_notice"): _acted_fix_history,
     }.get((firing.surface, firing.category))

--- a/tests/unit/cli/test_augment_search.py
+++ b/tests/unit/cli/test_augment_search.py
@@ -25,6 +25,14 @@ from repowise.cli.commands.augment_cmd import (
     _search_result_count,
     _targets_single_non_code_file,
 )
+from repowise.cli.commands.augment_cmd.search import (
+    _coverage_order,
+    _matched_files,
+    _pattern_terms,
+    _rescue,
+    _rrf,
+    _triage,
+)
 
 # ---------------------------------------------------------------------------
 # Grep/Glob tool_response fixtures — captured from real Claude Code
@@ -345,16 +353,66 @@ class TestDecisionTree:
             enrich.assert_not_called()
 
     def test_skip_when_outside_repowise_repo(self, tmp_path) -> None:
-        # No .repowise dir: silently skip without invoking the enrich path.
+        """No .repowise dir: silently skip without invoking the enrich path.
+
+        ``_find_repo_root`` is stubbed rather than relied on. A ``tmp_path``
+        cwd is not in fact outside a repo under pytest: the suite patches
+        ``HOME``, so ``_find_repo_root``'s "skip the user-level ``~/.repowise``"
+        guard no longer recognises the real home and the walk resolves to it.
+        Before the widened rescue this test passed anyway, on the focused-set
+        skip below rather than on the branch it names.
+        """
         with patch.object(augment_cmd.search, "_search_enrich") as enrich:
-            assert _call("Grep", "auth", "src/a.py:1: hit", tmp_path) is None
+            with patch.object(augment_cmd.search, "_find_repo_root", return_value=None):
+                assert _call("Grep", "auth", "src/a.py:1: hit", tmp_path) is None
             enrich.assert_not_called()
 
-    def test_skip_on_focused_result_set(self, repowise_cwd) -> None:
-        """1–14 lines = focused: agent has what it wanted, hook stays silent."""
+    def test_focused_result_set_reaches_the_widened_rescue(self, repowise_cwd) -> None:
+        """1–14 lines: the set-difference rescue gets a look (plan item 10).
+
+        It is still usually silent, since the gate is inside ``_rescue`` and
+        needs an exact symbol match in a file the grep did *not* return, but the
+        mode is no longer skipped before the query.
+        """
+        output = "\n".join(f"src/file{i}.py:1: hit" for i in range(5))
+        sentinel = object()
+        with (
+            patch.object(augment_cmd.search, "_search_enrich", return_value=sentinel) as enrich,
+            patch("asyncio.run", side_effect=lambda coro: (coro.close(), sentinel)[1]),
+        ):
+            _call("Grep", "parse_yaml", output, repowise_cwd)
+        args = enrich.call_args_list[0].args
+        assert args[2] == "rescue_wide"
+        # ...and it is handed the files grep actually matched, which is the
+        # only thing the gate can be computed against.
+        assert set(args[4]) == {f"src/file{i}.py" for i in range(5)}
+
+    @pytest.mark.parametrize("pattern", ["coverage", "score", "provider", "layer_id"])
+    def test_single_token_patterns_never_reach_the_widened_rescue(
+        self, repowise_cwd, pattern: str
+    ) -> None:
+        """Every false positive in the transcript replay had this shape.
+
+        "A symbol by that name is defined elsewhere" is true of half the repo
+        for a bare `coverage` or `score`. The guard is also what keeps the
+        query off the common path: it runs before any wiki lookup.
+        """
         output = "\n".join(f"src/file{i}.py:1: hit" for i in range(5))
         with patch.object(augment_cmd.search, "_search_enrich") as enrich:
-            assert _call("Grep", "auth", output, repowise_cwd) is None
+            assert _call("Grep", pattern, output, repowise_cwd) is None
+            enrich.assert_not_called()
+
+    def test_focused_result_set_stays_silent_without_parseable_files(
+        self, repowise_cwd
+    ) -> None:
+        """A result set whose files can't be read means no gate, so no rescue.
+
+        The pattern clears the single-token guard on purpose, so this pins the
+        parse gate rather than passing on the cheaper one above it.
+        """
+        output = "\n".join(f"unstructured line {i}" for i in range(5))
+        with patch.object(augment_cmd.search, "_search_enrich") as enrich:
+            assert _call("Grep", "parse_yaml", output, repowise_cwd) is None
             enrich.assert_not_called()
 
     @pytest.mark.parametrize(
@@ -383,16 +441,24 @@ class TestDecisionTree:
             assert mode == "rescue"
 
     def test_no_rescue_for_successful_files_mode_grep(self, repowise_cwd) -> None:
-        """The live bug: files_with_matches results must never read as zero."""
-        with patch.object(augment_cmd.search, "_search_enrich") as enrich:
-            result = _handle_search_post(
+        """The live bug: files_with_matches results must never read as zero.
+
+        Two matched files is a focused set, so this now reaches the *widened*
+        rescue. What must never happen is the zero-result ``rescue``, whose
+        text claims there was no literal match at all.
+        """
+        sentinel = object()
+        with (
+            patch.object(augment_cmd.search, "_search_enrich", return_value=sentinel) as enrich,
+            patch("asyncio.run", side_effect=lambda coro: (coro.close(), sentinel)[1]),
+        ):
+            _handle_search_post(
                 tool_name="Grep",
                 tool_input={"pattern": "distill_savings"},
                 tool_output=GREP_FILES_MODE,
                 cwd=str(repowise_cwd),
             )
-            assert not result
-            enrich.assert_not_called()
+        assert enrich.call_args_list[0].args[2] == "rescue_wide"
 
     @pytest.mark.parametrize(
         "tool_output",
@@ -486,15 +552,18 @@ class TestFloodDigest:
             assert out == sentinel
             assert enrich.called
 
-    def test_unparseable_flood_falls_through(self, repowise_cwd) -> None:
-        """Glob-style bare path lists can't be grouped — triage handles them."""
+    def test_unparseable_flood_stays_silent(self, repowise_cwd) -> None:
+        """No parseable files means no honest triage (plan item 8).
+
+        This used to fall through to a triage that ranked index candidates
+        with no reference to the grep output, which is precisely how it could
+        name a file the search had not matched. With nothing to rank, the
+        hook says nothing.
+        """
         big = "\n".join(f"line {i} of something unstructured" for i in range(60))
-        sentinel = "triaged"
-        with patch.object(augment_cmd.search, "_search_enrich", return_value=sentinel) as enrich:
-            with patch("asyncio.run", side_effect=lambda coro: (coro.close(), sentinel)[1]):
-                out = _call("Grep", "auth", big, repowise_cwd)
-            assert out == sentinel
-            assert enrich.called
+        with patch.object(augment_cmd.search, "_search_enrich") as enrich:
+            assert _call("Grep", "auth", big, repowise_cwd) is None
+            enrich.assert_not_called()
 
     def test_top_files_listed_first(self, repowise_cwd) -> None:
         flood = "\n".join(
@@ -506,3 +575,172 @@ class TestFloodDigest:
         assert out is not None
         file_lines = [ln for ln in out.splitlines() if "matches)" in ln]
         assert file_lines[0].strip().startswith("src/hot.py")
+
+
+# ---------------------------------------------------------------------------
+# Item 8/9/10: ranking over the grep's real results
+# ---------------------------------------------------------------------------
+
+
+class _FakeResult:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def all(self):
+        return self._rows
+
+
+class _FakeSession:
+    """Returns canned row sets in call order; records the statements it saw."""
+
+    def __init__(self, *row_sets):
+        self._queue = list(row_sets)
+        self.statements = []
+
+    async def execute(self, stmt):
+        self.statements.append(stmt)
+        return _FakeResult(self._queue.pop(0) if self._queue else [])
+
+
+class TestMatchedFiles:
+    """What the hook believes the search actually returned."""
+
+    def test_content_mode_gives_per_file_counts(self, repowise_cwd) -> None:
+        text = "src/a.py:1:x\nsrc/a.py:9:x\nsrc/b.py:3:x"
+        assert _matched_files(repowise_cwd, GREP_CONTENT_MODE, text) == {
+            "src/a.py": 2,
+            "src/b.py": 1,
+        }
+
+    def test_filenames_are_the_fallback_not_the_first_look(self, repowise_cwd) -> None:
+        """Content mode carries ``filenames`` too; the counts must win."""
+        payload = {"mode": "content", "filenames": ["src/z.py"], "content": ""}
+        text = "src/a.py:1:x\nsrc/a.py:2:x"
+        assert _matched_files(repowise_cwd, payload, text) == {"src/a.py": 2}
+
+    def test_files_with_matches_uses_filenames(self, repowise_cwd) -> None:
+        matched = _matched_files(repowise_cwd, GREP_FILES_MODE, "")
+        assert matched == {
+            "packages/web/src/lib/api/costs.ts": 1,
+            "packages/web/src/app/repos/[id]/costs/page.tsx": 1,
+        }
+
+    def test_absolute_paths_become_node_ids(self, repowise_cwd) -> None:
+        text = f"{repowise_cwd.as_posix()}/src/a.py:1:x"
+        assert _matched_files(repowise_cwd, {}, text) == {"src/a.py": 1}
+
+    def test_unreadable_output_is_none_not_empty(self, repowise_cwd) -> None:
+        """None means "unknowable" and must not read as "nothing matched"."""
+        assert _matched_files(repowise_cwd, {}, "some prose\nmore prose") is None
+
+
+class TestPatternTerms:
+    def test_splits_snake_and_camel(self) -> None:
+        assert _pattern_terms("record_saving") == ["record", "saving"]
+        assert _pattern_terms("recordSaving") == ["record", "saving"]
+
+    def test_drops_short_tokens_and_dedups(self) -> None:
+        assert _pattern_terms("db_id_handler_handler") == ["handler"]
+
+    def test_empty_pattern_has_no_terms(self) -> None:
+        assert _pattern_terms("()") == []
+
+
+class TestCoverageOrder:
+    def test_symbol_names_and_paths_both_count(self) -> None:
+        order = _coverage_order(
+            "record_saving",
+            ["src/misc.py", "src/savings.py", "src/ledger.py"],
+            {"src/ledger.py": ["record_saving"]},
+        )
+        # Full coverage from the symbol name beats half from the path, and
+        # the file covering neither term is absent rather than ranked last.
+        assert order == ["src/ledger.py", "src/savings.py"]
+
+    def test_no_terms_gives_an_empty_leg(self) -> None:
+        assert _coverage_order("[]", ["src/a.py"], {}) == []
+
+
+class TestRRF:
+    def test_agreement_across_legs_wins(self) -> None:
+        scores = _rrf([["a", "b"], ["b", "a"], ["b"]])
+        assert scores["b"] > scores["a"]
+
+    def test_absent_from_every_leg_is_absent(self) -> None:
+        assert "c" not in _rrf([["a"], ["b"]])
+
+
+class TestTriageRanksRealMatches:
+    async def test_only_matched_files_are_named(self) -> None:
+        matched = {"src/a.py": 3, "src/b.py": 1}
+        session = _FakeSession(
+            # WikiSymbol rows: (file_path, name)
+            [("src/b.py", "parse_yaml")],
+            # GraphNode rows: (node_id, pagerank). The index also knows an
+            # unmatched hub, which must never reach the output.
+            [("src/a.py", 0.9), ("src/b.py", 0.1)],
+        )
+        out = await _triage(session, 1, "parse_yaml", "parse_yaml", 40, matched)
+        assert out is not None
+        named = [ln.strip().split()[0] for ln in out.splitlines()[1:]]
+        assert set(named) <= set(matched)
+
+    async def test_coverage_lifts_the_definition_over_the_hub(self) -> None:
+        """Item 9: query-aware ranking beats bare PageRank.
+
+        ``src/hub.py`` has more matches and far more centrality; ``src/b.py``
+        is the only file whose symbol name covers the query. Two legs to one
+        is what RRF is for.
+        """
+        matched = {"src/hub.py": 30, "src/b.py": 2}
+        session = _FakeSession(
+            [("src/b.py", "parse_yaml")],
+            [("src/hub.py", 0.9), ("src/b.py", 0.01)],
+        )
+        out = await _triage(session, 1, "parse_yaml", "parse_yaml", 40, matched)
+        assert out.splitlines()[1].strip().startswith("src/b.py")
+
+    async def test_single_matched_file_is_not_worth_a_ranking(self) -> None:
+        session = _FakeSession([("src/a.py", "x")], [("src/a.py", 0.5)])
+        assert await _triage(session, 1, "x", "x", 40, {"src/a.py": 20}) is None
+
+    async def test_silent_when_the_index_knows_none_of_them(self) -> None:
+        session = _FakeSession([], [])
+        matched = {"src/a.py": 3, "src/b.py": 1}
+        assert await _triage(session, 1, "auth", "auth", 40, matched) is None
+
+    async def test_header_states_the_population(self) -> None:
+        matched = {"src/a.py": 3, "src/b.py": 1}
+        session = _FakeSession([], [("src/a.py", 0.9), ("src/b.py", 0.1)])
+        out = await _triage(session, 1, "auth", "auth", 40, matched)
+        assert out.splitlines()[0] == (
+            "[repowise] 40+ matches for `auth` across 2 files. "
+            "Most likely relevant, ranked over the files your search matched:"
+        )
+
+
+class TestWidenedRescueGate:
+    """Item 10: fire only on a file the grep did not return."""
+
+    async def test_silent_when_the_symbol_is_in_a_matched_file(self) -> None:
+        session = _FakeSession([("parse_yaml", "function", "src/a.py", 10)])
+        out = await _rescue(
+            session, None, 1, "parse_yaml", "parse_yaml", {"src/a.py": 3, "src/b.py": 1}
+        )
+        assert out is None
+
+    async def test_fires_on_a_file_outside_the_result_set(self) -> None:
+        session = _FakeSession([("parseYaml", "function", "src/other.py", 10)])
+        out = await _rescue(
+            session, None, 1, "parse_yaml", "parse_yaml", {"src/a.py": 3, "src/b.py": 1}
+        )
+        assert out == (
+            "[repowise] `parse_yaml` matched 2 files, but not src/other.py:10, "
+            "where indexed function `parseYaml` is defined."
+        )
+
+    async def test_no_fts_fallback_when_the_grep_found_things(self) -> None:
+        """A wiki page suggestion is not new information against real hits."""
+        session = _FakeSession([])
+        out = await _rescue(session, None, 1, "parse_yaml", "parse_yaml", {"src/a.py": 3})
+        assert out is None

--- a/tests/unit/sessions/test_efficacy.py
+++ b/tests/unit/sessions/test_efficacy.py
@@ -37,6 +37,16 @@ RESCUE = (
     "[repowise] No literal match for `parseYaml`. Closest indexed symbol: "
     "function `parse_yaml` in pkg/core/loader.py:12"
 )
+TRIAGE_V2 = (
+    "[repowise] 40+ matches for `parse_yaml` across 12 files. Most likely relevant, "
+    "ranked over the files your search matched:\n"
+    "  pkg/core/loader.py  (9 matches)\n"
+    "  pkg/core/schema.py  (2 matches)"
+)
+RESCUE_WIDE = (
+    "[repowise] `parse_yaml` matched 3 files, but not pkg/core/loader.py:12, "
+    "where indexed function `parseYaml` is defined."
+)
 FIXES = "[repowise] pkg/core/loader.py has been bug-fixed 9x in the last 6 months, last 3 days ago."
 REREAD = (
     "[repowise] You already read pkg/core/thing.py this session and it is unchanged — "
@@ -58,6 +68,8 @@ def test_parses_each_surface_with_its_target():
         (NUDGE, "read", "skeleton_nudge", "pkg/core/thing.py"),
         (TRIAGE, "search", "triage", "pkg/core/loader.py"),
         (RESCUE, "search", "rescue", "pkg/core/loader.py"),
+        (TRIAGE_V2, "search", "triage", "pkg/core/loader.py"),
+        (RESCUE_WIDE, "search", "rescue_wide", "pkg/core/loader.py"),
         (FIXES, "fix_history", "edit_notice", "pkg/core/loader.py"),
         (REREAD, "read", "reread", "pkg/core/thing.py"),
     ):
@@ -79,6 +91,27 @@ def test_triage_keeps_its_ranked_file_list_in_order():
     (firing,) = parse_emission(TRIAGE)
     assert firing.targets == ["pkg/core/loader.py", "pkg/core/schema.py"]
     assert firing.pattern == "parse_yaml"
+
+
+def test_the_retired_triage_header_still_parses():
+    """`hook backfill` replays transcripts written before the item-9 rewrite."""
+    (firing,) = parse_emission(TRIAGE)
+    assert (firing.surface, firing.category) == ("search", "triage")
+
+
+def test_new_triage_header_keeps_its_ranked_list_and_match_counts():
+    (firing,) = parse_emission(TRIAGE_V2)
+    assert firing.targets == ["pkg/core/loader.py", "pkg/core/schema.py"]
+    assert firing.pattern == "parse_yaml"
+
+
+def test_widened_rescue_is_scored_apart_from_the_zero_result_one():
+    """Same emitter, different population; pooling would move rescue's 44%."""
+    (firing,) = parse_emission(RESCUE_WIDE)
+    assert firing.category == "rescue_wide"
+    assert firing.targets == ["pkg/core/loader.py", "parseYaml"]
+    classify(firing, [_use("Read", file_path="pkg/core/loader.py")])
+    assert firing.acted is True
 
 
 def test_digest_paths_are_normalized_from_windows_spelling():


### PR DESCRIPTION
The Grep triage hook picked the files it names from the index, not from the
search. It built candidates with a `WikiSymbol` name ILIKE plus a `graph_nodes`
path ILIKE, ranked them by PageRank, and never read the grep output at all.

Replaying every Grep call in a month of local transcripts (1,899 calls with a
paired `toolUseResult`) against a live index and scoring each named file
against what that grep actually returned:

| | before | after |
|---|---|---|
| files named, scoreable against the real result set | 111 | 471 |
| of those, **not in the grep results** | **83 (74.8%)** | **0** |

Three files in four. Not an edge case.

## What changed

**Triage ranks the search's own results.** A new `_matched_files` parses the
tool output into `node id -> match count`, reusing `group_search_matches` and
falling back to the payload's `filenames` for the modes that carry no match
text. That set is now the entire candidate list, so 0% is structural rather
than lucky.

A flood whose files cannot be read stays silent instead of guessing. That is
396 of 602 eligible floods, almost all single-file context greps (`-C`/`-A`/
`-B`), which Claude Code renders with no path prefix. Those are exactly the
firings with the least business naming another file: the agent asked for
context in one named file and was pointed at three others.

**Ranking is query-aware, not fixed importance.** Three ranked lists fused by
Reciprocal Rank Fusion at k=60, the same arithmetic `_fused_retrieve` already
uses in the MCP search tool: grep match count, term coverage over the file's
path and its matching symbol names, and PageRank. Coverage is the leg that
separates the file defining a thing from the twenty that mention it; a file
present in two legs beats a file present in one, which is what RRF is for.

The coverage formula is ported from `_rerank_by_coverage`, but its
`raw * (FLOOR + (1-FLOOR)*coverage)` blend deliberately is not: that floor
exists to keep a BM25 score dominant while coverage modulates it, and there is
no BM25 score here. Coverage yields a rank and RRF does the blending. The
stopword set did not port either, since importing the answer pipeline into a
hook would pull the server stack in at hook startup.

**Rescue widens to 1-14 results behind a set-difference gate.** It speaks only
when the top exact-name symbol lives in a file the grep did not return, with no
fuzzy matching and no FTS fallback, so the "genuinely new information" bar that
earns rescue its action rate survives. Exactness is enforced in SQL rather than
by filtering a fetched page, because the substring query is unordered under a
LIMIT and post-filtering would have made the surface almost never fire,
silently.

On the real corpus it emits 7 times in 87 queries, and all seven name the true
definition site, three of them pure snake/camel drift:

```
build_repo_graph     -> pipeline/incremental.py:49
list_repos           -> api-client/src/repos.ts:14      (listRepos)
graph_builder        -> ingestion/graph/builder.py:31   (GraphBuilder)
docs_mode            -> core/docs_mode.py:21            (DocsMode)
mark_tombstone_pages -> pipeline/persist.py:54
iter_specs           -> generation/onboarding/registry.py:91
WikiSymbol           -> persistence/models.py:381
```

A single-token guard keeps out bare generic patterns. Every false positive the
replay produced had that shape (`coverage`, `score`, `provider`), where "a
symbol by that name is defined elsewhere" is true of half the repo. It is a
string check that runs before the query, so it buys precision and 40 fewer
queries at once.

This lands as its own `rescue_wide` ledger category rather than joining
`rescue`. Same emitter, different population: pooling them would move a
measured number without anything changing about the surface it describes.

## Cost

Measured same-checkout on the installed `repowise-augment` console script:

| bucket | before | after |
|---|---|---|
| flood >= 15 results | 1255ms | 1340ms |
| focused 1-14, multi-token pattern | 161ms | 1320ms |
| focused 1-14, single-token (gated) | 166ms | 159ms |
| unparseable context grep | 155ms | 173ms |

The widened rescue moves a bucket that used to return before any query onto a
path that reaches one, and reaching the index at all costs ~1.1s of cold
`repowise.core.persistence` import in a fresh hook process. The query itself,
warm, is 34ms; the same two lookups in stdlib `sqlite3` are 15ms. Over a month
of real work that is ~90s of added latency for 7 emissions. Under half a second
per session, but a poor per-emission trade, and stated here rather than
averaged away. A follow-up moves the three lookups that need no shared code
onto stdlib `sqlite3`, which also fixes the flood path that already pays this
today.

No module-scope imports were added; the augment package still imports in ~60ms.

## Not a savings

All three surfaces stay advisory: they append context next to tool output they
do not replace, so they spend tokens and their benefit is a counterfactual with
no grounded floor on the result. Nothing is recorded to the savings ledger, and
`HOOK_REPLACEMENT_SURFACES` is untouched, so no new consent surface exists and
the init prompt copy is unchanged.

Measured token cost: triage goes from ~51 to ~93 tokens per firing (longer
header plus per-file match counts); the widened rescue is ~39. Against that,
the old 51 tokens were 75% wrong.

## Tests

The old triage header keeps its parser entry so `hook backfill` still settles
the firings already in the corpus. New coverage for `_matched_files`,
`_pattern_terms`, `_coverage_order`, `_rrf`, the triage ranking, and the rescue
gate, plus `rescue_wide` parsing and classification.

`test_skip_when_outside_repowise_repo` now stubs `_find_repo_root`. It never
tested its own premise: the suite patches `HOME`, so `_find_repo_root`'s
"skip the user-level `~/.repowise`" guard stops recognising the real home and
the walk up from `tmp_path` resolves to it. It passed only because 1-14 results
returned early one branch later, and widening that branch exposed it.
