### PR TITLE
release: v0.38.0 - four new languages, orientation rebuilt, search and hooks reworked

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "name": "repowise",
       "source": "./plugins/claude-code",
       "description": "Codebase intelligence for Claude Code. Indexes your repo into five layers (Graph, Git, Docs, Decisions, Code Health) and gives Claude deep understanding of architecture, ownership, hotspots, decisions, and defect risk — fewer greps, fewer file reads, lower cost per query.",
-      "version": "0.37.0",
+      "version": "0.38.0",
       "category": "productivity",
       "keywords": [
         "codebase",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,70 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.38.0] — 2026-08-04
+
+Four new languages, an orientation set rebuilt around what a reader actually needs, and a wiki that draws on the repository's own vocabulary instead of writing generic prose about it. Svelte and Vue reach the Full tier through a byte-preserving projection into TypeScript; HTML lands at the import tier; reStructuredText documents are read as reStructuredText rather than silently yielding nothing. Onboarding is six pages now, ending in a glossary built entirely from mined terms, and a directory that heads a subsystem gets a chapter even when it also holds files of its own. Full-text search was rebuilt on both backends after the query shape turned out to match 65% of the corpus on a median question. The agent hooks got measurement first and then acted on it: the Grep flood is replaced by its digest instead of ranked next to it, triage ranks the files the search actually matched, and the three hot index lookups dropped an ORM import that cost a second per hook fire.
+
+### Added
+- **Svelte and Vue at the Full tier.** A markup grammar locates the JavaScript-bearing regions of a single-file component, every other byte is blanked to a space with newlines preserved, and each markup expression is fenced by rewriting its two surrounding delimiter bytes. The result is valid TypeScript at byte-identical offsets, so the TypeScript queries, language config and all three health dialects apply unchanged; only region location differs per language. Components reach the file tree, git history, wiki and health for the first time. (#1221, #1232)
+- **HTML at the import tier,** via `script src` and `link href`. HTML has no functions, classes or calls, so this ships an import-only tier and says so on every surface rather than minting symbols that do not exist. Template dialects are out of scope and that is stated: `{% extends %}` is plain text to an HTML grammar, and 744 of 749 measured dialect files produce no edges. (#1235)
+- **reStructuredText is read as reStructuredText.** Every pattern in the document miner was markdown-only, so a repository that documents itself in `.rst` looked identical to one that says nothing. flask, requests and django were all in that position. Underline-length, directive bodies and roles are each handled, and `.rst` prose written under a `.txt` extension is picked up too. (#1238, #1247)
+- **A glossary page, written entirely in the repository's own words.** House vocabulary (blast radius, change risk, co-change, distill) had no definition anywhere a reader could reach. Each row is a term, the repository's own defining sentence, where it is used and which document it was written in. The page has no model in its path at all: every cell is a fact the run already holds, so it costs no tokens and cannot hallucinate. (#1276)
+- **Subject chapters.** A parent directory was disqualified from heading its children whenever it also held loose files of its own, because both pages would collide on one page id. That excluded exactly the directories a reader most wants a chapter for, and did it silently: nine of thirteen chapters suppressed on this repository, five of six on django. (#1282)
+- **Perf dialects for Kotlin and C++, and a dataflow def/use dialect for C++,** which moves C++ to the Full tier with intra-procedural CFG, reaching definitions and Extract Method suggestions. C++ deliberately omits three markers other languages carry, each of which would be a guaranteed false positive there. (#1224, #1225)
+- **A page says how far it can be trusted.** `confidence` had been a constant 1.0 on every page ever generated, so the reader's low-confidence banner had never rendered for anyone and retrieval could not weight by it. A wiki where a provider outage left hundreds of structural stubs looked exactly as trustworthy as a complete one. (#1213)
+- **File pages and symbol spotlights name the questions they answer,** built from structure rather than prose, and emitted only where the page can actually answer them. (#1209, #1210)
+- **Hook efficacy measurement.** Four of five hook surfaces wrote rows nobody read, and the Read surface wrote none at all, so a nudge could fire 500 times at a 0.2% action rate with nothing in the product noticing. Transcripts are replayed to pair each emission with the tool calls that followed it. (#1272)
+- **Vocabulary mining with provenance.** Mined terms now carry their defining sentence, the document they were read from and every document that names them, which is what the overview, onboarding, key concepts and the glossary are built on. (#1233, #1241, #1242, #1249)
+- **`get_answer` meters what one synthesis call costs,** and configurable synthesis evidence lets a deployment choose how much the model is shown. (#1180, #1227)
+- **Retired page ids keep resolving,** and a retired page can hand off to the repository overview instead of dead-ending. (#1163, #1166)
+- **The OpenAI embedder honours a configured output width,** for deployments pinning a narrower vector than the model's default. (#1254)
+- **`update` names the orientation pages an index has never been offered** and points at `--full`, which is the path that can actually deliver them. An incremental run reads a changed-file slice, and every onboarding gate reads whole-repo signals. (#1288)
+
+### Changed
+- **The docs tree opens on the shape of the repository, not its contents.** Layers used to open by default, which was fine when a layer held a handful of children and wrong once layers grouped every module: roughly ninety module rows on the first screen, burying the layer names and the chapters alike. Layers start closed, the file corpus sits above the layer outline rather than under it, and an unclaimed module no longer poses as a layer. (#1184, #1185, #1186, #1187)
+- **A search hit's snippet is centred on what the query matched.** It used to be the first 200 characters of the page, which on a generated page is the same `## Overview` opener every time: identical across thousands of hits, and never the passage that matched. (#1191)
+- **The Grep flood is served as its digest, not ranked beside it.** Ranking a flood you also keep is a lens, not a saving; the digest was being added next to output the agent had already been billed for. It replaces the flood now, the same trade `distill` makes for shell output. Measured over real Grep payloads in 25 transcripts, the digest is 0.30 of the flood. (#1283)
+- **Grep triage ranks the files the search actually matched.** It built candidates from name and path matches ranked by PageRank without ever reading the grep output; replayed over 1,899 real Grep calls, 83 of the 111 files it named were not in the grep results at all. (#1296)
+- **The Read hook serves the skeleton instead of recommending it.** (#1275)
+- **`distill` rewrites safe command chains instead of bailing on their shape.** `repowise saved --missed` reported 138,827 tokens over 478 runs in 7 days that never reached distill. The binding gate was a re-quoting rule that refused any command containing a quote, a dollar sign or a backslash, so `grep -n "a\|b" f.py | head` bailed on the quotes it obviously contains. What `--missed` counts is corrected alongside. (#1291)
+- **Module pages name their own symbols** and stop opening with the same sentence as every other module page. (#1211, #1212)
+- **The overview carries the architecture map, counts its packages** rather than describing them, and says what the repository does in the repository's own words. (#1164, #1246, #1249)
+- **One recipe for every page vector,** with a page below the information floor getting no vector at all and pages that lose text at the embedding cap named rather than silently truncated. (#1200, #1192, #1203)
+- **Running one CLI command stops paying for the whole import graph.** Three module-level imports were charging their dependency tree to every invocation, including every hook fire: `repowise --version` drops from 1,240ms to 150ms, and a silent hook from 965ms to 167ms. (#1273)
+- **The three hot index lookups read through stdlib `sqlite3`.** Reaching the index from a hook cost a second, 95% of it a single import that none of the three plain SELECTs needed. (#1297)
+- **A command no longer waits out its own telemetry POST.** (#1286)
+- **Decisions rank a person above a document,** two sources that never landed are retired, and `get_why` path mode is bounded. (#1290, #1293)
+- **Layers group the docs tree without needing a page to hang off,** and pages carry the provenance of the layer that groups them. (#1165, #1170, #1171)
+
+### Fixed
+- **Full-text search was asking for most of the corpus.** Both backends built a MATCH expression that could not retrieve, failing in opposite directions: SQLite OR-ed every token with a prefix wildcard, so on a 3,678-page corpus the median question matched 65% of it and one matched everything; PostgreSQL handed the raw question to `plainto_tsquery`, which ANDs every lexeme and therefore matched almost nothing. A tombstoned page is also dropped from the index now, and a page can be too thin to be worth indexing. (#1188, #1190, #1198)
+- **The served skeleton never reached the agent.** `updatedToolOutput` is validated against the schema of the tool being replaced; the hook emitted a bare string where Read's output is an object, so Claude Code rejected it, used the original file, and the hook went on recording a saving. Every firing since the feature landed was a no-op that reported success. (#1278)
+- **The answer prompt formatter halved every page excerpt it fetched,** page content is attached on every retrieval rather than only the weak ones, and decision vectors and pageless ids stay out of the answer. (#1168, #1169, #1183)
+- **The first MCP tool call raced the lancedb import,** and the embedder API key is resolved from persisted config rather than the environment alone. (#1230, #1231)
+- **The data-shape fast path reads the question, not the whole paste,** and the early returns hand back the ranked pool they already hold. (#1284, #1289)
+- **Generation rejects pages that talk to the prompter,** refuses a structurally-keyed page with no key, drops sections a page cannot fill, tombstones a page whose file is gone, grounds flow narratives in exact source, and reads execution flows by the field names they have. A definition is taken to be prose the author wrote, not the markup below it. (#1172, #1201, #1202, #1206, #1207, #1208, #1229, #1245, #1248)
+- **JS/TS extraction picks up unparenthesized single-parameter arrow functions,** and HTML intrinsic elements no longer pose as JSX component call targets. (#1215, #1217)
+- **Python aliased imports parse correctly,** and a Node.js package `exports` wildcard may cross directory boundaries. (#1243, #1256)
+- **`doctor` reconciles the store against the database again.** (#1196)
+- **The Python perf dialect knows `pathlib` is filesystem I/O.** (#1269)
+- **The betweenness pool is bounded, live update locks are kept, and a failed page is counted once.** (#1262)
+- **Generation checks reach a normal run of `init` and `update`.** (#1178)
+- **Docker:** `/data` is created before `chown`, the image moves to `node:20-bookworm-slim` for glibc compatibility, and `.gitattributes` enforces LF on `.sh` files so the entrypoint runs on a Windows checkout. (#1266, #1268, #1270)
+- **The Stats punch card's UTC footnote describes rather than prescribes.** (#1240)
+
+### Documentation
+- The README carries media that renders on GitHub, a section and a picture for the PR bot, and cites the 21-repo health validation. (#1197, #1205, #1218)
+- Published measured results with a comparison against real peers. (#1287)
+- A `structurizr` export walkthrough in the examples and in the CLI package README. (#1175, #1176)
+- CONTRIBUTING documents how to claim an issue. (#1263)
+- The vocabulary overlap thresholds record what they actually measure. (#1181)
+
+### Dependencies
+- `tree-sitter-svelte` and `tree-sitter-html` are new, for Svelte and Vue respectively. There is no `tree-sitter-vue` on PyPI, and `tree-sitter-html` parses a Vue single-file component cleanly because `<template>`, `<script>` and `<style>` are ordinary elements to it.
+
+---
+
 ## [0.37.0] — 2026-07-29
 
 The release where the web UI got taken apart and put back together. Fourteen surfaces moved onto one design language: sections and hairlines instead of a grid of near-identical bordered cards, a sentence above every figure saying what the figure means, and a header row plus a key row on the pages whose canvas is the page. Overview, Docs, Commits, Contributors, Code Health, Coverage, Dead code, Chat, Settings, Decisions, Stats, Files, Refactoring, Knowledge Graph and Architecture all changed shape. The Architecture and Knowledge Graph canvases also got their marks named and their per-frame cost cut, and the docs page stopped downloading 38 MB of page bodies to draw a tree. Away from the UI there is a Structurizr DSL export, a first-run pass over interactive `init`, refreshed provider model defaults, and three MCP response fixes.

--- a/packages/cli/src/repowise/cli/__init__.py
+++ b/packages/cli/src/repowise/cli/__init__.py
@@ -16,4 +16,4 @@ from repowise.cli._stdio import _ensure_utf8_stdio
 # is already UTF-8.
 _ensure_utf8_stdio()
 
-__version__ = "0.37.0"
+__version__ = "0.38.0"

--- a/packages/core/src/repowise/core/__init__.py
+++ b/packages/core/src/repowise/core/__init__.py
@@ -6,4 +6,4 @@ generation engine. This is the heart of repowise — all other packages depend o
 Namespace package: repowise.core is part of the repowise namespace.
 """
 
-__version__ = "0.37.0"
+__version__ = "0.38.0"

--- a/packages/core/src/repowise/core/upgrade/_data/CHANGELOG.md
+++ b/packages/core/src/repowise/core/upgrade/_data/CHANGELOG.md
@@ -9,6 +9,70 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.38.0] — 2026-08-04
+
+Four new languages, an orientation set rebuilt around what a reader actually needs, and a wiki that draws on the repository's own vocabulary instead of writing generic prose about it. Svelte and Vue reach the Full tier through a byte-preserving projection into TypeScript; HTML lands at the import tier; reStructuredText documents are read as reStructuredText rather than silently yielding nothing. Onboarding is six pages now, ending in a glossary built entirely from mined terms, and a directory that heads a subsystem gets a chapter even when it also holds files of its own. Full-text search was rebuilt on both backends after the query shape turned out to match 65% of the corpus on a median question. The agent hooks got measurement first and then acted on it: the Grep flood is replaced by its digest instead of ranked next to it, triage ranks the files the search actually matched, and the three hot index lookups dropped an ORM import that cost a second per hook fire.
+
+### Added
+- **Svelte and Vue at the Full tier.** A markup grammar locates the JavaScript-bearing regions of a single-file component, every other byte is blanked to a space with newlines preserved, and each markup expression is fenced by rewriting its two surrounding delimiter bytes. The result is valid TypeScript at byte-identical offsets, so the TypeScript queries, language config and all three health dialects apply unchanged; only region location differs per language. Components reach the file tree, git history, wiki and health for the first time. (#1221, #1232)
+- **HTML at the import tier,** via `script src` and `link href`. HTML has no functions, classes or calls, so this ships an import-only tier and says so on every surface rather than minting symbols that do not exist. Template dialects are out of scope and that is stated: `{% extends %}` is plain text to an HTML grammar, and 744 of 749 measured dialect files produce no edges. (#1235)
+- **reStructuredText is read as reStructuredText.** Every pattern in the document miner was markdown-only, so a repository that documents itself in `.rst` looked identical to one that says nothing. flask, requests and django were all in that position. Underline-length, directive bodies and roles are each handled, and `.rst` prose written under a `.txt` extension is picked up too. (#1238, #1247)
+- **A glossary page, written entirely in the repository's own words.** House vocabulary (blast radius, change risk, co-change, distill) had no definition anywhere a reader could reach. Each row is a term, the repository's own defining sentence, where it is used and which document it was written in. The page has no model in its path at all: every cell is a fact the run already holds, so it costs no tokens and cannot hallucinate. (#1276)
+- **Subject chapters.** A parent directory was disqualified from heading its children whenever it also held loose files of its own, because both pages would collide on one page id. That excluded exactly the directories a reader most wants a chapter for, and did it silently: nine of thirteen chapters suppressed on this repository, five of six on django. (#1282)
+- **Perf dialects for Kotlin and C++, and a dataflow def/use dialect for C++,** which moves C++ to the Full tier with intra-procedural CFG, reaching definitions and Extract Method suggestions. C++ deliberately omits three markers other languages carry, each of which would be a guaranteed false positive there. (#1224, #1225)
+- **A page says how far it can be trusted.** `confidence` had been a constant 1.0 on every page ever generated, so the reader's low-confidence banner had never rendered for anyone and retrieval could not weight by it. A wiki where a provider outage left hundreds of structural stubs looked exactly as trustworthy as a complete one. (#1213)
+- **File pages and symbol spotlights name the questions they answer,** built from structure rather than prose, and emitted only where the page can actually answer them. (#1209, #1210)
+- **Hook efficacy measurement.** Four of five hook surfaces wrote rows nobody read, and the Read surface wrote none at all, so a nudge could fire 500 times at a 0.2% action rate with nothing in the product noticing. Transcripts are replayed to pair each emission with the tool calls that followed it. (#1272)
+- **Vocabulary mining with provenance.** Mined terms now carry their defining sentence, the document they were read from and every document that names them, which is what the overview, onboarding, key concepts and the glossary are built on. (#1233, #1241, #1242, #1249)
+- **`get_answer` meters what one synthesis call costs,** and configurable synthesis evidence lets a deployment choose how much the model is shown. (#1180, #1227)
+- **Retired page ids keep resolving,** and a retired page can hand off to the repository overview instead of dead-ending. (#1163, #1166)
+- **The OpenAI embedder honours a configured output width,** for deployments pinning a narrower vector than the model's default. (#1254)
+- **`update` names the orientation pages an index has never been offered** and points at `--full`, which is the path that can actually deliver them. An incremental run reads a changed-file slice, and every onboarding gate reads whole-repo signals. (#1288)
+
+### Changed
+- **The docs tree opens on the shape of the repository, not its contents.** Layers used to open by default, which was fine when a layer held a handful of children and wrong once layers grouped every module: roughly ninety module rows on the first screen, burying the layer names and the chapters alike. Layers start closed, the file corpus sits above the layer outline rather than under it, and an unclaimed module no longer poses as a layer. (#1184, #1185, #1186, #1187)
+- **A search hit's snippet is centred on what the query matched.** It used to be the first 200 characters of the page, which on a generated page is the same `## Overview` opener every time: identical across thousands of hits, and never the passage that matched. (#1191)
+- **The Grep flood is served as its digest, not ranked beside it.** Ranking a flood you also keep is a lens, not a saving; the digest was being added next to output the agent had already been billed for. It replaces the flood now, the same trade `distill` makes for shell output. Measured over real Grep payloads in 25 transcripts, the digest is 0.30 of the flood. (#1283)
+- **Grep triage ranks the files the search actually matched.** It built candidates from name and path matches ranked by PageRank without ever reading the grep output; replayed over 1,899 real Grep calls, 83 of the 111 files it named were not in the grep results at all. (#1296)
+- **The Read hook serves the skeleton instead of recommending it.** (#1275)
+- **`distill` rewrites safe command chains instead of bailing on their shape.** `repowise saved --missed` reported 138,827 tokens over 478 runs in 7 days that never reached distill. The binding gate was a re-quoting rule that refused any command containing a quote, a dollar sign or a backslash, so `grep -n "a\|b" f.py | head` bailed on the quotes it obviously contains. What `--missed` counts is corrected alongside. (#1291)
+- **Module pages name their own symbols** and stop opening with the same sentence as every other module page. (#1211, #1212)
+- **The overview carries the architecture map, counts its packages** rather than describing them, and says what the repository does in the repository's own words. (#1164, #1246, #1249)
+- **One recipe for every page vector,** with a page below the information floor getting no vector at all and pages that lose text at the embedding cap named rather than silently truncated. (#1200, #1192, #1203)
+- **Running one CLI command stops paying for the whole import graph.** Three module-level imports were charging their dependency tree to every invocation, including every hook fire: `repowise --version` drops from 1,240ms to 150ms, and a silent hook from 965ms to 167ms. (#1273)
+- **The three hot index lookups read through stdlib `sqlite3`.** Reaching the index from a hook cost a second, 95% of it a single import that none of the three plain SELECTs needed. (#1297)
+- **A command no longer waits out its own telemetry POST.** (#1286)
+- **Decisions rank a person above a document,** two sources that never landed are retired, and `get_why` path mode is bounded. (#1290, #1293)
+- **Layers group the docs tree without needing a page to hang off,** and pages carry the provenance of the layer that groups them. (#1165, #1170, #1171)
+
+### Fixed
+- **Full-text search was asking for most of the corpus.** Both backends built a MATCH expression that could not retrieve, failing in opposite directions: SQLite OR-ed every token with a prefix wildcard, so on a 3,678-page corpus the median question matched 65% of it and one matched everything; PostgreSQL handed the raw question to `plainto_tsquery`, which ANDs every lexeme and therefore matched almost nothing. A tombstoned page is also dropped from the index now, and a page can be too thin to be worth indexing. (#1188, #1190, #1198)
+- **The served skeleton never reached the agent.** `updatedToolOutput` is validated against the schema of the tool being replaced; the hook emitted a bare string where Read's output is an object, so Claude Code rejected it, used the original file, and the hook went on recording a saving. Every firing since the feature landed was a no-op that reported success. (#1278)
+- **The answer prompt formatter halved every page excerpt it fetched,** page content is attached on every retrieval rather than only the weak ones, and decision vectors and pageless ids stay out of the answer. (#1168, #1169, #1183)
+- **The first MCP tool call raced the lancedb import,** and the embedder API key is resolved from persisted config rather than the environment alone. (#1230, #1231)
+- **The data-shape fast path reads the question, not the whole paste,** and the early returns hand back the ranked pool they already hold. (#1284, #1289)
+- **Generation rejects pages that talk to the prompter,** refuses a structurally-keyed page with no key, drops sections a page cannot fill, tombstones a page whose file is gone, grounds flow narratives in exact source, and reads execution flows by the field names they have. A definition is taken to be prose the author wrote, not the markup below it. (#1172, #1201, #1202, #1206, #1207, #1208, #1229, #1245, #1248)
+- **JS/TS extraction picks up unparenthesized single-parameter arrow functions,** and HTML intrinsic elements no longer pose as JSX component call targets. (#1215, #1217)
+- **Python aliased imports parse correctly,** and a Node.js package `exports` wildcard may cross directory boundaries. (#1243, #1256)
+- **`doctor` reconciles the store against the database again.** (#1196)
+- **The Python perf dialect knows `pathlib` is filesystem I/O.** (#1269)
+- **The betweenness pool is bounded, live update locks are kept, and a failed page is counted once.** (#1262)
+- **Generation checks reach a normal run of `init` and `update`.** (#1178)
+- **Docker:** `/data` is created before `chown`, the image moves to `node:20-bookworm-slim` for glibc compatibility, and `.gitattributes` enforces LF on `.sh` files so the entrypoint runs on a Windows checkout. (#1266, #1268, #1270)
+- **The Stats punch card's UTC footnote describes rather than prescribes.** (#1240)
+
+### Documentation
+- The README carries media that renders on GitHub, a section and a picture for the PR bot, and cites the 21-repo health validation. (#1197, #1205, #1218)
+- Published measured results with a comparison against real peers. (#1287)
+- A `structurizr` export walkthrough in the examples and in the CLI package README. (#1175, #1176)
+- CONTRIBUTING documents how to claim an issue. (#1263)
+- The vocabulary overlap thresholds record what they actually measure. (#1181)
+
+### Dependencies
+- `tree-sitter-svelte` and `tree-sitter-html` are new, for Svelte and Vue respectively. There is no `tree-sitter-vue` on PyPI, and `tree-sitter-html` parses a Vue single-file component cleanly because `<template>`, `<script>` and `<style>` are ordinary elements to it.
+
+---
+
 ## [0.37.0] — 2026-07-29
 
 The release where the web UI got taken apart and put back together. Fourteen surfaces moved onto one design language: sections and hairlines instead of a grid of near-identical bordered cards, a sentence above every figure saying what the figure means, and a header row plus a key row on the pages whose canvas is the page. Overview, Docs, Commits, Contributors, Code Health, Coverage, Dead code, Chat, Settings, Decisions, Stats, Files, Refactoring, Knowledge Graph and Architecture all changed shape. The Architecture and Knowledge Graph canvases also got their marks named and their per-frame cost cut, and the docs page stopped downloading 38 MB of page bodies to draw a tree. Away from the UI there is a Structurizr DSL export, a first-run pass over interactive `init`, refreshed provider model defaults, and three MCP response fixes.

--- a/packages/server/src/repowise/server/__init__.py
+++ b/packages/server/src/repowise/server/__init__.py
@@ -7,4 +7,4 @@ Provides:
     - Background job scheduler (APScheduler)
 """
 
-__version__ = "0.37.0"
+__version__ = "0.38.0"

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "repowise",
   "description": "Codebase intelligence for Claude Code. Indexes your codebase into five layers (Graph, Git, Docs, Decisions, Code Health) and exposes them through ten task-shaped MCP tools — so Claude understands architecture, ownership, hotspots, why code is built the way it is, and where the defect risk lives.",
-  "version": "0.37.0",
+  "version": "0.38.0",
   "author": {
     "name": "Repowise",
     "email": "hello@repowise.dev",

--- a/plugins/claude-code/CHANGELOG.md
+++ b/plugins/claude-code/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the Repowise Claude Code plugin are documented here.
 
+## 0.38.0
+
+### Changed
+- Version bump to track the repowise 0.38.0 release. The MCP tool surface, the
+  CLI flags the commands document and the hook matchers in `hooks/hooks.json`
+  are unchanged this cycle; the parity check found no drift.
+
 ## 0.37.0
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "repowise"
-version = "0.37.0"
+version = "0.38.0"
 description = "The codebase intelligence layer for your AI coding agent — dependency graph, git history, dead code, decisions, and code health, exposed over MCP"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -3054,7 +3054,7 @@ wheels = [
 
 [[package]]
 name = "repowise"
-version = "0.37.0"
+version = "0.38.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },
@@ -3088,6 +3088,7 @@ dependencies = [
     { name = "tree-sitter-cpp" },
     { name = "tree-sitter-dart" },
     { name = "tree-sitter-go" },
+    { name = "tree-sitter-html" },
     { name = "tree-sitter-java" },
     { name = "tree-sitter-javascript" },
     { name = "tree-sitter-kotlin" },
@@ -3097,6 +3098,7 @@ dependencies = [
     { name = "tree-sitter-ruby" },
     { name = "tree-sitter-rust" },
     { name = "tree-sitter-scala" },
+    { name = "tree-sitter-svelte" },
     { name = "tree-sitter-swift" },
     { name = "tree-sitter-typescript" },
     { name = "uvicorn", extra = ["standard"] },
@@ -3180,6 +3182,7 @@ requires-dist = [
     { name = "tree-sitter-cpp", specifier = ">=0.23,<1" },
     { name = "tree-sitter-dart", specifier = ">=0.1,<1" },
     { name = "tree-sitter-go", specifier = ">=0.23,<1" },
+    { name = "tree-sitter-html", specifier = ">=0.23,<1" },
     { name = "tree-sitter-java", specifier = ">=0.23,<1" },
     { name = "tree-sitter-javascript", specifier = ">=0.23,<1" },
     { name = "tree-sitter-kotlin", specifier = ">=1,<2" },
@@ -3189,6 +3192,7 @@ requires-dist = [
     { name = "tree-sitter-ruby", specifier = ">=0.23,<1" },
     { name = "tree-sitter-rust", specifier = ">=0.23,<1" },
     { name = "tree-sitter-scala", specifier = ">=0.23,<1" },
+    { name = "tree-sitter-svelte", specifier = ">=1,<2" },
     { name = "tree-sitter-swift", specifier = ">=0.0.1" },
     { name = "tree-sitter-typescript", specifier = ">=0.23,<1" },
     { name = "types-networkx", marker = "extra == 'dev'", specifier = ">=3.3,<4" },
@@ -4047,6 +4051,21 @@ wheels = [
 ]
 
 [[package]]
+name = "tree-sitter-html"
+version = "0.23.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/06/ad1c53c79da15bef85939aa022d72301e12a9773e9bb9a5e6a6f65b7753a/tree_sitter_html-0.23.2.tar.gz", hash = "sha256:bc9922defe23144d9146bc1509fcd00d361bf6b3303f9effee6532c6a0296961", size = 13977, upload-time = "2024-11-11T05:58:07.403Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/27/b846852b567601c4df765bcb4636085a3260e9f03ae21e0ef2e7c7f957fc/tree_sitter_html-0.23.2-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:9e1641d5edf5568a246c6c47b947ed524b5bf944664e6473b21d4ae568e28ee9", size = 14787, upload-time = "2024-11-11T05:57:58.684Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/17/827c315deb156bb8cac541da800c4bd62878f50a28b7498fbb722bddd225/tree_sitter_html-0.23.2-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:3d0a83dd6cd1c7d4bcf6287b5145c92140f0194f8516f329ae8b9e952fbfa8ff", size = 15232, upload-time = "2024-11-11T05:58:00.139Z" },
+    { url = "https://files.pythonhosted.org/packages/91/cb/2028fe446d0e18edf3737d91edcb6430f2c97f2296b8cd760702dfa13d90/tree_sitter_html-0.23.2-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:81b3775732fffc0abd275a419ef018fd4c1ad4044b2a2e422f3378d93c30eded", size = 39109, upload-time = "2024-11-11T05:58:00.986Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bc/b24f5e66be51447cf7e9bcce3d9440a6b4f17021da85779a51566646a7c7/tree_sitter_html-0.23.2-cp39-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4bdaa7ac5030d416aea0c512d4810ef847bbbd62d61e3d213f370b64ce147293", size = 39630, upload-time = "2024-11-11T05:58:02.424Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/d5/31b46cb362ad9679af21ff8b75d846fb7522ecf949beea4fddc86e97815d/tree_sitter_html-0.23.2-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:d2e9631b66041a4fd792d7f79a0c4128adb3bfc71f3dcb7e1a3eab5dbee77d67", size = 37440, upload-time = "2024-11-11T05:58:03.819Z" },
+    { url = "https://files.pythonhosted.org/packages/28/30/03910b7c037105f33166439f0518dd0aa4f1b7ef8c9d7367c6e9cc6b5681/tree_sitter_html-0.23.2-cp39-abi3-win_amd64.whl", hash = "sha256:85095f49f9e57f0ac9087a3e830783352c8447fdda55b1c1139aa47e5eaa0e21", size = 17765, upload-time = "2024-11-11T05:58:05.163Z" },
+    { url = "https://files.pythonhosted.org/packages/20/32/63761055b03c69202a0e67b6e9a5cb3578da23aeefb62ee3e7ec2c1b0ff2/tree_sitter_html-0.23.2-cp39-abi3-win_arm64.whl", hash = "sha256:0f65ed9e877144d0f04ade5644e5b0e88bf98a9e60bce65235c99905623e2f1a", size = 15576, upload-time = "2024-11-11T05:58:06.577Z" },
+]
+
+[[package]]
 name = "tree-sitter-java"
 version = "0.23.5"
 source = { registry = "https://pypi.org/simple" }
@@ -4180,6 +4199,22 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/82/d0/45ddd0420cc9c08b21a7f62cbb662cbd5020cf0ef22d0ccebf07cf20f190/tree_sitter_scala-0.24.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:03da3b1a574d67aea41de1297eed0b36373636558ecfb7de70024cd4ef892d33", size = 592991, upload-time = "2025-06-08T18:16:33.501Z" },
     { url = "https://files.pythonhosted.org/packages/16/17/549c50360734cc2be73572f7a5055f0c703c6c63502161e3ee4dd7395e64/tree_sitter_scala-0.24.0-cp39-abi3-win_amd64.whl", hash = "sha256:a300c6e18fbaaf7d645bd66e598c9577ca3f9a34d0976db0ee7259dc4ed145bb", size = 475343, upload-time = "2025-06-08T18:16:34.596Z" },
     { url = "https://files.pythonhosted.org/packages/79/08/2f2d3895a387b3b8c04e6d9050b4436aaac0103fc31dc2354cd162e0d217/tree_sitter_scala-0.24.0-cp39-abi3-win_arm64.whl", hash = "sha256:5123eef2d5ef55e47943f958ad78605e20d1eec54926cd3296d8c6fc006b2ed7", size = 479012, upload-time = "2025-06-08T18:16:35.714Z" },
+]
+
+[[package]]
+name = "tree-sitter-svelte"
+version = "1.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bc/88/0b974d002bf819427e73155d69733530da75671fbdd3869490a46529d63d/tree_sitter_svelte-1.0.2.tar.gz", hash = "sha256:c7153ff70b09abda8eb6937653f374b722f8835abd20b728713a0e7bb90d0c2b", size = 28906, upload-time = "2024-09-08T00:50:06.299Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/a1/6474c819cb43a39c1b7ceec1cde24780c68914754fda673f14174ed3d1a6/tree_sitter_svelte-1.0.2-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:7a53e6ddb4c626e6595119d67231a4bf992af882d17640e279c33f7ede8e9ff8", size = 22733, upload-time = "2024-09-08T00:49:55.11Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/c5/470276ec3cef4d358d8bcb52a358ef8d97e1bfc19c71c8f6710ffbe9b825/tree_sitter_svelte-1.0.2-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:d263ad25dd26da5e1fa919b08aa997ccb042504d12a9ca80a5c7631edcc5a672", size = 23164, upload-time = "2024-09-08T00:49:56.256Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/5f/c85caa50a0c1892e350808f3fb59864a2021ddecd7e29212ed106e8b31c5/tree_sitter_svelte-1.0.2-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:eb529109f74808bed36bca613f5b2b3e0494e1f30a42346539738a0433ea8d50", size = 53367, upload-time = "2024-09-08T00:49:57.553Z" },
+    { url = "https://files.pythonhosted.org/packages/93/48/2fca4934927e1c272e57ca74a599ba773cd4bc52f327c58752a6b01da8d3/tree_sitter_svelte-1.0.2-cp39-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:00972e83ef9a4f6c05532cf0614488b2b40ee017b77e58bf8e6540e1ade4d52d", size = 54159, upload-time = "2024-09-08T00:49:58.914Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/35/c9c42e63e27995e7e41520829e35ee69d201c76fcdd116d5c8c06c46c68d/tree_sitter_svelte-1.0.2-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:0197d5b6430cc9cb59a3401526a5628fc06372f4905a55c4ee6f300e0890bb30", size = 52591, upload-time = "2024-09-08T00:50:00.301Z" },
+    { url = "https://files.pythonhosted.org/packages/48/fa/81b0795920f974111c27bf5a94b9b1c2a139b3f4dc25bcacae3c24b33619/tree_sitter_svelte-1.0.2-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:287fa2d5c1e0b1bd6c7c6e5c3314e4bc41d2d3f17a464e205e77265a2762bb8c", size = 52584, upload-time = "2024-09-08T00:50:01.953Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/cf/78c27487e249e4179d32e0ff8174fa98ba9f87cfd88d9340b6551d4fb6c0/tree_sitter_svelte-1.0.2-cp39-abi3-win_amd64.whl", hash = "sha256:febd1573c9469a1d4ce199801fd63d144d21e0f09e1458b1637ffb00f473ce0e", size = 25899, upload-time = "2024-09-08T00:50:03.32Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/91/a62ede59992e901c8bcb3696e0eb703d0c894d6e01a4837ed84bb22e629f/tree_sitter_svelte-1.0.2-cp39-abi3-win_arm64.whl", hash = "sha256:5675f49301e2079f0b7502912c7ef49e988cc2ad66a3c779b6cf3a689bb0b48f", size = 23414, upload-time = "2024-09-08T00:50:04.781Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Cuts 0.38.0 off `main` at 7c037e92. 100 commits since v0.37.0.

## What is in it

Svelte and Vue reach the Full tier through a byte-preserving projection into TypeScript, HTML lands at the import tier, and reStructuredText documents are read as reStructuredText instead of silently yielding nothing. Onboarding is six pages ending in a glossary built entirely from mined terms, and a directory that heads a subsystem gets a chapter even when it also holds files of its own. Full-text search was rebuilt on both backends after the query shape turned out to match 65% of the corpus on a median question. The agent hooks got measurement first and then acted on it: the Grep flood is replaced by its digest, triage ranks the files the search actually matched, and the three hot index lookups dropped an ORM import that cost a second per hook fire.

Full detail in `docs/CHANGELOG.md`.

## The bump

- `pyproject.toml`, the three package `__init__.py` files, `uv.lock`
- `.claude-plugin/marketplace.json` and `plugins/claude-code/.claude-plugin/plugin.json`
- `docs/CHANGELOG.md` plus its bundled copy under `packages/core/.../upgrade/_data/`

`STORE_FORMAT_VERSION` and `PARSER_SCHEMA_VERSION` are unchanged. The parse cache self-invalidates this cycle regardless: the `.scm` query sources and the `models.py` dataclass shapes both moved, and both are folded into the parse fingerprint.

`uv.lock` also picks up `tree-sitter-svelte` and `tree-sitter-html`, which the new language support added and which had not been relocked on `main`.

## Test plan

- [x] Version drift grep clean: no `0.37.0` hits outside the unrelated `referencing` package in `uv.lock`
- [x] `uv lock` moves the self-entry to 0.38.0
- [x] `uv build --wheel` produces `repowise-0.38.0-py3-none-any.whl`; 79 command modules, 54 `.scm`/`.j2` data files, bundled changelog present
- [x] `npm ci && npm run build --workspace packages/web` green, 60 routes, standalone `server.js` emitted, workspace UI code inlined into both server and client chunks
- [x] `tests/unit/upgrade/test_bundled_changelog_sync.py` passes
- [x] Plugin parity: live `list_tools()` matches what the skills and commands reference, no removed tool names outside the plugin CHANGELOG, hook matchers identical to `claude_config.py`
- [ ] CI green on the merge commit
- [ ] Tag `v0.38.0` on `main` after merge, watch `publish.yml`
- [ ] Final gate: install `repowise==0.38.0` from PyPI into a throwaway venv and cold-index `test-repos/microdot`

## Not in this PR

The VS Code extension is behind: `packages/vscode/package.json` already reads `0.7.0` but no `vscode-v0.7.0` tag exists, and 35 `packages/ui/src` commits have landed since `vscode-v0.6.0` across every subpath the webviews import (graph, docs, health, refactoring, c4, ui, shared, wiki, lib). That is a separate tag namespace and a separate call.