### PR TITLE
docs(vscode): release notes for the 0.7.0 extension release

### DIFF
--- a/packages/vscode/CHANGELOG.md
+++ b/packages/vscode/CHANGELOG.md
@@ -15,15 +15,26 @@ itself. Everything below is visible in the editor.
 
 ### Docs
 
-- The tree opens on the shape of the repository rather than its contents. Layers
-  used to expand by default, which put roughly ninety module rows on the first
-  screen once layers grouped every module in the repo. They start closed now, so
-  the first thing you see is the set of layers, the orientation chapters and the
-  way into the file corpus.
-- The file corpus sits above the layer outline instead of under it, an unclaimed
-  module no longer poses as a layer, and a top-level row shows its count only
-  when the number is meaningful.
-- Modules group under the layer their members belong to.
+- The tree reads as a table of contents rather than a directory listing. Every
+  group on the top rung opens on load and nothing below it does, so the first
+  screen is the outline: the layers, the orientation chapters and the way into
+  the file corpus. Expanding every rung used to put roughly ninety module rows
+  in front of you once layers grouped every module in the repo; limiting the
+  depth holds that back without hiding the outline to do it.
+- The file corpus closes the tree, still collapsed. It is a reference rather
+  than a section, and its row count was setting the shape of what you met first.
+- Selecting a page opens the chapters above it, so a deep link no longer
+  highlights a row inside a collapsed parent.
+- Outline group rows drop their folder glyph and their trailing graph link. Rows
+  with no page behind them were the one place the no-icons rule never reached.
+- An unclaimed module no longer poses as a layer, a top-level row shows its
+  count only when the number is meaningful, and modules group under the layer
+  their members belong to.
+- Diagrams scale to the column they are read in. They rendered at natural size
+  inside a scroll box, so an architecture map arrived clipped mid-subgraph with
+  two scrollbars over it. Width only, never enlarged past 1:1, and the height is
+  reserved so a fitted diagram does not sit in a pool of empty space. Maximize
+  still pans and zooms for the dense ones.
 - The docs page no longer loads every page's body to draw the tree. On a large
   repository that was several sequential round trips and tens of megabytes of
   text the tree never renders.

--- a/packages/vscode/CHANGELOG.md
+++ b/packages/vscode/CHANGELOG.md
@@ -1,0 +1,61 @@
+# Changelog
+
+Notable changes to the Repowise VS Code extension. The extension versions
+independently of the `repowise` Python package; the only cross-version coupling
+is the minimum server version it checks against.
+
+This file starts at 0.7.0. Earlier releases are described in the repository's
+release history.
+
+## 0.7.0
+
+The webviews compile the shared Repowise UI components at build time, so most of
+what changed here arrived with a rebuild rather than with edits to the extension
+itself. Everything below is visible in the editor.
+
+### Docs
+
+- The tree opens on the shape of the repository rather than its contents. Layers
+  used to expand by default, which put roughly ninety module rows on the first
+  screen once layers grouped every module in the repo. They start closed now, so
+  the first thing you see is the set of layers, the orientation chapters and the
+  way into the file corpus.
+- The file corpus sits above the layer outline instead of under it, an unclaimed
+  module no longer poses as a layer, and a top-level row shows its count only
+  when the number is meaningful.
+- Modules group under the layer their members belong to.
+- The docs page no longer loads every page's body to draw the tree. On a large
+  repository that was several sequential round trips and tens of megabytes of
+  text the tree never renders.
+- One breadcrumb instead of two, correct reader height, wrapping backlinks, and
+  links that land where their label says.
+- The command palette answers a keypress once rather than racing itself.
+
+### Architecture
+
+- One scope control instead of two. Scope used to live in both the tab strip and
+  a floating pill cluster, with the same option appearing twice on one screen.
+  Tabs select the dataset now and scope is a single labelled control.
+- The canvas stopped doing per-node and per-frame work it did not need, which is
+  most of the several seconds the view used to spend arriving.
+- The view no longer blames the backend while data is still loading.
+- Structurizr DSL export, built on typed node ids.
+
+### Health and refactoring
+
+- Code Health rebuilt on the section design language: a sentence above each
+  figure saying what the figure means, hairlines instead of a grid of
+  near-identical bordered cards.
+- The refactoring view leads with what the plan pile actually is. The
+  priority-by-effort quadrant plotted a small fraction of plans because most rate
+  small effort and the axis was one column; it is replaced with charts whose axes
+  spread.
+
+### Graph and decisions
+
+- Graph canvas performance work from the architecture pass applies here too.
+- Decisions rebuilt on the section design language.
+
+### Notes
+
+- Requires a Repowise server at 0.26.0 or newer, unchanged from 0.6.0.


### PR DESCRIPTION
Prep for cutting the VS Code extension at 0.7.0. The Marketplace is still serving 0.6.0.

## Why there is no version bump here

`packages/vscode/package.json` has read `0.7.0` since the v0.37.0 release commit (01b61af7), but no `vscode-v0.7.0` tag was ever pushed and no `workflow_dispatch` pre-release ran, so 0.7.0 has never been published. The last `publish-vscode.yml` run was `vscode-v0.6.0` on 2026-07-24. Tagging `vscode-v0.7.0` on `main` ships everything currently there; the version does not need to move again.

## What this PR adds

A `CHANGELOG.md` for the extension, which it has never had. 36 `packages/ui/src` commits have landed since `vscode-v0.6.0`, across every subpath the webviews import, so a user going from 0.6.0 to 0.7.0 gets a docs tree that opens differently, an architecture view with one scope control instead of two, and rebuilt health and refactoring views, with nothing anywhere saying so. `.vscodeignore` does not exclude the file, so it packages into the VSIX and renders on the Marketplace changelog tab.

Scope is what the seven webviews actually bundle. Surfaces that moved in the same UI pass but exist only in the web app (Commits, Contributors, Coverage, Dead code, Chat, Settings, Files) are deliberately left out.

## Build validation

Ran the full `packages/vscode/RELEASING.md` checklist on this branch:

- [x] `npm run type-check --workspace packages/vscode`
- [x] `npm run build --workspace packages/vscode` - host bundle 120.7 KB against a 300 KB budget
- [x] `npm run build:webview --workspace packages/vscode` - built in 24.5s, largest lazy chunk is ELK as expected
- [x] `npm run test:webview --workspace packages/vscode` - 43 tests across 12 files
- [x] `npm run test --workspace packages/vscode` - electron smoke, 4 passing, activation 0ms with no subprocess spawned
- [x] `npm run package --workspace packages/vscode` - `repowise-0.7.0.vsix`, 152 files, 2.22 MB, in line with 0.6.0
- [ ] Clean-profile VSIX install smoke test (walkthrough, diagnostics and gutter heat, a dashboard rendering, MCP tools in agent mode)
- [ ] Fork check in Cursor via the `.vscode/mcp.json` fallback

The last two need a human driving a fresh VS Code profile.

`MIN_SERVER_VERSION` stays at `0.26.0`. Nothing in this build relies on a newer server contract.

## After merge

```
git tag vscode-v0.7.0
git push origin vscode-v0.7.0
```

Separate tag namespace from `v0.38.0`, so it will not trigger the PyPI publish.

