### PR TITLE
feat(docs): read the wiki sidebar as a table of contents, and fit diagrams to the column

### DIFF
--- a/packages/ui/__tests__/docs/docs-tree.test.tsx
+++ b/packages/ui/__tests__/docs/docs-tree.test.tsx
@@ -407,16 +407,14 @@ describe("DocsTree", () => {
     // this cannot pass on an alphabetical grouping.
     expect(indexOfRow("Zebra Runtime")).toBeLessThan(indexOfRow("Alpha API"));
     expect("Zebra Runtime".localeCompare("Alpha API")).toBeGreaterThan(0);
-    // Each module reads under its own layer, not beside it. The layers start
-    // closed, so open them to see where their members land.
-    fireEvent.click(screen.getByText("Zebra Runtime"));
-    fireEvent.click(screen.getByText("Alpha API"));
+    // Each module reads under its own layer, not beside it. The layers open on
+    // load, so their members are there without a click.
     expect(indexOfRow("Zebra Runtime")).toBeLessThan(indexOfRow("runtime/engine"));
     expect(indexOfRow("runtime/engine")).toBeLessThan(indexOfRow("Alpha API"));
     expect(indexOfRow("Alpha API")).toBeLessThan(indexOfRow("api/routes"));
   });
 
-  it("starts every layer row closed, and opens one on a click", () => {
+  it("opens every layer row on load, and closes one on a click", () => {
     render(
       <DocsTree
         pages={[
@@ -434,21 +432,21 @@ describe("DocsTree", () => {
         onSelectPage={() => {}}
       />,
     );
-    // The layers themselves are the first screen: a reader meets the shape of
-    // the repository, not every module in it.
+    // The first screen is a table of contents: every layer named, and what each
+    // one holds listed under it, with no click spent to get there.
     expect(screen.getByText("Zebra Runtime")).toBeInTheDocument();
     expect(screen.getByText("Alpha API")).toBeInTheDocument();
-    expect(screen.queryByText("runtime/engine")).not.toBeInTheDocument();
-    expect(screen.queryByText("api/routes")).not.toBeInTheDocument();
-
-    // One click opens one layer and leaves the other shut — so this cannot
-    // pass on a tree that simply failed to render its modules at all.
-    fireEvent.click(screen.getByText("Zebra Runtime"));
     expect(screen.getByText("runtime/engine")).toBeInTheDocument();
-    expect(screen.queryByText("api/routes")).not.toBeInTheDocument();
+    expect(screen.getByText("api/routes")).toBeInTheDocument();
+
+    // One click shuts one layer and leaves the other open — so this cannot
+    // pass on a tree that merely ignores the expansion state.
+    fireEvent.click(screen.getByText("Zebra Runtime"));
+    expect(screen.queryByText("runtime/engine")).not.toBeInTheDocument();
+    expect(screen.getByText("api/routes")).toBeInTheDocument();
   });
 
-  it("puts the file corpus above the layers, so it never sinks under the outline", () => {
+  it("puts the file corpus below the layers, so it never fronts the outline", () => {
     render(
       <DocsTree
         pages={[
@@ -475,14 +473,14 @@ describe("DocsTree", () => {
         onSelectPage={() => {}}
       />,
     );
-    // Orientation first, then the way into the files, then the layer outline.
-    // The corpus is the largest thing in the wiki and the thing most readers
-    // came for; it cannot sit below a list that grows with the repository.
+    // Orientation, then the layer outline, then the way into the files. The
+    // corpus is a reference rather than a section, and a row whose count runs
+    // to four digits sitting mid-outline reads as the point of the sidebar.
     const corpus = indexOfRow("Auto-documented files (1)");
     expect(indexOfRow("Repository Overview: demo")).toBeLessThan(indexOfRow("Getting Started"));
-    expect(indexOfRow("Getting Started")).toBeLessThan(corpus);
-    expect(corpus).toBeLessThan(indexOfRow("Zebra Runtime"));
-    // The layers keep their own order behind it, so this cannot pass on a
+    expect(indexOfRow("Getting Started")).toBeLessThan(indexOfRow("Zebra Runtime"));
+    expect(indexOfRow("Alpha API")).toBeLessThan(corpus);
+    // The layers keep their own order ahead of it, so this cannot pass on a
     // build that merely shuffled the top-level rows.
     expect(indexOfRow("Zebra Runtime")).toBeLessThan(indexOfRow("Alpha API"));
     // Still a deliberate drill-in, not opened on load.
@@ -696,9 +694,8 @@ describe("DocsTree", () => {
         onSelectPage={() => {}}
       />,
     );
-    // Both grouping rows start closed, so open them to see where their members
-    // landed.
-    fireEvent.click(screen.getByText("Zebra Runtime"));
+    // The layer opens on load; the leftovers bucket is one of the two rows that
+    // does not, so open it to see where its member landed.
     fireEvent.click(screen.getByText("Modules with no layer (1)"));
     // The stamped module reads under its layer; the unstamped one reads under
     // the trailing group, which sits below every layer.
@@ -777,26 +774,48 @@ describe("DocsTree", () => {
     warn.mockRestore();
   });
 
-  it("points a layer row at the knowledge graph, where its diagram lives", () => {
-    render(
-      <DocsTree
-        pages={[
-          layeredRoot({ layer_order_ids: ["layer:api"] }),
-          stampedModule("module_page:api/routes", "Module: api/routes", {
-            layer_id: "layer:api",
-            layer_name: "Alpha API",
-          }),
-        ]}
-        selectedPageId={null}
-        onSelectPage={() => {}}
-        knowledgeGraphHref="/repos/r1/knowledge-graph"
-      />,
-    );
-    const link = screen.getByRole("link", { name: /Alpha API.*knowledge graph/i });
-    expect(link).toHaveAttribute("href", "/repos/r1/knowledge-graph");
+  // A chapter with chapters of its own — the rung below the one that opens.
+  const SUB_MODULE = makePage({
+    id: "module_page:runtime/engine/codecs",
+    page_type: "module_page",
+    title: "Module: runtime/engine/codecs",
+    target_path: "runtime/engine/codecs",
+    parent_page_id: MODULE.id,
+    display_order: 1,
+    section_number: "2.1.1",
   });
 
-  it("omits the graph link when the host has no route to offer", () => {
+  it("opens the top rung only, leaving a chapter's own chapters shut", () => {
+    render(
+      <DocsTree
+        pages={[...SPINE, SUB_MODULE]}
+        selectedPageId={null}
+        onSelectPage={() => {}}
+      />,
+    );
+    // The layer is open, so its chapter is on the first screen...
+    expect(screen.getByText("runtime/engine")).toBeInTheDocument();
+    // ...but the rung below it is not. Without this the outline came out four
+    // deep on load and the indentation stopped carrying rank.
+    expect(screen.queryByText("runtime/engine/codecs")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByText("runtime/engine"));
+    expect(screen.getByText("runtime/engine/codecs")).toBeInTheDocument();
+  });
+
+  it("reveals the selected page by opening the chapters above it", () => {
+    render(
+      <DocsTree
+        pages={[...SPINE, SUB_MODULE]}
+        selectedPageId={SUB_MODULE.id}
+        onSelectPage={() => {}}
+      />,
+    );
+    // Reached by a deep link rather than a click, so nothing opened its parent.
+    // A selected row inside a shut chapter is a highlight a reader cannot see.
+    expect(screen.getByText("runtime/engine/codecs")).toBeInTheDocument();
+  });
+
+  it("carries no link on a layer row — the outline is rows of text", () => {
     render(
       <DocsTree
         pages={[
@@ -811,7 +830,8 @@ describe("DocsTree", () => {
       />,
     );
     expect(screen.queryByRole("link")).not.toBeInTheDocument();
-    // Selecting the layer row still works — the link is an extra, not the row.
+    // The row itself is untouched — this cannot pass on a tree that dropped the
+    // layer along with its trailing button.
     expect(screen.getByText("Alpha API")).toBeInTheDocument();
   });
 

--- a/packages/ui/src/docs/docs-tree.tsx
+++ b/packages/ui/src/docs/docs-tree.tsx
@@ -41,7 +41,11 @@ const layerDirKey = (layerId: string) => `${LAYER_DIR_PREFIX}${layerId}`;
 const UNLAYERED_MODULES_KEY = "@group:unlayered-modules";
 // Tree expansion survives reloads (per-browser, not per-repo — paths rarely
 // collide across repos and the fallback is just the default expansion).
-const EXPANDED_DIRS_KEY = "repowise:docs-tree-expanded";
+//
+// Versioned because the saved set is unioned with the defaults rather than
+// replacing them: a reader whose browser recorded the old every-rung expansion
+// would carry it forward and never see the outline the defaults now describe.
+const EXPANDED_DIRS_KEY = "repowise:docs-tree-expanded:v2";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -55,10 +59,6 @@ interface TreeNode {
   children: TreeNode[];
   /** Dotted outline number from the stored tree ("2.4.1"), when the page has one. */
   section?: string;
-  /** Where the row's "see the picture" link goes, for rows that have one. */
-  href?: string;
-  /** What that link is for, read out to a screen reader. */
-  hrefLabel?: string;
 }
 
 interface DocsTreeProps {
@@ -66,15 +66,6 @@ interface DocsTreeProps {
   selectedPageId: string | null;
   onSelectPage: (page: DocPageSummary) => void;
   className?: string;
-  /**
-   * The host's knowledge-graph route, linked from every layer row.
-   *
-   * A layer is a grouping of the knowledge graph, and the graph is where its
-   * diagram is drawn and explorable — the tree only lists what is in the layer.
-   * Optional because the route is the host's to name, and a host that has no
-   * such view simply gets a row with no link rather than a dead one.
-   */
-  knowledgeGraphHref?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -359,6 +350,16 @@ const CONCEPT_CONTENT_TYPES = new Set([
 const hidesTreeIcon = (page?: DocPageSummary): boolean =>
   page ? CONCEPT_CONTENT_TYPES.has(page.page_type) : false;
 
+// The same rule, for the outline rows that have no page behind them: a layer,
+// the no-layer bucket, a by-type bucket. They were the one place a folder glyph
+// still survived on the spine, and a column of them down the top rung is the
+// texture the rule above exists to remove. The file corpus keeps its folder —
+// there the glyph is what says "this row is not part of the outline".
+const isOutlineGroupRow = (path: string): boolean =>
+  path.startsWith(LAYER_DIR_PREFIX) ||
+  path.startsWith(TYPE_GROUP_PREFIX) ||
+  path === UNLAYERED_MODULES_KEY;
+
 // The single bottom folder holding every deterministic page. Namespaced like
 // the other synthetic keys so it can never collide with a real page id.
 const AUTO_ROOT_KEY = "@group:auto-documented";
@@ -417,10 +418,7 @@ function reportLayerGrouping(
   }
 }
 
-function buildStoredTree(
-  pages: DocPageSummary[],
-  knowledgeGraphHref?: string,
-): TreeNode[] {
+function buildStoredTree(pages: DocPageSummary[]): TreeNode[] {
   // A tombstoned page documents a file that no longer exists. It keeps its row
   // and its content, but the tree deliberately has no place for it, so it must
   // be excluded here rather than treated as an unplaced page.
@@ -520,27 +518,12 @@ function buildStoredTree(
         .filter((child) => !unlayered.has(child.id))
         .map((child) => toNode(child, root)),
     );
-    // The file corpus sits directly after the orientation chapters, ahead of
-    // the layers. It is the largest thing in the wiki by a wide margin and the
-    // thing most readers arrive wanting, so it cannot be the last row of a list
-    // whose length grows with the repository — one layer opened and it is off
-    // the screen. Collapsed, so it costs a single row to keep it in reach.
-    if (referenceFolder) top.push(referenceFolder);
     for (const group of grouping.groups) {
       top.push({
         name: group.label,
         path: layerDirKey(group.id),
         isDir: true,
         children: group.pages.map((child) => toNode(child, root)),
-        // The tree can only list what a layer holds. The picture of it — which
-        // layer sits on which, and what crosses between them — is the
-        // knowledge graph, so the row carries a way there.
-        ...(knowledgeGraphHref
-          ? {
-              href: knowledgeGraphHref,
-              hrefLabel: `Show ${group.label} in the knowledge graph`,
-            }
-          : {}),
       });
     }
     // After the real layers, and named for what it is rather than as if it
@@ -586,11 +569,12 @@ function buildStoredTree(
     });
   }
 
-  // A store with no concept root has no orientation to sit behind, so the
-  // folder falls to the bottom rather than opening the tree with it.
-  if (referenceFolder && !top.includes(referenceFolder)) {
-    top.push(referenceFolder);
-  }
+  // The file corpus closes the tree, below every group above it and collapsed.
+  // It is the largest thing in the wiki by a wide margin, and a row whose count
+  // runs to four digits sitting mid-outline reads as the point of the sidebar
+  // rather than as the reference it is. One row at the bottom keeps it in reach
+  // without letting it set the shape of what a reader meets first.
+  if (referenceFolder) top.push(referenceFolder);
 
   return top;
 }
@@ -752,7 +736,7 @@ function TreeItem({
             pageType={node.page.page_type}
             className="h-3.5 w-3.5 shrink-0 text-[var(--color-accent-primary)]"
           />
-        ) : isExpanded ? (
+        ) : isOutlineGroupRow(node.path) ? null : isExpanded ? (
           <FolderOpen className="h-3.5 w-3.5 shrink-0 text-[var(--color-accent-primary)] opacity-70" />
         ) : (
           <Folder className="h-3.5 w-3.5 shrink-0 text-[var(--color-text-tertiary)]" />
@@ -778,24 +762,7 @@ function TreeItem({
 
     return (
       <div>
-        {node.href ? (
-          // The row itself expands; the trailing link leaves for the graph.
-          // Two separate targets rather than one that guesses which was meant,
-          // and an anchor rather than a button so it can be opened in a tab.
-          <div className="flex items-center">
-            {row}
-            <a
-              href={node.href}
-              aria-label={node.hrefLabel}
-              title={node.hrefLabel}
-              className="shrink-0 rounded-md p-1.5 text-[var(--color-text-tertiary)] transition-colors hover:bg-[var(--color-bg-elevated)] hover:text-[var(--color-accent-primary)]"
-            >
-              <Network className="h-3.5 w-3.5" />
-            </a>
-          </div>
-        ) : (
-          row
-        )}
+        {row}
 
         {isExpanded && hasChildren && (
           <div>
@@ -915,6 +882,23 @@ function RowMarkers({
 // Main DocsTree component
 // ---------------------------------------------------------------------------
 
+/** Keys of every dir on the way down to the row holding `pageId`, root first.
+ *  Empty when the page is not in this tree, or is on the top rung already. */
+function ancestorDirs(nodes: TreeNode[], pageId: string): string[] {
+  const trail: string[] = [];
+  function walk(list: TreeNode[]): boolean {
+    for (const node of list) {
+      if (node.page?.id === pageId) return true;
+      if (!node.children.length) continue;
+      trail.push(node.path);
+      if (walk(node.children)) return true;
+      trail.pop();
+    }
+    return false;
+  }
+  return walk(nodes) ? [...trail] : [];
+}
+
 type ViewMode = "domain" | "folder";
 
 export function DocsTree({
@@ -922,7 +906,6 @@ export function DocsTree({
   selectedPageId,
   onSelectPage,
   className,
-  knowledgeGraphHref,
 }: DocsTreeProps) {
   const [search, setSearch] = useState("");
   const [typeFilter, setTypeFilter] = useState<TypeFilter>("all");
@@ -930,37 +913,41 @@ export function DocsTree({
   // Default to the semantic "By domain" spine — overview/architecture/modules
   // first, filesystem second. The folder view is a toggle for power users.
   const [viewMode, setViewMode] = useState<ViewMode>("domain");
+  // Built before the expansion state because the defaults are read off the
+  // tree's own top rung rather than guessed from the flat page list.
+  const tree = useMemo(
+    () => (viewMode === "domain" ? buildStoredTree(pages) : buildTree(pages)),
+    [pages, viewMode],
+  );
   const [expandedDirs, setExpandedDirs] = useState<Set<string>>(() => {
-    // Auto-expand first two levels, the Onboarding folder, and the by-type
-    // buckets that hold pages the stored tree does not reach (on a store whose
-    // tree has not been built yet, those buckets are the whole tree, so
-    // leaving them collapsed would show almost nothing). Then ADD any
-    // previously expanded dirs from localStorage. Union (not replace) — the
-    // key is shared across repos, so a stale saved set must never collapse
-    // another repo's default-open rows.
+    // The Onboarding folder, the by-type buckets that hold pages the stored
+    // tree does not reach (on a store whose tree has not been built yet those
+    // buckets are the whole tree, so leaving them shut would show almost
+    // nothing), and the top rung below. Then ADD any previously expanded dirs
+    // from localStorage. Union (not replace) — the key is shared across repos,
+    // so a stale saved set must never collapse another repo's default-open rows.
     const dirs = new Set<string>(STRAY_GROUP_KEYS);
     dirs.add(ONBOARDING_DIR_KEY);
-    // Domain view: everything starts shut — the layer rows, concept pages, the
-    // bottom Auto-documented folder, and the file directories inside it — so
-    // the first screen is the shape of the repository rather than its contents.
+    // One rung, and only one. Every group on the top rung opens, so the first
+    // screen is a table of contents — the layers named, with what each holds
+    // listed under it — rather than a column of shut rows that says nothing
+    // until it is clicked.
     //
-    // The layers used to open on load, on the reasoning that a shut one hides
-    // the outline under it. That reasoning inverted once the layers became
-    // grouping rows over every module: opening them all put roughly ninety
-    // near-identically-named module rows on the first screen, which buries the
-    // layer names, the orientation chapters and the file corpus alike. A closed
-    // layer costs one click; an open one costs a reader the whole first screen.
+    // Nothing below that rung opens with it. A chapter that parents its own
+    // sub-chapters used to expand too, wherever it sat, and the outline came
+    // out four rungs deep on load: the indentation stopped carrying rank and
+    // the tree read as a filesystem. Shut, a chapter costs one click and its
+    // parent's list stays readable. This is also what the old layers-shut
+    // default was protecting against — roughly ninety module rows on the first
+    // screen — and the rung limit protects against it without hiding the
+    // outline to do so.
     //
-    // A concept page that parents other concept pages still opens, so a stored
-    // wiki that predates the grouping rows — where the modules hang off a page
-    // per layer — reads the same as it always did.
-    const hasSpineChild = new Set(
-      pages
-        .filter((p) => SPINE_TYPES.has(p.page_type) && p.parent_page_id)
-        .map((p) => p.parent_page_id as string),
-    );
-    for (const page of pages) {
-      if (hasSpineChild.has(page.id) && SPINE_TYPES.has(page.page_type)) dirs.add(page.id);
+    // Two exclusions, both rows that are a bucket rather than a section: the
+    // file corpus, which runs to thousands of rows, and the no-layer leftovers.
+    for (const node of tree) {
+      if (!node.isDir) continue;
+      if (node.path === AUTO_ROOT_KEY || node.path === UNLAYERED_MODULES_KEY) continue;
+      dirs.add(node.path);
     }
     if (typeof window !== "undefined") {
       try {
@@ -982,6 +969,21 @@ export function DocsTree({
       // Quota/SSR — persistence is best-effort.
     }
   }, [expandedDirs]);
+  // Reveal whatever is being read. Only the top rung opens by default, so a
+  // page reached by any route other than clicking its own row — a deep link, a
+  // "related pages" link, the command palette — would otherwise be selected
+  // inside a shut chapter with nothing in the tree to show where it sits.
+  useEffect(() => {
+    if (!selectedPageId) return;
+    const ancestors = ancestorDirs(tree, selectedPageId);
+    if (!ancestors.length) return;
+    setExpandedDirs((prev) => {
+      if (ancestors.every((p) => prev.has(p))) return prev;
+      const next = new Set(prev);
+      for (const p of ancestors) next.add(p);
+      return next;
+    });
+  }, [selectedPageId, tree]);
   // Filters are a power-user affordance — start hidden so the panel opens
   // calm; the funnel button shows a count when any filter is active.
   const [showFilters, setShowFilters] = useState(false);
@@ -989,13 +991,6 @@ export function DocsTree({
   // (or filtering by status) is how a reader audits staleness across the tree.
   const [showFreshness, setShowFreshness] = useState(false);
 
-  const tree = useMemo(
-    () =>
-      viewMode === "domain"
-        ? buildStoredTree(pages, knowledgeGraphHref)
-        : buildTree(pages),
-    [pages, viewMode, knowledgeGraphHref],
-  );
   // Numbering is decided on what actually renders, after filtering, so the
   // visible run stays contiguous even when a filter hides a numbered row.
   const filteredTree = useMemo(

--- a/packages/ui/src/wiki/mermaid-diagram.tsx
+++ b/packages/ui/src/wiki/mermaid-diagram.tsx
@@ -191,6 +191,14 @@ function svgNaturalSize(container: HTMLDivElement | null): { w: number; h: numbe
   return null;
 }
 
+/** Scale that fits `size` inside a box. Never above 1: magnifying a small
+ *  diagram to fill the column blurs it and says nothing extra. */
+function fitScale(size: { w: number; h: number } | null, boxW: number, boxH: number): number {
+  if (!size) return 1;
+  const s = Math.min(1, boxW / size.w, boxH / size.h);
+  return s > 0 && Number.isFinite(s) ? s : 1;
+}
+
 const GRID_BACKGROUND: React.CSSProperties = {
   backgroundImage:
     "linear-gradient(var(--color-diagram-grid) 1px, transparent 1px), " +
@@ -252,8 +260,7 @@ function MaximizedDialog({
     const size = svgNaturalSize(container);
     const vp = viewportRef.current;
     if (!size || !vp) return;
-    const fit = Math.min(1, (vp.clientWidth - 64) / size.w, (vp.clientHeight - 64) / size.h);
-    setZoom(fit > 0 ? fit : 1);
+    setZoom(fitScale(size, vp.clientWidth - 64, vp.clientHeight - 64));
     setPan({ x: 0, y: 0 });
   }, [renderTick, container]);
 
@@ -272,14 +279,8 @@ function MaximizedDialog({
   };
 
   const reset = () => {
-    const size = svgNaturalSize(container);
     const vp = viewportRef.current;
-    if (size && vp) {
-      const fit = Math.min(1, (vp.clientWidth - 64) / size.w, (vp.clientHeight - 64) / size.h);
-      setZoom(fit > 0 ? fit : 1);
-    } else {
-      setZoom(1);
-    }
+    setZoom(vp ? fitScale(svgNaturalSize(container), vp.clientWidth - 64, vp.clientHeight - 64) : 1);
     setPan({ x: 0, y: 0 });
   };
 
@@ -360,10 +361,40 @@ function MaximizedDialog({
   );
 }
 
+/** `p-4` on the frame, both sides — the width a diagram cannot use. */
+const FRAME_PADDING = 32;
+
 export function MermaidDiagram({ chart, securityLevel = "strict" }: MermaidDiagramProps) {
   const [container, setContainer] = useState<HTMLDivElement | null>(null);
   const [maximized, setMaximized] = useState(false);
-  const { error } = useMermaidRender(chart, container, securityLevel);
+  const frameRef = useRef<HTMLDivElement | null>(null);
+  const [fit, setFit] = useState<{ scale: number; height: number } | null>(null);
+  const { error, renderTick } = useMermaidRender(chart, container, securityLevel);
+
+  // Fit the rendered SVG to the column it is read in. Width only: a wide
+  // diagram clipped mid-subgraph is the failure this exists to stop, whereas a
+  // tall one still reads by scrolling the way the prose around it does.
+  //
+  // Reserving the *scaled* height is the other half — a transform does not
+  // change layout, so without it the frame keeps the natural height and a
+  // scaled-down diagram sits in a pool of empty space.
+  useEffect(() => {
+    const frame = frameRef.current;
+    if (!frame || renderTick === 0) return;
+    const refit = () => {
+      const size = svgNaturalSize(container);
+      if (!size) return;
+      const scale = fitScale(size, frame.clientWidth - FRAME_PADDING, Infinity);
+      setFit({ scale, height: size.h * scale });
+    };
+    refit();
+    // Re-fit when the column resizes — the sidebar collapsing is a resize, and
+    // a diagram fitted to the narrow column would otherwise stay small in the
+    // wide one.
+    const observer = new ResizeObserver(refit);
+    observer.observe(frame);
+    return () => observer.disconnect();
+  }, [renderTick, container]);
 
   if (error) {
     return (
@@ -376,6 +407,7 @@ export function MermaidDiagram({ chart, securityLevel = "strict" }: MermaidDiagr
   return (
     <>
       <figure
+        ref={frameRef}
         role="img"
         aria-label="Mermaid diagram"
         className="group relative my-4 rounded-lg border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)]"
@@ -390,10 +422,18 @@ export function MermaidDiagram({ chart, securityLevel = "strict" }: MermaidDiagr
         >
           <Maximize2 className="h-3.5 w-3.5" />
         </button>
-        {/* Natural size, centered when narrow, scrollable when wide/tall —
-            never scaled down (that's what made dense diagrams unreadable). */}
-        <div className="overflow-auto max-h-[75vh] p-4">
-          <div ref={setContainer} className="w-max mx-auto" />
+        {/* Scaled to the column and centred, so the whole diagram is on screen
+            at once. Dense ones do come out small; the maximize button above is
+            the way into those, and it pans and zooms. */}
+        <div
+          className="flex justify-center overflow-y-auto overflow-x-hidden p-4"
+          style={{ maxHeight: "75vh", ...(fit ? { height: fit.height + FRAME_PADDING } : {}) }}
+        >
+          <div
+            ref={setContainer}
+            className="w-max shrink-0"
+            style={fit ? { transform: `scale(${fit.scale})`, transformOrigin: "top center" } : {}}
+          />
         </div>
       </figure>
 

--- a/packages/web/src/components/docs/docs-explorer.tsx
+++ b/packages/web/src/components/docs/docs-explorer.tsx
@@ -255,9 +255,6 @@ export function DocsExplorer({ repoId }: DocsExplorerProps) {
       ) : (
         <DocsTree
           pages={pages}
-          // Where a layer row sends a reader after the picture rather than the
-          // list: the graph draws the layers and what crosses between them.
-          knowledgeGraphHref={`/repos/${repoId}/knowledge-graph`}
           // The id, not the fetched page: the row should highlight on click,
           // not once its body has come back.
           selectedPageId={selectedPageId}


### PR DESCRIPTION
## Sidebar

The docs sidebar opened as fifteen shut rows, expanded four rungs deep once opened, and put the four-digit file corpus sixth from the top. Four changes, so the first screen is an outline rather than a directory listing.

**One rung opens, and only one.** Every group on the top rung is open on load, so a reader meets the layers named with what each one holds listed under them. Nothing below that rung opens with it. A chapter that parents its own sub-chapters used to expand wherever it sat, and the outline came out four rungs deep on load, at which point the indentation stopped carrying rank. The old layers-shut default existed to keep ninety module rows off the first screen; the rung limit does that without hiding the outline to do it.

**The file corpus closes the tree** instead of sitting sixth from the top, still collapsed. It is a reference rather than a section, and a row whose count runs to four digits reads as the point of the sidebar when it sits mid-outline.

**Selecting a page opens the chapters above it.** Only the top rung opens by default, so a page reached by a deep link, a related-pages link or the command palette would otherwise be highlighted inside a shut chapter.

**Outline group rows lose their folder glyph and their trailing graph link.** The no-icons rule on the concept spine already covered every page-backed row; the grouping rows with no page behind them were the one place it did not reach, so the top rung was a column of identical glyphs. The knowledge graph is still one click away in the left rail.

The expansion key is versioned. The saved set is unioned with the defaults rather than replacing them, so a browser holding the old every-rung expansion would have carried it forward and never seen the new shape.

## Diagrams

Mermaid diagrams rendered at natural size inside a scroll box, with scaling down explicitly refused. The architecture map therefore arrived clipped mid-subgraph with a scrollbar on each axis.

They now scale to the column they are read in. Width only, since a wide diagram cut in half is the failure this addresses while a tall one still reads by scrolling the way the prose around it does. Never above 1:1, so a small diagram is not blurred to fill the space. The scaled height is reserved, because a transform does not change layout and without it a scaled-down diagram sat in a pool of empty space. Re-fitted on resize, so collapsing the sidebar re-fits rather than leaving the diagram small in a wide column. Maximize still pans and zooms for the dense ones.

This applies to every mermaid block in the wiki, not only the architecture map.

## Testing

`packages/ui` docs and wiki suites pass (73 tests). Two new cases cover the rung limit and the selected-page reveal; five existing cases were updated where they asserted the old defaults, ordering, or the graph link. `tsc --noEmit` clean on `packages/ui` and `packages/web`. Verified against a local index of this repository in the running web UI.
