### PR TITLE
release: v0.39.0 — candidate defines, a sidebar that reads as an outline, and a store that opens again

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "name": "repowise",
       "source": "./plugins/claude-code",
       "description": "Codebase intelligence for Claude Code. Indexes your repo into five layers (Graph, Git, Docs, Decisions, Code Health) and gives Claude deep understanding of architecture, ownership, hotspots, decisions, and defect risk — fewer greps, fewer file reads, lower cost per query.",
-      "version": "0.38.0",
+      "version": "0.39.0",
       "category": "productivity",
       "keywords": [
         "codebase",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,13 +9,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [0.38.1] — 2026-08-05
+## [0.39.0] — 2026-08-05
+
+A small release. `get_answer` stops handing back bare file paths, the docs sidebar reads as an outline instead of a directory listing, and a store upgraded from 0.37.0 opens again instead of taking the whole wiki down with its search index.
+
+### Added
+- **`get_answer` names what each candidate file defines,** not just its path. Of 499 paths served across the 25 flow questions, 65 carried any content at all, and 89% of the agent's post-answer searches were the same shape: take a name the payload gave, go fetch the substance it did not attach. Each candidate now carries its declarations as `name:line` pairs, question-named symbols first, imports and private names dropped. Substance per served path goes from 0.130 to 0.864, for 10% of the response and no change to which paths are served or in what order. (#1306)
+
+### Changed
+- **The docs sidebar reads as a table of contents.** Every group on the top rung opens on load and nothing below it does, so a chapter that parents sub-chapters no longer expands wherever it sits and makes the tree read as a filesystem. The four-digit file corpus closes the tree instead of fronting it, selecting a page opens the chapters above it, and outline rows drop the folder glyph the no-icons rule had never reached. (#1312)
+- **Mermaid diagrams scale to the column they are read in.** They rendered at natural size inside a scroll box, so the architecture map arrived clipped mid-subgraph behind two scrollbars. Width only, never above 1:1, with the scaled height reserved so a fitted diagram does not sit in a pool of empty space. Maximize still pans and zooms for the dense ones. (#1312)
 
 ### Fixed
 - **A store upgraded from 0.37.0 no longer refuses to open.** 0.38.0 widened `page_fts` from three columns to five, and FTS5 cannot be altered, so the index is dropped and refilled from `wiki_pages` the first time an upgraded install opens the store. That rebuild refused whenever the index held more rows than `wiki_pages` could account for, and the error it raised told the reader to run `repowise doctor --repair` — which opens the store the same way, hit the same refusal, and died before repairing anything. `serve` and the MCP server died there too, so a search index took the entire wiki down with it. The excess rows are orphans: pages swept from SQL whose index delete never ran, because it runs after the commit, outside the transaction, on a best-effort path, and nothing ever reconciled them. An orphan answers a query in full and 404s when the reader opens it, so the rebuild discards it and reports the count rather than refusing. (#1309)
 - **An interrupted sweep heals itself.** `ensure_index` prunes orphaned index rows on every open, which is the only thing that ever reconciled the two halves of the store; the residue could otherwise only grow. The scan is read-only and takes the write lock only when there is something to delete.
 - **`doctor --repair` finishes what it was called for.** A failing full-text schema upgrade is reported and stepped over instead of aborting the repair, and orphans are deleted in one transaction rather than one per id.
 - **`serve` and the MCP server start on a store whose index cannot be prepared,** falling back to whatever shape the index is in plus the vector arm, with a warning. Every other surface — the wiki, the graph, code health — was unreachable over a keyword index.
+
+### Documentation
+- **The benchmarks are rescored on the sealed half** after the retrieval gate fixes, and the token-efficiency figures are refreshed. The agent-loop result is reported as its own number rather than folded into the payload one, which measured a different thing. (#1307, #1308, #1310)
+
+### Dependencies
+- aiohttp 3.14.1 → 3.14.3, cryptography 48.0.1 → 50.0.0, gitpython 3.1.55 → 3.1.58, postcss 8.5.22 → 8.5.25, and the dev-only undici 7.28.0 → 7.29.0 and fast-uri 3.1.4 → 3.1.5. Clears the open security advisories against the tree. The cryptography floor moves rather than only its ceiling, so a fresh install of the published wheel cannot resolve back into the vulnerable range. (#1313)
 
 ---
 

--- a/packages/cli/src/repowise/cli/__init__.py
+++ b/packages/cli/src/repowise/cli/__init__.py
@@ -16,4 +16,4 @@ from repowise.cli._stdio import _ensure_utf8_stdio
 # is already UTF-8.
 _ensure_utf8_stdio()
 
-__version__ = "0.38.0"
+__version__ = "0.39.0"

--- a/packages/core/src/repowise/core/__init__.py
+++ b/packages/core/src/repowise/core/__init__.py
@@ -6,4 +6,4 @@ generation engine. This is the heart of repowise — all other packages depend o
 Namespace package: repowise.core is part of the repowise namespace.
 """
 
-__version__ = "0.38.0"
+__version__ = "0.39.0"

--- a/packages/core/src/repowise/core/upgrade/_data/CHANGELOG.md
+++ b/packages/core/src/repowise/core/upgrade/_data/CHANGELOG.md
@@ -9,13 +9,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [0.38.1] — 2026-08-05
+## [0.39.0] — 2026-08-05
+
+A small release. `get_answer` stops handing back bare file paths, the docs sidebar reads as an outline instead of a directory listing, and a store upgraded from 0.37.0 opens again instead of taking the whole wiki down with its search index.
+
+### Added
+- **`get_answer` names what each candidate file defines,** not just its path. Of 499 paths served across the 25 flow questions, 65 carried any content at all, and 89% of the agent's post-answer searches were the same shape: take a name the payload gave, go fetch the substance it did not attach. Each candidate now carries its declarations as `name:line` pairs, question-named symbols first, imports and private names dropped. Substance per served path goes from 0.130 to 0.864, for 10% of the response and no change to which paths are served or in what order. (#1306)
+
+### Changed
+- **The docs sidebar reads as a table of contents.** Every group on the top rung opens on load and nothing below it does, so a chapter that parents sub-chapters no longer expands wherever it sits and makes the tree read as a filesystem. The four-digit file corpus closes the tree instead of fronting it, selecting a page opens the chapters above it, and outline rows drop the folder glyph the no-icons rule had never reached. (#1312)
+- **Mermaid diagrams scale to the column they are read in.** They rendered at natural size inside a scroll box, so the architecture map arrived clipped mid-subgraph behind two scrollbars. Width only, never above 1:1, with the scaled height reserved so a fitted diagram does not sit in a pool of empty space. Maximize still pans and zooms for the dense ones. (#1312)
 
 ### Fixed
 - **A store upgraded from 0.37.0 no longer refuses to open.** 0.38.0 widened `page_fts` from three columns to five, and FTS5 cannot be altered, so the index is dropped and refilled from `wiki_pages` the first time an upgraded install opens the store. That rebuild refused whenever the index held more rows than `wiki_pages` could account for, and the error it raised told the reader to run `repowise doctor --repair` — which opens the store the same way, hit the same refusal, and died before repairing anything. `serve` and the MCP server died there too, so a search index took the entire wiki down with it. The excess rows are orphans: pages swept from SQL whose index delete never ran, because it runs after the commit, outside the transaction, on a best-effort path, and nothing ever reconciled them. An orphan answers a query in full and 404s when the reader opens it, so the rebuild discards it and reports the count rather than refusing. (#1309)
 - **An interrupted sweep heals itself.** `ensure_index` prunes orphaned index rows on every open, which is the only thing that ever reconciled the two halves of the store; the residue could otherwise only grow. The scan is read-only and takes the write lock only when there is something to delete.
 - **`doctor --repair` finishes what it was called for.** A failing full-text schema upgrade is reported and stepped over instead of aborting the repair, and orphans are deleted in one transaction rather than one per id.
 - **`serve` and the MCP server start on a store whose index cannot be prepared,** falling back to whatever shape the index is in plus the vector arm, with a warning. Every other surface — the wiki, the graph, code health — was unreachable over a keyword index.
+
+### Documentation
+- **The benchmarks are rescored on the sealed half** after the retrieval gate fixes, and the token-efficiency figures are refreshed. The agent-loop result is reported as its own number rather than folded into the payload one, which measured a different thing. (#1307, #1308, #1310)
+
+### Dependencies
+- aiohttp 3.14.1 → 3.14.3, cryptography 48.0.1 → 50.0.0, gitpython 3.1.55 → 3.1.58, postcss 8.5.22 → 8.5.25, and the dev-only undici 7.28.0 → 7.29.0 and fast-uri 3.1.4 → 3.1.5. Clears the open security advisories against the tree. The cryptography floor moves rather than only its ceiling, so a fresh install of the published wheel cannot resolve back into the vulnerable range. (#1313)
 
 ---
 

--- a/packages/server/src/repowise/server/__init__.py
+++ b/packages/server/src/repowise/server/__init__.py
@@ -7,4 +7,4 @@ Provides:
     - Background job scheduler (APScheduler)
 """
 
-__version__ = "0.38.0"
+__version__ = "0.39.0"

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "repowise",
   "description": "Codebase intelligence for Claude Code. Indexes your codebase into five layers (Graph, Git, Docs, Decisions, Code Health) and exposes them through ten task-shaped MCP tools — so Claude understands architecture, ownership, hotspots, why code is built the way it is, and where the defect risk lives.",
-  "version": "0.38.0",
+  "version": "0.39.0",
   "author": {
     "name": "Repowise",
     "email": "hello@repowise.dev",

--- a/plugins/claude-code/CHANGELOG.md
+++ b/plugins/claude-code/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to the Repowise Claude Code plugin are documented here.
 
+## 0.39.0
+
+### Changed
+- Version bump to track the repowise 0.39.0 release. The MCP tool surface, the
+  CLI flags the commands document and the hook matchers in `hooks/hooks.json`
+  are unchanged this cycle; the parity check found no drift. `get_answer`
+  gained a field in its response payload (#1306), which no command or skill
+  documents.
+
 ## 0.38.0
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "repowise"
-version = "0.38.0"
+version = "0.39.0"
 description = "The codebase intelligence layer for your AI coding agent — dependency graph, git history, dead code, decisions, and code health, exposed over MCP"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -3051,7 +3051,7 @@ wheels = [
 
 [[package]]
 name = "repowise"
-version = "0.38.0"
+version = "0.39.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
A small release. The section that sat in the changelog as `0.38.1` becomes `0.39.0` — it held only the full-text index repair, and three more changes landed after it.

## What ships

- **`get_answer` names what each candidate file defines** (#1306). Of 499 paths served across the 25 flow questions, 65 carried any content at all. Candidates now carry their declarations as `name:line` pairs, question-named symbols first. Substance per served path goes 0.130 to 0.864, for 10% of the response, with no change to which paths are served or in what order.
- **The docs sidebar reads as a table of contents** (#1312). Top-rung groups open on load and nothing below them does, the file corpus closes the tree instead of fronting it, and selecting a page opens the chapters above it.
- **Mermaid diagrams fit the column they are read in** (#1312). Width only, never above 1:1, with the scaled height reserved. Maximize still pans and zooms.
- **A store upgraded from 0.37.0 opens again** (#1309, via #1311). The FTS rebuild discards orphan rows and reports the count rather than refusing, `ensure_index` prunes on every open, and `serve` / the MCP server start on a store whose index cannot be prepared.
- **Benchmarks rescored on the sealed half**, with the agent-loop result separated from the payload number (#1307, #1308, #1310).
- **Dependency bumps** clearing the open advisories: aiohttp, cryptography, gitpython, postcss, and the dev-only undici and fast-uri (#1313).

## Version bump

`pyproject.toml`, the three package `__init__.py` files, `uv.lock`, and both plugin manifests. Drift grep for `0.38.0` across those paths returns nothing.

The plugin parity check found no drift — the MCP tool surface, the CLI flags the commands document and the hook matchers in `hooks/hooks.json` are all unchanged this cycle, so the plugin work is the version bump plus its changelog entry.

## Test plan

- [x] `uv lock` — self-entry moves 0.38.0 to 0.39.0
- [x] `uv build --wheel` — `repowise-0.39.0-py3-none-any.whl`, 83 CLI command modules, 54 `.scm`/`.j2` data files, bundled changelog inside reads 0.39.0
- [x] `tests/unit/upgrade/test_bundled_changelog_sync.py` passes
- [x] `npm ci && npm run build --workspace packages/web` — compiles clean, standalone `server.js` present, workspace-package code in the compiled chunks
- [x] Plugin tool-name grep matches live `list_tools()` output
- [ ] Tag `v0.39.0` on `main` after merge, watch `publish.yml`
- [ ] Install from PyPI into a throwaway venv and cold-index `test-repos/microdot`

## Not in this release

The VS Code extension moves on its own line. `packages/vscode/package.json` is already at `0.7.0` and was never tagged; #1304 carries its release notes and needs a line for #1312 before `vscode-v0.7.0` goes out.

`npm audit` reports a high-severity `brace-expansion` DoS, transitive under eslint, vsce and test-exclude. Dev-only — it reaches neither the wheel nor the web tarball — so it is left for a follow-up rather than churning this lockfile.
