### PR TITLE
fix(status/doctor): query configured DB when no local wiki.db exists

### DIFF
--- a/packages/cli/src/repowise/cli/commands/doctor_cmd/repo_checks.py
+++ b/packages/cli/src/repowise/cli/commands/doctor_cmd/repo_checks.py
@@ -9,6 +9,7 @@ from rich.table import Table
 
 from repowise.cli.helpers import (
     console,
+    db_configured,
     get_db_url_for_repo,
     get_repowise_dir,
     load_state,
@@ -67,9 +68,10 @@ def _run_repo_checks(
 
     # 3. Database connectable?
     db_path = repowise_dir / "wiki.db"
+    probed = db_path.exists() or db_configured()
     db_ok = False
     page_count = 0
-    if db_path.exists():
+    if probed:
         try:
 
             async def _check_db():
@@ -99,7 +101,7 @@ def _run_repo_checks(
             checks.append(_check("Database", False, str(e)))
     if db_ok:
         checks.append(_check("Database", True, f"{page_count} pages"))
-    elif not db_path.exists():
+    elif not probed:
         checks.append(_check("Database", False, "wiki.db not found"))
 
     # 4. state.json valid?

--- a/packages/cli/src/repowise/cli/commands/status_cmd.py
+++ b/packages/cli/src/repowise/cli/commands/status_cmd.py
@@ -12,6 +12,7 @@ from rich.table import Table
 from repowise.cli.helpers import (
     CommandTarget,
     console,
+    db_configured,
     get_db_url_for_repo,
     get_repowise_dir,
     load_state,
@@ -90,7 +91,7 @@ def _query_repo_counts(repo_path: Path) -> tuple[int, int]:
             await engine.dispose()
 
     db_path = get_repowise_dir(repo_path) / "wiki.db"
-    if not db_path.exists():
+    if not db_path.exists() and not db_configured():
         return 0, 0
     try:
         return run_async(_query())
@@ -133,7 +134,7 @@ def _query_page_count(repo_path: Path) -> int:
             await engine.dispose()
 
     db_path = get_repowise_dir(repo_path) / "wiki.db"
-    if not db_path.exists():
+    if not db_path.exists() and not db_configured():
         return 0
     try:
         return run_async(_query())
@@ -150,7 +151,7 @@ def _query_health_line(repo_path: Path) -> str | None:
         Health: 7.4 (avg) · 6.2 (hotspots) · 2.1 (worst: payments/processor.ts)
     """
     db_path = get_repowise_dir(repo_path) / "wiki.db"
-    if not db_path.exists():
+    if not db_path.exists() and not db_configured():
         return None
 
     async def _q() -> dict | None:
@@ -423,8 +424,8 @@ def status_command(path: str | None, workspace: bool, no_workspace: bool) -> Non
 
     # Page counts from DB
     db_path = repowise_dir / "wiki.db"
-    if not db_path.exists():
-        console.print("[yellow]Database not found.[/yellow]")
+    if not db_path.exists() and not db_configured():
+        console.print(f"[yellow]Database not found at {db_path}.[/yellow]")
         return
 
     async def _query_pages():

--- a/packages/cli/src/repowise/cli/helpers.py
+++ b/packages/cli/src/repowise/cli/helpers.py
@@ -182,6 +182,17 @@ def get_db_url_for_repo(repo_path: Path) -> str:
     return resolve_db_url(repo_path)
 
 
+def db_configured() -> bool:
+    """True when ``REPOWISE_DB_URL`` or ``REPOWISE_DATABASE_URL`` is set.
+
+    The DB may still be the repo-local ``wiki.db`` default — the file
+    existence check the callers pair this with decides that.
+    """
+    from repowise.core.persistence import get_configured_db_url
+
+    return get_configured_db_url() is not None
+
+
 # ---------------------------------------------------------------------------
 # State file
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -286,6 +286,110 @@ class TestDoctorAfterInit:
         assert "repowise Doctor" in result.output
 
 
+class TestStatusDoctorWithEnvDb:
+    """Regression guard for #1274: with REPOWISE_DB_URL set, status and doctor
+    must query the configured DB even when no repo-local wiki.db exists.
+
+    The env DB lives outside the repo (like a Postgres container), so the
+    pre-fix file-existence guards bailed out before ever resolving the URL.
+    """
+
+    @pytest.fixture
+    def env_db_repo(self, tmp_path, sample_repo_path, monkeypatch):
+        """sample_repo copy with REPOWISE_DB_URL pointing at an external DB."""
+        dest = tmp_path / "repo"
+        shutil.copytree(sample_repo_path, dest)
+        db_path = tmp_path / "external.db"
+        monkeypatch.setenv("REPOWISE_DB_URL", f"sqlite+aiosqlite:///{db_path}")
+        return dest
+
+    def test_status_queries_env_db_without_local_wiki_db(self, runner, env_db_repo):
+        result = runner.invoke(
+            cli,
+            ["init", str(env_db_repo), "--provider", "mock", "--yes"],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, result.output
+        # The scenario that used to fail: data in the env DB, no local wiki.db.
+        assert not (env_db_repo / ".repowise" / "wiki.db").exists()
+
+        result = runner.invoke(
+            cli,
+            ["status", str(env_db_repo)],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, result.output
+        assert "Sync State" in result.output
+        assert "Database not found" not in result.output
+        assert "Pages by Type" in result.output
+
+    def test_doctor_reports_db_ok_with_env_db(self, runner, env_db_repo):
+        runner.invoke(
+            cli,
+            ["init", str(env_db_repo), "--provider", "mock", "--yes"],
+            catch_exceptions=False,
+        )
+        assert not (env_db_repo / ".repowise" / "wiki.db").exists()
+
+        result = runner.invoke(
+            cli,
+            ["doctor", str(env_db_repo)],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, result.output
+        assert "wiki.db not found" not in result.output
+
+    def test_status_still_reports_not_found_with_no_db_configured(
+        self, runner, tmp_path, sample_repo_path, monkeypatch
+    ):
+        monkeypatch.delenv("REPOWISE_DB_URL", raising=False)
+        monkeypatch.delenv("REPOWISE_DATABASE_URL", raising=False)
+        dest = tmp_path / "repo"
+        shutil.copytree(sample_repo_path, dest)
+        # A .repowise/ dir with state but no DB — the "Database not found"
+        # branch requires an initialized repo to get past the earlier guard.
+        (dest / ".repowise").mkdir()
+        (dest / ".repowise" / "state.json").write_text("{}", encoding="utf-8")
+
+        result = runner.invoke(cli, ["status", str(dest)], catch_exceptions=False)
+        assert result.exit_code == 0, result.output
+        assert "Database not found" in result.output
+
+    def test_doctor_still_reports_fail_with_no_db_configured(
+        self, runner, tmp_path, sample_repo_path, monkeypatch
+    ):
+        monkeypatch.delenv("REPOWISE_DB_URL", raising=False)
+        monkeypatch.delenv("REPOWISE_DATABASE_URL", raising=False)
+        dest = tmp_path / "repo"
+        shutil.copytree(sample_repo_path, dest)
+
+        result = runner.invoke(cli, ["doctor", str(dest)], catch_exceptions=False)
+        assert result.exit_code == 0, result.output
+        assert "wiki.db not found" in result.output
+
+    def test_doctor_corrupt_local_db_shows_one_fail_row(
+        self, runner, tmp_path, sample_repo_path, monkeypatch
+    ):
+        """A local wiki.db that exists but cannot be opened must report the real
+        connection error — not an extra, contradictory "wiki.db not found" row
+        (regression guard for the reviewer finding on #1274)."""
+        monkeypatch.delenv("REPOWISE_DB_URL", raising=False)
+        monkeypatch.delenv("REPOWISE_DATABASE_URL", raising=False)
+        dest = tmp_path / "repo"
+        shutil.copytree(sample_repo_path, dest)
+        (dest / ".repowise").mkdir()
+        (dest / ".repowise" / "state.json").write_text("{}", encoding="utf-8")
+        # Corrupt: not a valid SQLite file.
+        (dest / ".repowise" / "wiki.db").write_text("this is not a database", encoding="utf-8")
+
+        result = runner.invoke(cli, ["doctor", str(dest)], catch_exceptions=False)
+        assert result.exit_code == 0, result.output
+        # Exactly one Database row — the real connection error, not a second
+        # contradictory "wiki.db not found" row.
+        assert "file is not a" in result.output
+        assert "wiki.db not found" not in result.output
+
+
 class TestSearchFulltext:
     def test_returns_results_or_no_error(self, runner, work_repo):
         runner.invoke(

--- a/tests/unit/cli/test_helpers.py
+++ b/tests/unit/cli/test_helpers.py
@@ -128,6 +128,20 @@ class TestDbUrl:
         assert url == f"sqlite+aiosqlite:///{expected_path}"
         assert (tmp_path / ".repowise").exists()
 
+    def test_configured_db_url_none_without_env(self, monkeypatch):
+        from repowise.core.persistence import get_configured_db_url
+
+        monkeypatch.delenv("REPOWISE_DB_URL", raising=False)
+        monkeypatch.delenv("REPOWISE_DATABASE_URL", raising=False)
+        assert get_configured_db_url() is None
+
+    def test_configured_db_url_returns_normalized_env_url(self, monkeypatch):
+        from repowise.core.persistence import get_configured_db_url
+
+        monkeypatch.delenv("REPOWISE_DATABASE_URL", raising=False)
+        monkeypatch.setenv("REPOWISE_DB_URL", "postgresql://user:pass@host:5432/db")
+        assert get_configured_db_url() == "postgresql+asyncpg://user:pass@host:5432/db"
+
 
 class TestResolveReasoning:
     def test_flag_wins_over_env(self, monkeypatch):


### PR DESCRIPTION
## Summary

Fixes #1274 — `repowise status` and `repowise doctor` falsely reported
"Database not found" / `wiki.db not found` when `REPOWISE_DB_URL` pointed to a
PostgreSQL backend and no local `<repo>/.repowise/wiki.db` file existed.

Both commands gated their DB queries on the existence of the local `wiki.db`
file. The query code right after each guard already resolved the active URL via
`get_db_url_for_repo()` (which honors `REPOWISE_DB_URL` first), so a
Postgres-backed repo with no local file never reached the query — even though
all data was in PostgreSQL and `search` / MCP tools worked fine.

## Root cause

```python
# status_cmd.py
db_path = repowise_dir / "wiki.db"
if not db_path.exists():          # filesystem check
    console.print("[yellow]Database not found.[/yellow]")
    return                        # bails before resolving the URL
```

Same shape in `doctor_cmd/repo_checks.py`: the `db_path.exists()` guard skipped
the connectivity probe entirely and hard-failed with `wiki.db not found`.

## Change

Replaced the filesystem-only guards with a combined check that only bails when
the local file is missing **and** no DB is configured via
`REPOWISE_DB_URL` / `REPOWISE_DATABASE_URL` (using the existing
`get_configured_db_url()` helper):

```python
if not db_path.exists() and _no_db_configured():
    ...  # genuinely no database configured — behave exactly as before
```

- A configured-but-empty DB now behaves like an empty local file.
- Real connection failures still surface as `FAIL` in `doctor` (existing
  `try/except` around the probe) — which is the case a Postgres user actually
  needs to see.
- Covers **all five guard sites**: the four in `status_cmd.py`
  (`_query_repo_counts`, `_query_page_count`, `_query_health_line`, and the
  main `status_command` flow) plus the Database check in
  `doctor_cmd/repo_checks.py`.

## Files changed

- `packages/cli/src/repowise/cli/commands/status_cmd.py`
- `packages/cli/src/repowise/cli/commands/doctor_cmd/repo_checks.py`
- `tests/integration/test_cli.py`
- `tests/unit/cli/test_helpers.py`

## Tests

- New `TestStatusDoctorWithEnvDb` integration tests: with `REPOWISE_DB_URL`
  set to an external DB and no local `wiki.db`, `status` shows the
  "Pages by Type" section (previously skipped) and `doctor` reports
  `Database │ OK`.
- Regression guards keep the genuinely-no-DB branch correct: `status` still
  prints "Database not found" and `doctor` still reports `wiki.db not found`
  when nothing is configured.
- Unit tests document the `get_configured_db_url()` contract
  (`tests/unit/cli/test_helpers.py`).

## Verification

- `uv run ruff check .` — passes
- `mypy` on both changed source files — no issues
- Unit tests covering the edited files (helpers + doctor/status suites) — pass
- `tests/integration/test_cli.py` status/doctor tests — pass
