### PR TITLE
fix(providers): send temperature=1 for kimi-for-coding models

### DIFF
--- a/packages/core/src/repowise/core/providers/llm/kimi.py
+++ b/packages/core/src/repowise/core/providers/llm/kimi.py
@@ -98,7 +98,10 @@ def _kimi_temperature(
     requested: float,
 ) -> float:
     if model.startswith("kimi-for-coding"):
-        return 0.6
+        # The Kimi coding endpoint rejects any temperature other than 1 for
+        # these models ("invalid temperature: only 1 is allowed for this
+        # model"), so the requested value cannot be honoured here.
+        return 1.0
     if model.startswith(("kimi-k2.5", "kimi-k2.6")):
         return 0.6 if normalize_reasoning(reasoning) in ("off", "none") else 1.0
     return requested

--- a/tests/unit/test_providers/test_kimi_provider.py
+++ b/tests/unit/test_providers/test_kimi_provider.py
@@ -200,7 +200,7 @@ async def test_kimi_for_coding_pins_sampling_parameters():
         )
 
     kwargs = mock_client.return_value.chat.completions.create.call_args.kwargs
-    assert kwargs["temperature"] == 0.6
+    assert kwargs["temperature"] == 1.0
     assert kwargs["top_p"] == 0.95
     assert "presence_penalty" not in kwargs
     assert "frequency_penalty" not in kwargs
@@ -218,7 +218,7 @@ async def test_kimi_for_coding_highspeed_pins_sampling_parameters():
         await provider.generate("system", "user", temperature=0.3)
 
     kwargs = mock_client.return_value.chat.completions.create.call_args.kwargs
-    assert kwargs["temperature"] == 0.6
+    assert kwargs["temperature"] == 1.0
     assert kwargs["top_p"] == 0.95
     assert "extra_body" not in kwargs
 
@@ -370,7 +370,7 @@ async def test_stream_chat_uses_kimi_sampling_parameters():
             events.append(event)
 
     kwargs = mock_client.return_value.chat.completions.create.call_args.kwargs
-    assert kwargs["temperature"] == 0.6
+    assert kwargs["temperature"] == 1.0
     assert kwargs["top_p"] == 0.95
     assert "presence_penalty" not in kwargs
     assert "frequency_penalty" not in kwargs


### PR DESCRIPTION
## Problem

The Kimi coding endpoint (`https://api.kimi.com/coding/v1`) rejects any `temperature` other than 1 for the `kimi-for-coding` model family:

```
400 invalid_request_error: invalid temperature: only 1 is allowed for this model
```

`_kimi_temperature()` pinned `0.6` for these models, so **every** request through the `kimi` provider failed validation. In practice, `repowise generate --provider kimi` failed on every page and silently wrote structural stubs (`stub_fallback`) instead of model-written prose — the run reported success while no prose was actually generated.

## Verification against the live endpoint

- `GET /coding/v1/models` lists `kimi-for-coding`, `kimi-for-coding-highspeed`, `k3`, `k3-256k`.
- `kimi-for-coding` with `temperature: 0.3` or `0.6` → 400 (error above).
- `kimi-for-coding` with `temperature: 1` or with the field omitted → 200.
- `k3` rejects `temperature != 1` the same way (out of scope here: unknown models currently fall through to the caller's requested value).

## Fix

Return `1.0` for the `kimi-for-coding*` family in `_kimi_temperature()`, with a comment explaining why the requested value cannot be honoured.

## Tests

- Updated the three assertions that pinned `0.6` for `kimi-for-coding` / `kimi-for-coding-highspeed` (generate and stream_chat paths) to `1.0`.
- `pytest tests/unit/test_providers/test_kimi_provider.py` — 18 passed.