### PR TITLE
fix(deadcode): surface deprecated unused exports above default min_confidence

### DIFF
--- a/packages/core/src/repowise/core/analysis/dead_code/analyzer.py
+++ b/packages/core/src/repowise/core/analysis/dead_code/analyzer.py
@@ -1098,7 +1098,7 @@ class DeadCodeAnalyzer:
                     continue
 
                 if is_deprecated:
-                    confidence = 0.3
+                    confidence = 0.4
                 elif file_has_importers:
                     confidence = 1.0
                 else:

--- a/tests/unit/dead_code/test_unused_exports.py
+++ b/tests/unit/dead_code/test_unused_exports.py
@@ -276,3 +276,58 @@ def test_unused_export_not_rescued_for_index_stem():
     )
     names = {f.symbol_name for f in report.findings if f.kind == DeadCodeKind.UNUSED_EXPORT}
     assert "stranded_export" in names
+
+
+def test_deprecated_unused_export_survives_default_min_confidence():
+    """A deprecated unused export must not be silently erased by the default min_confidence filter."""
+    g = _build_graph(
+        nodes={
+            "pkg/utils.py": {
+                "is_entry_point": False,
+                "is_test": False,
+                "is_api_contract": False,
+                "symbol_count": 1,
+                "symbols": [
+                    {
+                        "name": "legacy_helper_DEPRECATED",
+                        "kind": "function",
+                        "visibility": "public",
+                        "decorators": [],
+                        "start_line": 1,
+                        "end_line": 10,
+                        "complexity_estimate": 2,
+                    },
+                ],
+            },
+            "pkg/main.py": {
+                "is_entry_point": True,
+                "is_test": False,
+                "is_api_contract": False,
+                "symbol_count": 1,
+                "symbols": [],
+            },
+        },
+        # main.py imports utils.py but does NOT import legacy_helper_DEPRECATED by name
+        edges=[
+            (
+                "pkg/main.py",
+                "pkg/utils.py",
+                {"edge_type": "imports", "imported_names": ["other_func"]},
+            ),
+        ],
+    )
+    analyzer = DeadCodeAnalyzer(g, git_meta_map={})
+    # Default min_confidence is 0.4; the deprecated branch used to emit 0.3,
+    # which was filtered out, making the whole low-confidence bucket permanently 0.
+    report = analyzer.analyze(
+        {
+            "detect_unreachable_files": False,
+            "detect_unused_internals": False,
+            "detect_zombie_packages": False,
+        }
+    )
+    unused = [f for f in report.findings if f.kind == DeadCodeKind.UNUSED_EXPORT]
+    names = {f.symbol_name for f in unused}
+    assert "legacy_helper_DEPRECATED" in names
+    finding = next(f for f in unused if f.symbol_name == "legacy_helper_DEPRECATED")
+    assert finding.confidence >= 0.4


### PR DESCRIPTION
## What

Deprecated-suffix unused exports (_DEPRECATED, _LEGACY, _COMPAT) were assigned confidence 0.3, which is below the default min_confidence filter of 0.4. As a result the dead-code analyzer silently erased every deprecated unused export, and the low confidence bucket was permanently 0.

## Fix

Bump the deprecated branch to 0.4 so it passes the default filter and is reported to users as a medium-confidence review candidate.

## Verification

- Added regression test test_deprecated_unused_export_survives_default_min_confidence.
- All dead-code unit tests pass (6/6).

## Root cause / Gap filled

This is a genuine logic gap: the code explicitly special-cases deprecated symbols (indicating the author intended them to be review candidates), but the confidence value placed them below the very filter that decides what gets reported. No prior PR, issue, or doc claimed this was intentional.