### PR TITLE
fix(cli): guard status_cmd against None average_health/hotspot_health

### DIFF
--- a/packages/cli/src/repowise/cli/commands/status_cmd.py
+++ b/packages/cli/src/repowise/cli/commands/status_cmd.py
@@ -204,7 +204,10 @@ def _query_health_line(repo_path: Path) -> str | None:
     worst_repr = f"{worst_score:.1f}" if worst_score is not None else "—"
     from repowise.core.analysis.health.grading import BAND_LABEL, band_for
 
-    band = band_for(float(data["average_health"]))
+    avg = data.get("average_health")
+    if avg is None:
+        return None
+    band = band_for(float(avg))
     band_color = {"healthy": "green", "warning": "yellow", "alert": "red"}[band]
     # Maintainability and performance are co-surfaced pillars; show each when the
     # split has populated it (None on indexes that predate the relevant work).
@@ -219,10 +222,12 @@ def _query_health_line(repo_path: Path) -> str | None:
         if perf is not None
         else ""
     )
+    hotspot = data.get("hotspot_health")
+    hotspot_part = f"{hotspot:.1f} (hotspots) · " if hotspot is not None else ""
     return (
-        f"[bold]Health:[/bold] {data['average_health']:.1f} (avg) "
+        f"[bold]Health:[/bold] {avg:.1f} (avg) "
         f"[[{band_color}]{BAND_LABEL[band]}[/{band_color}]] · "
-        f"{data['hotspot_health']:.1f} (hotspots) · "
+        f"{hotspot_part}"
         f"{worst_repr} (worst: {worst_path})"
         f"{maint_part}"
         f"{perf_part}"

--- a/tests/unit/cli/test_status_cmd.py
+++ b/tests/unit/cli/test_status_cmd.py
@@ -1,8 +1,6 @@
 """Tests for status_cmd edge cases."""
 from __future__ import annotations
 
-from pathlib import Path
-
 from repowise.cli.commands.status_cmd import _query_health_line
 
 

--- a/tests/unit/cli/test_status_cmd.py
+++ b/tests/unit/cli/test_status_cmd.py
@@ -1,0 +1,29 @@
+"""Tests for status_cmd edge cases."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from repowise.cli.commands.status_cmd import _query_health_line
+
+
+def test_query_health_line_returns_none_when_average_health_is_none(monkeypatch, tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    repowise_dir = repo / ".repowise"
+    repowise_dir.mkdir()
+    (repowise_dir / "wiki.db").touch()
+
+    fake_data = {
+        "average_health": None,
+        "hotspot_health": None,
+        "worst_performer_path": "foo.py",
+        "worst_performer_score": None,
+        "file_count": 1,
+    }
+
+    monkeypatch.setattr(
+        "repowise.cli.commands.status_cmd.run_async",
+        lambda fn: fake_data,
+    )
+    result = _query_health_line(repo)
+    assert result is None


### PR DESCRIPTION
## What

_query_health_line dereferenced data["average_health"] and data["hotspot_health"] through float()/:.1f without a None guard, while every other optional health field (maintainability_average, performance_average, worst_performer_score) was already defended with .get() + conditional formatting. Older indexes can produce None for average_health; the unguarded access raised TypeError outside the try/except and crashed `repowise status`.

## Fix

Return None early when average_health is absent so the caller degrades gracefully, matching the documented behavior. Format hotspot_health conditionally when present.

## Verification

- Added regression test test_query_health_line_returns_none_when_average_health_is_none.
- pytest tests/unit/cli/test_status_cmd.py passes.

## Root cause / Gap filled

This is a genuine crash bug: the function's own design degraded gracefully for every other optional numeric field, but average_health and hotspot_health were hard-coded as required. No prior PR, issue, or doc claimed this was intentional.