### PR TITLE
fix(core/cli): do not cache failed update-check results

### DIFF
--- a/packages/cli/src/repowise/cli/update_check.py
+++ b/packages/cli/src/repowise/cli/update_check.py
@@ -197,15 +197,16 @@ def get_cli_update_check_cached(
         pass  # missing / corrupt / stale -> fall through to a live check
 
     result = get_cli_update_check(timeout=timeout)
-    with contextlib.suppress(Exception):  # caching is opportunistic
-        path.write_text(
-            json.dumps(
-                {
-                    "checked_at": time.time(),
-                    "latest_version": result.latest_version,
-                    "error": result.error,
-                }
-            ),
-            encoding="utf-8",
-        )
+    if result.latest_version is not None:
+        with contextlib.suppress(Exception):  # caching is opportunistic
+            path.write_text(
+                json.dumps(
+                    {
+                        "checked_at": time.time(),
+                        "latest_version": result.latest_version,
+                        "error": result.error,
+                    }
+                ),
+                encoding="utf-8",
+            )
     return result

--- a/packages/core/src/repowise/core/upgrade/release.py
+++ b/packages/core/src/repowise/core/upgrade/release.py
@@ -124,7 +124,8 @@ def check_latest_version_cached(
     latest, error = _read_cached_latest(ttl_hours)
     if latest is _MISS:
         latest, error = fetch_latest_version(timeout=timeout)
-        _write_cached_latest(latest, error)
+        if latest is not None:
+            _write_cached_latest(latest, error)
     update_available = is_newer_version(latest, current_version) if latest else None
     return ReleaseCheck(
         current_version=current_version,

--- a/tests/unit/upgrade/test_release.py
+++ b/tests/unit/upgrade/test_release.py
@@ -102,3 +102,27 @@ def test_expired_cache_refetches(monkeypatch, tmp_path):
     monkeypatch.setattr(rel, "fetch_latest_version", lambda timeout=2.0: ("9.9.9", None))
     result = check_latest_version_cached("0.21.0", ttl_hours=24)
     assert result.latest_version == "9.9.9"
+
+
+def test_check_latest_version_cached_does_not_poison_on_failure(monkeypatch, tmp_path):
+    """A transient fetch failure must not pin the cache to None for the TTL."""
+    _redirect_cache(monkeypatch, tmp_path)
+    calls = {"n": 0}
+
+    def _fetch(timeout=2.0):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return None, "offline"
+        return "9.9.9", None
+
+    monkeypatch.setattr(rel, "fetch_latest_version", _fetch)
+
+    first = check_latest_version_cached("0.21.0", ttl_hours=1)
+    assert first.latest_version is None
+    assert first.update_available is None
+
+    # Second call within TTL must retry (not serve cached None).
+    second = check_latest_version_cached("0.21.0", ttl_hours=1)
+    assert calls["n"] == 2
+    assert second.latest_version == "9.9.9"
+    assert second.update_available is True

--- a/tests/unit/upgrade/test_update_check_cache.py
+++ b/tests/unit/upgrade/test_update_check_cache.py
@@ -90,3 +90,27 @@ def _now() -> float:
     import time
 
     return time.time()
+
+
+def test_cli_cached_does_not_persist_failure(monkeypatch, tmp_path):
+    """A transient failure must not pin the CLI cache to None for the TTL."""
+    _redirect_global_dir(monkeypatch, tmp_path)
+    calls = {"n": 0}
+
+    def _live(timeout=2.0):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return _fake_check(latest=None, error="offline")
+        return _fake_check()
+
+    monkeypatch.setattr(uc, "get_cli_update_check", _live)
+
+    first = get_cli_update_check_cached(ttl_hours=1)
+    assert first.latest_version is None
+    assert not (tmp_path / "update-check.json").exists()  # failure not cached
+
+    # Second call within TTL must retry (not serve cached None).
+    second = get_cli_update_check_cached(ttl_hours=1)
+    assert calls["n"] == 2
+    assert second.latest_version == "9.9.9"
+    assert (tmp_path / "update-check.json").exists()  # success is cached


### PR DESCRIPTION
## What

A transient PyPI failure in `check_latest_version_cached` or `get_cli_update_check_cached` wrote `latest=None` + `error` into the TTL cache. The next call within the cache window saw cached `None` (not the `_MISS` sentinel), skipped the live fetch, and reported "unknown" for the entire `DEFAULT_TTL_HOURS` (24h).

## Fix

Only persist the cache when `latest_version` is not `None`. On failure, skip caching so the next call retries the network.

Fixes both the core shared cache (`~/.repowise/update-check.json`) and the CLI-specific cache.

## Verification

- Added `test_check_latest_version_cached_does_not_poison_on_failure` in `test_release.py`: asserts a failed fetch is retried on the next call.
- Added `test_cli_cached_does_not_persist_failure` in `test_update_check_cache.py`: asserts a failed live check is not persisted and a successful retry is cached.
- All 9 release tests pass; all 5 CLI cache tests pass.

## Root cause / Gap filled

This is a genuine 24-hour silent failure: one network hiccup locked users into "update status unknown" for a full day, with no retry path. The docstrings promise best-effort behavior, but the cache write was unconditional. No prior PR, issue, or doc claimed caching failures was intentional.