### PR TITLE
fix(mcp): bring the get_risk docstring back under the schema budget

### DIFF
--- a/packages/server/src/repowise/server/mcp_server/tool_risk/get_risk.py
+++ b/packages/server/src/repowise/server/mcp_server/tool_risk/get_risk.py
@@ -40,27 +40,26 @@ async def get_risk(
 
     Fuses git temporal signals (churn percentile, trend, bus factor) with
     graph topology (dependents, co-changes, impact surface) and security
-    findings. Consult before editing a file that is bug-fixed or busy. Pass
+    findings. Consult before editing a bug-fixed or busy file. Pass
     changed_files for PR mode: the response leads with a directive block
     (will_break, missing_cochanges, missing_tests, tests_to_run) — read it
     first. tests_to_run is coverage-backed: the tests the per-test map proves
-    exercise the changed files, empty when no coverage map is ingested.
-    To score a live commit or ``base..head`` diff by revspec instead of file
-    paths, use ``get_change_risk``.
+    exercise the changed files, empty when no coverage map is ingested. To
+    score a commit or ``base..head`` range instead, use ``get_change_risk``.
 
     defect_profile appears only on files with counted bug fixes: how many landed
     in the trailing 6 months, how long ago the last one was, a bug_magnet flag
-    for sustained recent fix pressure, and top_symbols. Those per-symbol counts
-    are approximate, because symbol spans are current-tree while each fix's line
-    ranges are numbered on its own parent commit, so read them as "mostly here"
-    rather than exact. Nothing here names the commit that introduced a bug.
-    global_hotspots ranks the same way: fix history first, churn as fallback.
+    for sustained recent fix pressure, and top_symbols. Read top_symbols as
+    "mostly here" rather than exact — symbol spans are current-tree while each
+    fix's line ranges are numbered on its own parent commit. Nothing names the
+    commit that introduced a bug. global_hotspots ranks the same way: fix
+    history first, churn as fallback.
 
-    episodes counts the dated records bound to a target — what happened here
-    and why, with a commit or a filesystem fact as evidence. It appears only
-    when there is at least one, and get_why serves the bodies. A directory
-    target aggregates everything beneath it, so the numbers compare within a
-    kind of target and not across kinds.
+    episodes counts the dated records bound to a target — what happened here and
+    why, evidenced by a commit or a filesystem fact. It appears only when there
+    is at least one, and get_why serves the bodies. A directory target
+    aggregates everything beneath it, so compare the numbers within a kind of
+    target, not across kinds.
 
     Args:
         targets: file paths to assess.

--- a/packages/server/src/repowise/server/mcp_server/tool_search.py
+++ b/packages/server/src/repowise/server/mcp_server/tool_search.py
@@ -920,10 +920,10 @@ async def search_codebase(
 
     For QUESTIONS ("how does X work", "where is Y handled", "why is Z like
     this"), call get_answer instead: it runs this same hybrid retrieval
-    internally and synthesizes a cited answer, so a search_codebase call
-    before get_answer is a wasted round-trip. Use this tool directly when you
-    want the raw ranked hits themselves — enumerating matches, resolving an
-    identifier to a symbol_id, or scoping a later get_context call.
+    internally and synthesizes a cited answer, so searching first is a wasted
+    round-trip. Use this tool when you want the raw ranked hits themselves —
+    enumerating matches, resolving an identifier to a symbol_id, or scoping a
+    later get_context call.
 
     mode="auto" (default) routes the query: identifier-shaped queries search
     the indexed symbols (returns symbol_id/file/line bounds — pipe into


### PR DESCRIPTION
## What broke

CI is red on `main` (run 31104714270, all three Python jobs). One test:

```
FAILED tests/unit/server/mcp/test_tool_docstrings.py::test_every_tool_docstring_fits_the_schema_budget
AssertionError: Tool docstrings over 1600 chars (~400 tokens): {'get_risk': 1655}
```

The `episodes` paragraph added in #1333 pushed `get_risk` past the 1600-char (~400 token) schema-docstring ceiling.

## The fix

Prose only, no behaviour change:

- `get_risk`: tighten the `defect_profile` and `episodes` paragraphs and shorten the `get_change_risk` pointer. 1655 → **1562**.
- `search_codebase`: it was sitting at **1599**, one character of margin, so the next docstring edit anywhere in that file would have broken CI the same way. Trimmed its `get_answer` preamble. 1599 → **1565**.

Every fact in both docstrings is preserved, just said in fewer words.

## Verification

Measured with the same normalization the test applies (`inspect.cleandoc` over the docstring literal). The method reproduces CI's reported `1655` exactly on the pre-fix file, so the post-fix numbers are trustworthy. Full sweep of all 15 registered MCP tools: none over 1600 chars, none with a first line over 90 chars. `ruff check` clean on both files.
