### PR TITLE
Retire the skeleton-nudge Read hook

### DIFF
--- a/docs/agent/DISTILL.md
+++ b/docs/agent/DISTILL.md
@@ -191,8 +191,11 @@ smarter than blind truncation.
 
 The existing PostToolUse hook complements this passively:
 
-- **Skeleton nudge** — after a large `Read` of an indexed file, the agent is
-  told the skeleton's token cost vs the full file (once per file per session).
+- **Skeleton replacement** — an unbounded `Read` of a large indexed file is
+  served *as* its skeleton, elision ranges intact, once per file per session
+  (opt-in: `hooks.read_skeleton`). The advisory version of this — a one-line
+  nudge naming the skeleton's token cost — was retired after 516 firings
+  showed no effect above the base rate.
 - **Stale-read notice** — after an `Edit`/`Write`, a later `Read` of the same
   file warns that earlier excerpts predate the edit.
 - **Search digest** — grep floods (≥50 lines) get a compact grouped-by-file

--- a/packages/cli/src/repowise/cli/commands/augment_cmd/command.py
+++ b/packages/cli/src/repowise/cli/commands/augment_cmd/command.py
@@ -46,9 +46,6 @@ Codex SessionStart/UserPromptSubmit: adds short repowise MCP usage guidance.
       served as its skeleton via updatedToolOutput, elision markers and
       1-indexed line ranges intact, once per file per session. Opt-in
       (hooks.read_skeleton), default off.
-    * Skeleton nudge: the fallback when the replacement does not apply —
-      a one-line pointer at get_context(include=["skeleton"]) with a cheap
-      bounds-arithmetic estimate.
     * Stale-read notice: when this file was Edited/Written after the
       session's previous Read of it, flag that earlier excerpts are stale.
       Once per file per session, never blocking.

--- a/packages/cli/src/repowise/cli/commands/augment_cmd/decision_inject.py
+++ b/packages/cli/src/repowise/cli/commands/augment_cmd/decision_inject.py
@@ -95,7 +95,7 @@ _CLIP_RATIONALE = 160
 
 # ---------------------------------------------------------------------------
 # Shared SQLite plumbing (read-only wiki.db, stdlib sqlite3 — the hook path
-# must not pay the sqlalchemy import; same pattern as the skeleton nudge)
+# must not pay the sqlalchemy import; same pattern as fast_lookup)
 # ---------------------------------------------------------------------------
 
 

--- a/packages/cli/src/repowise/cli/commands/augment_cmd/read_skeleton.py
+++ b/packages/cli/src/repowise/cli/commands/augment_cmd/read_skeleton.py
@@ -1,11 +1,19 @@
 """PostToolUse Read → serve the indexed skeleton instead of the whole file.
 
 The skeleton *nudge* — a one-line pointer at ``get_context(include=
-["skeleton"])`` — fired 502 times across 185 sessions and was acted on once.
+["skeleton"])`` — fired 516 times across 203 sessions and was acted on once.
 It did not fail on content. It failed by asking the agent to do something the
 hook could do itself. This module does it instead: when every gate below
 clears, the hook returns ``updatedToolOutput`` and the agent's Read of a large
 indexed file arrives as its skeleton.
+
+The nudge has since been retired outright rather than kept as a fallback: a
+replay under three looser judges, including the compliance form used for a
+notice that asks for a *non*-action, found it at or below the unconditioned
+base rate on every one, and a session's second nudge did no better than its
+first. ``sessions/efficacy.py`` carries the numbers. So a client that cannot
+honour a replacement now gets silence, which is the honest fallback for a
+surface with nothing to say.
 
 **This is not a silent truncation.** ``build_skeleton`` marks every elided
 span with its 1-indexed line range, so the agent can see exactly what was
@@ -17,7 +25,7 @@ time returns it whole; the header says so.
 Gates, cheapest first (:func:`skeleton_replacement`):
 
 1. **Unbounded read only.** A ranged Read is already a targeted question.
-2. **Above the size floor** the nudge already used.
+2. **Above the size floor** (100 output lines).
 3. **Opted in.** ``hooks.read_skeleton: true`` in ``.repowise/config.yaml``,
    default off. Read with a lazy ``yaml`` import and fail-closed.
 4. **Not a verification re-read.** A Read that follows an Edit of the same
@@ -49,8 +57,8 @@ if TYPE_CHECKING:  # pragma: no cover - the hook path imports these lazily
     from repowise.core.distill.skeleton import SkeletonResult, SkeletonSymbol
 
 #: Claude Code release that introduced ``updatedToolOutput``. Older clients
-#: ignore the field, which would silently drop the enrichment, so on those we
-#: fall back to the nudge (see :func:`supports_updated_output`).
+#: ignore the field, which would silently drop the enrichment, so on those the
+#: Read is left untouched (see :func:`supports_updated_output`).
 _MIN_CLIENT_VERSION = (2, 1, 218)
 
 #: Hard ceiling on the replacement string; shared with every other replacing
@@ -302,8 +310,8 @@ def _indexed_symbols(db_path: Path, rel: str) -> list[SkeletonSymbol]:
     """Persisted symbol rows for one file as ``SkeletonSymbol``s, or [].
 
     Read-only stdlib sqlite3 for the same reason
-    :func:`read_state._file_symbol_bounds` uses it: the hook path must not pay
-    the sqlalchemy import to read five columns.
+    :mod:`fast_lookup` uses it: the hook path must not pay the sqlalchemy
+    import to read five columns.
     """
     if not db_path.exists():
         return []

--- a/packages/cli/src/repowise/cli/commands/augment_cmd/read_state.py
+++ b/packages/cli/src/repowise/cli/commands/augment_cmd/read_state.py
@@ -1,7 +1,7 @@
 """PostToolUse Read/Edit/Write per-session read intelligence.
 
 A small JSON state file under .repowise/ tracks which files this agent
-session has Read and Edited, keyed by the hook payload's session_id. Three
+session has Read and Edited, keyed by the hook payload's session_id. Two
 behaviors ride on it:
 
   * Stale-read notice — a Read of a file whose previous Read predates a
@@ -10,21 +10,30 @@ behaviors ride on it:
     *served as* its skeleton via ``updatedToolOutput``, once per file per
     session, when the repo opted in. Gates and rationale live in
     :mod:`read_skeleton`; this module owns only the session-state gates.
-  * Skeleton nudge — the fallback when the replacement does not apply: a
-    one-line pointer at get_context(include=["skeleton"]) with a
-    bounds-arithmetic estimate. Measured at 0.2%, and on the way out — it
-    survives only to cover clients that cannot honour a replacement.
 
 Rate limiting is the state file itself (per-file, per-session lists), NOT
 the _claim_emission temp marker — that TTL-based dedup only suppresses the
 two concurrently-registered hooks racing on one tool event, which still
 applies on top. A new session_id resets the state.
 
-The re-read notice lived here too, and was retired: it scored 100%
-"respected" only because agents rarely read the same file a third time, so
-it was measuring the base rate and changing nothing. The case it argued —
-"you already have this, take a range instead" — is now handled by doing it
-rather than saying it.
+Two notices lived here and were retired for the same reason wearing two
+different disguises. The re-read notice scored 100% "respected" only because
+agents rarely read the same file a third time, so it was measuring the base
+rate and changing nothing.
+
+The skeleton nudge (a one-line pointer at ``get_context(include=
+["skeleton"])`` on a large Read) was the loudest surface in the system and
+the measurement never came back. Over 516 replayed firings a structure call
+followed 11.4% of the time, against an 11.9% unconditioned base rate. The
+offense it asks the agent to stop, reading the *next* large indexed file
+whole, followed 57.1% of first nudges and 53.4% of later ones, so repeated
+exposure moved nothing. It was also answering the wrong reads:
+``is_unbounded_read`` gates the *replacement*, and the nudge sat on the
+branch the replacement declines, so 53.3% of firings followed a ranged Read.
+That is advice to be more targeted, given to a read that already was.
+
+The case both notices argued, "you already have this, take the structure
+instead", is handled by the replacement doing it rather than saying it.
 """
 
 from __future__ import annotations
@@ -34,8 +43,11 @@ from pathlib import Path
 
 from ._shared import HookResult, _extract_output_text, _find_repo_root, _relativize
 
-_READ_NUDGE_MIN_LINES = 100  # Read output lines before a skeleton nudge
-_READ_NUDGE_MIN_TOKENS = 3000  # full-file tokens below which a nudge is noise
+#: Replacement gates. Named for the retired nudge they were first tuned for,
+#: and left that way on purpose: :mod:`search_digest` documents its own ratio
+#: against ``_READ_NUDGE_MAX_RATIO`` by name, and the counterfactual leg has to
+#: keep asking the same question as the real one.
+_READ_NUDGE_MIN_LINES = 100  # Read output lines before a replacement is worth it
 _READ_NUDGE_MIN_SAVINGS = 1500  # estimated tokens saved must clear this
 _READ_NUDGE_MAX_RATIO = 0.5  # skeleton must be at most this fraction of full
 
@@ -57,7 +69,6 @@ def _load_session_state(repo_path: Path, session_id: str) -> dict:
         "seq": 0,
         "reads": {},
         "edits": {},
-        "nudged": [],
         "stale_notified": [],
         # Files served as a skeleton this session. Doubles as the once-per-
         # file gate and as the "did the agent come back for it" marker.
@@ -194,7 +205,7 @@ def _handle_read_post(
     cwd: str,
     session_id: str,
 ) -> HookResult:
-    """Stale-read notice, then either a skeleton replacement or the nudge."""
+    """Stale-read notice, then the skeleton replacement where it applies."""
     file_path = tool_input.get("file_path") if isinstance(tool_input, dict) else None
     if not isinstance(file_path, str) or not file_path.strip():
         return HookResult()
@@ -233,11 +244,6 @@ def _handle_read_post(
     )
     if replacement is not None:
         fired.append(("skeleton_served", replacement.text))
-    else:
-        nudge = _skeleton_nudge(repo_path, rel, tool_output, state)
-        if nudge:
-            notices.append(nudge)
-            fired.append(("skeleton_nudge", nudge))
 
     persisted = _save_session_state(repo_path, state)
     if not persisted:
@@ -507,69 +513,3 @@ def _read_output_line_count(tool_output: object) -> int:
                 return content.count("\n") + 1
     text = _extract_output_text(tool_output)
     return (text.count("\n") + 1) if text.strip() else 0
-
-
-def _skeleton_nudge(repo_path: Path, rel: str, tool_output: object, state: dict) -> str | None:
-    """One-line skeleton pointer for a large Read of an indexed file.
-
-    Cheap by construction: bails before any non-stdlib import when the repo
-    has no wiki.db, and the size estimate is pure bounds arithmetic — the
-    skeleton itself is never rendered on the hook path.
-    """
-    if rel in state["nudged"]:
-        return None
-    if _read_output_line_count(tool_output) < _READ_NUDGE_MIN_LINES:
-        return None
-    db_path = repo_path / ".repowise" / "wiki.db"
-    if not db_path.exists():
-        return None
-
-    bounds = _file_symbol_bounds(db_path, rel)
-    if not bounds:
-        return None
-    try:
-        size = (repo_path / rel).stat().st_size
-    except OSError:
-        return None
-    full_tokens = size // 4
-    if full_tokens < _READ_NUDGE_MIN_TOKENS:
-        return None
-
-    from repowise.core.distill.skeleton import estimate_skeleton_tokens
-
-    skeleton_tokens = estimate_skeleton_tokens(bounds, file_size_bytes=size)
-    if skeleton_tokens > full_tokens * _READ_NUDGE_MAX_RATIO:
-        return None
-    # A nudge is only worth the agent's attention when acting on it buys a
-    # real saving — a few hundred tokens on a mid-size file is noise.
-    if full_tokens - skeleton_tokens < _READ_NUDGE_MIN_SAVINGS:
-        return None
-
-    state["nudged"].append(rel)
-    return (
-        f"[repowise] A skeleton of {rel} is ~{skeleton_tokens} tokens vs ~{full_tokens} "
-        f'for the full file. For structure-level questions use get_context(["{rel}"], '
-        'include=["skeleton"]).'
-    )
-
-
-def _file_symbol_bounds(db_path: Path, rel: str) -> list[tuple[int, int]]:
-    """Persisted (start_line, end_line) pairs for one file, or [] on any miss.
-
-    Direct read-only stdlib sqlite3 — the hook path must not pay the
-    sqlalchemy import for two integers per symbol.
-    """
-    import sqlite3
-
-    try:
-        con = sqlite3.connect(f"file:{db_path.as_posix()}?mode=ro", uri=True, timeout=1)
-        try:
-            rows = con.execute(
-                "SELECT start_line, end_line FROM wiki_symbols WHERE file_path = ?",
-                (rel,),
-            ).fetchall()
-        finally:
-            con.close()
-    except sqlite3.Error:
-        return []
-    return [(s, e) for s, e in rows if isinstance(s, int) and isinstance(e, int) and s > 0]

--- a/packages/cli/src/repowise/cli/editor_integrations/claude_config.py
+++ b/packages/cli/src/repowise/cli/editor_integrations/claude_config.py
@@ -207,7 +207,7 @@ def enable_tool_search_in_claude_code() -> Path | None:
 
 
 # Current augment PostToolUse matcher. Read/Edit/Write power the distill
-# read-intelligence layer (skeleton nudges + per-file stale-read notices);
+# read-intelligence layer (skeleton replacement + per-file stale-read notices);
 # PowerShell is the Windows Claude Code shell tool (same payload shape as
 # Bash); the mcp__ pattern feeds the read-after-served ledger (read_enrich)
 # and matches the repowise MCP server under any registration name (local,

--- a/packages/core/src/repowise/core/distill/skeleton.py
+++ b/packages/core/src/repowise/core/distill/skeleton.py
@@ -38,7 +38,6 @@ __all__ = [
     "SkeletonResult",
     "SkeletonSymbol",
     "build_skeleton",
-    "estimate_skeleton_tokens",
 ]
 
 #: Default total token budget for smart mode (signatures + kept bodies).
@@ -185,33 +184,6 @@ def build_skeleton(
         symbol_count=len(usable),
         bodies_kept=bodies_kept,
     )
-
-
-def estimate_skeleton_tokens(
-    symbol_bounds: Sequence[tuple[int, int]],
-    *,
-    file_size_bytes: int,
-    total_lines: int | None = None,
-) -> int:
-    """Cheap skeleton-size estimate from bounds arithmetic alone.
-
-    For hook paths that must not render anything: approximates the kept
-    fraction (preamble + ~2 signature lines + 1 elision line per symbol)
-    and scales the file's chars/4 token count by it. Within ~2x of the real
-    skeleton size, which is all a "~M tokens vs K" nudge needs.
-    """
-    if not symbol_bounds or file_size_bytes <= 0:
-        return max(0, file_size_bytes // 4)
-    starts = [s for s, _ in symbol_bounds if s > 0]
-    if not starts:
-        return file_size_bytes // 4
-    lines_total = total_lines or max(e for _, e in symbol_bounds)
-    if lines_total <= 0:
-        return file_size_bytes // 4
-    preamble = min(min(starts) - 1, _PREAMBLE_KEEP_LINES)
-    kept_lines = preamble + 3 * len(symbol_bounds)  # ~2 sig lines + 1 marker
-    fraction = min(1.0, kept_lines / lines_total)
-    return max(1, int(file_size_bytes // 4 * fraction))
 
 
 # ---------------------------------------------------------------------------

--- a/packages/core/src/repowise/core/sessions/efficacy.py
+++ b/packages/core/src/repowise/core/sessions/efficacy.py
@@ -29,6 +29,7 @@ What counts as acting, per surface
 surface       category        acted when, within the window
 ============= =============== ==================================================
 read          skeleton_nudge  a skeleton/structure call on the named file
+                              (retired; historical rows only — see below)
 read          skeleton_served n/a — the hook already did it (see below)
 read          stale_read      n/a — a warning, not a pointer
 search        triage          a named file is touched
@@ -50,6 +51,34 @@ A ranged Read after a skeleton nudge is deliberately **not** acting: reading a
 range of a file you just read in full is ordinary edit-prep and cannot be
 attributed to the nudge. It is tracked separately as
 :data:`AMBIGUOUS` evidence so the generous bound stays reportable.
+
+The nudge itself no longer fires (see ``augment_cmd/read_state.py``). Its
+judge stays because ``hook backfill`` still has to settle the firings already
+in the corpus, and because the reason it was retired is worth keeping beside
+the code that measured it.
+
+The suspicion was that the judge above is too strict, crediting only a
+structure call on a file the agent has just read in full, which the agent has
+no reason to make. So three looser readings were replayed over 516 firings
+before the surface was touched, and none of them found an effect. A structure
+call on *any* file followed 11.4% of nudges, against an 11.9% unconditioned
+base rate; ``get_context`` on a file not yet read, 2.9% against 3.4%. Both sit
+at or below chance. Read as compliance instead, which is the shape
+``read``/``reread`` uses (did the agent stop doing the thing, rather than
+start doing another), 54.8% of nudges were followed within the window by a
+second nudge, meaning another large indexed file read whole, a median of six
+tool calls later.
+
+The number that settles it is the dose. A session's *first* nudge was
+followed by another 57.1% of the time, a later one 53.4%, so being told again
+changed nothing. The judge was not the problem.
+
+One thing the replay found that no rate would have: 53.3% of firings answered
+a *ranged* Read. The unbounded-read gate belonged to the replacement, and the
+nudge sat on the branch the replacement declines, so over half of it was
+advice to be more targeted handed to a read that already was. That also means
+the ``AMBIGUOUS`` bucket below was reading the ranged form backwards about as
+often as not: for those firings the ranged read came *before* the nudge.
 
 The *replacement* rows (``skeleton_served`` and its two recovery categories,
 and ``digest_served``) are structurally unlike the rest: their text goes out as
@@ -147,6 +176,8 @@ def ledger_key(surface: str, category: str, text: str) -> str:
 # the emitted text. Each capture group named below feeds the classifier:
 # ``target`` is the file or symbol the hook pointed at.
 _PATTERNS: tuple[tuple[str, str, re.Pattern[str]], ...] = (
+    # Retired on the emission side; kept so a backfill still settles the rows
+    # already in the corpus. Nothing new lands here.
     (
         "read",
         "skeleton_nudge",

--- a/tests/unit/cli/test_augment_read_skeleton.py
+++ b/tests/unit/cli/test_augment_read_skeleton.py
@@ -8,7 +8,7 @@ Two things are under test and they are not the same thing:
    argument that it fires only when it should.
 2. **The contract.** A replacement that does not carry its elision ranges is
    a silent truncation, which is the one outcome that would make this worse
-   than the nudge it replaces. That is asserted directly, not implied.
+   than the nudge it replaced. That is asserted directly, not implied.
 """
 
 from __future__ import annotations
@@ -465,14 +465,19 @@ def test_no_index_at_all_is_left_alone(repo: Path) -> None:
     assert _read(repo).replacement is None
 
 
-def test_an_unsupported_client_falls_back_to_the_nudge(
+def test_an_unsupported_client_gets_its_read_untouched(
     repo: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Older clients ignore updatedToolOutput — emitting it would lose the win."""
+    """Older clients ignore updatedToolOutput — emitting it would lose the win.
+
+    This used to fall back to the skeleton nudge. The nudge was retired for
+    having no measurable effect, so the fallback is silence: there is nothing
+    to say to a client that cannot be handed the skeleton.
+    """
     monkeypatch.setenv("REPOWISE_HOOK_UPDATED_OUTPUT", "0")
     result = _read(repo)
     assert result.replacement is None
-    assert "A skeleton of pkg/big.py is ~" in (result.context or "")
+    assert result.context is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/distill/test_read_intelligence.py
+++ b/tests/unit/distill/test_read_intelligence.py
@@ -1,4 +1,4 @@
-"""Read-intelligence PostToolUse behaviors: skeleton nudges + stale reads.
+"""Read-intelligence PostToolUse behaviors: stale reads, and what was retired.
 
 Exercises the augment handlers directly (the `_handle_post_tool_use`
 dispatch layer), below `_emit_response`'s cross-process dedup, so the
@@ -50,7 +50,7 @@ def _index_file(repo: Path, rel: str, bounds: list[tuple[int, int]]) -> None:
 
 
 def _write_big_file(repo: Path, rel: str, lines: int = 600) -> Path:
-    """Default size clears the nudge's full-file token floor (~3k tokens)."""
+    """Default size clears the replacement's full-file token floor (~3k tokens)."""
     path = repo / rel
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text("\n".join(f"x{n} = {n}  # padding padding" for n in range(lines)) + "\n")
@@ -86,78 +86,59 @@ def _edit_event(repo: Path, rel: str, tool: str = "Edit", session: str = SESSION
     )
 
 
-class TestSkeletonNudge:
-    def test_fires_for_big_read_of_indexed_file(self, repo: Path) -> None:
+class TestRetiredSkeletonNudge:
+    """The skeleton nudge was deleted; these keep it deleted.
+
+    It was the loudest surface in the system and it never earned a number.
+    Three readings were replayed over 516 firings before it was touched: a
+    structure call on any file followed 11.4% of nudges against an 11.9%
+    unconditioned base rate, ``get_context`` on a not-yet-read file 2.9%
+    against 3.4%, and read as compliance — did the agent stop reading large
+    indexed files whole — 54.8% re-offended inside the window. A session's
+    first nudge re-offended at 57.1% and its later ones at 53.4%, so being
+    told again changed nothing. What it asked for is now done by the
+    replacement rather than said.
+    """
+
+    def test_a_big_read_of_an_indexed_file_says_nothing(self, repo: Path) -> None:
         _write_big_file(repo, "src/big.py")
         _index_file(repo, "src/big.py", [(10, 60), (70, 150), (160, 195)])
+        assert _read_event(repo, "src/big.py") is None
 
-        result = _read_event(repo, "src/big.py")
-        assert result is not None
-        assert 'include=["skeleton"]' in result
-        assert "src/big.py" in result
-        assert "tokens" in result
-
-    def test_fires_exactly_once_per_file_per_session(self, repo: Path) -> None:
+    def test_no_pointer_survives_on_any_read_of_that_file(self, repo: Path) -> None:
+        """Including the second and a fresh session, which used to re-fire."""
         _write_big_file(repo, "src/big.py")
         _index_file(repo, "src/big.py", [(10, 60), (70, 150), (160, 195)])
-
-        first = _read_event(repo, "src/big.py")
-        assert first is not None and 'include=["skeleton"]' in first
-        # Every subsequent read of the same file this session is silent.
         assert _read_event(repo, "src/big.py") is None
         assert _read_event(repo, "src/big.py") is None
-        # A new session resets the claim — skeleton pointer fires again.
-        third_session = _read_event(repo, "src/big.py", session="session-2")
-        assert third_session is not None and 'include=["skeleton"]' in third_session
+        assert _read_event(repo, "src/big.py", session="session-2") is None
 
-    def test_silent_below_line_threshold(self, repo: Path) -> None:
-        _write_big_file(repo, "src/big.py")
-        _index_file(repo, "src/big.py", [(10, 60), (70, 150)])
-        assert _read_event(repo, "src/big.py", num_lines=40) is None
-
-    def test_silent_without_wiki_db(self, repo: Path) -> None:
-        _write_big_file(repo, "src/big.py")
-        assert _read_event(repo, "src/big.py") is None
-
-    def test_silent_when_file_not_indexed(self, repo: Path) -> None:
-        _write_big_file(repo, "src/big.py")
-        _index_file(repo, "src/other.py", [(1, 50)])
-        assert _read_event(repo, "src/big.py") is None
-
-    def test_silent_outside_any_repowise_repo(self, tmp_path: Path) -> None:
+    def test_a_read_outside_any_repowise_repo_is_left_alone(self, tmp_path: Path) -> None:
+        """`_handle_read_post`'s own early return, which the nudge tests used to
+        be the only cover for. It guards every Read notice, not just the one
+        that went."""
         plain = tmp_path / "plain"
         _write_big_file(plain, "src/big.py")
-        result = _post(
-            "Read",
-            tool_input={"file_path": str(plain / "src/big.py")},
-            tool_output={"file": {"numLines": 150}},
-            cwd=str(plain),
-            session_id=SESSION,
+        assert (
+            _post(
+                "Read",
+                tool_input={"file_path": str(plain / "src/big.py")},
+                tool_output={"file": {"numLines": 150}},
+                cwd=str(plain),
+                session_id=SESSION,
+            )
+            is None
         )
-        assert result is None
 
-    def test_silent_for_tiny_file(self, repo: Path) -> None:
-        # 150 reported lines but the on-disk file is too small to matter.
-        path = repo / "src" / "small.py"
-        path.parent.mkdir(parents=True)
-        path.write_text("x = 1\n" * 30)
-        _index_file(repo, "src/small.py", [(1, 30)])
-        assert _read_event(repo, "src/small.py") is None
-
-    def test_silent_below_token_floor(self, repo: Path) -> None:
-        # The live noise case: a ~1.5k-token file with a perfectly valid
-        # skeleton (~600 tokens saved) is a hint nobody should act on.
-        _write_big_file(repo, "src/mid.py", lines=200)
-        _index_file(repo, "src/mid.py", [(10, 60), (70, 150), (160, 195)])
-        assert _read_event(repo, "src/mid.py") is None
-
-    def test_fires_above_token_floor_with_real_savings(self, repo: Path) -> None:
-        # Same shape as the noise case, just genuinely large: ≥3k full-file
-        # tokens with ≥1.5k estimated savings.
-        _write_big_file(repo, "src/big.py", lines=600)
+    def test_the_stale_read_notice_is_unaffected(self, repo: Path) -> None:
+        """The one Read notice that survived, asserted on the nudge's own shape."""
+        _write_big_file(repo, "src/big.py")
         _index_file(repo, "src/big.py", [(10, 60), (70, 150), (160, 195)])
-        result = _read_event(repo, "src/big.py")
-        assert result is not None and 'include=["skeleton"]' in result
+        _read_event(repo, "src/big.py")
+        _edit_event(repo, "src/big.py")
+        notice = _read_event(repo, "src/big.py")
+        assert notice is not None and "stale" in notice
+        assert 'include=["skeleton"]' not in notice
 
 
 class TestStaleReadNotice:
@@ -267,7 +248,6 @@ class TestSessionState:
             "session_id": SESSION,
             "reads": {f"f{i}.py": float(i) for i in range(600)},
             "edits": {},
-            "nudged": [],
             "stale_notified": [],
         }
         _save_session_state(repo, state)

--- a/tests/unit/distill/test_skeleton.py
+++ b/tests/unit/distill/test_skeleton.py
@@ -16,7 +16,6 @@ from repowise.core.distill.skeleton import (
     SkeletonResult,
     SkeletonSymbol,
     build_skeleton,
-    estimate_skeleton_tokens,
 )
 
 
@@ -209,30 +208,6 @@ class TestSignatureEndHeuristics:
         sigs = build_skeleton(source, sym, mode="signatures")
         assert "Summary line." not in sigs.text
         assert "x = 1" not in sigs.text
-
-
-class TestEstimate:
-    def test_estimate_tracks_real_skeleton(self, python_case) -> None:
-        source, symbols = python_case
-        real = build_skeleton(source, symbols, mode="signatures")
-        est = estimate_skeleton_tokens(
-            [(s.start_line, s.end_line) for s in symbols],
-            file_size_bytes=len(source.encode("utf-8")),
-            total_lines=len(source.splitlines()),
-        )
-        # Within 2x either way — good enough for a "~M tokens vs K" nudge.
-        assert real.skeleton_tokens / 2 <= est <= real.skeleton_tokens * 2
-
-    def test_estimate_empty_bounds(self) -> None:
-        assert estimate_skeleton_tokens([], file_size_bytes=4000) == 1000
-
-    def test_estimate_is_below_full(self, python_case) -> None:
-        source, symbols = python_case
-        size = len(source.encode("utf-8"))
-        est = estimate_skeleton_tokens(
-            [(s.start_line, s.end_line) for s in symbols], file_size_bytes=size
-        )
-        assert est < size // 4
 
 
 class TestResultShape:

--- a/tests/unit/sessions/test_efficacy.py
+++ b/tests/unit/sessions/test_efficacy.py
@@ -151,6 +151,11 @@ def test_ranged_read_after_a_nudge_is_ambiguous_not_acted():
     """Reading a range of a file you just read in full is ordinary edit prep.
 
     Crediting it is what turns the nudge's real 0.2% into a flattering 19.7%.
+    The suspicion that fell out of that — that 0.2% measured the judge rather
+    than the surface — was tested and did not hold: three looser readings all
+    came back at or below the base rate, and the nudge has been retired on the
+    emission side. Every skeleton_nudge case in this file now guards a
+    historical population, not a live one.
     """
     (firing,) = parse_emission(NUDGE)
     classify(firing, [_use("Read", file_path="pkg/core/thing.py", offset=40, limit=20)])


### PR DESCRIPTION
## What

Removes the skeleton-nudge Read hook. On a large Read of an indexed file it
emitted:

```
[repowise] A skeleton of <path> is ~N tokens vs ~M for the full file.
For structure-level questions use get_context(["<path>"], include=["skeleton"]).
```

It was the highest-volume thing the hook layer said and it did not change what
the agent did next.

## Why

The classifier that scores this surface credits only a structure call on the
nudged file. That is a demanding thing to ask for: the agent has just read the
file in full, so it has little reason to go and ask for its shape. A low rate
under that judge is therefore ambiguous between "the surface does nothing" and
"the judge cannot see it working".

Replaying 516 firings across 203 sessions of real transcripts under three
progressively looser readings settles it, each with its own control:

| reading | after a nudge | control |
| --- | --- | --- |
| structure call on the nudged file | 0.8% | 0.0% |
| structure call on any file | 11.4% | 11.9% |
| `get_context` on a file not yet read | 2.9% | 3.4% |
| re-offended (read another large indexed file whole) | 54.8% | n/a |

The two transferred readings sit at or below an unconditioned base rate, so
the judge was not hiding an effect.

The deciding number is the dose. A bare compliance rate is not evidence on its
own, because "N% respected" collapses into sessions divided by firings for any
surface with a once-per-file gate, which measures how talkative it is. What
makes it a measurement is the second exposure. A session's first nudge was
followed by another 57.1% of the time and a later one 53.4%: being told again
read the same as being told once.

Two things worth recording from the replay:

The offense needs no heuristic. "Did the agent go on to read another large
indexed file whole" is answered by the hook's own next firing, which is
already in the transcript, so no file-size proxy or index lookup is involved.

53.3% of firings answered a **ranged** Read. `is_unbounded_read` gates the
skeleton *replacement*, and the nudge sat on the branch the replacement
declines, so over half of the volume was advice to be more targeted handed to
a read that already was.

## How

* `augment_cmd/read_state.py`: `_skeleton_nudge` and its `_file_symbol_bounds`
  helper are gone, along with the `nudged` per-session state key and the
  `_READ_NUDGE_MIN_TOKENS` floor that only it used. The remaining gate
  constants keep their names, since `search_digest` documents its own ratio
  against `_READ_NUDGE_MAX_RATIO` by name.
* `core/distill/skeleton.py`: `estimate_skeleton_tokens` is removed. The nudge
  was its only caller.
* `core/sessions/efficacy.py`: the emission pattern and `_acted_skeleton` are
  deliberately kept, so `repowise hook backfill` still settles firings already
  in the efficacy ledger. This matches how the re-read notice was retired. The
  module docstring carries the numbers above beside the code that produced
  them.

## Behavior

* A large unbounded Read of an indexed file in a repo that has not opted into
  `hooks.read_skeleton` now says nothing where it used to emit one line.
* With `hooks.read_skeleton: true` there is no change: the replacement already
  suppressed the nudge whenever it fired.
* A client too old for `updatedToolOutput` gets its Read untouched instead of
  falling back to the pointer.
* The stale-read notice and the skeleton replacement, including its recovery
  counters, are unaffected.
* No stored value changes meaning. Existing ledger rows keep their semantics
  and their judge.

## Verification

* `tests/unit/cli`, `tests/unit/distill` and `tests/unit/sessions`: 2226 pass.
  The only failures are the wall-clock assertions in
  `tests/unit/distill/test_rewrite_perf.py`, which are load-sensitive and fail
  the same way on an untouched checkout.
* `ruff check .` clean.
* `repowise hook backfill --all-projects` over 543 transcripts settles all 516
  historical nudge rows, confirming the retired surface's classifier still
  works end to end.
* The `TestSkeletonNudge` suite is replaced by `TestRetiredSkeletonNudge`,
  which asserts the silence rather than assuming it, and keeps cover on
  `_handle_read_post`'s outside-a-repo early return that those tests were the
  only exercise of.
