### PR TITLE
fix(codex): Match the Codex shell tool by the names Codex actually sends

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -57,7 +57,7 @@ overlap on different layers, and this table says exactly which.
 | Finding the right files | CodeGraph, Graphify, code-review-graph | [§1](#1-finding-the-right-files) **we win**, n=42 held out, p=0.00004 |
 | Work saved in a real agent loop | CodeGraph, Serena, Graphify, code-review-graph, bare agent | [§2](#2-what-changes-in-a-real-agent-loop) **we win**, n=43 on Codex at p&lt;0.0001, and the only tool to clear the bar on both agent harnesses we tried |
 | Loading one commit's context | naive file reads, `git diff` | [§3](#3-loading-one-commits-context-the-easy-number) **35.6x** fewer tokens than naive |
-| Command-output compression | no comparable tool in the field | [§4](#4-command-output-compression) |
+| Command-output compression | RTK | [§4](#4-command-output-compression) **not measured head to head** |
 | Code health and defect prediction | CodeScene | [§5](#5-code-health-predicts-defects) **we win**, p=0.003 |
 | Indexing time | CodeGraph, Graphify, code-review-graph | [§6](#6-indexing-time-the-row-we-lose) **we lose**, 22x, because we build four more layers in the same pass |
 | Documentation generation | DeepWiki, Google Code Wiki, Swimm | **not measured** |
@@ -66,7 +66,9 @@ overlap on different layers, and this table says exactly which.
 The last two rows are capability comparisons, not measurements, and they live in
 the [README's feature table](../README.md#how-it-compares-on-capability) where a
 reader can tell the difference. We would rather say "not measured" than let a
-checkmark do a number's job.
+checkmark do a number's job. **§4 carries the same label for the same reason**:
+RTK does exactly what `repowise distill` does, and we have not run the two
+against each other.
 
 ---
 
@@ -223,10 +225,25 @@ same setup on later days returned 4 of 15 and then 3 of 15 for us, and 2 of 14
 for CodeGraph. It is a property of the pairing of tool and harness on a given
 day, not of the tool.
 
-We used Sonnet here. Sonnet reaches for MCP tools noticeably less than Codex
-does under an identical setup, and harness and model cannot be separated by this
-design, so **we plan to rerun this half on Opus** to see which of the two is
-doing the work. That result will be added when we have it.
+### Is that adoption collapse the model or the harness? Inconclusive.
+
+The same 15 questions on Opus, everything else held fixed, against bands set
+before the run: **12 or more means the model**, 6 or fewer means **the harness's
+schema deferral**, 7 to 11 is inconclusive.
+
+**It came back at 7.** Published as inconclusive.
+
+The mechanism is more useful than the verdict. Opus goes looking on **11 of 15**
+against Sonnet's 13 of 30, then declines about a third of the times it looks. So
+schema deferral is part of the story and not all of it. Ordering across the three
+instruments is Sonnet 3 to 4, Opus 7, Codex 15.
+
+**That run's token column also fails its own control**, at -9.3% when the tool
+was called against -10.7% when it was not, so no token figure is quoted from it
+for any tool including ours. Same class of artifact as the 43%-cheaper dollar
+control above, from position and variance at n=15 rather than caching. The Codex
+run is unaffected: different harness, three times the `n`, every tool called on
+every question.
 
 ### How to read those tables
 
@@ -342,7 +359,8 @@ mechanism rather than a result, and it stays labelled as one until we run it.
 | Codex, 48 questions x 6 tools | 261 | 4.9h | $17.62 |
 | Codex, earlier 15-question run | 90 | 1.7h | $6.08 |
 | Codex, proof-of-life checks and a second language | 30 | 0.5h | $1.58 |
-| Claude Code, 15 questions x 6 tools | 90 | 1.8h | $18.77 |
+| Claude Code with Sonnet, 15 questions x 6 tools | 90 | 1.8h | $18.77 |
+| Claude Code with Opus, the promised rerun | 90 | 2.1h | $28.57 |
 
 The two harnesses' dollar figures are not comparable and are given only as what
 each cost to produce: Claude Code reports its own spend, while Codex reports
@@ -356,11 +374,14 @@ indexes were then reused by every later run, so the second harness cost agent
 time only.
 
 Two things are not in that table and are most of the real effort. **The
-competitor setups**: code-review-graph alone needs three steps that are not in
-its README, each of which produces a clean, plausible zero when missed, and
-getting Serena to answer anything at all needs an explicit project activation.
-A tool scoring zero because we set it up wrong is not a result, and finding that
-out is most of what this work is.
+competitor setups**:
+[code-review-graph](https://github.com/repowise-dev/repowise-bench/blob/master/head-to-head/arms/code-review-graph.md)
+alone needs three steps that are not in its README, each of which produces a
+clean, plausible zero when missed, and getting
+[Serena](https://github.com/repowise-dev/repowise-bench/blob/master/head-to-head/arms/serena.md)
+to answer anything at all needs an explicit project activation. A tool scoring
+zero because we set it up wrong is not a result, and finding that out is most of
+what this work is. The setup each tool needs is written up per tool.
 
 **And the checks that come before any number is allowed to count.** Every arm is
 probed before each run to confirm its server actually answers, and a control
@@ -431,6 +452,21 @@ output. One run per command on one repository, so these are point measurements,
 not a distribution. Reduction is also not comprehension: the bytes removed are
 measured, and the evidence they were safe to remove is narrower, being preserved
 failure lines plus CI-asserted zero-error-line-loss fixtures.
+
+**There is a comparable tool and we have not run it.**
+[RTK](https://blog.jetbrains.com/ai/2026/07/rtk-claude-code-token-savings/) does
+this and essentially only this. It is also the tool in the table at the top of
+this page whose advertised 60 to 90% came back **7.6% more expensive** under
+JetBrains' rerun. So the table above is a before-and-after of our own output, not
+a head to head, and a before-and-after is the weaker design. Only a paired run
+against RTK would settle it.
+
+**One row above is inflated, by the mechanism that broke RTK's number.** A saving
+may only count output the agent would actually have received, and a host
+truncates a command result at 30,000 characters. The engine applies that cap;
+`git diff`'s 62,833 raw tokens is eight times it and predates it. **Treat that
+86% as unsupported until re-measured.** `pytest` and `git log` sit under the cap
+and are unaffected.
 
 Full guide: **[docs/agent/DISTILL.md](agent/DISTILL.md)**
 
@@ -549,9 +585,18 @@ It is also a one-time cost. Updates after the first index are incremental.
 
 Beyond the ones stated in each section:
 
-- **Python and Go only.** No TypeScript or JavaScript row appears anywhere on
-  this page. That was a scope choice made for instance density in the benchmark
-  corpus, not a statement about language support.
+- **Every number here is Python or Go.** A JavaScript/TypeScript corpus
+  (`mui/material-ui`, six tools, a 12x size range) is built and half graded, but
+  **its sealed half is unrun and nothing from it is quoted here.** Publishing the
+  development half is what that split exists to prevent, so the row arrives when the sealed
+  half is evaluated, once.
+- **We index code files only, which depresses our own coverage on repositories
+  with documentation.** Deliberate: on doc-heavy repositories the docs outweigh
+  the code, and indexing them polluted the index and degraded retrieval for the
+  code questions the tool exists to answer. The cost is invisible in a coverage
+  figure. On the JavaScript corpus above, **21% of gold files are `.md` or
+  `.json`**, unreachable to us by construction rather than by ranking. A tool
+  making the opposite trade retrieves some of them and pays for it on code.
 - **§2 is one repository**, `django/django` at one commit, which is in every
   model's training data.
 - **§2 measures single-session questions**, roughly nine turns each. Nothing on
@@ -561,15 +606,20 @@ Beyond the ones stated in each section:
   number, never as the result.
 - **§2's difficulty split is post-hoc.** The median split was chosen after seeing
   the data. The pre-registered comparisons on this page are stronger evidence.
+- **§4 has no head-to-head and one row that needs re-measuring.** See that
+  section.
 
 ## Method and provenance
 
-The full methodology, the pre-registration files with their commit timestamps,
-the arm-parity rules, the statistical tests, and the list of measurement traps
-that produced wrong numbers before we caught them all live in
-**[repowise-bench](https://github.com/repowise-dev/repowise-bench)**. That
-repository also holds every raw run, kept permanently, including the invalidated
-ones with their invalidation notes attached.
+The method, drawn end to end with every gate and the failure that put it there,
+is **[THE\_LOOP.md](https://github.com/repowise-dev/repowise-bench/blob/master/head-to-head/THE_LOOP.md)**.
+One page per tool in the field, with its setup traps, is
+**[head-to-head](https://github.com/repowise-dev/repowise-bench/tree/master/head-to-head)**.
+The pre-registration files with their commit timestamps, the arm-parity rules and
+the statistical tests are in
+**[repowise-bench](https://github.com/repowise-dev/repowise-bench)**, which also
+holds every raw run permanently, including the invalidated ones with their
+invalidation notes attached.
 
 Tool versions as measured: CodeGraph 1.5.0, Graphify 0.9.31, Serena 1.6.2.dev0,
 code-review-graph 2.3.7.

--- a/packages/cli/src/repowise/cli/agent_adapters/codex.py
+++ b/packages/cli/src/repowise/cli/agent_adapters/codex.py
@@ -3,9 +3,9 @@
 Protocol reference (Codex hooks, developers.openai.com/codex/hooks): hooks
 load from ``~/.codex/hooks.json`` (or a repo-local ``.codex/hooks.json``); a
 PreToolUse hook receives JSON on stdin with snake_case
-``hook_event_name``/``tool_name``/``tool_input``/``cwd`` — the shell tool is
-named ``Bash`` and ``tool_input.command`` is a string — and answers with
-camelCase ``hookSpecificOutput`` JSON on stdout.
+``hook_event_name``/``tool_name``/``tool_input``/``cwd`` — the shell tool
+answers to several names (:data:`SHELL_TOOL_NAMES`) and ``tool_input.command``
+is a string — and answers with camelCase ``hookSpecificOutput`` JSON on stdout.
 
 Two protocol limits shape this adapter's honesty posture:
 
@@ -24,13 +24,38 @@ Two protocol limits shape this adapter's honesty posture:
 from __future__ import annotations
 
 import json
-import os.path
+import os
 from typing import TYPE_CHECKING, ClassVar
 
 from repowise.cli.agent_adapters.base import AgentAdapter, RewriteRequest, RewriteResult
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+
+#: Every name Codex has given the tool that carries a shell command *string*,
+#: because it has given it more than one and the rewrite is dead for any name
+#: it does not answer to.
+#:
+#: This started as the single literal ``"Bash"``. Measured against 18 real
+#: rollouts from Codex 0.145: ``"Bash"`` does not appear once, and the shell
+#: calls are ``shell_command`` (322), whose ``tool_input.command`` is a string
+#: — the shape :meth:`CodexAdapter.parse_hook_payload` already reads. A rename
+#: upstream is silent here (the gate stops matching and the hook never fires),
+#: so this is a set and new names are added rather than swapped in.
+#:
+#: **``exec`` is deliberately not in it.** It looks like a shell tool in the
+#: rollouts (423 calls) and is not one: it is a ``custom_tool_call`` whose
+#: input is a *JavaScript program* that calls ``tools.shell_command(...)``
+#: internally. There is no command string to read and nothing to rewrite, so
+#: matching it would buy 423 hook subprocesses that can only decline. A name
+#: belongs here once it is observed carrying ``tool_input.command``.
+SHELL_TOOL_NAMES: frozenset[str] = frozenset({"Bash", "shell_command"})
+
+#: The same set as a hooks.json matcher. Derived rather than written twice —
+#: an installer whose matcher disagrees with the adapter's gate installs a
+#: hook that runs and then declines every payload it is handed.
+SHELL_TOOL_MATCHER: str = "|".join(sorted(SHELL_TOOL_NAMES))
 
 
 class CodexAdapter(AgentAdapter):
@@ -51,9 +76,10 @@ class CodexAdapter(AgentAdapter):
             return None
         if payload.get("hook_event_name") != "PreToolUse":
             return None
-        # Codex's shell tool is named "Bash" (there is no separate
-        # PowerShell tool); the command is always a string.
-        if payload.get("tool_name") != "Bash":
+        # Codex has no separate PowerShell tool, but it has renamed the shell
+        # one; see SHELL_TOOL_NAMES. The command is a string on every name
+        # that reaches the check below.
+        if payload.get("tool_name") not in SHELL_TOOL_NAMES:
             return None
         tool_input = payload.get("tool_input")
         command = tool_input.get("command") if isinstance(tool_input, dict) else None
@@ -63,7 +89,14 @@ class CodexAdapter(AgentAdapter):
         return RewriteRequest(
             command=command,
             cwd=cwd if isinstance(cwd, str) else "",
-            shell="posix",
+            # Codex names its shell tool the same on every platform, so the
+            # dialect has to come from the platform. It is PowerShell on
+            # Windows — the real rollouts are full of `get-content`,
+            # `get-childitem` and `$env:` — and calling that "posix" skips
+            # `decide`'s PowerShell-alias bailout, which exists precisely to
+            # stop an alias command being re-run through cmd.exe. Dead code
+            # until the gate above started matching; live now.
+            shell="powershell" if os.name == "nt" else "posix",
         )
 
     def render_response(self, result: RewriteResult) -> str:

--- a/packages/cli/src/repowise/cli/commands/augment_cmd/command.py
+++ b/packages/cli/src/repowise/cli/commands/augment_cmd/command.py
@@ -91,6 +91,8 @@ from pathlib import Path
 
 import click
 
+from repowise.cli.agent_adapters.codex import SHELL_TOOL_NAMES
+
 from ._shared import HookResult, as_result
 from .bash_staleness import _handle_bash_post
 from .codex import _handle_codex_context_event, _handle_post_edit_use
@@ -101,6 +103,13 @@ from .session_start import _handle_claude_session_start
 from .wrong_path import _handle_tool_failure
 
 _EDIT_TOOL_NAMES = {"apply_patch", "Edit", "Write"}
+
+#: Shell tools, across both harnesses. ``PowerShell`` is Windows Claude Code;
+#: the rest are what Codex has called its shell tool, owned by the adapter so
+#: the dispatch here and the installed matcher cannot disagree. Free at module
+#: scope: ``agent_adapters`` is stdlib-only by its own hot-path contract, and
+#: `tests/unit/cli/test_augment_hook_perf.py` holds that.
+_SHELL_TOOL_NAMES = SHELL_TOOL_NAMES | {"PowerShell"}
 
 
 @click.command("augment")
@@ -340,9 +349,10 @@ def _handle_post_tool_use(
         # Read-after-served KPI: logged to the ledger, never spoken about.
         _log_read_after_served(tool_input, tool_output, cwd, session_id)
         return _handle_read_post(tool_input, tool_output, cwd, session_id)
-    if tool_name in ("Bash", "PowerShell"):
-        # The PowerShell tool (Windows Claude Code) surfaces the same
-        # stdout/stderr response shape as Bash — one handler covers both.
+    if tool_name in _SHELL_TOOL_NAMES:
+        # The PowerShell tool (Windows Claude Code) and Codex's several names
+        # for its shell all surface the same stdout/stderr response shape as
+        # Bash — one handler covers them.
         return as_result(_handle_bash_post(tool_input, tool_output, cwd))
     if tool_name in ("Grep", "Glob"):
         # ``client`` reaches this one because the flood digest can *replace*

--- a/packages/cli/src/repowise/cli/editor_integrations/codex_config.py
+++ b/packages/cli/src/repowise/cli/editor_integrations/codex_config.py
@@ -24,6 +24,12 @@ import re
 import subprocess
 from pathlib import Path
 
+# The adapter owns what Codex calls its shell tool; the installed matcher is
+# derived from it so the two cannot drift. Safe at module scope: the adapter
+# imports this module lazily, inside its methods, so there is no cycle, and
+# its own imports are stdlib only.
+from repowise.cli.agent_adapters.codex import SHELL_TOOL_MATCHER
+
 #: First Codex release whose PreToolUse hooks honor an ``updatedInput``
 #: command rewrite; earlier builds report it as an unsupported hook output.
 CODEX_REWRITE_MIN_VERSION: tuple[int, int] = (0, 137)
@@ -31,7 +37,7 @@ CODEX_REWRITE_MIN_VERSION: tuple[int, int] = (0, 137)
 _REWRITE_HOOK_COMMAND = "repowise-rewrite"
 
 _REWRITE_HOOK_ENTRY = {
-    "matcher": "Bash",
+    "matcher": SHELL_TOOL_MATCHER,
     "hooks": [
         {
             "type": "command",
@@ -41,6 +47,65 @@ _REWRITE_HOOK_ENTRY = {
         }
     ],
 }
+
+
+#: Matchers this entry has shipped with, current one excluded. An install
+#: predating a Codex tool rename holds one of these and therefore matches
+#: nothing — and because :func:`_is_rewrite_hook` keys on the *command*, a
+#: reinstall would find it, call it present, and leave it dead forever. So
+#: install upgrades a matcher it recognises as its own. Only these exact
+#: strings are moved: a user who narrowed the matcher deliberately keeps it.
+_LEGACY_REWRITE_MATCHERS = ("Bash",)
+
+
+def _migrate_rewrite_matcher(hook_list: list) -> bool:
+    """Repoint an existing repowise entry at the current matcher.
+
+    Returns True when something moved, so the caller knows to write.
+    """
+    changed = False
+    for entry in hook_list:
+        if not isinstance(entry, dict):
+            continue
+        if not any(_is_rewrite_hook(h) for h in entry.get("hooks", []) or []):
+            continue
+        if entry.get("matcher") in _LEGACY_REWRITE_MATCHERS:
+            entry["matcher"] = SHELL_TOOL_MATCHER
+            changed = True
+    return changed
+
+
+def migrate_codex_rewrite_hook() -> bool:
+    """Repoint an already-installed rewrite hook at the current matcher.
+
+    The twin of :func:`~repowise.cli.editor_integrations.claude_config.migrate_claude_code_hooks`,
+    and it exists for the same reason: a user who opted in before a Codex
+    tool rename holds an entry that matches nothing, and reinstalling is a
+    step nobody knows to take. Never installs — it only moves a matcher on an
+    entry that is already ours, so someone who removed the hook on purpose
+    stays without it. Returns True when the file was rewritten.
+    """
+    from repowise.cli.mcp_config import load_existing_config
+
+    hooks_path = _codex_hooks_path()
+    if not hooks_path.exists():
+        return False
+    try:
+        existing = load_existing_config(hooks_path)
+        hooks = existing.get("hooks")
+        if not isinstance(hooks, dict):
+            return False
+        pre_hooks = hooks.get("PreToolUse")
+        if not isinstance(pre_hooks, list):
+            return False
+        if not _migrate_rewrite_matcher(pre_hooks):
+            return False
+        hooks_path.write_text(json.dumps(existing, indent=2) + "\n", encoding="utf-8")
+        return True
+    except Exception:
+        # Same posture as install: a malformed or unreadable hooks file is a
+        # migration that did not happen, never an error the user sees.
+        return False
 
 
 def _codex_hooks_path() -> Path:
@@ -107,6 +172,10 @@ def install_codex_rewrite_hook() -> Path | None:
         pre_hooks = hooks.setdefault("PreToolUse", [])
         if not _has_rewrite_hook(pre_hooks):
             pre_hooks.append(json.loads(json.dumps(_REWRITE_HOOK_ENTRY)))
+            hooks_path.write_text(json.dumps(existing, indent=2) + "\n", encoding="utf-8")
+        elif _migrate_rewrite_matcher(pre_hooks):
+            # Present but pointed at a name Codex no longer uses. Reinstalling
+            # is the only repair path a user has, so it has to be one.
             hooks_path.write_text(json.dumps(existing, indent=2) + "\n", encoding="utf-8")
         return hooks_path
     except Exception:

--- a/packages/cli/src/repowise/cli/main.py
+++ b/packages/cli/src/repowise/cli/main.py
@@ -26,6 +26,18 @@ def cli(ctx: click.Context) -> None:
             migrate_claude_code_hooks()
         except Exception:
             pass
+        # And the same for an installed Codex rewrite hook whose matcher
+        # names a tool Codex has since renamed. That one cannot self-heal
+        # from its own hook the way the Claude side does — a hook matching
+        # nothing never runs — so the CLI is the only place it can happen.
+        try:
+            from repowise.cli.editor_integrations.codex_config import (
+                migrate_codex_rewrite_hook,
+            )
+
+            migrate_codex_rewrite_hook()
+        except Exception:
+            pass
 
 
 _COMMANDS_PKG = "repowise.cli.commands"

--- a/plugins/codex/hooks/hooks.json
+++ b/plugins/codex/hooks/hooks.json
@@ -27,7 +27,7 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "Bash",
+        "matcher": "Bash|shell_command",
         "hooks": [
           {
             "type": "command",

--- a/tests/unit/cli/test_codex_plugin.py
+++ b/tests/unit/cli/test_codex_plugin.py
@@ -4,6 +4,13 @@ import json
 import re
 from pathlib import Path
 
+from repowise.cli.agent_adapters.codex import (
+    SHELL_TOOL_MATCHER,
+    SHELL_TOOL_NAMES,
+    CodexAdapter,
+)
+from repowise.cli.commands.augment_cmd.command import _SHELL_TOOL_NAMES
+
 ROOT = Path(__file__).resolve().parents[3]
 PLUGIN_ROOT = ROOT / "plugins" / "codex"
 
@@ -38,7 +45,7 @@ def test_codex_plugin_hooks_match_supported_codex_events() -> None:
     assert set(hooks) == {"SessionStart", "UserPromptSubmit", "PostToolUse"}
     assert hooks["SessionStart"][0]["matcher"] == "startup|resume|clear"
     assert [entry["matcher"] for entry in hooks["PostToolUse"]] == [
-        "Bash",
+        SHELL_TOOL_MATCHER,
         "apply_patch|Edit|Write",
     ]
 
@@ -55,6 +62,46 @@ def test_codex_plugin_hooks_match_supported_codex_events() -> None:
         for entry in entries
         for hook in entry["hooks"]
     ] == [30] * 4
+
+
+def test_codex_shell_matcher_covers_the_names_codex_actually_sends() -> None:
+    """The matcher, the dispatch and the rewrite gate agree on one set.
+
+    This is a regression test with a real defect behind it: the matcher was
+    the single literal ``"Bash"``, which Codex has not called its shell tool
+    in any measured release — 18 rollouts from 0.145 carry ``shell_command``
+    and ``exec`` and never ``Bash``. A hook that matches nothing is silent in
+    exactly the way a working one is, so nothing caught it. Pinning the three
+    sites to one another is what makes the next rename a failing test rather
+    than a surface that quietly stops firing.
+    """
+    for name in ("Bash", "shell_command"):
+        assert name in SHELL_TOOL_NAMES
+        assert name in SHELL_TOOL_MATCHER.split("|")
+        # The augment dispatch routes it to the shell handler...
+        assert name in _SHELL_TOOL_NAMES
+        # ...and the rewrite hook accepts rather than declines it.
+        payload = json.dumps(
+            {
+                "hook_event_name": "PreToolUse",
+                "tool_name": name,
+                "tool_input": {"command": "pytest -q"},
+                "cwd": "/repo",
+            }
+        )
+        assert CodexAdapter().parse_hook_payload(payload) is not None
+
+
+def test_codex_exec_is_excluded_because_it_carries_no_command() -> None:
+    """`exec` looks like a shell tool in the rollouts and is not one.
+
+    It is a `custom_tool_call` whose input is a JavaScript program that calls
+    `tools.shell_command(...)` internally — no command string, nothing to
+    rewrite. Matching it would buy a hook subprocess per call (423 of them in
+    the measured corpus) that can only ever decline.
+    """
+    assert "exec" not in SHELL_TOOL_NAMES
+    assert "exec" not in SHELL_TOOL_MATCHER.split("|")
 
 
 def test_codex_plugin_skills_have_metadata_and_neutral_wording() -> None:

--- a/tests/unit/distill/test_agent_adapters.py
+++ b/tests/unit/distill/test_agent_adapters.py
@@ -8,12 +8,14 @@ migration-safe, and preserves user hooks and the augment PostToolUse entry.
 from __future__ import annotations
 
 import json
+import os
 
 import pytest
 
+from repowise.cli.agent_adapters import codex as codex_module
 from repowise.cli.agent_adapters.base import RewriteResult
 from repowise.cli.agent_adapters.claude_code import ClaudeCodeAdapter
-from repowise.cli.agent_adapters.codex import CodexAdapter
+from repowise.cli.agent_adapters.codex import SHELL_TOOL_MATCHER, CodexAdapter
 from repowise.cli.editor_integrations import claude_config, codex_config
 from repowise.cli.editor_integrations.claude_config import (
     claude_code_rewrite_hook_installed,
@@ -290,13 +292,36 @@ class TestCodexParsePayload:
         assert req is not None
         assert req.command == "pytest -x"
         assert req.cwd == "/repo"
-        assert req.shell == "posix"
+        assert req.shell == ("powershell" if os.name == "nt" else "posix")
+
+    def test_shell_dialect_follows_the_platform(self, codex_adapter, monkeypatch) -> None:
+        """Codex names its shell tool the same everywhere; the shell differs.
+
+        The dialect was hardcoded to ``posix``, which was harmless only
+        because the tool-name gate above it never matched. On Windows the
+        real rollouts are PowerShell (`get-content`, `get-childitem`,
+        `$env:`), and calling that posix skips `decide`'s alias bailout —
+        the guard that stops an alias command being re-run through cmd.exe.
+        """
+        raw = json.dumps(
+            {
+                "hook_event_name": "PreToolUse",
+                "tool_name": "shell_command",
+                "tool_input": {"command": "ls -Force"},
+                "cwd": "/repo",
+            }
+        )
+        monkeypatch.setattr(codex_module.os, "name", "nt")
+        assert codex_adapter.parse_hook_payload(raw).shell == "powershell"
+        monkeypatch.setattr(codex_module.os, "name", "posix")
+        assert codex_adapter.parse_hook_payload(raw).shell == "posix"
 
     @pytest.mark.parametrize(
         "mutation",
         [
             {"hook_event_name": "PostToolUse"},
             {"tool_name": "PowerShell"},  # Codex has no PowerShell tool
+            {"tool_name": "exec"},  # a JS program, not a command string
             {"tool_name": "apply_patch"},
             {"tool_input": {}},
             {"tool_input": {"command": "   "}},
@@ -385,7 +410,11 @@ class TestCodexHooksInstall:
         assert install_codex_rewrite_hook() == codex_hooks_path
         entries = _codex_pre_hooks(codex_hooks_path)
         assert len(entries) == 1
-        assert entries[0]["matcher"] == "Bash"
+        # Derived from the adapter's own gate, not a literal: an installed
+        # matcher naming a tool the gate declines is a hook that runs for
+        # nothing, and one missing a name the gate accepts never runs at all.
+        assert entries[0]["matcher"] == SHELL_TOOL_MATCHER
+        assert "shell_command" in entries[0]["matcher"]
         hook = entries[0]["hooks"][0]
         assert hook["command"] == "repowise-rewrite --agent codex"
         assert codex_rewrite_hook_installed() is True
@@ -394,6 +423,111 @@ class TestCodexHooksInstall:
         install_codex_rewrite_hook()
         install_codex_rewrite_hook()
         assert len(_codex_pre_hooks(codex_hooks_path)) == 1
+
+    def test_reinstall_upgrades_a_matcher_codex_no_longer_uses(
+        self, codex_hooks_path
+    ) -> None:
+        """An existing install must not stay dead just because it is present.
+
+        ``_is_rewrite_hook`` keys on the command, so an entry left over from
+        when the matcher was the bare literal ``Bash`` — a name Codex has not
+        used for its shell tool in any measured release — is found by the
+        presence check and would otherwise be skipped forever. Reinstalling
+        is the only repair a user has.
+        """
+        codex_hooks_path.parent.mkdir(parents=True, exist_ok=True)
+        stale = {
+            "matcher": "Bash",
+            "hooks": [{"type": "command", "command": "repowise-rewrite --agent codex"}],
+        }
+        codex_hooks_path.write_text(
+            json.dumps({"hooks": {"PreToolUse": [stale]}}), encoding="utf-8"
+        )
+
+        install_codex_rewrite_hook()
+
+        entries = _codex_pre_hooks(codex_hooks_path)
+        assert len(entries) == 1, "upgrade in place, never a second entry"
+        assert entries[0]["matcher"] == SHELL_TOOL_MATCHER
+
+    def test_self_heal_upgrades_without_being_asked(self, codex_hooks_path) -> None:
+        """`repowise <anything>` repairs a stale matcher; the hook cannot.
+
+        A hook whose matcher matches nothing never runs, so unlike the Claude
+        side it has no way to heal itself. The CLI is the only place it can
+        happen, and a user who opted in months ago will not think to re-run
+        install.
+        """
+        codex_hooks_path.parent.mkdir(parents=True, exist_ok=True)
+        codex_hooks_path.write_text(
+            json.dumps(
+                {
+                    "hooks": {
+                        "PreToolUse": [
+                            {
+                                "matcher": "Bash",
+                                "hooks": [
+                                    {
+                                        "type": "command",
+                                        "command": "repowise-rewrite --agent codex",
+                                    }
+                                ],
+                            }
+                        ]
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        assert codex_config.migrate_codex_rewrite_hook() is True
+        assert _codex_pre_hooks(codex_hooks_path)[0]["matcher"] == SHELL_TOOL_MATCHER
+        # Idempotent: a second pass has nothing to do and writes nothing.
+        assert codex_config.migrate_codex_rewrite_hook() is False
+
+    def test_self_heal_never_installs_for_someone_who_opted_out(
+        self, codex_hooks_path
+    ) -> None:
+        """No hooks file, or no repowise entry, means nothing to migrate."""
+        assert codex_config.migrate_codex_rewrite_hook() is False
+
+        codex_hooks_path.parent.mkdir(parents=True, exist_ok=True)
+        codex_hooks_path.write_text(
+            json.dumps(
+                {
+                    "hooks": {
+                        "PreToolUse": [
+                            {
+                                "matcher": "Bash",
+                                "hooks": [
+                                    {"type": "command", "command": "my-validator"}
+                                ],
+                            }
+                        ]
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        assert codex_config.migrate_codex_rewrite_hook() is False
+        assert _codex_pre_hooks(codex_hooks_path)[0]["matcher"] == "Bash"
+
+    def test_reinstall_leaves_a_deliberately_narrowed_matcher_alone(
+        self, codex_hooks_path
+    ) -> None:
+        """Only matchers this installer shipped are moved, not the user's."""
+        codex_hooks_path.parent.mkdir(parents=True, exist_ok=True)
+        theirs = {
+            "matcher": "shell_command",
+            "hooks": [{"type": "command", "command": "repowise-rewrite --agent codex"}],
+        }
+        codex_hooks_path.write_text(
+            json.dumps({"hooks": {"PreToolUse": [theirs]}}), encoding="utf-8"
+        )
+
+        install_codex_rewrite_hook()
+
+        assert _codex_pre_hooks(codex_hooks_path)[0]["matcher"] == "shell_command"
 
     def test_preserves_user_hooks(self, codex_hooks_path) -> None:
         codex_hooks_path.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## What

The Codex rewrite hook was gated on `tool_name == "Bash"`. Codex does not call
its shell tool that, so `repowise-rewrite --agent codex` has never fired.

Across 18 real Codex 0.145 rollouts, the shell calls are `shell_command`
(322 of them) and **`Bash` appears zero times**. Three sites hardcoded the
literal: the adapter's own gate, the matcher it installs into
`~/.codex/hooks.json`, and the plugin's `PostToolUse` matcher.

A hook whose matcher matches nothing is silent in exactly the way a working
one is. There is no error, no log line and no missing output to notice, which
is why this sat there.

## Why a set rather than a corrected literal

The failure mode is an upstream rename going unnoticed. Replacing `"Bash"`
with `"shell_command"` would leave that exactly as it was.

`SHELL_TOOL_NAMES` now lives on the adapter, the installed matcher and the
augment dispatch derive from it, and tests pin all three to each other. The
next rename is a failing test instead of a surface that quietly stops firing.

A name earns a place in that set by being observed carrying
`tool_input.command`, not by appearing near one.

## Three things beyond the rename

**`exec` is not a shell tool**, despite 423 rollout appearances. It is a
`custom_tool_call` whose input is a JavaScript program calling
`tools.shell_command(...)` internally, so there is no command string to read.
Matching it would buy a hook subprocess per call that can only ever decline.
Excluded, with the reason pinned by a test.

**The shell dialect was hardcoded to `posix`**, which was harmless only while
the gate above it never matched. Codex names its shell tool the same on every
platform, so the dialect has to come from the platform, and on Windows the
real commands are PowerShell (`get-content`, `get-childitem`, `$env:`).
Labelling those posix skips the alias bailout in `decide`, the guard that
stops an alias command being re-run through `cmd.exe`. Replaying all 322 real
commands through both dialects found no actual divergence, so the mechanism is
real and the observed hit rate on this corpus is zero.

**Reinstalling did not repair an existing install.** The presence check keys on
the hook command rather than the matcher, so an entry left from the `Bash` days
was reported installed and skipped forever, and every current Codex user would
have stayed broken after this fix. Install now upgrades a matcher it recognises
as its own and leaves a deliberately narrowed one alone, and
`migrate_codex_rewrite_hook` self-heals on any CLI invocation. That last part
is necessary rather than convenient: this hook cannot heal from itself, because
a hook matching nothing never runs.

Uninstall was already safe, since it also keys on the command.

## Not settled

Whether Codex reads a hooks.json `matcher` as a regex or as an exact string.
This does not block the change:

- under regex, `Bash|shell_command` is strictly better than the bare `Bash` it
  replaces;
- under exact-string, `Bash` already matched nothing, so there is no
  regression.

Worth knowing that the second branch would imply the pre-existing
`apply_patch|Edit|Write` and `startup|resume|clear` matchers are dead too,
which is a larger and separate finding this change neither causes nor worsens.

A live payload capture was attempted to settle it and could not be run, so the
evidence here is the rollout corpus plus the Codex binary's payload fields
rather than a captured hook fire. `Bash` is kept in the set for that reason.

## Behavior

* A Codex shell call now reaches the distill rewrite and the staleness notice.
  Neither could fire before.
* An existing Codex install is repaired on the next `repowise` invocation.
* No change for Claude Code. Its installed matcher does not carry these names,
  and the shared set is exact membership, so no real Claude tool routes
  differently.
* `exec` calls stay silent, deliberately.

## Verification

* `tests/unit/cli`, `tests/unit/distill/test_read_intelligence.py`,
  `test_agent_adapters.py`, `test_rewrite_hook.py`: **1613 passed, 2 skipped**.
* `ruff check .` clean.
* The hook import-graph budget still passes. The new module-scope import
  measures **1.25ms** under `-X importtime` against a 155ms budget, and
  `agent_adapters` is stdlib-only at module scope by its own contract.
* The self-heal was checked against a real `~/.codex/hooks.json`: reset to
  `Bash`, one CLI invocation, repaired to `Bash|shell_command`.

## Known, not addressed here

That same check shows the CLI group callback writes to the developer's real
home from inside the test suite. It is pre-existing (the Claude migration has
had the exposure since it was written), but this change adds a second writer.
Guarding it properly means changing how every CLI test is isolated, which does
not belong in a PR about tool names.
