### PR TITLE
fix(health): show the line on file-level findings, and stop one biomarker flooding the drawer

### DIFF
--- a/packages/ui/__tests__/health/health-file-drawer.test.tsx
+++ b/packages/ui/__tests__/health/health-file-drawer.test.tsx
@@ -66,8 +66,264 @@ describe("HealthFileDrawer finding grouping", () => {
     render(
       <HealthFileDrawer open onClose={() => {}} metric={metric()} findings={findings} />,
     );
-    expect(screen.getByText("File-level signals")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /File-level signals/ })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /_run_repo_checks/ })).toBeInTheDocument();
+  });
+
+  /** A file-level biomarker that fires per occurrence must not flood the drawer
+   *  with sibling rows. `error_handling` reaches 34 on one file in this repo. */
+  it("groups file-level markers by biomarker, not into one undifferentiated list", () => {
+    const findings: HealthDrawerFinding[] = [
+      ...[202, 46, 58].map((line) =>
+        finding({
+          biomarker_type: "error_handling",
+          function_name: null,
+          line_start: line,
+          line_end: line,
+          health_impact: 0.15,
+          reason: "broad `except Exception` catches unrelated errors.",
+        }),
+      ),
+      finding({
+        biomarker_type: "change_entropy",
+        function_name: null,
+        line_start: null,
+        health_impact: 2.0,
+        reason: "File changes touch many unrelated concerns.",
+      }),
+    ];
+    render(
+      <HealthFileDrawer open onClose={() => {}} metric={metric()} findings={findings} />,
+    );
+
+    // The three error_handling markers collapse into one header carrying their
+    // subtotal — not three siblings, and not merged with change_entropy.
+    // Scoped to the group header: an expanded group also renders an
+    // "About Error handling" InfoTip button.
+    const eh = screen.getByRole("button", { name: /Error handling · file-level/i });
+    expect(within(eh).getByText(/3 markers/)).toBeInTheDocument();
+    expect(within(eh).getByText(/−0\.45/)).toBeInTheDocument();
+    // The lone change_entropy marker stays in the pooled bucket rather than
+    // earning a group of its own.
+    expect(screen.getByRole("button", { name: /File-level signals/ })).toBeInTheDocument();
+  });
+
+  it("renders and links the line for a file-level marker that has no function", () => {
+    const findings: HealthDrawerFinding[] = [
+      finding({
+        biomarker_type: "error_handling",
+        function_name: null,
+        line_start: 202,
+        line_end: 202,
+        health_impact: 0.15,
+        reason: "broad `except Exception` catches unrelated errors.",
+      }),
+    ];
+    render(
+      <HealthFileDrawer
+        open
+        onClose={() => {}}
+        metric={metric()}
+        findings={findings}
+        fileViewHrefFor={(line) => `/files/doctor_cmd.py#L${line}`}
+      />,
+    );
+    // Gating the anchor on function_name hid the only field distinguishing one
+    // error_handling marker from the next, which is what made them read as
+    // duplicates.
+    const link = screen.getByRole("link", { name: /line 202/ });
+    expect(link).toHaveAttribute("href", "/files/doctor_cmd.py#L202");
+  });
+
+  it("marks a file-level group as capped when the server says its category shed weight", () => {
+    const findings: HealthDrawerFinding[] = [1, 2, 3].map((line) =>
+      finding({
+        biomarker_type: "error_handling",
+        function_name: null,
+        line_start: line,
+        health_impact: 0.1,
+        reason: "broad `except Exception` catches unrelated errors.",
+      }),
+    );
+    render(
+      <HealthFileDrawer
+        open
+        onClose={() => {}}
+        metric={metric()}
+        findings={findings}
+        breakdown={{
+          score: 9.7,
+          total_deduction: 0.3,
+          categories: [
+            {
+              category: "error_handling",
+              cap: 0.5,
+              raw_deduction: 5.1,
+              applied_deduction: 0.3,
+              capped: true,
+              finding_count: 3,
+              findings: [],
+            },
+          ],
+        }}
+      />,
+    );
+    // Scoped to the group header: an expanded group also renders an
+    // "About Error handling" InfoTip button.
+    const eh = screen.getByRole("button", { name: /Error handling · file-level/i });
+    expect(within(eh).getByText("capped")).toBeInTheDocument();
+  });
+
+  it("does not claim 'capped' when other biomarkers share the capped category", () => {
+    // `nested_complexity` and `brain_method` both sit in structural_complexity,
+    // so neither group owns the ceiling and neither may name it.
+    const findings: HealthDrawerFinding[] = [
+      finding({
+        biomarker_type: "nested_complexity",
+        function_name: null,
+        line_start: 5,
+        health_impact: 0.2,
+        reason: "Deeply nested control flow.",
+      }),
+      finding({
+        biomarker_type: "nested_complexity",
+        function_name: null,
+        line_start: 9,
+        health_impact: 0.2,
+        reason: "Deeply nested control flow.",
+      }),
+      finding({
+        biomarker_type: "brain_method",
+        function_name: null,
+        line_start: 12,
+        health_impact: 0.2,
+        reason: "Oversized, deeply-nested function.",
+      }),
+      finding({
+        biomarker_type: "brain_method",
+        function_name: null,
+        line_start: 20,
+        health_impact: 0.2,
+        reason: "Oversized, deeply-nested function.",
+      }),
+    ];
+    render(
+      <HealthFileDrawer
+        open
+        onClose={() => {}}
+        metric={metric()}
+        findings={findings}
+        breakdown={{
+          score: 9.5,
+          total_deduction: 0.5,
+          categories: [
+            {
+              category: "structural_complexity",
+              cap: 4.0,
+              raw_deduction: 9.1,
+              applied_deduction: 4.0,
+              capped: true,
+              finding_count: 4,
+              findings: [],
+            },
+          ],
+        }}
+      />,
+    );
+    for (const label of [/Nested complexity · file-level/i, /Brain method · file-level/i]) {
+      expect(within(screen.getByRole("button", { name: label })).queryByText("capped"))
+        .not.toBeInTheDocument();
+    }
+  });
+
+  /** The regression an adversarial review caught: splitting every file-level
+   *  biomarker out turned one collapsed row into several EXPANDED ones,
+   *  because singleton groups render expanded. 53% of files in this repo carry
+   *  2+ distinct one-off file-level markers. One-offs must stay pooled. */
+  it("pools one-off file-level markers instead of giving each its own group", () => {
+    const findings: HealthDrawerFinding[] = [
+      finding({
+        biomarker_type: "dry_violation",
+        function_name: null,
+        line_start: null,
+        health_impact: 0.4,
+        reason: "Duplicated block.",
+      }),
+      finding({
+        biomarker_type: "change_entropy",
+        function_name: null,
+        line_start: null,
+        health_impact: 0.3,
+        reason: "File changes touch many unrelated concerns.",
+      }),
+      finding({
+        biomarker_type: "co_change_scatter",
+        function_name: null,
+        line_start: null,
+        health_impact: 0.2,
+        reason: "Co-changes scatter widely.",
+      }),
+    ];
+    render(
+      <HealthFileDrawer open onClose={() => {}} metric={metric()} findings={findings} />,
+    );
+    const pooled = screen.getByRole("button", { name: /File-level signals/ });
+    expect(within(pooled).getByText(/3 markers/)).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /Dry violation · file-level/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("splits out a repeating file-level biomarker but leaves the one-offs pooled", () => {
+    const findings: HealthDrawerFinding[] = [
+      ...[10, 20, 30].map((line) =>
+        finding({
+          biomarker_type: "error_handling",
+          function_name: null,
+          line_start: line,
+          health_impact: 0.05,
+          reason: "broad `except Exception` catches unrelated errors.",
+        }),
+      ),
+      finding({
+        biomarker_type: "dry_violation",
+        function_name: null,
+        line_start: null,
+        health_impact: 0.4,
+        reason: "Duplicated block.",
+      }),
+      finding({
+        biomarker_type: "change_entropy",
+        function_name: null,
+        line_start: null,
+        health_impact: 0.3,
+        reason: "File changes touch many unrelated concerns.",
+      }),
+    ];
+    render(
+      <HealthFileDrawer open onClose={() => {}} metric={metric()} findings={findings} />,
+    );
+    const eh = screen.getByRole("button", { name: /Error handling · file-level/i });
+    expect(within(eh).getByText(/3 markers/)).toBeInTheDocument();
+    const pooled = screen.getByRole("button", { name: /File-level signals/ });
+    expect(within(pooled).getByText(/2 markers/)).toBeInTheDocument();
+  });
+
+  /** A C++/Rust function can legitimately be named `file::read`, so the group
+   *  key must not be a collidable string prefix. */
+  it("keeps a function named like the file-level sentinel in its function group", () => {
+    const findings: HealthDrawerFinding[] = [
+      finding({ function_name: "file::read", biomarker_type: "brain_method" }),
+      finding({ function_name: "file::read", biomarker_type: "nested_complexity" }),
+    ];
+    render(
+      <HealthFileDrawer open onClose={() => {}} metric={metric()} findings={findings} />,
+    );
+    const group = screen.getByRole("button", { name: /file::read/ });
+    expect(within(group).getByText(/2 markers/)).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /· file-level/i }),
+    ).not.toBeInTheDocument();
   });
 });
 

--- a/packages/ui/src/health/health-file-drawer.tsx
+++ b/packages/ui/src/health/health-file-drawer.tsx
@@ -8,6 +8,7 @@ import {
   biomarkerLabel,
   biomarkerInfo,
   biomarkerDimension,
+  CATEGORY_CAP,
   CATEGORY_LABEL,
   DIMENSION_CHIP,
   DIMENSION_LABEL,
@@ -97,6 +98,11 @@ export interface HealthFileDrawerProps {
     | undefined;
 }
 
+/** Bucket for one-off file-level markers, kept pooled so a file with several
+ *  distinct singletons still reads as one collapsed row. Not a biomarker name,
+ *  and never compared against one. */
+const POOLED_FILE_KEY = "__file_level__";
+
 const TRIAGE_STATUSES: { value: string; label: string }[] = [
   { value: "open", label: "Open" },
   { value: "acknowledged", label: "Acknowledged" },
@@ -177,8 +183,16 @@ export function HealthFileDrawer({
               </span>
             );
           })()}
-          {f.function_name ? (() => {
-            const label = `${f.function_name}${f.line_start ? `:${f.line_start}` : ""}`;
+          {/* Anchor on line_start, not function_name. Gating the whole anchor on
+              the function dropped the line for every file-level marker that has
+              one — `error_handling` fires per occurrence with a precise line and
+              no function, so 34 markers on one file rendered as 34 rows whose
+              only distinguishing field was the one being withheld. That is what
+              made them read as duplicates. */}
+          {f.function_name || f.line_start != null ? (() => {
+            const label = f.function_name
+              ? `${f.function_name}${f.line_start != null ? `:${f.line_start}` : ""}`
+              : `line ${f.line_start}`;
             const lineHref =
               f.line_start != null && fileViewHrefFor
                 ? fileViewHrefFor(f.line_start)
@@ -238,25 +252,88 @@ export function HealthFileDrawer({
     );
   };
 
-  // Group findings by the function they fire on so one oversized function reads
-  // as a single collapsible group instead of N sibling rows. File-level markers
-  // (no function_name — co_change_scatter, change_entropy, …) collect into one
-  // "File-level signals" group. Sections sort by summed impact so the dominant
-  // cause leads; the worst section starts expanded.
+  // Categories the scorer held at their ceiling, per the server breakdown.
+  // `capped` is the server's verdict and is never recomputed here. The cap
+  // VALUE is only ever displayed, so it falls back to the glossary mirror the
+  // way `score-breakdown.tsx` does — older payloads carry `capped` without
+  // `cap`, and losing the chip over a missing display number helps nobody.
+  const cappedCategories = new Map<string, number | null>();
+  for (const c of breakdown?.categories ?? []) {
+    if (c.capped) cappedCategories.set(String(c.category), c.cap ?? null);
+  }
+
+  // Group findings by the function they fire on, so one oversized function
+  // reads as a single collapsible group instead of N sibling rows.
+  //
+  // Markers with no function used to pool into one "File-level signals" list,
+  // which defeated that fix for the biomarker that needs it most:
+  // `error_handling` sets no function_name and fires once per occurrence, so a
+  // single file in this repo reaches 34 sibling rows repeating one 12-word
+  // reason — worth 0.51 points, because the category caps at 0.5.
+  //
+  // So a file-level biomarker gets its own group only when it actually repeats.
+  // Splitting *every* file-level biomarker out was measurably worse: singleton
+  // groups render expanded, and 53% of files carry 2+ distinct one-off
+  // file-level markers (`dry_violation` alone fires exactly once on ~1,500
+  // files), so it turned one collapsed row into several expanded ones. The
+  // one-offs stay pooled; only the floods split.
   const findingSections = (() => {
-    const groups = new Map<string, HealthDrawerFinding[]>();
+    const byFunction = new Map<string, HealthDrawerFinding[]>();
+    const byBiomarker = new Map<string, HealthDrawerFinding[]>();
     for (const f of findings) {
-      const key = f.function_name ?? " file";
-      const bucket = groups.get(key);
+      // Two separate maps, never one keyed by a sentinel string: a C++ or Rust
+      // function_name can legitimately be `file::read`, so any "file" prefix is
+      // collidable and would silently strip that function's name from its
+      // header.
+      const map = f.function_name ? byFunction : byBiomarker;
+      const key = f.function_name ?? f.biomarker_type;
+      const bucket = map.get(key);
       if (bucket) bucket.push(f);
-      else groups.set(key, [f]);
+      else map.set(key, [f]);
     }
-    return [...groups.entries()]
-      .map(([key, group]) => {
-        const isFile = key === " file";
+
+    const pooled: HealthDrawerFinding[] = [];
+    const fileGroups: { key: string; group: HealthDrawerFinding[] }[] = [];
+    for (const [key, group] of byBiomarker) {
+      if (group.length > 1) fileGroups.push({ key, group });
+      else pooled.push(...group);
+    }
+    if (pooled.length > 0) fileGroups.push({ key: POOLED_FILE_KEY, group: pooled });
+
+    const sections = [
+      ...[...byFunction.entries()].map(([key, group]) => ({ key, group, isFile: false })),
+      ...fileGroups.map(({ key, group }) => ({ key, group, isFile: true })),
+    ];
+
+    return sections
+      .map(({ key, group, isFile }) => {
+        // Inside a single-biomarker group every marker carries the same label
+        // and the same impact, so impact cannot order them and the line is the
+        // only axis a reader can follow. Unlined markers sort last.
+        if (isFile && key !== POOLED_FILE_KEY) {
+          group.sort((a, b) => (a.line_start ?? Infinity) - (b.line_start ?? Infinity));
+        }
         const total = group.reduce((s, f) => s + f.health_impact, 0);
         const worst = group.reduce((a, b) => (b.health_impact > a.health_impact ? b : a));
-        return { key, group, isFile, total, worst };
+        // Claim the cap only when this group IS the category — otherwise the
+        // ceiling belongs to markers outside the group and naming it here
+        // misattributes it. Decided from the findings on screen rather than by
+        // matching the server's subtotal, because a host may scope the two
+        // differently (hosted excludes triaged findings from the breakdown but
+        // not from this list) and a float comparison would then silently fail.
+        const cat = biomarkerInfo(worst.biomarker_type).category;
+        const ownsCategory =
+          key !== POOLED_FILE_KEY &&
+          findings.every(
+            (f) =>
+              biomarkerInfo(f.biomarker_type).category !== cat ||
+              f.biomarker_type === worst.biomarker_type,
+          );
+        const atCap =
+          isFile && ownsCategory && cappedCategories.has(cat)
+            ? (cappedCategories.get(cat) ?? CATEGORY_CAP[cat] ?? null)
+            : null;
+        return { key, group, isFile, total, worst, atCap };
       })
       .sort((a, b) => b.total - a.total);
   })();
@@ -405,12 +482,14 @@ export function HealthFileDrawer({
                   <div className="flex flex-col">
                     {findingSections.map((s) => (
                       <FunctionFindingsGroup
-                        key={s.key}
+                        key={s.isFile ? `file:${s.key}` : `fn:${s.key}`}
                         isFile={s.isFile}
+                        pooled={s.key === POOLED_FILE_KEY}
                         functionName={s.isFile ? null : s.key}
                         findings={s.group}
                         total={s.total}
                         worst={s.worst}
+                        atCap={s.atCap}
                         // Single-marker groups have nothing to collapse; multi-
                         // marker groups start collapsed so the drawer opens as
                         // compact headers, since the leading-cause line above
@@ -430,11 +509,12 @@ export function HealthFileDrawer({
 }
 
 /**
- * One collapsible group of findings that fire on the same function (or the
- * "File-level signals" bucket when they have no function). The header names the
+ * One collapsible group of findings that fire on the same function, or — for
+ * markers with no function — on the same biomarker. The header names the
  * function plus its worst marker so a 7-marker oversized function reads as one
- * row, not seven — the P2 "looks padded" fix. Single-finding groups render
- * expanded; the caller expands the highest-impact group by default.
+ * row, not seven — the P2 "looks padded" fix. A file-level group leads with the
+ * biomarker instead, and carries a `capped` chip when the scorer is holding
+ * that category at its ceiling. Single-finding groups render expanded.
  */
 /**
  * Which symbols this file's recent bug fixes landed in, behind a disclosure.
@@ -488,18 +568,24 @@ function BugHistorySection({ signals }: { signals: FileSignals | null | undefine
 
 function FunctionFindingsGroup({
   isFile,
+  pooled,
   functionName,
   findings,
   total,
   worst,
+  atCap,
   defaultExpanded,
   renderFinding,
 }: {
   isFile: boolean;
+  /** The mixed bucket of one-off file-level markers, not a single biomarker. */
+  pooled: boolean;
   functionName: string | null;
   findings: HealthDrawerFinding[];
   total: number;
   worst: HealthDrawerFinding;
+  /** The enforced cap when this group's category is holding at it, else null. */
+  atCap: number | null;
   defaultExpanded: boolean;
   renderFinding: (f: HealthDrawerFinding) => React.ReactNode;
 }) {
@@ -527,8 +613,15 @@ function FunctionFindingsGroup({
           <ChevronRight className="h-4 w-4 shrink-0 text-[var(--color-text-tertiary)]" />
         )}
         {isFile ? (
-          <span className="text-sm font-medium text-[var(--color-text-primary)]">
-            File-level signals
+          <span className="min-w-0 truncate text-sm font-medium text-[var(--color-text-primary)]">
+            {pooled ? (
+              "File-level signals"
+            ) : (
+              <>
+                {worstLabel}
+                <span className="text-[var(--color-text-tertiary)]"> · file-level</span>
+              </>
+            )}
           </span>
         ) : (
           <span className="min-w-0 truncate text-sm font-medium text-[var(--color-text-primary)]">
@@ -541,6 +634,19 @@ function FunctionFindingsGroup({
             {findings.length} {findings.length === 1 ? "marker" : "markers"}
           </span>
           <span className="text-[var(--color-error)]">−{total.toFixed(2)}</span>
+          {/* Why 34 markers cost half a point. Without this the count reads as
+              the severity and the capped total looks like a bug. The
+              explanation rides in the accessible name, not a `title`: a bare
+              `title` on a span with its own text never reaches the accessible
+              name, so it would be mouse-only. */}
+          {atCap !== null ? (
+            <span
+              className="rounded-sm bg-[var(--color-bg-surface)] px-1 py-px text-[10px] font-normal text-[var(--color-text-tertiary)]"
+              aria-label={`capped: held at its ${atCap.toFixed(2)}-point ceiling, so further markers of this kind add no deduction`}
+            >
+              capped
+            </span>
+          ) : null}
         </span>
       </div>
       {expanded ? (

--- a/packages/web/src/components/health/health-file-drawer-host.tsx
+++ b/packages/web/src/components/health/health-file-drawer-host.tsx
@@ -41,7 +41,13 @@ export function HealthFileDrawerHost({
       permalinkHref={filePageHref ? `${filePageHref}?tab=health` : undefined}
       fileViewHref={filePageHref}
       fileViewHrefFor={
-        filePageHref ? () => `${filePageHref}?tab=health` : undefined
+        // Carry the line through. This used to discard its argument, which was
+        // survivable while the link only appeared next to a function name; now
+        // that file-level markers render their own line, dropping it would make
+        // 34 visually distinct "line N" links resolve to one identical URL.
+        filePageHref
+          ? (lineStart) => `${filePageHref}?tab=health#L${lineStart}`
+          : undefined
       }
       onPartnerHref={(path) => fileEntityPath(prefix, path)}
       onFindingStatusChange={async (findingId, status) => {


### PR DESCRIPTION
Opening a file from the code-health map showed what looked like duplicate findings: 34 rows on `core/pipeline/incremental.py` identical in every visible field. The table has no duplicates — grouping all 10,357 open findings on every column except `id` and the timestamps returns **zero** identical groups. The drawer was withholding the one field that told them apart.

## The line was never rendered

The `function:line` anchor was gated on `function_name`. `error_handling` sets `function_name` to null but carries an exact `line_start`, and its reason string carries no line either — so all **1,057** error_handling findings in this repo rendered with no line shown and nothing to click. Every other visible field (label, category, dimension chip, severity, impact, 12-word reason) is identical across them.

Now anchored on `line_start`: a marker with no function renders `line 202` as a deep-link.

## One biomarker was flooding the drawer

The drawer already groups findings by function so an oversized function reads as one collapsible row instead of N siblings. That never reached markers with no function, which all pooled into one flat "File-level signals" list — including the biomarker that fires once per occurrence and reaches 34 on a single file:

```
34 findings / 30 lines  core/pipeline/incremental.py
25 findings / 25 lines  cli/commands/update_cmd/persistence.py
22 findings / 22 lines  cli/commands/update_cmd/command.py
21 findings / 16 lines  core/workspace/update.py
```

A file-level biomarker now gets its own group when it repeats, so that reads as one `Error handling · file-level · 34 markers · −0.51` header.

**One-offs stay pooled, and that part is load-bearing.** Splitting every file-level biomarker out made 53% of files worse: singleton groups render expanded, and `dry_violation` fires exactly once on ~1,500 files. Measured over the 2,315 files with file-level findings:

| variant | groups | auto-expanded groups |
|---|---|---|
| before | 2,315 | 991 |
| split every biomarker | 5,092 | **4,687** |
| shipped | 2,706 | 1,079 |

Rows inside a split group sort by line, since every marker there carries the same label and the same impact, so impact cannot order them.

## The count no longer implies an impact the scorer capped away

34 markers costing 0.51 looks like a bug until you know `error_handling` has a 0.5 category cap. Group headers now carry a `capped` chip.

The verdict comes from the server breakdown and is never recomputed client-side. The displayed ceiling falls back to the glossary mirror the way `score-breakdown.tsx` already does, because older payloads carry `capped` without `cap`. The chip appears only when the group is the whole category — decided from the findings on screen rather than by matching the server's subtotal, since a host may scope the two differently (the hosted wrapper excludes triaged findings from the breakdown but not from the findings list, which would have made the chip silently vanish).

## Notes

- Group keys are two maps rather than one string with a sentinel prefix: a C++ or Rust `function_name` can legitimately be `file::read`, and a collidable prefix would have stripped that function's name from its own header. Covered by a test.
- Also fixes the OSS drawer host, which discarded the line argument when building the file href. Survivable while the link only appeared beside a function name; with per-line markers it would have made 34 distinct links resolve to one identical URL.
- The `capped` chip carries its explanation in `aria-label`, not `title` — a bare `title` on a span with its own text never reaches the accessible name.

`packages/ui` is published, so the hosted frontend inherits this.

## Still open

A finding row is not itself clickable — no `onClick`, no `href` on the `<li>`. The line link is the only navigation target and it is small. Making the whole row navigate needs care, because the row also carries triage buttons and info tooltips whose clicks must not be swallowed.

## Tests

66 pass in `packages/ui/__tests__/health`, including 8 new ones covering the pooling rule, the split rule, the line link, the `file::` collision, and both cap cases. `tests/unit/health` (1,068) and `tests/unit/server/mcp` pass. Typecheck clean.
