### PR TITLE
fix(tests): give the SCC test double the state the mixin reads

### DIFF
--- a/tests/integration/test_generation_determinism.py
+++ b/tests/integration/test_generation_determinism.py
@@ -147,6 +147,8 @@ class TestSccSlug:
 
     def test_component_order_survives_graph_insertion_order(self):
         """GraphBuilder-level check that the component list itself is stable."""
+        import threading
+
         from repowise.core.ingestion.graph._metrics import MetricsMixin
 
         cycles = [("a.py", "b.py"), ("c.py", "d.py"), ("e.py", "f.py")]
@@ -156,7 +158,15 @@ class TestSccSlug:
             for u, v in edge_order:
                 g.add_edge(u, v)
                 g.add_edge(v, u)
-            holder = type("H", (MetricsMixin,), {})()
+            # The mixin reads the subgraph cache and its lock, both of which
+            # GraphBuilder.__init__ owns. A double that stands in for the mixin
+            # has to carry them or it is testing a state the real class never
+            # has.
+            holder = type(
+                "H",
+                (MetricsMixin,),
+                {"_cycle_subgraph_cache": None, "_subgraph_lock": threading.Lock()},
+            )()
             holder.graph = lambda: g
             holder.file_subgraph = lambda: g
             return [sorted(c) for c in holder.strongly_connected_components()]


### PR DESCRIPTION
## What

`main` is red. `test_component_order_survives_graph_insertion_order` fails with

```
AttributeError: 'H' object has no attribute '_cycle_subgraph_cache'
```

#1354 routed `strongly_connected_components()` through the new `cycle_subgraph()`, which reads `_cycle_subgraph_cache` and `_subgraph_lock`. Both belong to `GraphBuilder.__init__`, and this test stands a bare `MetricsMixin` subclass up without going through it.

## Fix

The double carries both attributes now.

Fixing the double rather than the mixin: every real subclass is a `GraphBuilder`, which sets them in `__init__` and restores them in `__setstate__` for the pickle boundary. A missing-attribute fallback inside `cycle_subgraph()` would defend against a state production never reaches, and would make the lock optional in a method whose whole point is that the cache write is guarded.

## Why CI missed it

Integration tests run on push to `main`, not on pull requests, so #1354 was green as a PR and only went red once merged. Worth a separate look at whether that job should also run on PRs touching `packages/core/src/repowise/core/ingestion/graph/`.

## Verification

- `pytest tests/integration/test_generation_determinism.py` — 8 passed (the failing test reproduced first, then fixed).
- `ruff check` clean on the changed file.