### PR TITLE
fix(tests): make the integration JobStore double honour its filters

### DIFF
--- a/tests/integration/test_pipeline_fast_checkpoint.py
+++ b/tests/integration/test_pipeline_fast_checkpoint.py
@@ -43,7 +43,16 @@ class _FakeJobStore:
         return rec
 
     async def list_jobs(self, *, repository_id=None, phase=None, state=None, limit=100):
-        return list(self.jobs.values())
+        # Honour every filter SqlJobStore applies: callers push predicates down
+        # to the store, so a double that ignores them hides real bugs.
+        matches = [
+            j
+            for j in self.jobs.values()
+            if (repository_id is None or j.repository_id == repository_id)
+            and (phase is None or j.phase == phase)
+            and (state is None or j.state == state)
+        ]
+        return matches[:limit]
 
 
 async def test_fast_mode_skips_generation_and_co_change(sample_repo_path: Path) -> None:


### PR DESCRIPTION
## Problem

CI on `main` is red: `tests/integration/test_pipeline_fast_checkpoint.py::test_interrupted_phase_excluded_from_resume_set` fails with `assert 'generation' not in {'generation'}` ([run 31324839545](https://github.com/repowise-dev/repowise/actions/runs/31324839545)).

## Cause

#1329 moved the completed-state filter out of Python and into the store:

```python
jobs = await job_store.list_jobs(repository_id=repository_id, state=JobState.COMPLETED)
return {j.phase for j in jobs}
```

`SqlJobStore.list_jobs` honours `state`, and the unit fake in `tests/unit/pipeline/test_checkpoint.py` was updated to match. The integration fake was not: its `list_jobs` returned `list(self.jobs.values())` regardless of `repository_id`, `phase`, `state` or `limit`. With the client-side filter gone, a job left in `RUNNING` came back as completed, which is exactly the case that test asserts against.

Product code is correct; the double was lying.

## Fix

The integration fake now applies every predicate `SqlJobStore` applies, `limit` included, so a double that quietly ignores a filter cannot hide the next pushdown change.

## Verification

`tests/integration/test_pipeline_fast_checkpoint.py` and `tests/unit/pipeline` pass locally (12 and 76 tests).