### PR TITLE
docs(examples): add dead-code CLI walkthrough

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -8,6 +8,7 @@ self-contained README under `examples/<name>/`.
 | Example | What it shows |
 |---------|----------------|
 | [codex/](codex/) | Codex CLI setup: `repowise init --codex`, smoke checks, local plugin install |
+| [dead-code/](dead-code/) | `repowise dead-code` — unused exports and cleanup candidates (no LLM key) |
 | [decisions/](decisions/) | `repowise decision` list/health/confirm — architectural records (no LLM key) |
 | [distill/](distill/) | `distill` / `expand` / `saved` — compress command output (no LLM key) |
 | [health-coverage/](health-coverage/) | Code health, coverage ingest, and impacted-tests (no LLM key) |
@@ -33,6 +34,7 @@ self-contained README under `examples/<name>/`.
 - [Codex integration](../docs/agent/CODEX.md)
 - [OpenCode integration](../docs/agent/OPENCODE.md)
 - [Code health](../docs/layers/CODE_HEALTH.md)
+- [Dead code](../docs/layers/DEAD_CODE.md)
 - [Decisions](../docs/layers/DECISIONS.md)
 - [Change risk](../docs/layers/CHANGE_RISK.md)
 - [Test intelligence](../docs/layers/TEST_INTELLIGENCE.md)

--- a/examples/dead-code/README.md
+++ b/examples/dead-code/README.md
@@ -1,0 +1,56 @@
+# Dead-Code Example
+
+Walk through `repowise dead-code` — unreachable files, unused exports, and
+cleanup candidates ranked by confidence. No LLM key required.
+
+## Prerequisites
+
+1. A git repository with indexed sources.
+2. `repowise` on `PATH` (`uv tool install repowise` or from this repo:
+   `uv sync --all-packages`).
+3. Index once (index-only is enough):
+
+```bash
+cd /path/to/your-repo
+repowise init --index-only --yes
+```
+
+## 1. Scan the repo
+
+```bash
+repowise dead-code
+repowise dead-code --kind unused_export
+repowise dead-code --safe-only --min-confidence 0.8
+```
+
+`--safe-only` keeps findings marked safe to delete. Raise `--min-confidence`
+when you want a shorter, higher-trust list.
+
+## 2. Filter and export
+
+```bash
+repowise dead-code --no-unreachable          # skip unreachable-file rows
+repowise dead-code --no-unused-exports       # skip unused-export rows
+repowise dead-code --format json | head      # machine-readable
+repowise dead-code --format md > report.md   # shareable markdown (shell redirect; no -o flag)
+```
+
+In a workspace, scope to one repo:
+
+```bash
+repowise dead-code --repo backend
+```
+
+## Smoke checklist
+
+| Step | Expected |
+|------|----------|
+| `repowise dead-code` | Table of findings (or empty if none) |
+| `repowise dead-code --safe-only --min-confidence 0.8` | Subset with safe-to-delete markers |
+| `repowise dead-code --format json` | JSON array; no API key needed |
+
+## Related docs
+
+- [Dead code layer](../../docs/layers/DEAD_CODE.md)
+- [CLI: `repowise dead-code`](../../docs/reference/CLI_REFERENCE.md)
+- [Quickstart](../../docs/start/QUICKSTART.md)


### PR DESCRIPTION
## Summary
- Add `examples/dead-code/` walkthrough for `repowise dead-code` filters and JSON output
- Register the example in `examples/README.md` with a link to `DEAD_CODE.md`

## Why
`dead-code` is a first-class, no-LLM CLI surface promoted in Quickstart step 2, but there was no copy-paste example alongside risk, health-coverage, and security-scan.

## Test plan
- [x] `repowise init --index-only --yes` then `repowise dead-code`
- [x] `repowise dead-code --safe-only --min-confidence 0.8`
- [x] `repowise dead-code --format json`
- [x] Flags match `docs/reference/CLI_REFERENCE.md`