### PR TITLE
docs(examples): add wiki-export walkthrough

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -14,6 +14,7 @@ self-contained README under `examples/<name>/`.
 | [risk/](risk/) | `repowise risk` change / PR defect scoring (no LLM key) |
 | [security-scan/](security-scan/) | Working-tree security signals + OSS `security scan --history` (no LLM key) |
 | [structurizr-export/](structurizr-export/) | `export --format structurizr` fragment vs standalone (no LLM key) |
+| [wiki-export/](wiki-export/) | `export` markdown / html / json wiki pages (no LLM key) |
 
 ## Conventions
 

--- a/examples/wiki-export/README.md
+++ b/examples/wiki-export/README.md
@@ -21,7 +21,7 @@ repowise init --index-only --yes
 repowise export                                    # markdown → .repowise/export/
 repowise export --format markdown -o ./wiki-export
 repowise export --format html -o ./wiki-html
-repowise export --format json -o ./wiki.json       # single wiki_pages.json
+repowise export --format json -o ./wiki-json    # writes ./wiki-json/wiki_pages.json
 ```
 
 ## 2. Host or archive offline
@@ -33,6 +33,7 @@ wiki programmatically.
 ```bash
 ls ./wiki-export | head
 ls ./wiki-html | head
+ls ./wiki-json/wiki_pages.json
 ```
 
 ## Smoke checklist
@@ -41,7 +42,7 @@ ls ./wiki-html | head
 |------|----------|
 | `repowise export --format markdown -o /tmp/wiki-md` | Directory of `.md` files |
 | `repowise export --format html -o /tmp/wiki-html` | Directory of `.html` files |
-| `repowise export --format json -o /tmp/wiki.json` | `wiki_pages.json` created |
+| `repowise export --format json -o /tmp/wiki-json` | `/tmp/wiki-json/wiki_pages.json` created |
 | No index present | Error: run `repowise init` first |
 
 ## Related docs

--- a/examples/wiki-export/README.md
+++ b/examples/wiki-export/README.md
@@ -1,0 +1,51 @@
+# Wiki Export Example
+
+Export indexed wiki pages to static files with `repowise export`. Supports
+markdown, HTML, and JSON — no LLM key required. For Structurizr DSL, see
+[structurizr-export/](../structurizr-export/).
+
+## Prerequisites
+
+1. A git repository with `repowise init` completed (index-only is enough).
+2. `repowise` on `PATH` (`uv tool install repowise` or from this repo:
+   `uv sync --all-packages`).
+
+```bash
+cd /path/to/your-repo
+repowise init --index-only --yes
+```
+
+## 1. Export wiki pages
+
+```bash
+repowise export                                    # markdown → .repowise/export/
+repowise export --format markdown -o ./wiki-export
+repowise export --format html -o ./wiki-html
+repowise export --format json -o ./wiki.json       # single wiki_pages.json
+```
+
+## 2. Host or archive offline
+
+Markdown and HTML exports are ordinary files — commit them, publish to static
+hosting, or attach to a release. JSON is useful for tooling that reads the
+wiki programmatically.
+
+```bash
+ls ./wiki-export | head
+ls ./wiki-html | head
+```
+
+## Smoke checklist
+
+| Step | Expected |
+|------|----------|
+| `repowise export --format markdown -o /tmp/wiki-md` | Directory of `.md` files |
+| `repowise export --format html -o /tmp/wiki-html` | Directory of `.html` files |
+| `repowise export --format json -o /tmp/wiki.json` | `wiki_pages.json` created |
+| No index present | Error: run `repowise init` first |
+
+## Related docs
+
+- [CLI: `repowise export`](../../docs/reference/CLI_REFERENCE.md)
+- [Structurizr export example](../structurizr-export/)
+- [User guide](../../docs/start/USER_GUIDE.md)


### PR DESCRIPTION
## Summary
- Add `examples/wiki-export/` walkthrough for `repowise export` markdown, html, and json outputs
- Register the example in `examples/README.md` (complements existing `structurizr-export/`)

## Why
`export` supports multiple wiki formats beyond Structurizr DSL, but only structurizr had an example.

## Test plan
- [x] `repowise export --format markdown -o /tmp/wiki-md`
- [x] `repowise export --format html -o /tmp/wiki-html`
- [x] `repowise export --format json -o /tmp/wiki.json`
- [x] Flags match `docs/reference/CLI_REFERENCE.md`