### PR TITLE
fix(mcp): add explicit --host control and security warning for network transports 

### DIFF
--- a/packages/cli/src/repowise/cli/commands/mcp_cmd.py
+++ b/packages/cli/src/repowise/cli/commands/mcp_cmd.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 import click
@@ -45,6 +46,7 @@ def _workspace_summary(path: Path) -> dict[str, object] | None:
 def _print_network_startup(
     transport: str,
     repo_path: Path,
+    host: str,
     port: int,
     workspace: dict[str, object] | None,
 ) -> None:
@@ -52,8 +54,16 @@ def _print_network_startup(
     endpoint = "mcp" if transport == "streamable-http" else "sse"
     console.print(
         f"[bold green]Starting repowise MCP server ({label})[/bold green]\n"
-        f"URL: http://127.0.0.1:{port}/{endpoint}"
+        f"URL: http://{host}:{port}/{endpoint}"
     )
+
+    if not os.environ.get("REPOWISE_API_KEY") and host in ("0.0.0.0", "::"):
+        console.print(
+            "[bold yellow]SECURITY WARNING:[/bold yellow] MCP server is binding to "
+            f"[bold]{host}[/bold] without REPOWISE_API_KEY set. "
+            "All tools are unauthenticated and network-accessible. "
+            "Set REPOWISE_API_KEY or bind to 127.0.0.1."
+        )
 
     if workspace is not None:
         aliases = workspace["aliases"]
@@ -85,6 +95,15 @@ def _print_network_startup(
     help="Port for HTTP/SSE transports (default: 7338).",
 )
 @click.option(
+    "--host",
+    default=None,
+    help=(
+        "Host to bind for HTTP/SSE transports. Defaults to the REPOWISE_HOST "
+        "environment variable, or 127.0.0.1. Use 0.0.0.0 to listen on all "
+        "interfaces (without REPOWISE_API_KEY a security warning will be printed)."
+    ),
+)
+@click.option(
     "--tools",
     default=None,
     help=(
@@ -106,6 +125,7 @@ def mcp_command(
     path: str | None,
     transport: str,
     port: int,
+    host: str | None,
     tools: str | None,
     all_tools: bool,
 ) -> None:
@@ -145,8 +165,10 @@ def mcp_command(
             "Run 'repowise init' first to generate documentation."
         )
 
+    resolved_host = host or os.environ.get("REPOWISE_HOST", "127.0.0.1")
+
     if transport in {"sse", "streamable-http"}:
-        _print_network_startup(transport, repo_path, port, workspace)
+        _print_network_startup(transport, repo_path, resolved_host, port, workspace)
     else:
         # stdio mode — no console output (it would corrupt the protocol)
         pass
@@ -158,6 +180,7 @@ def mcp_command(
     run_mcp(
         transport=transport,
         repo_path=str(repo_path),
+        host=resolved_host,
         port=port,
         tools=tools_override,
     )

--- a/packages/server/src/repowise/server/mcp_server/_server.py
+++ b/packages/server/src/repowise/server/mcp_server/_server.py
@@ -555,6 +555,7 @@ def create_mcp_server(
 def run_mcp(
     transport: str = "stdio",
     repo_path: str | None = None,
+    host: str = "127.0.0.1",
     port: int = 7338,
     tools: str | list[str] | None = None,
 ) -> None:
@@ -570,10 +571,26 @@ def run_mcp(
     apply_tool_selection(mcp, repo_path=repo_path, override=tools)
 
     if transport == "sse":
+        mcp.settings.host = host
         mcp.settings.port = port
+        if host in ("0.0.0.0", "::") and not os.environ.get("REPOWISE_API_KEY"):
+            _log.warning(
+                "SECURITY WARNING: MCP server (sse) is binding to %s without "
+                "REPOWISE_API_KEY. All tools are unauthenticated and "
+                "network-accessible. Set REPOWISE_API_KEY or bind to 127.0.0.1.",
+                host,
+            )
         mcp.run(transport="sse")
     elif transport == "streamable-http":
+        mcp.settings.host = host
         mcp.settings.port = port
+        if host in ("0.0.0.0", "::") and not os.environ.get("REPOWISE_API_KEY"):
+            _log.warning(
+                "SECURITY WARNING: MCP server (streamable-http) is binding to %s without "
+                "REPOWISE_API_KEY. All tools are unauthenticated and "
+                "network-accessible. Set REPOWISE_API_KEY or bind to 127.0.0.1.",
+                host,
+            )
         mcp.run(transport="streamable-http")
     else:
         # stdout is the JSON-RPC channel on stdio, so every log line written

--- a/tests/unit/cli/test_mcp_transport.py
+++ b/tests/unit/cli/test_mcp_transport.py
@@ -31,6 +31,7 @@ def test_mcp_cli_passes_tools_override(monkeypatch, tmp_path: Path) -> None:
 
     assert result.exit_code == 0
     assert captured["tools"] == "+get_execution_flows,-get_dead_code"
+    assert captured["host"] == "127.0.0.1"
 
 
 def test_mcp_cli_all_flag_overrides_tools(monkeypatch, tmp_path: Path) -> None:
@@ -44,6 +45,7 @@ def test_mcp_cli_all_flag_overrides_tools(monkeypatch, tmp_path: Path) -> None:
 
     assert result.exit_code == 0
     assert captured["tools"] == "all"
+    assert captured["host"] == "127.0.0.1"
 
 
 def test_mcp_cli_accepts_streamable_http_transport(
@@ -75,6 +77,7 @@ def test_mcp_cli_accepts_streamable_http_transport(
     assert captured == {
         "transport": "streamable-http",
         "repo_path": str(tmp_path.resolve()),
+        "host": "127.0.0.1",
         "port": 7339,
         "tools": None,
     }
@@ -126,6 +129,7 @@ def test_mcp_cli_streamable_http_prints_workspace_summary(
     assert captured == {
         "transport": "streamable-http",
         "repo_path": str(workspace.resolve()),
+        "host": "127.0.0.1",
         "port": 7341,
         "tools": None,
     }
@@ -152,6 +156,7 @@ def test_run_mcp_dispatches_streamable_http(monkeypatch) -> None:
 
     _server.run_mcp(transport="streamable-http", repo_path="/tmp/repo", port=7340)
 
+    assert _server.mcp.settings.host == "127.0.0.1"
     assert _server.mcp.settings.port == 7340
     assert calls == [{"transport": "streamable-http"}]
     assert watchdog_started is False
@@ -181,3 +186,104 @@ def test_run_mcp_keeps_existing_stdio_and_sse_dispatch(monkeypatch) -> None:
 
     assert calls == [{"transport": "sse"}, {"transport": "stdio"}]
     assert watchdog_calls == 1
+
+
+# ---------------------------------------------------------------------------
+# New tests: --host flag, REPOWISE_HOST env, security warnings
+# ---------------------------------------------------------------------------
+
+
+def test_mcp_cli_passes_host_to_run_mcp(monkeypatch, tmp_path: Path) -> None:
+    """--host 0.0.0.0 is forwarded to run_mcp."""
+    (tmp_path / ".repowise").mkdir()
+    captured: dict[str, object] = {}
+    monkeypatch.setattr("repowise.server.mcp_server.run_mcp", lambda **kw: captured.update(kw))
+    monkeypatch.delenv("REPOWISE_API_KEY", raising=False)
+
+    result = CliRunner().invoke(
+        cli,
+        ["mcp", str(tmp_path), "--transport", "streamable-http", "--host", "0.0.0.0", "--port", "7342"],
+    )
+
+    assert result.exit_code == 0
+    assert captured["host"] == "0.0.0.0"
+
+
+def test_mcp_cli_defaults_host_to_loopback(monkeypatch, tmp_path: Path) -> None:
+    """No --host flag → run_mcp receives host='127.0.0.1'."""
+    (tmp_path / ".repowise").mkdir()
+    captured: dict[str, object] = {}
+    monkeypatch.setattr("repowise.server.mcp_server.run_mcp", lambda **kw: captured.update(kw))
+    monkeypatch.delenv("REPOWISE_HOST", raising=False)
+
+    result = CliRunner().invoke(
+        cli,
+        ["mcp", str(tmp_path), "--transport", "streamable-http", "--port", "7342"],
+    )
+
+    assert result.exit_code == 0
+    assert captured["host"] == "127.0.0.1"
+
+
+def test_mcp_cli_inherits_repowise_host_env(monkeypatch, tmp_path: Path) -> None:
+    """REPOWISE_HOST=0.0.0.0 (no --host flag) → run_mcp receives host='0.0.0.0'."""
+    (tmp_path / ".repowise").mkdir()
+    captured: dict[str, object] = {}
+    monkeypatch.setattr("repowise.server.mcp_server.run_mcp", lambda **kw: captured.update(kw))
+    monkeypatch.setenv("REPOWISE_HOST", "0.0.0.0")
+    monkeypatch.delenv("REPOWISE_API_KEY", raising=False)
+
+    result = CliRunner().invoke(
+        cli,
+        ["mcp", str(tmp_path), "--transport", "streamable-http", "--port", "7342"],
+    )
+
+    assert result.exit_code == 0
+    assert captured["host"] == "0.0.0.0"
+
+
+def test_mcp_cli_prints_security_warning_on_wide_bind(monkeypatch, tmp_path: Path) -> None:
+    """--host 0.0.0.0 without REPOWISE_API_KEY → security warning in output."""
+    (tmp_path / ".repowise").mkdir()
+    monkeypatch.setattr("repowise.server.mcp_server.run_mcp", lambda **kw: None)
+    monkeypatch.delenv("REPOWISE_API_KEY", raising=False)
+
+    result = CliRunner().invoke(
+        cli,
+        ["mcp", str(tmp_path), "--transport", "streamable-http", "--host", "0.0.0.0"],
+    )
+
+    assert result.exit_code == 0
+    assert "SECURITY WARNING" in result.output
+    assert "0.0.0.0" in result.output
+    assert "REPOWISE_API_KEY" in result.output
+
+
+def test_mcp_cli_no_warning_with_api_key(monkeypatch, tmp_path: Path) -> None:
+    """--host 0.0.0.0 WITH REPOWISE_API_KEY → no security warning."""
+    (tmp_path / ".repowise").mkdir()
+    monkeypatch.setattr("repowise.server.mcp_server.run_mcp", lambda **kw: None)
+    monkeypatch.setenv("REPOWISE_API_KEY", "some-key")
+
+    result = CliRunner().invoke(
+        cli,
+        ["mcp", str(tmp_path), "--transport", "streamable-http", "--host", "0.0.0.0"],
+    )
+
+    assert result.exit_code == 0
+    assert "SECURITY WARNING" not in result.output
+
+
+def test_run_mcp_sets_host_on_settings(monkeypatch) -> None:
+    """run_mcp sets mcp.settings.host (parallel to existing port test)."""
+    from repowise.server.mcp_server import _server
+
+    calls: list[dict] = []
+    monkeypatch.setattr(_server.mcp, "run", lambda **kw: calls.append(kw))
+    monkeypatch.delenv("REPOWISE_API_KEY", raising=False)
+
+    _server.run_mcp(transport="streamable-http", host="0.0.0.0", port=7343)
+
+    assert _server.mcp.settings.host == "0.0.0.0"
+    assert _server.mcp.settings.port == 7343
+    assert calls == [{"transport": "streamable-http"}]


### PR DESCRIPTION
## Summary

- Added `--host` option to `repowise mcp` CLI command (defaults to `REPOWISE_HOST` env var or `127.0.0.1`).
- Ensured `run_mcp` explicitly assigns `mcp.settings.host = host` for `streamable-http` and `sse` transports so network bind host is strictly controlled by repowise.
- Updated startup banner and server log output to warn when binding to wide interfaces (`0.0.0.0`, `::`) without `REPOWISE_API_KEY` set (matching `repowise serve` security posture).

## Related Issues

Fixes #1400 

## Test Plan

- [x] Unit tests pass (`pytest tests/unit/cli/test_mcp_transport.py`)
- [x] Verified `--host` flag pass-through to `run_mcp`
- [x] Verified `REPOWISE_HOST` environment variable inheritance
- [x] Verified security warning triggers on `0.0.0.0` when `REPOWISE_API_KEY` is not set
- [x] Verified no warning triggers when `REPOWISE_API_KEY` is present

## Checklist

- [x] My code follows the project's code style
- [x] I have added tests for new functionality
- [x] All existing tests still pass
