### PR TITLE
fix(ui): align chat tool labels with the live 7-tool registry

### DIFF
--- a/packages/ui/src/chat/source-citations.tsx
+++ b/packages/ui/src/chat/source-citations.tsx
@@ -110,21 +110,6 @@ export function extractSources(
         }
       }
     }
-
-    if (tc.name === "get_architecture_diagram") {
-      const pageId = "architecture_diagram:";
-      if (!seen.has(pageId)) {
-        seen.add(pageId);
-        sources.push({
-          id: `${tc.id}:arch-diagram`,
-          pageId,
-          title: "Knowledge Graph",
-          pageType: "architecture_diagram",
-          targetPath: "",
-          toolName: tc.name,
-        });
-      }
-    }
   }
 
   return sources;

--- a/packages/ui/src/chat/tool-call-block.tsx
+++ b/packages/ui/src/chat/tool-call-block.tsx
@@ -21,11 +21,10 @@ const TOOL_LABELS: Record<string, string> = {
   get_overview: "Getting codebase overview",
   get_context: "Looking up context",
   get_risk: "Assessing risk",
+  get_change_risk: "Scoring change risk",
   get_why: "Querying decisions",
   search_codebase: "Searching codebase",
-  get_dependency_path: "Tracing dependency path",
   get_dead_code: "Checking dead code",
-  get_architecture_diagram: "Generating architecture diagram",
 };
 
 const MICRO_LABEL =


### PR DESCRIPTION
## Summary
- Remove dead `get_dependency_path` / `get_architecture_diagram` labels and citation branch
- Add `get_change_risk` label so chat steps show a real name

## Why
Follow-up from chat registry consolidation: UI still mapped removed tools and omitted `get_change_risk`. Not covered by docs PR #1173.

## Test plan
- [x] Labels match `chat_tools.py` registry names
- [x] No `get_architecture_diagram` citation source