### PR TITLE
fix(ui): replace dead architecture-diagram chat suggestion

### DIFF
--- a/packages/ui/src/chat/chat-interface.tsx
+++ b/packages/ui/src/chat/chat-interface.tsx
@@ -38,7 +38,7 @@ import type { SourceReference } from "./source-citations";
 const DEFAULT_SUGGESTIONS = [
   "Give me an overview of this codebase",
   "What are the highest-risk files to modify?",
-  "Show me the architecture diagram",
+  "Score the change risk of HEAD",
   "What dead code can be safely removed?",
   "What architectural decisions have been made?",
   "Search for authentication-related code",


### PR DESCRIPTION
## Summary
- Empty-state suggestion still asked for an architecture diagram from a removed chat tool
- Replace with a `get_change_risk`-shaped prompt

## Why
Users clicking the suggestion would hit a tool the chat registry no longer exposes.

## Test plan
- [x] `DEFAULT_SUGGESTIONS` no longer mentions architecture diagram