### PR TITLE
fix(server): drop dead get_architecture_diagram chat summary

### DIFF
--- a/packages/server/src/repowise/server/routers/chat.py
+++ b/packages/server/src/repowise/server/routers/chat.py
@@ -584,7 +584,4 @@ def _build_tool_summary(tool_name: str, result: dict[str, Any]) -> str:
         lines = summary.get("deletable_lines", 0)
         return f"{total} findings ({high_count} high-confidence), {lines} deletable lines"
 
-    if tool_name == "get_architecture_diagram":
-        return f"Generated {result.get('diagram_type', 'diagram')}"
-
     return "Completed"


### PR DESCRIPTION
## Summary
- Remove unreachable `_build_tool_summary` branch for `get_architecture_diagram`

## Why
Tool was removed from the chat registry; the summary handler could never fire.

## Test plan
- [x] Diff removes only the dead branch