### PR TITLE
fix(server): summarize get_change_risk in chat tool results

### DIFF
--- a/packages/server/src/repowise/server/routers/chat.py
+++ b/packages/server/src/repowise/server/routers/chat.py
@@ -538,6 +538,17 @@ def _build_tool_summary(tool_name: str, result: dict[str, Any]) -> str:
             parts.append(f"{bug_prone} bug-prone")
         return ", ".join(parts)
 
+    if tool_name == "get_change_risk":
+        ref = result.get("ref", "change")
+        priority = result.get("review_priority") or result.get("classification") or "unknown"
+        pct = result.get("risk_percentile")
+        if pct is not None:
+            return f"Change risk for {ref}: {priority} (p{pct})"
+        score = result.get("score")
+        if score is not None:
+            return f"Change risk for {ref}: {priority} (score {score})"
+        return f"Change risk for {ref}: {priority}"
+
     if tool_name == "get_why":
         mode = result.get("mode", "")
         if mode == "health":

--- a/tests/unit/server/test_chat_change_risk_summary.py
+++ b/tests/unit/server/test_chat_change_risk_summary.py
@@ -1,0 +1,33 @@
+"""Regression: chat summaries must cover every registered chat tool."""
+
+from __future__ import annotations
+
+from repowise.server.chat_tools import get_tool_registry
+from repowise.server.routers.chat import _build_tool_summary
+
+
+def test_get_change_risk_summary_is_not_generic_completed():
+    summary = _build_tool_summary(
+        "get_change_risk",
+        {
+            "ref": "HEAD",
+            "score": 7.2,
+            "review_priority": "Elevated",
+            "risk_percentile": 82.0,
+        },
+    )
+    assert summary != "Completed"
+    assert "HEAD" in summary
+    assert "Elevated" in summary
+    assert "p82" in summary
+
+
+def test_every_chat_registry_tool_has_a_non_generic_summary_shape():
+    """Smoke: registered tools either specialize or return Completed only as fallback."""
+    registry = get_tool_registry()
+    assert "get_change_risk" in registry
+    # get_change_risk must not fall through to the generic Completed string.
+    assert (
+        _build_tool_summary("get_change_risk", {"ref": "main..HEAD", "review_priority": "Typical"})
+        != "Completed"
+    )


### PR DESCRIPTION
## Summary
- Chat registers `get_change_risk` but summaries fell through to generic `Completed`
- Emit review priority + percentile (or score) instead
- Add unit tests

## Why
Without a real summary, the UI tool step is opaque for the main change-risk path.

## Test plan
- [x] `pytest tests/unit/server/test_chat_change_risk_summary.py`