### PR TITLE
fix(server): align chat system prompt with the 7-tool registry

### DIFF
--- a/packages/server/src/repowise/server/routers/chat.py
+++ b/packages/server/src/repowise/server/routers/chat.py
@@ -41,11 +41,12 @@ _MAX_AGENTIC_LOOPS = 10
 
 _SYSTEM_PROMPT_TEMPLATE = """You are a codebase intelligence assistant for the repository "{repo_name}" located at {repo_path}.
 
-You have access to 8 specialized tools for querying the codebase wiki, dependency graph, git history, and architectural decisions. Use them proactively — do NOT answer from memory when a tool gives more accurate answers.
+You have access to 7 specialized tools for querying the codebase wiki, dependency graph, git history, and architectural decisions. Use them proactively — do NOT answer from memory when a tool gives more accurate answers.
 
 Guidelines:
 - Call get_overview first if the user asks about the codebase generally and no prior context exists
 - Pass all relevant targets to get_context and get_risk in a single call — never call the same tool twice for different targets when they can be batched
+- Call get_change_risk for commit / PR-range defect scoring (revspec)
 - Call get_why for any "why was this built this way" question
 - Call search_codebase for broad questions about where something is implemented
 - Cite specific file paths, function names, and line numbers from tool results — be concrete, not general

--- a/tests/unit/server/test_chat_system_prompt_tools.py
+++ b/tests/unit/server/test_chat_system_prompt_tools.py
@@ -1,0 +1,13 @@
+"""Chat system prompt must match the live tool registry size."""
+
+from __future__ import annotations
+
+from repowise.server.chat_tools import get_tool_registry
+from repowise.server.routers.chat import _build_system_prompt
+
+
+def test_system_prompt_tool_count_matches_registry():
+    n = len(get_tool_registry())
+    prompt = _build_system_prompt("demo", "/tmp/demo")
+    assert f"{n} specialized tools" in prompt
+    assert "get_change_risk" in prompt


### PR DESCRIPTION
## Summary
- System prompt claimed **8** specialized tools; live registry has **7**
- Mention `get_change_risk` in guidelines
- Drift test against `get_tool_registry()`

## Why
Wrong count mis-trains the chat model about available tools.

## Test plan
- [x] `pytest tests/unit/server/test_chat_system_prompt_tools.py`
- [x] `len(get_tool_registry()) == 7`