### PR TITLE
fix(mcp): align FastMCP instructions with the live tool surface

### DIFF
--- a/packages/server/src/repowise/server/mcp_server/_server.py
+++ b/packages/server/src/repowise/server/mcp_server/_server.py
@@ -521,9 +521,10 @@ mcp = FastMCP(
     instructions=(
         "repowise is a codebase documentation engine. Use these tools to query "
         "the wiki for architecture overviews, contextual docs on files/modules/"
-        "symbols, modification risk assessment, architectural decision rationale, "
-        "semantic search, dependency paths, dead code, and architecture diagrams. "
-        "If the tools report that the repo has no index, tell the user to run "
+        "symbols, modification and change-risk assessment, architectural decision "
+        "rationale, semantic search, dead code, and code health. In workspace mode, "
+        "get_architecture and get_blast_radius are also available. If the tools "
+        "report that the repo has no index, tell the user to run "
         "'repowise init --yes' in the repo root; it needs no API key. Suggest it, "
         "do not run it yourself."
     ),


### PR DESCRIPTION
## Summary
- MCP server blurb still advertised architecture diagrams and default dependency paths
- Update instructions to match default tools (change-risk, health) + workspace extras

## Why
Agents read FastMCP `instructions` at connect time; stale copy steers them toward removed/opt-in surfaces.

## Test plan
- [x] Diff against `docs/agent/MCP_TOOLS.md` default set