### PR TITLE
fix(server): drop unused get_dependency_path chat summary

### DIFF
--- a/packages/server/src/repowise/server/routers/chat.py
+++ b/packages/server/src/repowise/server/routers/chat.py
@@ -564,18 +564,6 @@ def _build_tool_summary(tool_name: str, result: dict[str, Any]) -> str:
         results = result.get("results", [])
         return f"Found {len(results)} result(s)"
 
-    if tool_name == "get_dependency_path":
-        dist = result.get("distance", -1)
-        if dist >= 0:
-            return f"Path found (distance: {dist})"
-        ctx = result.get("visual_context", {})
-        ancestors = ctx.get("nearest_common_ancestors", [])
-        if ancestors:
-            return f"No direct path — nearest bridge: {ancestors[0]['node']}"
-        if ctx.get("disconnected"):
-            return "No path — nodes are in separate dependency clusters"
-        return "No direct path found"
-
     if tool_name == "get_dead_code":
         summary = result.get("summary", {})
         tiers = result.get("tiers", {})


### PR DESCRIPTION
## Summary
- Remove unreachable `_build_tool_summary` branch for `get_dependency_path`

## Why
Chat never registers that tool (MCP opt-in only); the summary branch was dead code.

## Test plan
- [x] Diff removes only the dead branch