### PR TITLE
feat(claude-plugin): add /repowise:context slash command and docs

### DIFF
--- a/plugins/claude-code/CHANGELOG.md
+++ b/plugins/claude-code/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the Repowise Claude Code plugin are documented here.
 
+## Unreleased
+
+### Added
+- `/repowise:context` runs `repowise context` — the CLI adapter over
+  `get_context` — so Claude can pull triage cards (layer, hotspot, fix history,
+  freshness) for files, modules, or symbols without MCP-only flows.
+
 ## 0.40.0
 
 ### Added

--- a/plugins/claude-code/README.md
+++ b/plugins/claude-code/README.md
@@ -50,6 +50,7 @@ defect-validated score from deterministic markers).
 | `/repowise:status` | Health check — sync state, page counts, provider info |
 | `/repowise:update` | Incremental update — sync the index with recent code changes |
 | `/repowise:search` | Search the codebase wiki (fulltext, semantic, or symbol) |
+| `/repowise:context` | Triage card for files/modules/symbols (layer, hotspot, freshness) |
 | `/repowise:reindex` | Rebuild the vector store (re-embed; no LLM calls) |
 | `/repowise:health` | Code-health KPIs, lowest-scoring files, refactoring targets, trends |
 | `/repowise:coverage` | Ingest or inspect coverage reports (lights up untested hotspots + per-test map) |

--- a/plugins/claude-code/commands/context.md
+++ b/plugins/claude-code/commands/context.md
@@ -1,0 +1,50 @@
+---
+description: Triage card for files, modules, or symbols — layer, hotspot, fix history, freshness (relationships, not source bytes).
+allowed-tools: Bash, Read
+---
+
+# Repowise Context
+
+Pull a triage card for one or more files, modules, or symbols. This is the CLI
+adapter over `get_context`: title, summary, architectural layer, hotspot /
+bug-fix history, doc freshness, and optional relationship blocks. Relationships
+and risk signals — **not** source bytes by default.
+
+## Steps
+
+1. If `.repowise/` doesn't exist: "This repo isn't indexed yet. Run `/repowise:init` first." Stop.
+2. Resolve targets from `$ARGUMENTS`. If empty, ask which file / module /
+   `path::Symbol` to inspect.
+3. Run `repowise context` and present each card: layer, stale bit, hotspot,
+   summary. Call out fix history when present.
+
+## Choosing the invocation
+
+TARGETS are file paths, module paths, or `path/to/file.py::Symbol` ids. Batch
+them in one call.
+
+- Default triage → `repowise context <targets…>`
+- Opt-in blocks (repeatable) → `--include callers|callees|ownership|metrics|decisions|skeleton|…`
+- Richer card → `repowise context <targets…> --no-compact`
+- Machine-readable / raw payload → `--format json` / `--full`
+
+```
+repowise context src/api/routes.py src/api/auth.py
+repowise context src/api/routes.py::login --include callers --include metrics
+repowise context src/api/routes.py --include skeleton
+```
+
+`--include skeleton` adds the body-elided, line-verified file shape. For the
+exact function body, prefer `/repowise:symbol` (or `get_symbol`) with a
+`symbol_id` from the card.
+
+Shared targeting flags (`--path`, `--repo`, `--no-workspace`) work the same as
+the other tool-adapter commands.
+
+## Notes
+
+- Prefer this before opening many files with Read — one call batches cards.
+- A target the index cannot resolve returns an `error` card; report that
+  plainly instead of inventing structure.
+- For a synthesised Q&A answer, use `/repowise:ask`. For "why is it shaped
+  this way", use `/repowise:why`.

--- a/plugins/claude-code/skills/codebase-exploration/SKILL.md
+++ b/plugins/claude-code/skills/codebase-exploration/SKILL.md
@@ -55,6 +55,9 @@ Otherwise the response is current — act on it.
   Add `--no-editor-setup` if this repo is a scratch clone, a fixture, or a
   worktree: `init` otherwise repoints the user's single global `repowise` MCP
   entry at it.
+- MCP tools unavailable → prefer the matching CLI slash commands when the
+  plugin is installed (`/repowise:context` for triage cards, `/repowise:search`
+  for wiki search) rather than grepping blind.
 - `get_answer`/`search_codebase` come back empty → the repo may have a
   template-rendered wiki. Fall back to `get_context` with explicit paths, and note
   that model-written pages (`repowise generate`, or `/repowise:init` with an LLM

--- a/tests/unit/cli/test_claude_plugin.py
+++ b/tests/unit/cli/test_claude_plugin.py
@@ -155,6 +155,7 @@ def test_claude_plugin_commands_have_frontmatter() -> None:
     command_paths = sorted((PLUGIN_ROOT / "commands").glob("*.md"))
 
     assert {path.stem for path in command_paths} == {
+        "context",
         "coverage",
         "dead-code",
         "decision",

--- a/website/claude-code-plugin.md
+++ b/website/claude-code-plugin.md
@@ -96,6 +96,16 @@ Claude will ask for your query and search mode (fulltext, semantic, or symbol), 
 
 ---
 
+### `/repowise:context`
+
+Triage card for files, modules, or symbols (`repowise context`). CLI adapter
+over `get_context`: architectural layer, hotspot / fix history, doc freshness,
+and optional relationship blocks (`--include callers`, `skeleton`, …). Batch
+targets in one call. No source bytes by default — use `/repowise:symbol` for
+exact bodies.
+
+---
+
 ### `/repowise:reindex`
 
 Rebuild the vector search index without making LLM calls.

--- a/website/cli-reference.md
+++ b/website/cli-reference.md
@@ -262,6 +262,44 @@ repowise search "database connection" --limit 20
 
 ---
 
+## `context`
+
+Triage card for files, modules or symbols: title, summary, architectural layer,
+hotspot and bug-fix history, doc freshness, and the shape of the verified
+skeleton. Relationships and risk signals, not source bytes. Batch targets in one
+call.
+
+```bash
+repowise context <TARGETS...> [OPTIONS]
+```
+
+TARGETS are file paths, module paths, or `path/to/file.py::Symbol` ids.
+
+### Options
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--include` | choice | — | Opt-in block, repeatable: `full_doc`, `ownership`, `last_change`, `callers`, `callees`, `metrics`, `community`, `decisions`, `skeleton` |
+| `--no-compact` | flag | false | Add structure, imports and docstrings to each card |
+| `--path` | string | cwd | Repo (or workspace) root |
+| `--repo` | string | — | Workspace repo alias to query |
+| `--no-workspace` | flag | false | Force single-repo mode even inside a workspace |
+| `--format` | choice | table | `table` or `json` |
+| `--full` | flag | false | Emit the raw MCP tool payload |
+
+### Examples
+
+```bash
+repowise context src/api/routes.py src/api/auth.py
+repowise context src/api/routes.py::login --include callers --include metrics
+repowise context src/api/routes.py --include skeleton   # + the file's source shape
+```
+
+Pass `--include skeleton` for the whole file body-elided and line-verified, or
+use [`symbol`](#symbol) for one function body. Also available as `/repowise:context`.
+
+---
+
 ## `reindex`
 
 Rebuild the vector search index from existing wiki pages. Does not make LLM calls.


### PR DESCRIPTION
## Summary
- Add `/repowise:context` Claude Code slash command over the `repowise context` / `get_context` CLI adapter (triage cards for files/modules/symbols).
- Document `context` on the website CLI reference and Claude plugin page.
- Update plugin README/CHANGELOG, exploration skill CLI fallback, and command inventory test.

## Test plan
- [x] `pytest tests/unit/cli/test_claude_plugin.py`
- [x] `/repowise:context packages/cli/src/repowise/cli/main.py` on an indexed repo
- [x] Confirm website sections render