### PR TITLE
feat(claude-plugin): add /repowise:symbol slash command and docs

### DIFF
--- a/plugins/claude-code/CHANGELOG.md
+++ b/plugins/claude-code/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the Repowise Claude Code plugin are documented here.
 
+## Unreleased
+
+### Added
+- `/repowise:symbol` runs `repowise symbol` — the CLI adapter over
+  `get_symbol` — so Claude can fetch one live-verified symbol body (or a
+  distill omission ref) without MCP-only flows.
+
 ## 0.40.0
 
 ### Added

--- a/plugins/claude-code/README.md
+++ b/plugins/claude-code/README.md
@@ -50,6 +50,7 @@ defect-validated score from deterministic markers).
 | `/repowise:status` | Health check — sync state, page counts, provider info |
 | `/repowise:update` | Incremental update — sync the index with recent code changes |
 | `/repowise:search` | Search the codebase wiki (fulltext, semantic, or symbol) |
+| `/repowise:symbol` | Read one symbol body with live-verified line bounds |
 | `/repowise:reindex` | Rebuild the vector store (re-embed; no LLM calls) |
 | `/repowise:health` | Code-health KPIs, lowest-scoring files, refactoring targets, trends |
 | `/repowise:coverage` | Ingest or inspect coverage reports (lights up untested hotspots + per-test map) |

--- a/plugins/claude-code/commands/symbol.md
+++ b/plugins/claude-code/commands/symbol.md
@@ -1,0 +1,48 @@
+---
+description: Read one symbol's body with live-verified line bounds (path::Name, live range, or distill omission ref).
+allowed-tools: Bash, Read
+---
+
+# Repowise Symbol
+
+Read one function, class, or constant with live-verified line bounds. This is
+the CLI adapter over `get_symbol`. Prefer it over a raw file Read when you
+already have a `symbol_id` from `/repowise:context` or `search_codebase`.
+
+## Steps
+
+1. If `.repowise/` doesn't exist: "This repo isn't indexed yet. Run `/repowise:init` first." Stop.
+2. Resolve the symbol id from `$ARGUMENTS`. If empty, ask for
+   `path/to/file.py::Name`, a live range (`path:start-end`), or a
+   `repowise#<hex>` omission ref from distill.
+3. Run `repowise symbol` and present the body. Report `verified: true/false`
+   when shown. If the id is ambiguous, show every matching body — do not
+   silently pick one.
+
+## Choosing the invocation
+
+- Named symbol → `repowise symbol "src/api/routes.py::login"`
+- Live range read → `repowise symbol "src/api/routes.py:140-180"`
+- Distill omission ref → `repowise symbol "repowise#a1b2c3d4e5f6"`
+- Extra surrounding lines → `--context-lines N` (0–50)
+- Filter restored omission lines → `--query <regex-or-substring>`
+- Machine-readable / raw payload → `--format json` / `--full`
+
+```
+repowise symbol "src/api/routes.py::login"
+repowise symbol "src/api/routes.py:140-180"
+repowise symbol "repowise#a1b2c3d4e5f6"
+repowise symbol "src/api/routes.py::login" --context-lines 3
+```
+
+A truncated body carries a `continuation` you can pass straight back to
+`repowise symbol`. Shared targeting flags (`--path`, `--repo`,
+`--no-workspace`) match the other tool-adapter commands.
+
+## Notes
+
+- Cheaper and more precise than Read + offset math when you have a
+  `symbol_id`.
+- For triage (layer / hotspot / callers) without bytes, use
+  `/repowise:context`.
+- Never invent source — if the command errors or returns no body, say so.

--- a/plugins/claude-code/skills/codebase-exploration/SKILL.md
+++ b/plugins/claude-code/skills/codebase-exploration/SKILL.md
@@ -55,6 +55,9 @@ Otherwise the response is current — act on it.
   Add `--no-editor-setup` if this repo is a scratch clone, a fixture, or a
   worktree: `init` otherwise repoints the user's single global `repowise` MCP
   entry at it.
+- MCP tools unavailable → prefer the matching CLI slash commands when the
+  plugin is installed (`/repowise:symbol` for a live-verified body,
+  `/repowise:search` for wiki search) rather than grepping blind.
 - `get_answer`/`search_codebase` come back empty → the repo may have a
   template-rendered wiki. Fall back to `get_context` with explicit paths, and note
   that model-written pages (`repowise generate`, or `/repowise:init` with an LLM

--- a/tests/unit/cli/test_claude_plugin.py
+++ b/tests/unit/cli/test_claude_plugin.py
@@ -167,6 +167,7 @@ def test_claude_plugin_commands_have_frontmatter() -> None:
         "search",
         "security",
         "status",
+        "symbol",
         "update",
     }
 

--- a/website/claude-code-plugin.md
+++ b/website/claude-code-plugin.md
@@ -96,6 +96,16 @@ Claude will ask for your query and search mode (fulltext, semantic, or symbol), 
 
 ---
 
+### `/repowise:symbol`
+
+Read one symbol body with live-verified line bounds (`repowise symbol`). CLI
+adapter over `get_symbol`. Accepts `path/to/file.py::Name`, a live range
+(`path:start-end`), or a `repowise#<hex>` distill omission ref.
+`--context-lines` adds surrounding lines; a truncated body returns a
+`continuation` you can pass straight back.
+
+---
+
 ### `/repowise:reindex`
 
 Rebuild the vector search index without making LLM calls.

--- a/website/cli-reference.md
+++ b/website/cli-reference.md
@@ -262,6 +262,46 @@ repowise search "database connection" --limit 20
 
 ---
 
+## `symbol`
+
+Read one function, class or constant with live-verified line bounds. `source`
+arrives in the same line-numbered format a file read produces; `verified: true`
+means the bounds were checked against the live file.
+
+```bash
+repowise symbol <SYMBOL_ID> [OPTIONS]
+```
+
+`SYMBOL_ID` is `path/to/file.py::Name` (as `repowise context` reports it),
+`path/to/file.py:140-180` for a live range read, or a `repowise#<hex>`
+omission ref from a distilled command.
+
+### Options
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--context-lines` | int | 0 | Extra lines before and after the body (0–50) |
+| `--query` | string | — | Omission refs only: regex or substring filter on restored lines |
+| `--path` | string | cwd | Repo (or workspace) root |
+| `--repo` | string | — | Workspace repo alias to query |
+| `--no-workspace` | flag | false | Force single-repo mode even inside a workspace |
+| `--format` | choice | table | `table` or `json` |
+| `--full` | flag | false | Emit the raw MCP tool payload |
+
+### Examples
+
+```bash
+repowise symbol "src/api/routes.py::login"
+repowise symbol "src/api/routes.py:140-180"     # live range read
+repowise symbol "repowise#a1b2c3d4e5f6"          # a distill omission ref
+```
+
+An ambiguous id returns every matching body rather than silently picking one.
+A truncated body carries a `continuation` you can pass straight back.
+Also available as `/repowise:symbol`.
+
+---
+
 ## `reindex`
 
 Rebuild the vector search index from existing wiki pages. Does not make LLM calls.


### PR DESCRIPTION
## Summary
- Add `/repowise:symbol` Claude Code slash command over the `repowise symbol` / `get_symbol` CLI adapter (live-verified bodies + distill omission refs).
- Document `symbol` on the website CLI reference and Claude plugin page.
- Update plugin README/CHANGELOG, exploration skill CLI fallback, and command inventory test.

## Test plan
- [x] `pytest tests/unit/cli/test_claude_plugin.py`
- [x] `/repowise:symbol "path/to/file.py::Name"` on an indexed repo
- [x] Confirm website sections render