### PR TITLE
feat(claude-plugin): add /repowise:why slash command and docs

### DIFF
--- a/plugins/claude-code/CHANGELOG.md
+++ b/plugins/claude-code/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the Repowise Claude Code plugin are documented here.
 
+## Unreleased
+
+### Added
+- `/repowise:why` runs `repowise why` — the CLI adapter over `get_why` — so
+  Claude can query decisions, alignment, and git archaeology (or the
+  decision-health dashboard) without MCP-only flows.
+
 ## 0.40.0
 
 ### Added

--- a/plugins/claude-code/README.md
+++ b/plugins/claude-code/README.md
@@ -58,6 +58,7 @@ defect-validated score from deterministic markers).
 | `/repowise:security` | Full-history secret scan (`repowise security scan --history`) |
 | `/repowise:dead-code` | Unreachable files, unused exports, zombie packages by confidence |
 | `/repowise:decision` | List, inspect, add, or confirm architectural decisions |
+| `/repowise:why` | Why the code is shaped this way (decisions + archaeology) |
 | `/repowise:doctor` | Diagnose (and optionally repair) the setup, keys, and index drift |
 
 ### Automatic skills

--- a/plugins/claude-code/commands/why.md
+++ b/plugins/claude-code/commands/why.md
@@ -1,0 +1,48 @@
+---
+description: Why the code is shaped this way — decisions, rationale, and git archaeology (question, path, or decision-health dashboard).
+allowed-tools: Bash, Read
+---
+
+# Repowise Why
+
+Answer *why* the code looks the way it does: decision records, rationale, and
+git archaeology. This is the CLI adapter over `get_why`. Worth running before a
+refactor or a deliberate divergence from a pattern.
+
+`/repowise:decision` manages decision records (list / add / confirm). This
+command **queries** why something is shaped a certain way.
+
+## Steps
+
+1. If `.repowise/` doesn't exist: "This repo isn't indexed yet. Run `/repowise:init` first." Stop.
+2. Map `$ARGUMENTS` to a mode (below), run `repowise why`, and present
+   decisions, alignment, and archaeology. Never invent rationale — if the
+   command falls back to git archaeology, say that plainly.
+
+## Modes
+
+- Question → `repowise why "why is auth using JWT?"`
+- File path (governing decisions + origin story) → `repowise why src/api/auth.py`
+- Target-anchored search → `repowise why "why the retry cap?" --target src/api/client.py`
+  (`--target` is repeatable)
+- No args → `repowise why` (decision-health dashboard: stale / proposed /
+  ungoverned hotspots)
+- Machine-readable / raw payload → `--format json` / `--full`
+
+```
+repowise why "why is auth using JWT?"
+repowise why src/api/auth.py
+repowise why "why the retry cap?" --target src/api/client.py
+repowise why
+```
+
+Shared targeting flags (`--path`, `--repo`, `--no-workspace`) match the other
+tool-adapter commands.
+
+## Notes
+
+- Falls back to git archaeology when a path has no decisions, so it is never
+  empty — call that out so the user knows it is reconstructed, not recorded.
+- For *managing* ADR records (add / confirm / deprecate), use
+  `/repowise:decision`.
+- Before contradicting an existing decision, surface it to the user first.

--- a/plugins/claude-code/skills/architectural-decisions/SKILL.md
+++ b/plugins/claude-code/skills/architectural-decisions/SKILL.md
@@ -45,8 +45,10 @@ Call `get_why()` with no arguments to get the decision-health dashboard:
 - Proposed decisions awaiting confirmation
 - Ungoverned hotspots (high-churn files with no recorded decisions)
 
-The same signals surface in the CLI via `repowise decision health`, and you can
-review auto-proposed decisions with `repowise decision confirm`.
+The same signals surface in the CLI via `repowise decision health` /
+`/repowise:decision`, and you can query *why* mid-task with `repowise why` /
+`/repowise:why` (the `get_why` adapter). Review auto-proposed decisions with
+`repowise decision confirm`.
 
 ## When a file has decision markers
 

--- a/tests/unit/cli/test_claude_plugin.py
+++ b/tests/unit/cli/test_claude_plugin.py
@@ -168,6 +168,7 @@ def test_claude_plugin_commands_have_frontmatter() -> None:
         "security",
         "status",
         "update",
+        "why",
     }
 
     for path in command_paths:

--- a/website/claude-code-plugin.md
+++ b/website/claude-code-plugin.md
@@ -152,6 +152,16 @@ List, inspect, add, or confirm architectural decisions.
 
 ---
 
+### `/repowise:why`
+
+Why the code is shaped this way (`repowise why`). CLI adapter over `get_why`:
+decision search by question, governing decisions + origin story for a path,
+target-anchored search (`--target`), or the decision-health dashboard with no
+args. Falls back to git archaeology when no decision is recorded.
+`/repowise:decision` manages records; this command queries them.
+
+---
+
 ### `/repowise:doctor`
 
 Diagnose (and optionally repair) setup, keys, and index drift.

--- a/website/cli-reference.md
+++ b/website/cli-reference.md
@@ -262,6 +262,46 @@ repowise search "database connection" --limit 20
 
 ---
 
+## `why`
+
+Why the code is shaped this way: decision records, rationale and git
+archaeology. Worth running before a refactor or a deliberate divergence from a
+pattern.
+
+```bash
+repowise why [QUERY] [OPTIONS]
+```
+
+QUERY is a question (`why is auth using JWT?`), a file path (its governing
+decisions, origin story and alignment score), or omitted for the
+decision-health dashboard.
+
+### Options
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--target` | string | — | File path to anchor the search to (repeatable) |
+| `--path` | string | cwd | Repo (or workspace) root |
+| `--repo` | string | — | Workspace repo alias to query |
+| `--no-workspace` | flag | false | Force single-repo mode even inside a workspace |
+| `--format` | choice | table | `table` or `json` |
+| `--full` | flag | false | Emit the raw MCP tool payload |
+
+### Examples
+
+```bash
+repowise why "why is auth using JWT?"           # question
+repowise why src/api/auth.py                     # governing decisions + origin story
+repowise why "why the retry cap?" --target src/api/client.py
+repowise why                                     # decision health dashboard
+```
+
+Falls back to git archaeology when a path has no decisions, so it is never
+empty. Also available as `/repowise:why`. Use `repowise decision` /
+`/repowise:decision` to manage the records themselves.
+
+---
+
 ## `reindex`
 
 Rebuild the vector search index from existing wiki pages. Does not make LLM calls.


### PR DESCRIPTION
## Summary
- Add `/repowise:why` Claude Code slash command over the `repowise why` / `get_why` CLI adapter (decisions, alignment, archaeology, health dashboard).
- Document `why` on the website CLI reference and Claude plugin page; distinguish from `/repowise:decision` record management.
- Update architectural-decisions skill, plugin README/CHANGELOG, and command inventory test.

## Test plan
- [x] `pytest tests/unit/cli/test_claude_plugin.py`
- [x] `/repowise:why` and `/repowise:why "why is X?"` on an indexed repo
- [x] Confirm website sections render