### PR TITLE
feat(claude-plugin): add /repowise:export slash command and docs

### DIFF
--- a/plugins/claude-code/CHANGELOG.md
+++ b/plugins/claude-code/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the Repowise Claude Code plugin are documented here.
 
+## Unreleased
+
+### Added
+- `/repowise:export` runs `repowise export` so Claude can dump the wiki to
+  markdown / HTML / JSON (including `--full` archives) or emit a Structurizr
+  DSL architecture model without leaving the session.
+
 ## 0.40.0
 
 ### Added

--- a/plugins/claude-code/README.md
+++ b/plugins/claude-code/README.md
@@ -57,6 +57,7 @@ defect-validated score from deterministic markers).
 | `/repowise:risk` | Defect-risk score for a change (commit or `base..head` range) |
 | `/repowise:security` | Full-history secret scan (`repowise security scan --history`) |
 | `/repowise:dead-code` | Unreachable files, unused exports, zombie packages by confidence |
+| `/repowise:export` | Export wiki pages or a Structurizr architecture model |
 | `/repowise:decision` | List, inspect, add, or confirm architectural decisions |
 | `/repowise:doctor` | Diagnose (and optionally repair) the setup, keys, and index drift |
 

--- a/plugins/claude-code/commands/export.md
+++ b/plugins/claude-code/commands/export.md
@@ -1,0 +1,60 @@
+---
+description: Export the wiki (or architecture model) to markdown, HTML, JSON, or Structurizr DSL.
+allowed-tools: Bash, Read
+---
+
+# Repowise Export
+
+Export indexed wiki pages to files, or emit a Structurizr DSL architecture
+model. Use this when the user wants a shareable dump, a static site, a JSON
+archive, or a C4/Structurizr model — not when they need an interactive Q&A
+answer (`/repowise:ask`).
+
+## Steps
+
+1. If `.repowise/` doesn't exist: "This repo isn't indexed yet. Run `/repowise:init` first." Stop.
+2. Resolve format and output from `$ARGUMENTS` (see below).
+3. Run `repowise export` and report where files were written (page count /
+   output path). Do not invent page content.
+
+## Choosing the invocation
+
+Default — markdown under `.repowise/export`:
+```
+repowise export
+```
+
+Handle `$ARGUMENTS`:
+- "html" / "site" → `repowise export --format html`
+- "json" → `repowise export --format json`
+- "json full" / "archive" → `repowise export --format json --full`
+  (`--full` keeps tombstones and adds decisions / dead code / hotspots)
+- "structurizr" / "c4" / "dsl" → `repowise export --format structurizr`
+- "structurizr standalone" → `repowise export --format structurizr --standalone`
+- "structurizr components" → add `--components`
+- "to <dir>" / "-o <dir>" → pass `--output <dir>`
+  (for structurizr, a path ending in `.dsl` names the file itself)
+- A repo path → `repowise export <path> …`
+
+```
+repowise export
+repowise export --format html -o ./site
+repowise export --format json --full
+repowise export --format structurizr --standalone --components
+repowise export --format structurizr -o architecture.dsl
+```
+
+## Structurizr notes
+
+- Default structurizr output is a **model fragment** to include from your own
+  `workspace.dsl`. Pass `--standalone` for a complete workspace with default
+  views.
+- `--force` overwrites an output file even if Repowise did not write it
+  (`--standalone` often targets `workspace.dsl`).
+- `--no-externals` leaves third-party dependencies out of the model.
+
+## Notes
+
+- Markdown / HTML / JSON write a directory of pages; structurizr writes DSL.
+- Never fabricate export contents. If the command reports no pages, say so and
+  suggest `/repowise:init`.

--- a/tests/unit/cli/test_claude_plugin.py
+++ b/tests/unit/cli/test_claude_plugin.py
@@ -159,6 +159,7 @@ def test_claude_plugin_commands_have_frontmatter() -> None:
         "dead-code",
         "decision",
         "doctor",
+        "export",
         "health",
         "impacted-tests",
         "init",

--- a/website/claude-code-plugin.md
+++ b/website/claude-code-plugin.md
@@ -146,6 +146,16 @@ Unreachable files, unused exports, and zombie packages by confidence.
 
 ---
 
+### `/repowise:export`
+
+Export wiki pages or the architecture model (`repowise export`). Formats:
+`markdown` (default), `html`, `json`, and `structurizr`. JSON `--full` keeps
+tombstones and adds decisions / dead code / hotspots. Structurizr can emit a
+model fragment or a `--standalone` workspace (`--components`,
+`--no-externals`, `--force`).
+
+---
+
 ### `/repowise:decision`
 
 List, inspect, add, or confirm architectural decisions.

--- a/website/cli-reference.md
+++ b/website/cli-reference.md
@@ -598,7 +598,7 @@ See [CLAUDE.md Generator →](claude-md-generator) for how the file is structure
 
 ## `export`
 
-Export wiki pages to files.
+Export wiki pages to files, or emit a Structurizr DSL architecture model.
 
 ```bash
 repowise export [PATH] [OPTIONS]
@@ -608,8 +608,13 @@ repowise export [PATH] [OPTIONS]
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
-| `--format` / `-f` | choice | markdown | `markdown`, `html`, or `json` |
-| `--output` / `-o` | string | `.repowise/export` | Output directory |
+| `--format` / `-f` | choice | markdown | `markdown`, `html`, `json`, or `structurizr` |
+| `--output` / `-o` | string | `.repowise/export` | Output directory (for structurizr, a path ending in `.dsl` names the file) |
+| `--full` | flag | false | JSON: include tombstones plus decisions, dead code, and hotspot metadata |
+| `--standalone` | flag | false | Structurizr: emit a complete workspace with default views |
+| `--components` | flag | false | Structurizr: include the component level (one box per directory) |
+| `--force` | flag | false | Structurizr: overwrite the output file even if Repowise did not write it |
+| `--no-externals` | flag | false | Structurizr: leave third-party dependencies out of the model |
 
 ### Examples
 
@@ -617,7 +622,12 @@ repowise export [PATH] [OPTIONS]
 repowise export                          # Export all pages as markdown
 repowise export --format html -o ./site  # HTML export to ./site
 repowise export --format json            # Machine-readable JSON dump
+repowise export --format json --full     # Archival JSON with decisions / dead code
+repowise export --format structurizr --standalone --components
+repowise export --format structurizr -o architecture.dsl
 ```
+
+Also available as the Claude Code slash command `/repowise:export`.
 
 ---
 


### PR DESCRIPTION
## Summary
- Add `/repowise:export` Claude Code slash command for wiki dumps and Structurizr DSL export.
- Expand the website export reference to cover `structurizr`, `--full`, `--standalone`, `--components`, `--force`, and `--no-externals` (site docs were still markdown/html/json-only).
- Update plugin README/CHANGELOG and command inventory test.

## Test plan
- [x] `pytest tests/unit/cli/test_claude_plugin.py`
- [x] `/repowise:export` and structurizr modes on an indexed repo
- [x] Confirm updated website export section matches CLI flags