### PR TITLE
fix: suppress banner in dead-code --format json output

### DIFF
--- a/packages/cli/src/repowise/cli/commands/dead_code_cmd.py
+++ b/packages/cli/src/repowise/cli/commands/dead_code_cmd.py
@@ -14,6 +14,7 @@ from repowise.cli.helpers import (
     run_async,
     silence_logs_for_machine_output,
 )
+from repowise.cli.output import notice_console
 from repowise.core.analysis.dead_code.risk_factors import RISK_CAP_CONFIDENCE
 
 
@@ -110,7 +111,8 @@ def dead_code_command(
         no_workspace_flag=no_workspace,
         repo_alias=repo_alias,
     )
-    target.notice(console, command="dead-code")
+    notices = notice_console(fmt)
+    target.notice(notices, command="dead-code")
 
     if target.is_workspace:
         if target.repo_filter is not None:
@@ -123,13 +125,12 @@ def dead_code_command(
             if primary is None:
                 raise click.ClickException("Workspace has no primary repo configured.")
             repo_path = primary
-            console.print("[dim]  (Tip: pass --repo <alias> to analyze a different repo.)[/dim]")
+            notices.print("[dim]  (Tip: pass --repo <alias> to analyze a different repo.)[/dim]")
     else:
         assert target.repo_path is not None
         repo_path = target.repo_path
 
-    if fmt != "json":
-        console.print(f"[bold]repowise dead-code[/bold] — {repo_path}")
+    notices.print(f"[bold]repowise dead-code[/bold] — {repo_path}")
 
     # Ingest — honor the persisted submodule flags so the analyzed file set
     # matches what `init` indexed (a flagless traverser on a submodule-indexed

--- a/packages/cli/src/repowise/cli/commands/dead_code_cmd.py
+++ b/packages/cli/src/repowise/cli/commands/dead_code_cmd.py
@@ -128,7 +128,8 @@ def dead_code_command(
         assert target.repo_path is not None
         repo_path = target.repo_path
 
-    console.print(f"[bold]repowise dead-code[/bold] — {repo_path}")
+    if fmt != "json":
+        console.print(f"[bold]repowise dead-code[/bold] — {repo_path}")
 
     # Ingest — honor the persisted submodule flags so the analyzed file set
     # matches what `init` indexed (a flagless traverser on a submodule-indexed

--- a/tests/unit/cli/test_format_json_rollout.py
+++ b/tests/unit/cli/test_format_json_rollout.py
@@ -50,6 +50,7 @@ _FORMAT_COMMANDS = [
     ("repowise.cli.commands.workspace_cmd", "workspace_check"),
     ("repowise.cli.commands.workspace_cmd", "workspace_diagnostics"),
     ("repowise.cli.commands.workspace_cmd", "workspace_metrics"),
+    ("repowise.cli.commands.dead_code_cmd", "dead_code_command"),
 ]
 
 # Commands that shipped a machine mode under a different name. The old flag


### PR DESCRIPTION
## Summary

`repowise dead-code --format json` printed a human-readable banner to stdout before the JSON payload, making the output invalid JSON. Every other agent-facing command that grew `--format json` keeps stdout clean; `dead-code` is the one that doesn't.

## Change

Wrap the banner in a `fmt` check so it only prints for `table` and `md` formats:

```python
# Before
console.print(f"[bold]repowise dead-code[/bold] — {repo_path}")

# After
if fmt != "json":
    console.print(f"[bold]repowise dead-code[/bold] — {repo_path}")
```

Fixes #1436