### PR TITLE
fix(cli): name the real error when a command fails, and flag pytest runs

### DIFF
--- a/packages/cli/src/repowise/cli/_instrumented_group.py
+++ b/packages/cli/src/repowise/cli/_instrumented_group.py
@@ -132,6 +132,19 @@ class InstrumentedGroup(click.Group):
                 status = "interrupted"
             else:
                 status = "error"
+                # Mirror the ``Exit`` branch above and name the class, or this
+                # bucket records a failure with no error type at all. Commands
+                # that raise ``SystemExit`` directly rather than via
+                # ``ctx.exit()`` all land here, so leaving it unset loses the
+                # only diagnostic the event carries. Prefer the chained cause
+                # when there is one: a bare ``SystemExit(1)`` says nothing on
+                # its own, whereas the exception that forced the exit does.
+                # ``from None`` is honoured — a suppressed context is the
+                # author saying it is not the explanation.
+                cause = exc.__cause__
+                if cause is None and not exc.__suppress_context__:
+                    cause = exc.__context__
+                error_type = type(cause).__name__ if cause else "SystemExit"
             raise
         except (KeyboardInterrupt, click.exceptions.Abort):
             # User cancelled (Ctrl-C / declined a prompt). Not a failure — long-

--- a/packages/cli/src/repowise/cli/commands/init_cmd/command.py
+++ b/packages/cli/src/repowise/cli/commands/init_cmd/command.py
@@ -45,6 +45,7 @@ from repowise.cli.helpers import (
     save_config_partial,
     save_state,
 )
+from repowise.cli.platform import telemetry
 from repowise.cli.providers import resolve_embedder
 from repowise.cli.providers.embedders import embedder_was_requested as _embedder_was_requested
 from repowise.cli.state_persistence import build_kg_state, save_knowledge_graph_json
@@ -769,6 +770,7 @@ def init_command(
     repo_path = resolve_repo_path(path)
 
     if not repo_path.is_dir():
+        telemetry.add_command_outcome(failure_reason="invalid_path")
         raise click.ClickException(f"Not a directory: {repo_path}")
 
     # ---- Workspace detection ----
@@ -794,6 +796,7 @@ def init_command(
     if seed_from:
         seed_base = Path(seed_from).resolve()
         if seed_base == repo_path.resolve():
+            telemetry.add_command_outcome(failure_reason="seed_from_is_target")
             raise click.ClickException("--seed-from cannot be the same as the target directory.")
     elif not no_seed and not (repo_path / ".repowise" / "state.json").exists():
         detected = detect_worktree_base(repo_path)
@@ -1105,6 +1108,7 @@ def init_command(
             "written versions stay in page history."
         )
         if not sys.stdin.isatty():
+            telemetry.add_command_outcome(failure_reason="wiki_overwrite_unconfirmed")
             raise click.ClickException(
                 "Refusing to replace a model-written wiki with template pages. "
                 "Re-run with --yes to confirm, or drop --index-only."
@@ -1218,6 +1222,7 @@ def init_command(
                         )
                     )
                 except ProviderError as exc:
+                    telemetry.add_command_outcome(failure_reason="provider_validation_failed")
                     raise click.ClickException(f"Provider validation failed: {exc}") from exc
             console.print("  [green]✓[/green] Provider connection verified")
 

--- a/packages/cli/src/repowise/cli/helpers.py
+++ b/packages/cli/src/repowise/cli/helpers.py
@@ -798,6 +798,11 @@ def resolve_provider(
             # as a raw traceback that escaped every caller's handler —
             # OLLAMA_BASE_URL=http://localhost:abc makes httpx raise
             # InvalidURL, which killed `init` outright.
+            # Imported here, not at module scope: the telemetry spool imports
+            # this module back for the global config dir.
+            from repowise.cli.platform import telemetry
+
+            telemetry.add_command_outcome(failure_reason="provider_setup_failed")
             raise click.ClickException(
                 f"Could not set up the {name} provider: {exc}. Check its "
                 "settings in your environment and .repowise/config.yaml."
@@ -822,6 +827,9 @@ def resolve_provider(
         if provider_credentials_present(candidate):
             return _build(candidate)
 
+    from repowise.cli.platform import telemetry
+
+    telemetry.add_command_outcome(failure_reason="no_provider_configured")
     raise click.ClickException(
         "No provider configured. Use --provider, set REPOWISE_PROVIDER, "
         "or set ANTHROPIC_API_KEY / OPENAI_API_KEY / OPENROUTER_API_KEY / "

--- a/packages/cli/src/repowise/cli/platform/telemetry/emitter.py
+++ b/packages/cli/src/repowise/cli/platform/telemetry/emitter.py
@@ -55,8 +55,12 @@ def _under_test() -> bool:
     events under a freshly minted install. Only delivery is suppressed:
     consent resolution stays real, so its own tests still exercise the actual
     precedence rules.
+
+    Shares the env-var check with :func:`environment.under_pytest` so the two
+    cannot drift. The ``sys.modules`` fallback is kept because this guard is
+    only consulted in-process, where an import is evidence enough.
     """
-    return "PYTEST_CURRENT_TEST" in os.environ or "pytest" in sys.modules
+    return environment.under_pytest() or "pytest" in sys.modules
 
 
 def build_envelope(event: TelemetryEvent) -> dict[str, object]:

--- a/packages/cli/src/repowise/cli/platform/telemetry/environment.py
+++ b/packages/cli/src/repowise/cli/platform/telemetry/environment.py
@@ -1,9 +1,9 @@
 """Coarse, non-identifying environment facts attached to every event.
 
 Deliberately low-resolution: OS family, CPU architecture, a major.minor Python
-version, and a CI boolean. Nothing here can identify a machine or a person — no
-hostname, no username, no full version string, no IP (the server never records
-the source address).
+version, and an automated-run boolean. Nothing here can identify a machine or a
+person — no hostname, no username, no full version string, no IP (the server
+never records the source address).
 """
 
 from __future__ import annotations
@@ -40,9 +40,28 @@ def python_version() -> str:
     return f"{info[0]}.{info[1]}"
 
 
+def under_pytest() -> bool:
+    """Return whether a pytest session is in progress, judged from the env.
+
+    Read from the environment rather than ``sys.modules`` so the answer survives
+    a subprocess boundary: the suite drives real ``repowise`` commands, and a
+    child interpreter sees the inherited env vars but has its own module table.
+    ``PYTEST_CURRENT_TEST`` covers the window while a test runs;
+    ``PYTEST_VERSION`` (pytest 8.1+) also covers collection and teardown, when
+    no test is current but an atexit flush can still fire.
+    """
+    return bool(os.environ.get("PYTEST_CURRENT_TEST") or os.environ.get("PYTEST_VERSION"))
+
+
 def is_ci() -> bool:
-    """Return whether we appear to be running in a CI environment."""
-    return any(os.environ.get(var) for var in _CI_ENV_VARS)
+    """Return whether this looks like an automated rather than a human run.
+
+    Counts a pytest session as automated. Test fixtures relocate the home
+    directory that holds ``anon_id``, so every run would otherwise register as
+    a brand new install whose usage is not a user's, which is the same reason
+    CI is flagged.
+    """
+    return under_pytest() or any(os.environ.get(var) for var in _CI_ENV_VARS)
 
 
 def base_facts() -> dict[str, object]:

--- a/packages/server/src/repowise/server/mcp_server/_server.py
+++ b/packages/server/src/repowise/server/mcp_server/_server.py
@@ -558,6 +558,37 @@ def create_mcp_server(
     return mcp
 
 
+#: Depth bound when unwrapping nested task-group failures. Groups nest one or
+#: two deep in practice; the cap only stops a pathological cycle from hanging.
+_MAX_GROUP_DEPTH = 10
+
+
+def _run_transport(transport: str) -> None:
+    """Run the server, raising the cause of a task-group failure rather than the group.
+
+    ``mcp.run`` drives an anyio event loop, and anyio reports a child task's
+    failure as an ``ExceptionGroup`` wrapping the real exception. Anything that
+    reads the outermost class then learns only that *a* task failed: the CLI
+    records the wrapper's name as the error type, so a missing dependency, a
+    permission problem and a closed pipe are indistinguishable after the fact.
+    Unwrap to the first leaf and raise that, so the layers above name the real
+    error. A group holding several distinct failures loses the siblings, which
+    is worth it to stop losing the cause entirely.
+    """
+    try:
+        mcp.run(transport=transport)
+    except BaseExceptionGroup as group:
+        leaf: BaseException = group
+        for _ in range(_MAX_GROUP_DEPTH):
+            if not isinstance(leaf, BaseExceptionGroup) or not leaf.exceptions:
+                break
+            leaf = leaf.exceptions[0]
+        # A cancelled run is how a client-initiated shutdown looks, not a fault.
+        if isinstance(leaf, Exception):
+            _log.error("MCP server (%s) stopped: %r", transport, leaf, exc_info=leaf)
+        raise leaf from group
+
+
 def run_mcp(
     transport: str = "stdio",
     repo_path: str | None = None,
@@ -588,7 +619,7 @@ def run_mcp(
                 "network-accessible. Set REPOWISE_API_KEY or bind to 127.0.0.1.",
                 host,
             )
-        mcp.run(transport="sse")
+        _run_transport("sse")
     elif transport == "streamable-http":
         mcp.settings.host = host
         mcp.settings.port = port
@@ -599,7 +630,7 @@ def run_mcp(
                 "network-accessible. Set REPOWISE_API_KEY or bind to 127.0.0.1.",
                 host,
             )
-        mcp.run(transport="streamable-http")
+        _run_transport("streamable-http")
     else:
         # stdout is the JSON-RPC channel on stdio, so every log line written
         # there arrives at the client as a malformed protocol frame. Move the
@@ -614,4 +645,4 @@ def run_mcp(
         from repowise.server.mcp_server._watchdog import start_parent_watchdog
 
         start_parent_watchdog()
-        mcp.run(transport="stdio")
+        _run_transport("stdio")

--- a/tests/unit/cli/test_mcp_transport.py
+++ b/tests/unit/cli/test_mcp_transport.py
@@ -287,3 +287,53 @@ def test_run_mcp_sets_host_on_settings(monkeypatch) -> None:
     assert _server.mcp.settings.host == "0.0.0.0"
     assert _server.mcp.settings.port == 7343
     assert calls == [{"transport": "streamable-http"}]
+
+
+def test_task_group_failure_surfaces_the_real_error(monkeypatch) -> None:
+    """anyio wraps a child task's error; the wrapper must not be what escapes.
+
+    The event loop reports a failed task as an ExceptionGroup, so callers that
+    read the outermost class learn only that something failed. Every start-up
+    failure then looks identical from the outside.
+    """
+    import pytest
+
+    from repowise.server.mcp_server import _server
+
+    def boom(**_kw):
+        raise ExceptionGroup("task failed", [PermissionError("wiki.db is locked")])
+
+    monkeypatch.setattr(_server.mcp, "run", boom)
+
+    with pytest.raises(PermissionError):
+        _server.run_mcp(transport="stdio")
+
+
+def test_nested_task_groups_unwrap_to_the_leaf(monkeypatch) -> None:
+    import pytest
+
+    from repowise.server.mcp_server import _server
+
+    def boom(**_kw):
+        inner = ExceptionGroup("inner", [ModuleNotFoundError("no mcp")])
+        raise ExceptionGroup("outer", [inner])
+
+    monkeypatch.setattr(_server.mcp, "run", boom)
+
+    with pytest.raises(ModuleNotFoundError):
+        _server.run_mcp(transport="stdio")
+
+
+def test_a_plain_error_is_left_alone(monkeypatch) -> None:
+    """Only grouped failures are unwrapped; an ungrouped one already names itself."""
+    import pytest
+
+    from repowise.server.mcp_server import _server
+
+    def boom(**_kw):
+        raise OSError("address in use")
+
+    monkeypatch.setattr(_server.mcp, "run", boom)
+
+    with pytest.raises(OSError):
+        _server.run_mcp(transport="stdio")

--- a/tests/unit/cli/test_telemetry.py
+++ b/tests/unit/cli/test_telemetry.py
@@ -102,6 +102,31 @@ class TestEnvelopePrivacy:
         env = emitter.build_envelope(CommandRunEvent(command="status"))
         assert env["python_version"].count(".") == 1  # major.minor only
 
+    def test_a_pytest_run_is_flagged_automated(self):
+        # This assertion runs under pytest, so it is its own fixture: the
+        # suite's fixtures relocate the home holding anon_id, and every run
+        # would otherwise arrive as a brand new install.
+        env = emitter.build_envelope(CommandRunEvent(command="status"))
+        assert env["is_ci"] is True
+
+    def test_automated_detection_reads_the_env_not_sys_modules(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        # A test may shell out to a real repowise process: the child inherits
+        # the env but builds its own module table, so the env is what travels.
+        from repowise.cli.platform.telemetry import environment
+
+        monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+        monkeypatch.delenv("PYTEST_VERSION", raising=False)
+        for var in environment._CI_ENV_VARS:
+            monkeypatch.delenv(var, raising=False)
+        assert environment.under_pytest() is False
+        assert environment.is_ci() is False
+
+        monkeypatch.setenv("PYTEST_VERSION", "8.4.1")
+        assert environment.under_pytest() is True
+        assert environment.is_ci() is True
+
     def test_flags_carry_no_values(self):
         env = emitter.build_envelope(
             CommandRunEvent(command="update", flags=["--provider", "--exclude"])
@@ -338,6 +363,52 @@ class TestOutcomeClassification:
         props = rec[0]["properties"]
         assert props["file_count_bucket"] == "500-999"
         assert props["docs_mode"] is False
+
+    def test_bare_system_exit_still_names_a_class(self, monkeypatch: pytest.MonkeyPatch):
+        # Commands that exit via ``SystemExit`` rather than ``ctx.exit()`` used
+        # to record an error with no class at all, which left the whole bucket
+        # undiagnosable.
+        def body() -> None:
+            raise SystemExit(1)
+
+        rec = self._run(monkeypatch, body)
+        assert rec and rec[0]["properties"]["status"] == "error"
+        assert rec[0]["properties"]["error_type"] == "SystemExit"
+
+    def test_system_exit_reports_the_cause_it_was_raised_from(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        # ``raise SystemExit(1) from exc`` carries the real reason; report that
+        # rather than the exit wrapper.
+        def body() -> None:
+            try:
+                raise ModuleNotFoundError("no uvicorn")
+            except ModuleNotFoundError as exc:
+                raise SystemExit(1) from exc
+
+        rec = self._run(monkeypatch, body)
+        assert rec and rec[0]["properties"]["error_type"] == "ModuleNotFoundError"
+
+    def test_suppressed_context_is_not_reported(self, monkeypatch: pytest.MonkeyPatch):
+        # ``from None`` is the author saying the in-flight exception is not the
+        # explanation, so it must not be mined for an error class.
+        def body() -> None:
+            try:
+                raise ModuleNotFoundError("no uvicorn")
+            except ModuleNotFoundError:
+                raise SystemExit(1) from None
+
+        rec = self._run(monkeypatch, body)
+        assert rec and rec[0]["properties"]["error_type"] == "SystemExit"
+
+    def test_clean_system_exit_records_no_error_class(self, monkeypatch: pytest.MonkeyPatch):
+        # Exit code 0 is a success: naming a class here would invent a failure.
+        def body() -> None:
+            raise SystemExit(0)
+
+        rec = self._run(monkeypatch, body)
+        assert rec and rec[0]["properties"]["status"] == "ok"
+        assert rec[0]["properties"].get("error_type") is None
 
 
 class TestBucketCount:


### PR DESCRIPTION
## Why

When a command fails, the outcome record keeps only the exception class, by
design: no message, no traceback, no paths. That makes the class the entire
diagnosis, and four separate defects were quietly destroying it.

The result was a reporting surface that could not distinguish a crash from a
clean exit, could not name what went wrong when the MCP server refused to
start, and counted our own test suite as ordinary usage.

## What changed

**A command that exits via `SystemExit` now names its error class.** The branch
handling it set the status to `error` but never set the error class, so those
failures arrived with nothing attached. The `Exit` branch immediately above
already named its class, so this is the same treatment. Commands that exit by
raising `SystemExit` rather than through `ctx.exit()` all take this path, so the
gap covered every one of them. Where the exit was raised `from` something, the
cause is reported instead, because a bare `SystemExit(1)` says nothing while the
exception that forced it does. A context suppressed with `from None` is honoured
and left alone.

**A failing MCP transport now surfaces the real error.** `mcp.run` drives an
anyio event loop, and anyio reports a child task's failure as an
`ExceptionGroup` wrapping the actual exception. Nothing unwrapped it, so a
missing dependency, a locked database and a closed pipe were indistinguishable
from each other and from any other start-up failure. The three transports now
share one helper that unwraps to the first leaf and raises that, and logs it on
stderr, which stdio has already been switched to by that point. A group holding
several distinct failures loses the siblings; that is worth it to stop losing
the cause entirely.

**A pytest run counts as an automated run.** The environment facts flagged CI
but not pytest. Since the suite drives real commands and its fixtures relocate
the home directory holding the install identifier, every run looked like a
first-time install by a new user. This folds pytest into the existing
automated-run boolean rather than adding a field, because the reason CI is
flagged is exactly the reason pytest should be, and anything already excluding
automated runs then needs no change.

Detection reads the environment rather than `sys.modules`, since a test may
shell out to a real `repowise` process: the child inherits the environment but
builds its own module table. `PYTEST_VERSION` is read alongside
`PYTEST_CURRENT_TEST` so collection and teardown count, when no test is current
but an exit-time flush can still fire. The emitter's existing delivery guard now
shares this check so the two cannot drift.

**`init` records a coarse reason when it cannot proceed.** A bad path, a
provider with no credentials, a provider that failed its connection check, and a
refusal to overwrite a written wiki all reported the same class name and were
therefore indistinguishable. Each site now stashes a fixed enum through the
outcome mechanism the command already uses on its success path, so there is no
new field and no schema change. Two of the reasons sit in `resolve_provider`,
which `update` and `generate` share, so they attribute those commands too.

## Notes for review

- The privacy contract is unchanged. Everything added is a fixed enum or an
  exception class name. No messages, paths, repository names or user values.
- `is_ci` changes meaning slightly, from "in CI" to "not a human run". The
  docstrings and the module header say so. Nothing asserted on its value.
- The unwrap helper is bounded, so a pathological self-referential group cannot
  spin. Ungrouped exceptions are deliberately left untouched, since they already
  name themselves.
- `resolve_provider` imports telemetry inside the functions rather than at
  module scope, because the telemetry spool imports that module back for the
  global config directory.

## Testing

Nine tests added, covering: a bare `SystemExit` naming a class, an exit
reporting the cause it was raised from, a suppressed context being left alone, a
clean exit inventing no failure, pytest being flagged automated, detection
reading the environment rather than the module table, a grouped transport
failure surfacing its leaf, nested groups unwrapping, and an ungrouped error
passing through untouched.

`tests/unit/cli` passes in full (1691 passed, 2 skipped). `ruff check .` clean.
