### PR TITLE
fix(answer): stop reading backtick strings as code, and validate the withheld symbol_id

### DIFF
--- a/packages/server/src/repowise/server/mcp_server/tool_answer/answer.py
+++ b/packages/server/src/repowise/server/mcp_server/tool_answer/answer.py
@@ -114,6 +114,11 @@ from repowise.server.mcp_server._meta import build_meta as _build_meta
 from repowise.server.mcp_server._neighbor_rerank import (
     expand_via_neighbor_rerank as _expand_via_neighbor_rerank,
 )
+from repowise.server.mcp_server._symbol_lookup import (
+    bare_name,
+    parse_symbol_id,
+    resolve_symbol_rows,
+)
 from repowise.server.mcp_server.tool_answer.confidence import (
     _answer_is_hedged,
     _frame_term_grounding,
@@ -167,6 +172,7 @@ from repowise.server.mcp_server.tool_answer.symbols import (
     _extract_value_answer,
     _hydrate_candidate_defines,
     _hydrate_symbols_for_hits,
+    _read_repo_text,
     _read_symbol_source,
     build_homonym_union_bodies,
     is_symbol_lookup_question,
@@ -519,6 +525,48 @@ def _is_readable_path(target: str) -> bool:
     dot = t.rfind(".")
     ext = t[dot + 1 :] if dot != -1 else ""
     return bool(ext) and ext.isalnum() and len(ext) <= 6
+
+
+async def _first_resolvable_id(
+    ids: list[str], ctx, repository, exclude_spec
+) -> str | None:
+    """The first id ``get_symbol`` would actually answer, or None if none would.
+
+    The note and ``next_action_hint`` below interpolate a ``symbol_id`` straight
+    out of the scanner. The scanner is a regex over source lines, so it can name
+    something that is not a symbol, and an answer must never advertise a next
+    action that dead-ends.
+
+    ``get_symbol`` has THREE outcomes and only one of them is a failure: an
+    indexed row, a live-grep fallback when the name is in the file but not the
+    index, and nothing at all. Treating the live-grep case as unresolvable is a
+    mistake already made once while measuring this — it read mui as "90%
+    unresolvable" when the truth was "90% no index row, all still usable" — so
+    the live-grep outcome counts as resolved here too.
+
+    Deliberately conservative in the other direction: an id whose file cannot be
+    read is KEPT, because an unreadable file is absence of evidence, not
+    evidence the id is fabricated. Only a positive read that does not contain
+    the name, with no index row either, disqualifies one.
+    """
+    repo_root = Path(str(ctx.path)) if getattr(ctx, "path", None) else None
+    for sid in ids:
+        file_part, name_part = parse_symbol_id(sid)
+        if not file_part or not name_part:
+            continue
+        if is_excluded(file_part, exclude_spec):
+            # get_symbol refuses excluded paths outright, index row or not.
+            continue
+        text = _read_repo_text(repo_root, file_part)
+        if text is None or bare_name(name_part) in text:
+            return sid
+        # The name is provably absent from the live file, so the live-grep leg
+        # cannot fire. An indexed row is the only way get_symbol still answers.
+        with contextlib.suppress(Exception):
+            async with get_session(ctx.session_factory) as session:
+                if await resolve_symbol_rows(session, repository.id, sid):
+                    return sid
+    return None
 
 
 def _gather_code_rationale(ctx, hits: list[dict], fallback_targets: list[str], question: str):
@@ -2033,12 +2081,23 @@ async def get_answer(
             ]
             _continuing_names = {b["name"] for b in _continuing}
             _absent = [n for n in withheld_implicated if n not in _continuing_names]
-            _ids = [
-                s["symbol_id"]
-                for b in symbol_bodies
-                for s in (b.get("withheld_symbols") or [])
-                if s.get("name") in set(_absent)
-            ]
+            # Only advertise an id get_symbol can actually answer. The scanner
+            # that produced these is a regex over source lines, so it can name
+            # something that is not a symbol, and the id does not stay in a list
+            # of eight — it becomes the next action the payload tells the agent
+            # to take. When none resolves the names are still reported; only the
+            # dead pointer is withheld.
+            _hint_id = await _first_resolvable_id(
+                [
+                    s["symbol_id"]
+                    for b in symbol_bodies
+                    for s in (b.get("withheld_symbols") or [])
+                    if s.get("name") in set(_absent)
+                ],
+                ctx,
+                repository,
+                exclude_spec,
+            )
             _parts = []
             if _absent:
                 _parts.append(
@@ -2046,8 +2105,8 @@ async def get_answer(
                     f"{', '.join(_absent)}."
                     + (
                         " Continue in this tool with "
-                        f"get_symbol id='{_ids[0]}' before relying on the mechanism."
-                        if _ids
+                        f"get_symbol id='{_hint_id}' before relying on the mechanism."
+                        if _hint_id
                         else ""
                     )
                 )
@@ -2063,8 +2122,8 @@ async def get_answer(
                 )
             payload["note"] = " ".join(_parts)
             payload["next_action_hint"] = (
-                f"call get_symbol id='{_ids[0]}' for the withheld body"
-                if _ids
+                f"call get_symbol id='{_hint_id}' for the withheld body"
+                if _hint_id
                 else (
                     f"call get_symbol id='{_continuing[0]['continuation']}' for the rest "
                     f"of {_continuing[0]['name']}"

--- a/packages/server/src/repowise/server/mcp_server/tool_answer/config.py
+++ b/packages/server/src/repowise/server/mcp_server/tool_answer/config.py
@@ -384,7 +384,17 @@ _HIGH_CONFIDENCE_SCORE_FLOOR = 1.5
 # by its `continuation` range instead of being reported as "not served" with a
 # get_symbol pointer to a body the caller already holds most of. Cached pre-v14
 # rows carry both the old `high` and the old note, so they must bypass.
-_ANSWER_SCHEMA_VERSION = 14
+# v15: the scanner behind `withheld_symbols` stops reading backtick strings as
+# code. Go raw strings and TS template literals were never masked, so the
+# GraphQL and interpolated text inside them was emitted as symbols — 282 of
+# 22,898 sweep entries on cli/cli, 19 of them the HEADLINE entry the note tells
+# the agent to fetch. Those ids are not dead (`get_symbol` answers them with a
+# live grep, since the name really is on that line) but they are misleading:
+# the "symbol" is a GraphQL field. A cached pre-v15 row still lists them, so it
+# must bypass. Secondarily, the note no longer advertises a symbol_id that
+# resolves to nothing at all — a guard rather than an observed fix, since 0 of
+# the 130 ids on the corpus were dead ends.
+_ANSWER_SCHEMA_VERSION = 15
 
 # Hard TTL on answer-cache rows. Commit-based invalidation (the payload's
 # stamped ``_indexed_commit`` vs the repo's current head) is the primary

--- a/packages/server/src/repowise/server/mcp_server/tool_answer/symbols.py
+++ b/packages/server/src/repowise/server/mcp_server/tool_answer/symbols.py
@@ -1051,44 +1051,196 @@ def _match_definition(raw: str, next_raw: str = "") -> re.Match[str] | None:
 
 # Anything that could open a string or a comment. A line with none of these
 # cannot change the scanner's state, so it skips the character walk.
-_QUOTEISH_RE = re.compile(r"""["'#]|/[*/]""")
+_QUOTEISH_RE = re.compile(r"""["'`#]|/[*/]""")
 
 
-@lru_cache(maxsize=8)
-def _string_masked_lines(lines: tuple[str, ...]) -> frozenset[int]:
-    """1-based line numbers that START inside a multi-line string or comment.
+def _skip_quoted(raw: str, i: int) -> int:
+    """Index just past the single- or double-quoted run starting at ``i``."""
+    quote, i = raw[i], i + 1
+    while i < len(raw):
+        if raw[i] == "\\":
+            i += 2
+            continue
+        if raw[i] == quote:
+            return i + 1
+        i += 1
+    return i
 
-    Repowise's own docstrings are full of indented ``def``/``class`` examples,
-    and without this every one of them becomes a ``symbol_id`` the note tells the
-    agent to fetch and that resolves to nothing.
 
-    Deliberately a lexer-lite: it tracks Python triple quotes and C-style
-    ``/* */`` blocks and stops at ``#`` / ``//``. It does not know about raw
-    strings, template literals or nested-language escapes. The ceiling is
-    acceptable because the cost of a miss is one spurious name in a list of at
-    most eight, not a wrong answer; upgrading means parsing, which this helper
-    exists to avoid.
+# Extensions where a backtick actually opens a string: Go raw strings and the
+# JS/TS template-literal family. Everywhere else a backtick is punctuation --
+# Rust doc comments, Ruby heredocs and Python docstrings all carry markdown
+# fences and shell quotes -- so masking on it can only ever be a misfire.
+#
+# Not a style choice, a measured one. Before this gate, a markdown fence inside
+# an ordinary Rust string opened a phantom frame that a stray backtick 260 lines
+# later re-closed, and `goose/crates/goose-cli/src/session/export.rs` lost FIVE
+# real `pub fn` definitions from `withheld_symbols` with the containment below
+# provably inert. Three more files in the corpus did the same (two Ruby
+# heredocs, one Rust raw string).
+_BACKTICK_STRING_SUFFIXES = frozenset(
+    {".go", ".js", ".jsx", ".mjs", ".cjs", ".ts", ".tsx", ".mts", ".cts"}
+)
 
-    Cached on the line tuple: this is a per-character Python loop over the whole
-    file (68 ms on a 424 KB one), and the homonym-union path calls it once per
-    truncated body, re-masking the same file each time.
+# Characters after which a ``/`` starts a REGEX rather than a division. Notably
+# excludes ``)``, ``]`` and anything alphanumeric, which are the positions where
+# a division's left operand ends -- so Go's and Python's ``a / b`` is never
+# mistaken for a regex.
+_REGEX_CAN_START_AFTER = frozenset("(,=:[!&|?{};+-*%~^<>\n")
+
+# ...and the keywords a regex can follow, which end in an alphanumeric and so
+# would otherwise read as a division's left operand. `return /[`]/.test(x)` is
+# the one that matters here: it opens a phantom frame exactly like the
+# character-class case `_skip_regex` exists for.
+_REGEX_CAN_START_AFTER_WORD = frozenset(
+    {
+        "return", "case", "typeof", "yield", "await", "throw", "in", "of",
+        "new", "delete", "instanceof", "do", "else", "void",
+    }
+)
+
+
+def _regex_position(raw: str, i: int, prev: str) -> bool:
+    """Whether the ``/`` at ``i`` starts a regex rather than a division."""
+    if prev in _REGEX_CAN_START_AFTER:
+        return True
+    if not (prev.isalnum() or prev == "_"):
+        return False
+    word = ""
+    j = i - 1
+    while j >= 0 and raw[j].isspace():
+        j -= 1
+    while j >= 0 and (raw[j].isalnum() or raw[j] == "_"):
+        word = raw[j] + word
+        j -= 1
+    return word in _REGEX_CAN_START_AFTER_WORD
+
+
+def _skip_regex(raw: str, i: int) -> int:
+    """Index past a regex literal starting at ``i``, or ``i`` if it is not one.
+
+    Only exists because a backtick inside a regex otherwise opens a phantom
+    template literal. When a later backtick closes that phantom again the walk
+    ends with an EMPTY stack, so the containment in ``_string_masked_lines``
+    never fires and the mask silently eats everything between.
+
+    Isolated on one real file: ``mui/packages/markdown/parseMarkdown.js:203``,
+    ``return matches[1].replace(/`/g, '');``. Without this branch that file
+    masks 61 lines instead of 52, stays balanced, and hides the real
+    ``function getDescription`` at line 206.
+
+    Regex literals cannot span lines, so a run with no closing ``/`` on the same
+    line is not one and is left alone.
+    """
+    j = i + 1
+    in_class = False
+    while j < len(raw):
+        c = raw[j]
+        if c == "\\":
+            j += 2
+            continue
+        if c == "[":
+            in_class = True
+        elif c == "]":
+            in_class = False
+        elif c == "/" and not in_class:
+            return j + 1
+        j += 1
+    return i
+
+
+def _walk_string_state(
+    lines: tuple[str, ...], *, backticks: bool
+) -> tuple[set[int], bool]:
+    """(lines starting inside a string/comment, template literal left open at EOF).
+
+    ``stack`` models template-literal nesting: a ``None`` frame is the string
+    part of a backtick literal, an ``int`` frame is the unclosed-brace depth
+    inside a ``${...}`` interpolation. An interpolation holds CODE, so its lines
+    are not masked and a backtick inside one opens its own nested literal rather
+    than closing the outer one.
+
+    That nesting is not optional sophistication, and the reason is not the one
+    it looks like. Nesting alone does NOT unbalance a flat open/close counter --
+    four synthetic nested fixtures all re-balance. What breaks is the
+    combination: a flat counter reads the nested literal's OPENING backtick as
+    closing the outer one, which puts the walk at code level inside what is
+    really string content, and a code-level rule then eats the rest of the line
+    along with the real closing backtick. On mui's
+    ``DisabledDefaultClasses.tsx`` that rule is ``#`` firing on the CSS colour
+    ``#fff``, and the outer literal then never closes.
+
+    The same shape has two other triggers, and those two are worse because they
+    leave the stack BALANCED, which the containment in ``_string_masked_lines``
+    cannot see: an escaped backtick (handled here) and a backtick inside a regex
+    (handled by ``_skip_regex``). The nesting case usually ends UNBALANCED and
+    so is caught by the fallback anyway -- interpolation tracking is here for
+    precision, measured as 1,926 fabrications against 60 on the 16 corpus files
+    where a flat walk and this one disagree.
     """
     masked: set[int] = set()
     delim: str | None = None
     in_block = False
+    stack: list[int | None] = []
     for n, raw in enumerate(lines, 1):
-        if delim is not None or in_block:
+        if delim is not None or in_block or (stack and stack[-1] is None):
             masked.add(n)
-        elif not _QUOTEISH_RE.search(raw):
+        elif not stack and not _QUOTEISH_RE.search(raw):
             # Nothing on this line can open a string or comment, so the
             # character walk below cannot change state. Most lines are this
             # line, and skipping them is what keeps a whole-file scan cheap.
             continue
         i = 0
+        # Last non-space character seen at CODE level, for the regex test below.
+        prev = "\n"
         while i < len(raw):
+            if stack:
+                if stack[-1] is None:
+                    if raw[i] == "\\":
+                        # An escaped backtick does not close the literal. Without
+                        # this, `` `x\`y` `` closes early and re-opens on the real
+                        # terminator, inverting the parity for the rest of the
+                        # file with a balanced stack the containment cannot see.
+                        i += 2
+                    elif raw.startswith("${", i):
+                        stack.append(1)
+                        i += 2
+                    elif raw[i] == "`":
+                        stack.pop()
+                        i += 1
+                    else:
+                        i += 1
+                    continue
+                # Inside ${...}, so the ordinary code tokens apply again --
+                # including the regex probe, without which a backtick in a
+                # character class here (``${s.replace(/[`]/g, "")}``) opens the
+                # same phantom frame _skip_regex exists to prevent.
+                if raw[i] == "{":
+                    stack[-1] += 1
+                elif raw[i] == "}":
+                    stack[-1] -= 1
+                    if stack[-1] <= 0:
+                        stack.pop()
+                elif raw[i] == "`":
+                    stack.append(None)
+                elif raw.startswith("//", i):
+                    break
+                elif raw[i] == "/" and _regex_position(raw, i, prev):
+                    j = _skip_regex(raw, i)
+                    if j > i:
+                        i, prev = j, "/"
+                        continue
+                elif raw[i] in ('"', "'"):
+                    i = _skip_quoted(raw, i)
+                    prev = '"'
+                    continue
+                if not raw[i].isspace():
+                    prev = raw[i]
+                i += 1
+                continue
             if delim is not None:
                 if raw.startswith(delim, i):
-                    delim, i = None, i + 3
+                    delim, i = None, i + len(delim)
                 else:
                     i += 1
                 continue
@@ -1101,23 +1253,79 @@ def _string_masked_lines(lines: tuple[str, ...]) -> frozenset[int]:
             if raw.startswith('"""', i) or raw.startswith("'''", i):
                 delim, i = raw[i : i + 3], i + 3
                 continue
+            if backticks and raw[i] == "`":
+                stack.append(None)
+                i += 1
+                continue
             if raw.startswith("/*", i):
                 in_block, i = True, i + 2
                 continue
             if raw[i] == "#" or raw.startswith("//", i):
                 break
+            if raw[i] == "/" and _regex_position(raw, i, prev):
+                j = _skip_regex(raw, i)
+                if j > i:
+                    i, prev = j, "/"
+                    continue
             if raw[i] in ('"', "'"):
-                quote, i = raw[i], i + 1
-                while i < len(raw):
-                    if raw[i] == "\\":
-                        i += 2
-                        continue
-                    if raw[i] == quote:
-                        i += 1
-                        break
-                    i += 1
+                i = _skip_quoted(raw, i)
+                prev = '"'
                 continue
+            if not raw[i].isspace():
+                prev = raw[i]
             i += 1
+    return masked, bool(stack)
+
+
+def _has_backtick_strings(file_path: str) -> bool:
+    """Whether a backtick opens a string in this file's language."""
+    dot = file_path.rfind(".")
+    return dot != -1 and file_path[dot:].lower() in _BACKTICK_STRING_SUFFIXES
+
+
+@lru_cache(maxsize=8)
+def _string_masked_lines(
+    lines: tuple[str, ...], backticks: bool = True
+) -> frozenset[int]:
+    """1-based line numbers that START inside a multi-line string or comment.
+
+    Repowise's own docstrings are full of indented ``def``/``class`` examples,
+    and without this every one of them becomes a ``symbol_id`` the note tells the
+    agent to fetch and that resolves to nothing.
+
+    Deliberately a lexer-lite: it tracks Python triple quotes, backtick template
+    literals / Go raw strings, and C-style ``/* */`` blocks, and stops at ``#`` /
+    ``//``. Known ceilings, all measured rather than assumed:
+
+    * C# verbatim strings (``@"..."``) and Rust raw strings (``r#"..."#``) are
+      not tracked. C# because the exposure is 27 multi-line literals in 4,284
+      files; Rust because its 35,484 interior lines yielded 0 fabrications --
+      Go raw strings hold GraphQL, which matches the definition patterns, while
+      Rust raw strings hold TOML, which does not.
+    * Inside a ``${...}`` interpolation, ``/* */`` and ``#`` are not handled, so
+      a ``}`` inside a block comment there can close the frame early. Every
+      constructed case ended unbalanced and was caught by the fallback below.
+    * Markdown fenced blocks and inline code spans are now masked too, which is
+      wanted (a ``def`` inside a ```` ``` ```` fence is not a definition) but is
+      a behaviour change worth knowing about.
+
+    Cached on the line tuple: this is a per-character Python loop over the whole
+    file (68 ms on a 424 KB one), and the homonym-union path calls it once per
+    truncated body, re-masking the same file each time. The fallback below can
+    double that on a file whose literals do not balance, because the fast-path
+    line skip is disabled while a frame is open -- measured at 8x on a
+    synthetic 1.2 MB file with one stray backtick on line 1. Bounded at two
+    walks, and the cache means it is paid once per file.
+    """
+    masked, template_left_open = _walk_string_state(lines, backticks=backticks)
+    if template_left_open:
+        # The lexer-lite lost track: a template literal opened and never closed,
+        # so every line below it is masked to EOF and every definition there is
+        # silently suppressed. That failure is invisible -- no error, just
+        # missing symbols -- so it must not be the one we ship. Fall back to the
+        # pre-backtick walk for this file, which under-masks instead: the cost is
+        # a spurious name in a list, not an absent real one.
+        masked, _ = _walk_string_state(lines, backticks=False)
     return frozenset(masked)
 
 
@@ -1171,7 +1379,7 @@ def withheld_definitions(
     lines = text.splitlines()
     if lo < 1 or lo > len(lines):
         return []
-    masked = _string_masked_lines(tuple(lines))
+    masked = _string_masked_lines(tuple(lines), _has_backtick_strings(path))
 
     def _entry(line_no: int, m: re.Match[str], *, cut: bool = False) -> dict:
         name = m.group("name")

--- a/tests/unit/server/mcp/test_answer_backtick_masking.py
+++ b/tests/unit/server/mcp/test_answer_backtick_masking.py
@@ -1,0 +1,526 @@
+"""D2: backtick strings were read as code, so their contents became symbols.
+
+``_string_masked_lines`` tracked Python triple quotes and ``/* */`` but had no
+backtick branch, and backtick was not even in ``_QUOTEISH_RE`` -- so a line whose
+only quote-ish character was a backtick skipped the character walk entirely.
+Go raw strings and TS template literals were therefore scanned as source, and
+the GraphQL and interpolated text inside them was emitted as ``withheld_symbols``
+entries pointing at ids that resolve to nothing. Measured on cli/cli: 282 of
+22,898 sweep entries, 19 of them the HEADLINE the note tells the agent to fetch.
+
+Proof direction:
+  test_graphql_in_a_go_raw_string_is_not_a_symbol       -- FAILS at the parent.
+  test_a_template_literal_is_not_read_as_code           -- FAILS at the parent.
+  test_a_go_function_after_a_raw_string_is_still_found  -- passes both (control).
+
+The last two are GUARDS on the hazard this fix introduces rather than
+before/after proofs -- they pass at the parent for the trivial reason that the
+parent masks no backticks at all. They are here because over-masking is the
+failure this change could cause and it is invisible in a passing corpus run: a
+file whose template literals do not balance would be masked to EOF and every
+definition in it silently suppressed. Measured on mui, a flat open/close counter
+did exactly that to a real file (90 emitted entries down to 0).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+def test_graphql_in_a_go_raw_string_is_not_a_symbol(tmp_path) -> None:
+    """The cli/cli shape: GraphQL embedded in a Go backtick raw string.
+
+    ``repository(owner: $owner, name: $name) {`` matched the brace-member
+    pattern and was emitted as ``name='repository'``, ``kind='member'``,
+    ``symbol_id='<path>::repository'`` -- 51 times in the sweep, and the single
+    most common fabricated name.
+    """
+    from repowise.server.mcp_server.tool_answer.symbols import withheld_definitions
+
+    (tmp_path / "queries.go").write_text(
+        "package api\n"
+        "\n"
+        "var repoQuery = `\n"
+        "\tquery RepositoryInfo($owner: String!, $name: String!) {\n"
+        "\t\trepository(owner: $owner, name: $name) {\n"
+        "\t\t\tname\n"
+        "\t\t\towner { login }\n"
+        "\t\t}\n"
+        "\t}\n"
+        "`\n"
+        "\n"
+        "func FetchRepo(client *Client) error {\n"
+        "\treturn client.Do(repoQuery)\n"
+        "}\n",
+        encoding="utf-8",
+    )
+
+    got = withheld_definitions(tmp_path, "queries.go:3-14")
+    names = [d["name"] for d in got]
+    assert "repository" not in names, got
+    assert "owner" not in names, got
+    # The real definition below the raw string must still be reported.
+    assert "FetchRepo" in names, got
+
+
+def test_a_template_literal_is_not_read_as_code(tmp_path) -> None:
+    """The mui shape: a definition-looking line inside a TS template literal."""
+    from repowise.server.mcp_server.tool_answer.symbols import withheld_definitions
+
+    (tmp_path / "gen.ts").write_text(
+        "const header = 'x';\n"
+        "\n"
+        "export const template = `\n"
+        "  function GeneratedThing() {\n"
+        "    return null;\n"
+        "  }\n"
+        "`;\n"
+        "\n"
+        "export function realExport(a: number) {\n"
+        "  return a + 1;\n"
+        "}\n",
+        encoding="utf-8",
+    )
+
+    got = withheld_definitions(tmp_path, "gen.ts:3-11")
+    names = [d["name"] for d in got]
+    assert "GeneratedThing" not in names, got
+    assert "realExport" in names, got
+
+
+# The mui shape, minimised. Reproduces the real mechanism: a nested template
+# literal inside `${...}` whose body holds a CSS colour. The trailing
+# `const tick` re-balances the stack so the containment fallback cannot rescue
+# it -- without that the guard proves nothing.
+_NESTED_WITH_A_CSS_COLOUR = (
+    "const Root = styled('div')(\n"
+    "  ({ ownerState }) => `\n"
+    "    color: red;\n"
+    "    ${ownerState.disabled\n"
+    "      ? `left: 14px;\n"
+    "         background-color: #fff;`\n"
+    "      : ''}\n"
+    "  `,\n"
+    ");\n"
+    "\n"
+    "export function afterTheTemplate(x: number) {\n"
+    "  return x;\n"
+    "}\n"
+    "\n"
+    "const tick = '`';\n"
+    "\n"
+    "export function afterTheTick(y: number) {\n"
+    "  return y;\n"
+    "}\n"
+)
+
+
+def test_a_nested_template_literal_does_not_mask_to_eof(tmp_path) -> None:
+    """GUARD on the over-mask hazard, not a before/after proof.
+
+    The mechanism, traced on the real file rather than guessed at. A flat
+    open/close counter reads the NESTED literal's opening backtick as CLOSING
+    the outer one, which puts the walk at code level inside what is really
+    string content. A code-level rule then eats the rest of the line -- here the
+    ``#`` of a CSS colour, which this lexer-lite treats as a comment start -- and
+    with it the real closing backtick. The outer literal never closes and the
+    mask runs to EOF.
+
+    So nesting alone is NOT enough; four synthetic nested fixtures all
+    re-balanced under a flat counter. It takes nesting plus a ``#`` or ``//``
+    inside the nested body, which is exactly what
+    ``docs/data/base/getting-started/customization/DisabledDefaultClasses.tsx``
+    in mui has (``background-color: #fff``). There the flat walk takes the file
+    from 90 emitted entries to 0 and its recall miss from 58/77 cuts to 77/77.
+    """
+    from repowise.server.mcp_server.tool_answer.symbols import withheld_definitions
+
+    (tmp_path / "styled.tsx").write_text(_NESTED_WITH_A_CSS_COLOUR, encoding="utf-8")
+
+    names = [d["name"] for d in withheld_definitions(tmp_path, "styled.tsx:3-17")]
+    assert "afterTheTemplate" in names, names
+    assert "afterTheTick" in names, names
+
+
+def test_the_nested_guard_is_not_vacuous(tmp_path) -> None:
+    """Runs the rejected design against the fixture above, so the guard bites.
+
+    The first version of this pair was vacuous: an adversarial review showed the
+    fixture re-balanced under a flat counter, so the guard passed under the very
+    design its docstring claimed to reject. The flat walk is therefore executed
+    here rather than described -- same structure as the shipped one, minus the
+    interpolation stack.
+    """
+    from repowise.server.mcp_server.tool_answer.symbols import (
+        _skip_quoted,
+        _string_masked_lines,
+    )
+
+    lines = tuple(_NESTED_WITH_A_CSS_COLOUR.splitlines())
+
+    def _flat(src):
+        masked, open_ = set(), False
+        for n, raw in enumerate(src, 1):
+            if open_:
+                masked.add(n)
+            i = 0
+            while i < len(raw):
+                if open_:
+                    if raw[i] == "`":
+                        open_ = False
+                    i += 1
+                    continue
+                if raw[i] == "`":
+                    open_, i = True, i + 1
+                    continue
+                if raw[i] == "#" or raw.startswith("//", i):
+                    break
+                if raw[i] in ('"', "'"):
+                    i = _skip_quoted(raw, i)
+                    continue
+                i += 1
+        return masked, open_
+
+    target = 11  # the `export function afterTheTemplate` line
+    flat_masked, _flat_open = _flat(lines)
+    assert target in flat_masked, sorted(flat_masked)
+    assert target not in _string_masked_lines(lines), sorted(_string_masked_lines(lines))
+
+
+def test_a_backtick_inside_a_regex_literal_does_not_open_a_template(tmp_path) -> None:
+    """FAILS without regex handling, and the containment CANNOT save it.
+
+    ``/^\\s*[~`]{3}/m`` is real code in angular. The backtick in the character
+    class opens a phantom template literal; a later stray backtick closes it
+    again, so the walk ends with a BALANCED stack and the unterminated-at-EOF
+    fallback never fires. That is the whole danger of this class -- an
+    unbalanced file is rescued, a re-balanced one is not. Measured on
+    ``vscode-ng-language-service/server/src/text_render.ts``: 212 of 295 lines
+    masked, hiding 6 real top-level functions. Found by an adversarial review.
+
+    The trailing ``const tick`` line is load-bearing: without it the fixture
+    ends unbalanced, the fallback rescues it, and the test proves nothing.
+    """
+    from repowise.server.mcp_server.tool_answer.symbols import withheld_definitions
+
+    (tmp_path / "render.ts").write_text(
+        "export function isFenced(text: string): boolean {\n"
+        "  if (/^\\s*[~`]{3}/m.test(text)) {\n"
+        "    return true;\n"
+        "  }\n"
+        "  return false;\n"
+        "}\n"
+        "\n"
+        "export function hiddenByTheRegex(x: number) {\n"
+        "  return x;\n"
+        "}\n"
+        "\n"
+        "const tick = '`';\n"
+        "\n"
+        "export function afterTheTick(y: number) {\n"
+        "  return y;\n"
+        "}\n",
+        encoding="utf-8",
+    )
+
+    names = [d["name"] for d in withheld_definitions(tmp_path, "render.ts:2-16")]
+    assert "hiddenByTheRegex" in names, names
+    assert "afterTheTick" in names, names
+
+
+def test_an_escaped_backtick_does_not_close_the_literal(tmp_path) -> None:
+    """FAILS without escape handling, and the containment cannot save it either.
+
+    ``\\`` inside a template literal escapes the backtick. Closing on it leaves
+    an odd count, and a later stray backtick re-balances the stack, so this is
+    the same invisible-to-the-fallback class as the regex case above.
+    """
+    from repowise.server.mcp_server.tool_answer.symbols import withheld_definitions
+
+    (tmp_path / "esc.ts").write_text(
+        "const a = `x\\`y`;\n"
+        "\n"
+        "export function hiddenByTheEscape(x: number) {\n"
+        "  return x;\n"
+        "}\n"
+        "\n"
+        "const tick = '`';\n"
+        "\n"
+        "export function afterTheTick(y: number) {\n"
+        "  return y;\n"
+        "}\n",
+        encoding="utf-8",
+    )
+
+    names = [d["name"] for d in withheld_definitions(tmp_path, "esc.ts:2-11")]
+    assert "hiddenByTheEscape" in names, names
+    assert "afterTheTick" in names, names
+
+
+def test_a_language_without_backtick_strings_is_untouched(tmp_path) -> None:
+    """FAILS without the language gate, and this was a live corpus regression.
+
+    A backtick only opens a string in Go and the JS/TS family. Everywhere else
+    it is punctuation -- Rust doc comments, Ruby heredocs and Python docstrings
+    all carry markdown fences -- so masking on it can only misfire. Measured
+    before the gate: ``goose/crates/goose-cli/src/session/export.rs`` lost FIVE
+    real ``pub fn`` definitions, because a markdown fence inside an ordinary
+    Rust string opened a phantom frame that a stray backtick 260 lines later
+    re-closed, leaving the walk balanced and the containment inert. Three more
+    corpus files did the same.
+
+    Verified as an invariant, not just here: across 39,070 backtick-bearing
+    files in non-backtick languages, 0 masks differ from the parent's.
+
+    A Rust DOC-COMMENT fence would not do -- ``///`` breaks the walk before it
+    reaches the backticks, so the fixture would be vacuous. The real shape is a
+    multi-line Rust string literal: the quote skip runs off the end of its line,
+    the next line is walked as code, and its ``` opens the phantom frame.
+    """
+    from repowise.server.mcp_server.tool_answer.symbols import withheld_definitions
+
+    body = (
+        "pub fn render() -> String {\n"
+        '    let s = "a long message that continues\n'
+        "``` fenced block inside the string\n"
+        'more text";\n'
+        "    s\n"
+        "}\n"
+        "\n"
+        "pub fn after_the_string() -> u32 {\n"
+        "    1\n"
+        "}\n"
+        "\n"
+        'const TICK: &str = "`";\n'
+        "\n"
+        "pub fn after_the_tick() -> u32 {\n"
+        "    2\n"
+        "}\n"
+    )
+    (tmp_path / "export.rs").write_text(body, encoding="utf-8")
+
+    names = [d["name"] for d in withheld_definitions(tmp_path, "export.rs:2-16")]
+    assert "after_the_string" in names, names
+    assert "after_the_tick" in names, names
+
+
+def test_a_regex_after_return_is_not_read_as_division(tmp_path) -> None:
+    """The preceder test cannot be punctuation-only.
+
+    ``if (/re/...)`` is covered because ``(`` precedes it, but
+    ``return /[`]/.test(x)`` ends in an alphanumeric and would read as a
+    division, re-opening the phantom-frame hole for the most common way to
+    write a regex.
+    """
+    from repowise.server.mcp_server.tool_answer.symbols import withheld_definitions
+
+    (tmp_path / "r.ts").write_text(
+        "export function isTick(x: string) {\n"
+        "  return /[`]/.test(x);\n"
+        "}\n"
+        "\n"
+        "export function hiddenAfterReturn(y: number) {\n"
+        "  return y;\n"
+        "}\n"
+        "\n"
+        "const tick = '`';\n"
+        "\n"
+        "export function afterTheTick(z: number) {\n"
+        "  return z;\n"
+        "}\n",
+        encoding="utf-8",
+    )
+
+    names = [d["name"] for d in withheld_definitions(tmp_path, "r.ts:2-13")]
+    assert "hiddenAfterReturn" in names, names
+    assert "afterTheTick" in names, names
+
+
+def test_a_regex_inside_an_interpolation_is_skipped(tmp_path) -> None:
+    """The ``${...}`` branch runs code, so it needs the regex probe too.
+
+    Without it a backtick in a regex inside an interpolation opens exactly the
+    phantom frame ``_skip_regex`` exists to prevent, and a later ordinary
+    closing brace can leave the stack balanced. No corpus instance, so this is a
+    guard on a latent hole rather than a measured regression.
+    """
+    from repowise.server.mcp_server.tool_answer.symbols import withheld_definitions
+
+    (tmp_path / "i.ts").write_text(
+        "export function fence(s: string) {\n"
+        '  return `x ${ s.replace(/[`]/g, "") } y`;\n'
+        "}\n"
+        "\n"
+        "export function hiddenAfterInterp(y: number) {\n"
+        "  return y;\n"
+        "}\n"
+        "\n"
+        "const tick = '`';\n"
+        "\n"
+        "export function afterTheTick(z: number) {\n"
+        "  return z;\n"
+        "}\n",
+        encoding="utf-8",
+    )
+
+    names = [d["name"] for d in withheld_definitions(tmp_path, "i.ts:2-13")]
+    assert "hiddenAfterInterp" in names, names
+    assert "afterTheTick" in names, names
+
+
+@pytest.mark.parametrize(
+    "src,expect_end",
+    [
+        ("/[/]/", 5),      # a slash inside a character class does not close it
+        ("/a\\/b/", 6),    # nor does an escaped slash
+        ("/x[y/", 0),      # unterminated class: not a regex, index unchanged
+        ("/abc", 0),       # no closing slash on the line: not a regex
+        ("/a/g", 3),       # ordinary case, flags are not consumed
+    ],
+)
+def test_skip_regex_boundaries(src, expect_end) -> None:
+    """``_skip_regex``'s class and escape handling, which nothing else pins.
+
+    Round two flagged both as correctness-critical to the newest code and
+    completely untested.
+    """
+    from repowise.server.mcp_server.tool_answer.symbols import _skip_regex
+
+    assert _skip_regex(src, 0) == expect_end, src
+
+
+def test_go_division_is_not_mistaken_for_a_regex(tmp_path) -> None:
+    """Control on the regex branch, which is the riskiest thing here.
+
+    The masker is language-agnostic, so the regex test runs over Go and Python
+    too, where ``/`` is only ever division. It keys on the preceding non-space
+    character, and every way a division's left operand can end -- an identifier,
+    a digit, ``)``, ``]`` -- is excluded.
+    """
+    from repowise.server.mcp_server.tool_answer.symbols import withheld_definitions
+
+    (tmp_path / "calc.go").write_text(
+        "package main\n"
+        "\n"
+        "func Ratio(a int, b int) int {\n"
+        "\tmid := (a + b) / 2\n"
+        "\tarr := []int{1, 2}\n"
+        "\tn := arr[0] / mid\n"
+        "\treturn n / a\n"
+        "}\n"
+        "\n"
+        "func AfterDivision() int { return 1 }\n",
+        encoding="utf-8",
+    )
+
+    names = [d["name"] for d in withheld_definitions(tmp_path, "calc.go:3-10")]
+    assert "Ratio" in names and "AfterDivision" in names, names
+
+
+def test_an_unbalanced_backtick_does_not_silence_the_rest_of_the_file(tmp_path) -> None:
+    """GUARD: when the lexer-lite loses track it must under-mask, not over-mask.
+
+    A template literal that opens and never closes would otherwise mask every
+    remaining line, suppressing real definitions with no error and no signal.
+    The walk detects that it ended inside a literal and falls back to the
+    pre-backtick behaviour for the file. Not hypothetical: across ~121,000 files
+    in the local corpora, 244 end the walk still inside a backtick string.
+    """
+    from repowise.server.mcp_server.tool_answer.symbols import withheld_definitions
+
+    (tmp_path / "odd.go").write_text(
+        "package main\n"
+        "\n"
+        "var broken = `this literal never closes\n"
+        "\n"
+        "func StillFound(x int) int {\n"
+        "\treturn x\n"
+        "}\n",
+        encoding="utf-8",
+    )
+
+    names = [d["name"] for d in withheld_definitions(tmp_path, "odd.go:3-7")]
+    assert "StillFound" in names, names
+
+
+def test_a_go_function_after_a_raw_string_is_still_found(tmp_path) -> None:
+    """Control: masking must not swallow ordinary code around a raw string."""
+    from repowise.server.mcp_server.tool_answer.symbols import withheld_definitions
+
+    (tmp_path / "m.go").write_text(
+        "package main\n"
+        "\n"
+        "func Before() {}\n"
+        "\n"
+        "const usage = `usage: tool [flags]`\n"
+        "\n"
+        "func After() {}\n",
+        encoding="utf-8",
+    )
+
+    names = [d["name"] for d in withheld_definitions(tmp_path, "m.go:2-7")]
+    assert "Before" in names and "After" in names, names
+
+
+def test_a_python_docstring_example_is_still_masked(tmp_path) -> None:
+    """Control: the case the masker was built for must not regress.
+
+    The Python corpus is the control for this change -- measured byte-identical
+    across 44,331 sweep entries before and after -- and this is its unit-level
+    counterpart.
+    """
+    from repowise.server.mcp_server.tool_answer.symbols import withheld_definitions
+
+    (tmp_path / "d.py").write_text(
+        "import os\n"
+        "\n"
+        "def outer():\n"
+        '    """Docs.\n'
+        "\n"
+        "    Example::\n"
+        "\n"
+        "        def not_a_real_symbol():\n"
+        "            pass\n"
+        '    """\n'
+        "    return 1\n"
+        "\n"
+        "def real_one():\n"
+        "    return 2\n",
+        encoding="utf-8",
+    )
+
+    names = [d["name"] for d in withheld_definitions(tmp_path, "d.py:4-14")]
+    assert "not_a_real_symbol" not in names, names
+    assert "real_one" in names, names
+
+
+def test_the_fallback_costs_at_most_one_extra_walk(tmp_path) -> None:
+    """Bounds the worst case rather than asserting the cache exists.
+
+    An earlier version of this test claimed the fallback "must not defeat the
+    cache", which it structurally cannot -- the fallback runs INSIDE the cached
+    function, so the assertion could not fail. What is actually worth pinning is
+    that the fallback re-walks once and only once, since the fast-path skip is
+    disabled while a template frame is open and a pathological file therefore
+    pays a full per-character walk twice.
+    """
+    from repowise.server.mcp_server.tool_answer import symbols as mod
+
+    calls = []
+    real = mod._walk_string_state
+
+    def _counting(lines, *, backticks):
+        calls.append(backticks)
+        return real(lines, backticks=backticks)
+
+    mod._walk_string_state = _counting
+    try:
+        mod._string_masked_lines.cache_clear()
+        mod._string_masked_lines(("const x = `unclosed", "def real():", "    return 1"))
+        assert calls == [True, False], calls
+        calls.clear()
+        mod._string_masked_lines.cache_clear()
+        mod._string_masked_lines(("def real():", "    return 1"))
+        assert calls == [True], calls
+    finally:
+        mod._walk_string_state = real

--- a/tests/unit/server/mcp/test_answer_withheld_id_validation.py
+++ b/tests/unit/server/mcp/test_answer_withheld_id_validation.py
@@ -1,0 +1,230 @@
+"""D5: the note advertised a ``symbol_id`` nobody had checked resolves.
+
+``answer.py`` took ``symbol_bodies[].withheld_symbols[].symbol_id`` straight from
+the scanner and interpolated it into both ``note`` and ``next_action_hint``. The
+scanner is a regex over source lines, so it can name something that is not a
+symbol -- and the id does not end up in a list of eight, it becomes the next
+action the payload tells the agent to take.
+
+The subtlety this file exists to pin down: ``get_symbol`` has THREE outcomes and
+only ONE is a failure.
+
+  indexed row   -- resolves
+  live_grep     -- no index row, but the name is in the live file, so it answers
+                   with ``resolution: "live_grep"`` and ``fallback_lines``
+  nothing       -- the only real failure
+
+Counting the middle case as unresolvable is a mistake already made once while
+measuring this: it read mui as "90% unresolvable" when the truth was "90% no
+index row, all still usable". A guard that suppressed those would delete a
+useful pointer on nine ids out of ten on that tree.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+
+def _patch_provider(monkeypatch, answer_mod, content: str):
+    class _Provider:
+        provider_name = "mock"
+        model_name = "mock-1"
+
+        async def generate(self, **kwargs):
+            return SimpleNamespace(content=content)
+
+    monkeypatch.setattr(answer_mod, "_resolve_provider_for_answer", lambda _p: _Provider())
+
+
+def _build_tree(tmp_path, monkeypatch, mcp_mod, answer_mod, *, answer_text):
+    """A truncated ``big_handler`` whose withheld range holds ``ghost_helper``."""
+    src = ["import os", ""]
+    src.append("def big_handler(request):")
+    src.append('    """Handle it."""')
+    for i in range(300):
+        src.append(f"    step_{i} = {i}")
+    src.append("    return step_0")
+    src.append("")
+    src.append("def ghost_helper(value):")
+    src.append("    return value")
+    (tmp_path / "handler.py").write_text("\n".join(src) + "\n", encoding="utf-8")
+    monkeypatch.setattr(mcp_mod, "_repo_path", str(tmp_path))
+
+    symbol = {
+        "name": "big_handler",
+        "kind": "function",
+        "signature": "def big_handler(request)",
+        "docstring": "Handle it.",
+        "start_line": 3,
+        "end_line": len(src),
+        "_matched": True,
+        "source_excerpt": "def big_handler(request):\n    step_0 = 0",
+    }
+
+    async def _fake_retrieve(question, ctx):
+        return [{"page_id": "file_page:handler.py", "score": 5.0}]
+
+    async def _fake_hydrate(hits, ctx, *, scope=None):
+        for h in hits:
+            h["target_path"] = "handler.py"
+            h["title"] = "handler.py"
+            h["summary"] = "Handler module."
+            h["snippet"] = ""
+            h["page_type"] = "file_page"
+            h["symbols"] = [dict(symbol)]
+        return hits
+
+    monkeypatch.setattr(answer_mod, "_hybrid_retrieve", _fake_retrieve)
+    monkeypatch.setattr(answer_mod, "_hydrate_hits", _fake_hydrate)
+    _patch_provider(monkeypatch, answer_mod, answer_text)
+
+
+@pytest.mark.asyncio
+async def test_an_id_that_only_live_greps_is_still_advertised(
+    setup_mcp, monkeypatch, tmp_path
+):
+    """The middle outcome. Passes at the parent, and MUST keep passing.
+
+    ``ghost_helper`` is a real name on a real line with no index row behind it
+    in this fixture, which is exactly the population that measured 91.5% indexed
+    / 8.5% live-grep / 0% dead across 130 corpus ids. A guard that rejected it
+    would be a regression dressed as a fix, so this is the control that stops
+    the guard from over-reaching.
+    """
+    import repowise.server.mcp_server as mcp_mod
+    import repowise.server.mcp_server.tool_answer.answer as answer_mod
+    from repowise.server.mcp_server import get_answer
+
+    # The withheld name is implicated by the QUESTION, not by the answer text:
+    # naming it in the answer instead trips the earlier claim-support gate (the
+    # term is absent from every retrieved excerpt, because it was withheld) and
+    # the note never reaches the branch under test.
+    _build_tree(
+        tmp_path,
+        monkeypatch,
+        mcp_mod,
+        answer_mod,
+        answer_text="big_handler runs each step in order and returns the first.",
+    )
+
+    result = await get_answer("how does big_handler use ghost_helper on each step")
+
+    note = result.get("note") or ""
+    hint = result.get("next_action_hint") or ""
+    assert "ghost_helper" in note, note
+    assert "handler.py::ghost_helper" in hint, hint
+
+
+@pytest.mark.asyncio
+async def test_an_id_that_resolves_to_nothing_is_not_advertised(
+    setup_mcp, monkeypatch, tmp_path
+):
+    """FAILS at the parent: a name absent from the file is still promoted.
+
+    The scanner is monkeypatched to emit a name that is nowhere in the live
+    source. That is the shape D2 and D3 produced naturally -- GraphQL field
+    names out of Go raw strings, and the Go keyword ``func`` -- and with both
+    now fixed the honest way to exercise the consumer's guard is to inject one
+    directly rather than to wait for the next regex defect to supply it.
+
+    The name still appears in the note (the answer does depend on something that
+    was not served); only the dead pointer is withheld.
+    """
+    import repowise.server.mcp_server as mcp_mod
+    import repowise.server.mcp_server.tool_answer.answer as answer_mod
+    from repowise.server.mcp_server import get_answer
+
+    _build_tree(
+        tmp_path,
+        monkeypatch,
+        mcp_mod,
+        answer_mod,
+        answer_text="big_handler runs each step in order and returns the first.",
+    )
+
+    real = answer_mod.withheld_definitions
+
+    def _fabricating(repo_root, continuation):
+        out = list(real(repo_root, continuation))
+        out.append(
+            {
+                "name": "phantomThing",
+                "kind": "member",
+                "line": 40,
+                "symbol_id": "handler.py::phantomThing",
+                "signature": "member phantomThing",
+            }
+        )
+        return out
+
+    monkeypatch.setattr(answer_mod, "withheld_definitions", _fabricating)
+
+    result = await get_answer("how does big_handler use phantomThing on each step")
+
+    note = result.get("note") or ""
+    hint = result.get("next_action_hint") or ""
+    assert "phantomThing" not in (tmp_path / "handler.py").read_text(encoding="utf-8")
+    assert "phantomThing" in note, "the unserved name should still be reported"
+    assert "handler.py::phantomThing" not in note, note
+    assert "handler.py::phantomThing" not in hint, hint
+
+
+@pytest.mark.asyncio
+async def test_an_unreadable_file_does_not_disqualify_its_id(
+    setup_mcp, monkeypatch, tmp_path
+):
+    """Absence of evidence is not evidence of fabrication.
+
+    If the file behind an id cannot be read, the guard has learned nothing and
+    must keep the id. Suppressing on an unreadable file would silently drop a
+    valid pointer on every repo whose sources moved since indexing.
+    """
+    import repowise.server.mcp_server as mcp_mod
+    import repowise.server.mcp_server.tool_answer.answer as answer_mod
+    from repowise.server.mcp_server import get_answer
+
+    _build_tree(
+        tmp_path,
+        monkeypatch,
+        mcp_mod,
+        answer_mod,
+        answer_text="big_handler runs each step in order and returns the first.",
+    )
+
+    real = answer_mod.withheld_definitions
+
+    def _from_a_vanished_file(repo_root, continuation):
+        out = list(real(repo_root, continuation))
+        out.append(
+            {
+                "name": "movedAway",
+                "kind": "function",
+                "line": 7,
+                "symbol_id": "gone/vanished.py::movedAway",
+                "signature": "def movedAway()",
+            }
+        )
+        return out
+
+    monkeypatch.setattr(answer_mod, "withheld_definitions", _from_a_vanished_file)
+
+    result = await get_answer("how does big_handler use movedAway on each step")
+
+    hint = result.get("next_action_hint") or ""
+    note = result.get("note") or ""
+    assert not (tmp_path / "gone" / "vanished.py").exists()
+    assert "gone/vanished.py::movedAway" in (note + hint), (note, hint)
+
+
+def test_answer_schema_version_was_bumped_for_this_change() -> None:
+    """Without the bump a cached row serves the pre-fix payload for 14 days.
+
+    Both changes in this pair alter payload CONTENT -- which names
+    ``withheld_symbols`` reports, and which id ``next_action_hint`` names -- so
+    the staleness test (``cached < current``) has to see a new number.
+    """
+    from repowise.server.mcp_server.tool_answer.config import _ANSWER_SCHEMA_VERSION
+
+    assert _ANSWER_SCHEMA_VERSION >= 15


### PR DESCRIPTION
Two independent fixes to the scanner behind `symbol_bodies[].withheld_symbols`,
and a schema bump so cached answers cannot serve the old payload.

## 1. Backtick strings were read as code

`_string_masked_lines` tracked Python triple quotes and `/* */` but had no
backtick branch, and backtick was not in `_QUOTEISH_RE` — so a line whose only
quote-ish character was a backtick skipped the character walk entirely. Go raw
strings and TS template literals were scanned as source, and the GraphQL and
interpolated text inside them was emitted as `withheld_symbols` entries.

Those ids are not dead ends: `get_symbol` answers them with a live grep, because
the name really is on that line. But the "symbol" is a GraphQL field, and 19
times it was the **headline** entry the note told the agent to fetch next.

Sweep against a tree-sitter oracle, both arms measured in one process against
one corpus snapshot:

| corpus | metric | before | after |
|---|---|---|---|
| cli/cli (Go) | not-a-definition | 282 / 22,898 (1.23%) | **1 / 22,769 (0.00%)** |
| | headline bad | 19 | **0** |
| | cuts returning nothing | 1.07% | 0.95% |
| mui (TS) | not-a-definition | 11 / 7,190 (0.15%) | **0 / 7,178 (0.00%)** |
| | cuts returning nothing | 21.42% | 21.40% |
| repowise (Py) | not-a-definition | 0 / 44,355 | 0 / 44,355 |
| | recall miss | 43 / 7,859 | 43 / 7,859 |

The Python control is byte-identical in every column. The one remaining Go entry
is oracle error rather than a fabrication — `type Direction = int` parses as
`type_alias`, which the oracle's node set omits.

### Most of the work was the instrument, not the fix

Masking backticks can **over-mask**, and a random-cut sweep structurally cannot
see that: it samples 12 cuts in 600 files, so a whole silenced file can pass
every gate. The replacement runs over every file and counts real definition
lines the backtick walk masks and the plain walk does not, with tree-sitter for
ground truth (a definition start can never legitimately sit inside a template
literal).

| corpus | files | real defs hidden | fabrications prevented |
|---|---|---|---|
| TS/JS, 9 repos | 50,170 | **0** | 6,618 |
| Go, 3 repos | 1,977 | **0** | 81 |
| non-backtick languages | 39,070 | **0 mask differences at all** | — |

That instrument was wrong three times before it settled, and each time it
flattered the conclusion. The third version only covered TS/JS and Go, which is
how a real regression reached a commit: in Rust, a markdown fence inside a
multi-line string opened a phantom frame and
`goose/crates/goose-cli/src/session/export.rs` lost five real `pub fn`
definitions. The walk is now gated on file extension — a backtick opens a string
only in Go and the JS/TS family.

The rest of the design is measured rather than argued:

- **Interpolation tracking**, because a flat counter reads a nested literal's
  opening backtick as closing the outer one. 1,926 fabrications against 60 on
  the 16 corpus files where the two disagree.
- **Escape and regex-literal handling**, because both produce a phantom frame
  that is re-closed later, leaving the stack balanced where the fallback below
  cannot see it.
- **A containment fallback**: a walk that ends still inside a literal discards
  its result and re-walks with backticks off. A lexer-lite that has lost track
  must under-mask rather than silently suppress a file. 24 of 114,215 files
  reach it.

C# verbatim and Rust raw strings stay untracked, measured rather than assumed:
C# has 27 multi-line verbatim literals in 4,284 files, and Rust has 35,484
interior lines across 4,559 literals but produces 0 fabrications inside a string
in 29,660 entries on the tree that has them. Go raw strings hold GraphQL, which
matches the definition patterns; Rust raw strings hold TOML, which does not.

## 2. A withheld `symbol_id` was advertised without a resolution check

`note` and `next_action_hint` interpolated `withheld_symbols[].symbol_id`
straight from the scanner. `_first_resolvable_id` now picks the first id
`get_symbol` would actually answer; when none would, the withheld names are
still reported and only the dead pointer is dropped.

`get_symbol` has three outcomes and only one is a failure — an indexed row, a
live-grep fallback, and nothing at all — so the guard accepts live-grep, and
keeps an id whose file cannot be read, since that is absence of evidence rather
than evidence of fabrication. Checked against the 130 unique ids a corpus run
emitted, chased through the real `get_symbol` on six trees: 119 indexed, 11
live-grep, 0 dead, **0 valid ids suppressed**.

This half is a guard rather than a fix for observed harm, and is labelled that
way: 0 of those 130 resolved to nothing, and the fabricated ids the first fix
removes were misleading rather than dead.

## Schema 14 → 15

Both changes alter payload content — which names `withheld_symbols` reports, and
which id `next_action_hint` names — so cached rows must bypass.

## Testing

`ruff check .` clean. Full `tests/unit`: 12,098 passed, 3 skipped, 0 failed.

Every one of the nine branches in the masker is covered by a test that fails
when that branch is removed, verified mechanically rather than by inspection —
four fixtures were vacuous before that check existed, each passing with its own
branch deleted because the containment rescued the fixture.
