### PR TITLE
fix(generation): name the directory a concept group is actually under

### DIFF
--- a/packages/core/src/repowise/core/generation/concept_tree/naming.py
+++ b/packages/core/src/repowise/core/generation/concept_tree/naming.py
@@ -346,7 +346,15 @@ def deterministic_scope(group: ConceptGroup) -> str:
     if len(dirs) == 1:
         where = dirs[0] or "the repository root"
     else:
-        where = f"{len(dirs)} directories under {group.target_path or 'the repository root'}"
+        # Relative to what the directories share, not to ``target_path``. The
+        # target is one of the group's directories and is not always a prefix
+        # of the others — ``_assign_targets`` falls through to the first sorted
+        # member when the true ancestor is not itself a member — so naming it
+        # here produced "4 directories under src/lib/a" directly above a
+        # membership line holding three directories that are not under it. The
+        # sentence falsified itself against the line above.
+        common = _common_prefix(dirs)
+        where = f"{len(dirs)} directories" + (f" under {common}" if common else "")
     return (
         f"Covers the {group.file_count} source files in {where}. "
         "Does not cover code outside those directories, which is documented on "

--- a/tests/unit/generation/test_concept_scope_line.py
+++ b/tests/unit/generation/test_concept_scope_line.py
@@ -1,0 +1,49 @@
+"""The scope line must name a directory the group is actually under.
+
+``deterministic_scope`` phrased its boundary as "under ``target_path``", but
+``target_path`` is one of the group's own directories, not their common
+ancestor: ``_assign_targets`` falls through to the first sorted member when
+the true ancestor is not itself a member. A group spanning ``src/lib/a`` …
+``src/lib/d`` is targeted at ``src/lib/a``, so the page read "4 directories
+under src/lib/a" directly above a membership line naming three directories
+that are not under it.
+"""
+
+from __future__ import annotations
+
+from repowise.core.generation.concept_tree.grouping import ConceptGroup
+from repowise.core.generation.concept_tree.naming import deterministic_scope
+
+
+def _group(dirs: list[str], target_path: str) -> ConceptGroup:
+    members = [f"{d}/mod{i}.py" for i, d in enumerate(dirs)]
+    return ConceptGroup(members=members, dirs=dirs, target_path=target_path)
+
+
+def test_scope_names_the_common_ancestor_not_the_target() -> None:
+    dirs = ["src/lib/a", "src/lib/b", "src/lib/c", "src/lib/d"]
+    line = deterministic_scope(_group(dirs, target_path="src/lib/a"))
+
+    assert "4 directories under src/lib." in line
+    # The target is not a prefix of the other three, so it must not be the
+    # boundary the sentence claims.
+    assert "under src/lib/a" not in line
+
+
+def test_scope_drops_the_clause_when_nothing_is_shared() -> None:
+    """Siblings of the repository root share no ancestor worth naming, and
+    "under the repository root" says nothing the next sentence does not."""
+    line = deterministic_scope(_group(["src/app", "lib/util"], target_path="src/app"))
+
+    assert "2 directories." in line
+    assert "under" not in line.split(".")[0]
+
+
+def test_single_directory_is_unchanged() -> None:
+    line = deterministic_scope(_group(["src/lib/a"], target_path="src/lib/a"))
+    assert "in src/lib/a." in line
+
+
+def test_repository_root_single_directory_is_unchanged() -> None:
+    line = deterministic_scope(_group([""], target_path=""))
+    assert "in the repository root." in line


### PR DESCRIPTION
## What

A concept page's scope line phrased its boundary as "under `{target_path}`", but `target_path` is one of the group's own directories rather than their common ancestor.

`_assign_targets` only picks the true ancestor when that ancestor is itself a member directory. `group.dirs` holds the immediate parent of each member, so for members under `src/lib/a`, `src/lib/b`, `src/lib/c` and `src/lib/d`, the ancestor `src/lib` is absent and the assignment falls through to the first sorted member.

The page then read:

> Covers the 14 source files in 4 directories under `src/lib/a`.

directly above a membership line naming three directories that are not under `src/lib/a`. The sentence falsified itself against the line above it.

## How

Derive the boundary from what the directories share, using the `_common_prefix` helper the payload builder already uses for this exact reason two functions down, and drop the clause when they share nothing rather than claiming the repository root. The following sentence already states the boundary, so nothing is lost.

`_common_prefix` compares path segments rather than strings, so `src/lib` and `src/library` correctly reduce to `src`.

## Behavior

Prose only. Page ids, grouping and the graph are untouched: the page id is `{page_type}:{target_path}` and abstract identity is a hash of the members, neither of which reads this string. The new expression computes the same value as the old one wherever `target_path` was already the true ancestor, so the change is confined to the fall-through case.

This does not address the underlying grouping that put four unrelated directories in one group.

## Verification

- New `tests/unit/generation/test_concept_scope_line.py`, four cases; the two that carry the fix verified failing against `main`
- `tests/unit/generation`: no new failures
- `ruff check` clean