### PR TITLE
fix(ingestion): index const bindings whose value is a call in TS/JS

### DIFF
--- a/packages/core/src/repowise/core/ingestion/extractors/bindings/ts_js.py
+++ b/packages/core/src/repowise/core/ingestion/extractors/bindings/ts_js.py
@@ -203,6 +203,67 @@ def collect_cjs_requires(stmt_node: Node, src: str) -> list[str]:
     return out
 
 
+# Wrapper nodes that sit between a declarator and the call it really binds,
+# each unwrapped through its single named child. ``as_expression`` and
+# ``satisfies_expression`` put the expression first and the type second, so
+# the same rule holds; neither exists in the JavaScript grammar, which simply
+# means those entries never match there.
+_VALUE_WRAPPER_NODE_TYPES = frozenset(
+    {
+        "await_expression",
+        "parenthesized_expression",
+        "non_null_expression",
+        "as_expression",
+        "satisfies_expression",
+    }
+)
+
+
+def declarator_value_is_module_ref(declarator: Node, src: str) -> bool:
+    """True when a ``const x = …`` value binds a module rather than a symbol.
+
+    ``require('./svc')``, ``import('./lazy')`` and ``await import('./lazy')``
+    bind a module, so the declarator must not be indexed as a symbol. The
+    symbol query cannot make this call itself: a tree-sitter predicate can
+    only test a capture it can name, and the callee hides behind ``await`` /
+    parentheses / ``!`` / ``as T`` / a member pick. Unwrapping here keeps the
+    decision in one place.
+
+    The member pick is unwrapped one level only, deliberately. One level is
+    exactly what the CommonJS import patterns match
+    (``value: (member_expression object: (call_expression …))``), so
+    ``require('./x').y`` is suppressed here *and* carries an import edge.
+    ``require('./x').y.z`` matches no import pattern, and suppressing it too
+    would leave the file advertising neither a binding nor a dependency.
+    Ceiling: the two stay in step by construction rather than by a shared
+    definition. Upgrade path is to widen the import patterns to unwrap the
+    same shells, at which point this can unwrap without a depth limit.
+    """
+    if declarator.type != "variable_declarator":
+        return False
+    value = declarator.child_by_field_name("value")
+
+    while value is not None and value.type in _VALUE_WRAPPER_NODE_TYPES:
+        value = value.named_children[0] if value.named_children else None
+    if value is not None and value.type == "member_expression":
+        value = value.child_by_field_name("object")
+        while value is not None and value.type in _VALUE_WRAPPER_NODE_TYPES:
+            value = value.named_children[0] if value.named_children else None
+
+    if value is None or value.type != "call_expression":
+        return False
+    fn = value.child_by_field_name("function")
+    if fn is None:
+        return False
+    # ``import(...)`` is its own node type in both grammars; ``require`` is a
+    # plain identifier, so the text check must not accept ``obj.require``.
+    # Ceiling: the match is textual, so a locally shadowed ``const require =
+    # …`` suppresses its callers' bindings. The import query's ``#eq?``
+    # predicate is blind the same way, so the two agree; a scope-aware fix
+    # would have to change both.
+    return fn.type == "import" or (fn.type == "identifier" and node_text(fn, src) == "require")
+
+
 def cjs_statement_is_reexport(stmt_node: Node, src: str) -> bool:
     """True when a CJS require statement re-exports through ``module.exports``.
 

--- a/packages/core/src/repowise/core/ingestion/parser.py
+++ b/packages/core/src/repowise/core/ingestion/parser.py
@@ -43,6 +43,7 @@ from .extractors import (
     refine_kotlin_class_kind,
 )
 from .extractors.bindings.python import expand_bare_relative_imports
+from .extractors.bindings.ts_js import declarator_value_is_module_ref
 from .extractors.synthetic_symbols import extract_synthetic_symbols
 from .extractors.visibility import (
     refine_cpp_visibility,
@@ -520,6 +521,16 @@ class ASTParser:
             # with no letters (``_``, ``__all__``) fall to "variable" rather
             # than being mislabelled constants by ``name == name.upper()``.
             if node_type in _MODULE_ANCHORED_NODE_TYPES:
+                # TS/JS: the symbol query admits call_expression values so
+                # forwardRef / memo / onCall / styled() bindings exist at all,
+                # which also lets `const svc = require('./svc')` through. Those
+                # bind a module and are already imports — drop them here rather
+                # than in the query, which cannot see past the await / paren /
+                # non-null / member-pick shells.
+                if file_info.language in _TS_JS_LANGUAGES and declarator_value_is_module_ref(
+                    def_node, src
+                ):
+                    continue
                 kind = "constant" if name.isupper() else "variable"
 
             # Params signature text

--- a/packages/core/src/repowise/core/ingestion/queries/javascript.scm
+++ b/packages/core/src/repowise/core/ingestion/queries/javascript.scm
@@ -46,12 +46,18 @@
   )
 ) @symbol.def
 
-; Top-level const/let with a non-function value — module constants. The
-; declarator (not the lexical_declaration) is @symbol.def so the kind map
-; can distinguish it from the arrow-function pattern above. Anchored at
-; (program …) — directly or under an export_statement — so function-local
-; declarations never match. require() declarators (call_expression or
-; member_expression values) are imports, never symbols.
+; Top-level const/let bindings — module constants and call-expression
+; bindings. The declarator (not the lexical_declaration) is @symbol.def so
+; the kind map can distinguish it from the arrow-function pattern above.
+; Anchored at (program …) — directly or under an export_statement — so
+; function-local declarations never match.
+;
+; Kept in step with typescript.scm minus the TS-only node types
+; (as_expression / satisfies_expression do not exist in the JS grammar and
+; would fail query compilation). require() / import() declarators match
+; (call_expression) here too; the parser drops them via
+; ``declarator_value_is_module_ref`` rather than a query predicate, because
+; the await / paren / non-null / member-pick shells hide the callee.
 (program
   (lexical_declaration
     (variable_declarator
@@ -59,7 +65,9 @@
       value: [
         (string) (template_string) (number) (true) (false) (null) (undefined)
         (array) (object) (unary_expression) (binary_expression)
-        (new_expression)
+        (new_expression) (member_expression)
+        (call_expression) (function_expression) (class)
+        (await_expression) (parenthesized_expression)
       ]
     ) @symbol.def
   )
@@ -73,7 +81,9 @@
         value: [
           (string) (template_string) (number) (true) (false) (null) (undefined)
           (array) (object) (unary_expression) (binary_expression)
-          (new_expression)
+          (new_expression) (member_expression)
+          (call_expression) (function_expression) (class)
+          (await_expression) (parenthesized_expression)
         ]
       ) @symbol.def
     )

--- a/packages/core/src/repowise/core/ingestion/queries/typescript.scm
+++ b/packages/core/src/repowise/core/ingestion/queries/typescript.scm
@@ -76,11 +76,20 @@
   name: (property_identifier) @symbol.name
 ) @symbol.def
 
-; Top-level const/let with a non-function value — module constants. The
-; declarator (not the lexical_declaration) is @symbol.def so the kind map
-; can distinguish it from the arrow-function pattern above. Anchored at
-; (program …) — directly or under an export_statement — so function-local
-; declarations never match.
+; Top-level const/let bindings — module constants and call-expression
+; bindings. The declarator (not the lexical_declaration) is @symbol.def so
+; the kind map can distinguish it from the arrow-function pattern above.
+; Anchored at (program …) — directly or under an export_statement — so
+; function-local declarations never match; without that anchor every
+; module-internal ``const x = useMemo(...)`` would flood the index.
+;
+; (call_expression) is what makes forwardRef / memo / styled() /
+; createContext() / zod schemas / Firebase ``export const f = onCall(...)``
+; indexable at all. CommonJS declarators (``const svc = require('./svc')``,
+; ``await import('./lazy')``) match this too but are module references, not
+; symbols — the parser drops them via ``declarator_value_is_module_ref``,
+; which unwraps the await / paren / non-null / member-pick shells that a
+; query predicate cannot see through.
 (program
   (lexical_declaration
     (variable_declarator
@@ -89,6 +98,8 @@
         (string) (template_string) (number) (true) (false) (null) (undefined)
         (array) (object) (unary_expression) (binary_expression)
         (new_expression) (member_expression) (as_expression) (satisfies_expression)
+        (call_expression) (function_expression) (class)
+        (await_expression) (parenthesized_expression) (non_null_expression)
       ]
     ) @symbol.def
   )
@@ -103,6 +114,8 @@
           (string) (template_string) (number) (true) (false) (null) (undefined)
           (array) (object) (unary_expression) (binary_expression)
           (new_expression) (member_expression) (as_expression) (satisfies_expression)
+          (call_expression) (function_expression) (class)
+          (await_expression) (parenthesized_expression) (non_null_expression)
         ]
       ) @symbol.def
     )

--- a/tests/unit/ingestion/parser/test_commonjs_require.py
+++ b/tests/unit/ingestion/parser/test_commonjs_require.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from repowise.core.ingestion.parser import ASTParser
 from tests.unit.ingestion.parser._helpers import _make_file_info
 
@@ -127,3 +129,84 @@ def test_top_level_js_constants_extracted_but_requires_are_not(parser: ASTParser
     # require() declarators are imports, not symbols
     assert "svc" not in by_name
     assert "local" not in by_name
+
+
+# ---------------------------------------------------------------------------
+# Module-reference declarators are never symbols
+#
+# The symbol query admits ``call_expression`` values so that forwardRef / memo
+# / onCall bindings are indexed at all. That also lets every ``require(...)``
+# and ``import(...)`` declarator through, and each of those shapes already
+# emits an import edge — indexing it a second time as a symbol would invent a
+# module-named binding. The wrappers are the reason the check is parser-side:
+# a query predicate can only test a capture it can name, and the callee hides
+# behind ``await`` / parentheses / ``!`` / a member pick.
+# ---------------------------------------------------------------------------
+
+_MODULE_REF_SHAPES = [
+    ("const svc = require('./svc');\n", "svc", "./svc"),
+    ("const picked = require('./svc').member;\n", "picked", "./svc"),
+    ("const lazy = import('./lazy');\n", "lazy", "./lazy"),
+    ("const awaited = await import('./lazy');\n", "awaited", "./lazy"),
+    ("export const reexported = require('./svc');\n", "reexported", "./svc"),
+]
+
+
+@pytest.mark.parametrize(("source", "name", "module"), _MODULE_REF_SHAPES)
+@pytest.mark.parametrize("language", ["javascript", "typescript"])
+def test_module_reference_declarator_is_import_not_symbol(
+    parser: ASTParser, source: str, name: str, module: str, language: str
+) -> None:
+    result = _parse(parser, source, language=language)
+    assert any(i.module_path == module for i in result.imports), (
+        f"{source!r} lost its import edge"
+    )
+    assert name not in {s.name for s in result.symbols}, (
+        f"{source!r} was indexed as a symbol as well as an import"
+    )
+
+
+@pytest.mark.parametrize("cast", ["as Foo", "satisfies Foo"])
+def test_cast_require_is_not_a_symbol(parser: ASTParser, cast: str) -> None:
+    """``const a = require('./x') as Foo`` is idiomatic in TypeScript CJS.
+
+    ``as_expression`` / ``satisfies_expression`` were already in the value
+    allowlist before call bindings were admitted, so this shape minted a
+    module-named symbol on its own. It is the one cast form common enough to
+    matter, which is why the guard unwraps both.
+    """
+    result = _parse(parser, f"const a = require('./x') {cast};\n", language="typescript")
+    assert "a" not in {s.name for s in result.symbols}
+
+
+def test_deep_member_pick_keeps_its_symbol(parser: ASTParser) -> None:
+    """``require('./x').y.z`` is deliberately NOT suppressed.
+
+    The CommonJS import patterns unwrap one member level, so a two-level pick
+    produces no import edge. Suppressing the symbol as well would leave the
+    file advertising neither a binding nor a dependency, so the guard stops at
+    the depth the import side can actually match.
+    """
+    result = _parse(parser, "const deep = require('./x').y.z;\n", language="typescript")
+    assert "deep" in {s.name for s in result.symbols}
+
+
+@pytest.mark.parametrize("language", ["javascript", "typescript"])
+def test_parenthesised_require_is_not_a_symbol(parser: ASTParser, language: str) -> None:
+    """``const x = (require('./svc'))`` is not a symbol either.
+
+    Known ceiling: the *import* queries do not see through the parentheses, so
+    this shape yields no import edge (it never did — the value allowlist had no
+    ``parenthesized_expression`` before, so it yielded nothing at all). The
+    guard keeps that parity rather than inventing a module-named symbol.
+    Upgrade path: widen the CommonJS import patterns to unwrap the same shells
+    ``declarator_value_is_module_ref`` already unwraps.
+    """
+    result = _parse(parser, "const wrapped = (require('./svc'));\n", language=language)
+    assert "wrapped" not in {s.name for s in result.symbols}
+
+
+def test_method_call_named_require_is_still_a_symbol(parser: ASTParser) -> None:
+    """``loader.require(...)`` is an ordinary method call, not CommonJS."""
+    result = _parse(parser, "const cfg = loader.require('./thing');\n")
+    assert "cfg" in {s.name for s in result.symbols}

--- a/tests/unit/ingestion/parser/test_typescript.py
+++ b/tests/unit/ingestion/parser/test_typescript.py
@@ -456,3 +456,97 @@ function g() {
         names = {s.name for s in syms}
         assert "localConst" not in names
         assert "inner" not in names
+
+
+class TestTypeScriptCallExpressionBindings:
+    """``const X = someCall(...)`` is a symbol.
+
+    The whole React/Firebase idiom lives in this shape — forwardRef, memo,
+    styled(), createContext(), zod schemas, ``export const f = onCall(...)``.
+    Until the value allowlist admitted ``call_expression`` none of it was
+    indexed at all, so such a file read as having almost no symbols.
+    """
+
+    TSX_SOURCE = b"""
+import * as React from "react";
+import { onCall } from "firebase-functions/v2/https";
+import styled from "styled-components";
+import { z } from "zod";
+
+const AccordionItem = React.forwardRef((props, ref) => {
+  return null;
+});
+const Memoized = React.memo(function Inner() { return null; });
+const Ctx = createContext(null);
+const KlassExpr = class Foo {};
+const fnExpr = function named() { return 1; };
+const wrapped = (makeThing());
+const asserted = makeThing()!;
+export const myFunction = onCall(async (req) => {
+  return { ok: true };
+});
+export const Button = styled.button`color: red;`;
+export const schema = z.object({ a: z.string() });
+export const loaded = await loadThing();
+
+function outer() {
+  const memo = useMemo(() => 1, []);
+  return memo;
+}
+"""
+
+    def _names(self, parser: ASTParser, path: str = "src/accordion.tsx") -> set[str]:
+        fi = _make_file_info(path, "typescript")
+        return {s.name for s in parser.parse_file(fi, self.TSX_SOURCE).symbols}
+
+    def test_forward_ref_component_is_indexed(self, parser: ASTParser) -> None:
+        assert "AccordionItem" in self._names(parser)
+
+    def test_memo_component_is_indexed(self, parser: ASTParser) -> None:
+        assert "Memoized" in self._names(parser)
+
+    def test_exported_firebase_handler_is_indexed(self, parser: ASTParser) -> None:
+        assert "myFunction" in self._names(parser)
+
+    def test_factory_and_schema_bindings_are_indexed(self, parser: ASTParser) -> None:
+        assert {"Ctx", "Button", "schema"} <= self._names(parser)
+
+    def test_class_and_function_expression_bindings_are_indexed(self, parser: ASTParser) -> None:
+        assert {"KlassExpr", "fnExpr"} <= self._names(parser)
+
+    def test_wrapped_call_bindings_are_indexed(self, parser: ASTParser) -> None:
+        """Parenthesised / non-null / awaited calls unwrap to the same shape."""
+        assert {"wrapped", "asserted", "loaded"} <= self._names(parser)
+
+    def test_function_local_call_binding_is_not_indexed(self, parser: ASTParser) -> None:
+        """The (program …) anchor is what keeps ``useMemo`` out of the index."""
+        assert "memo" not in self._names(parser)
+
+    def test_plain_ts_grammar_variant_agrees_with_tsx(self, parser: ASTParser) -> None:
+        assert self._names(parser, "src/accordion.ts") == self._names(parser)
+
+
+class TestJavaScriptCallExpressionBindings:
+    """JavaScript was strictly worse than TypeScript: its allowlist also
+    omitted ``member_expression``, so even a plain alias yielded no symbol."""
+
+    JS_SOURCE = b"""
+const AccordionItem = React.forwardRef((props, ref) => null);
+const Accordion = AccordionPrimitive.Root;
+const KlassExpr = class Foo {};
+const fnExpr = function named() { return 1; };
+export const handler = onCall(async () => 1);
+"""
+
+    def _names(self, parser: ASTParser) -> set[str]:
+        fi = _make_file_info("src/accordion.js", "javascript")
+        return {s.name for s in parser.parse_file(fi, self.JS_SOURCE).symbols}
+
+    def test_call_bindings_are_indexed(self, parser: ASTParser) -> None:
+        assert {"AccordionItem", "handler"} <= self._names(parser)
+
+    def test_member_expression_alias_is_indexed(self, parser: ASTParser) -> None:
+        assert "Accordion" in self._names(parser)
+
+    def test_class_and_function_expression_bindings_are_indexed(self, parser: ASTParser) -> None:
+        assert {"KlassExpr", "fnExpr"} <= self._names(parser)


### PR DESCRIPTION
## What

`const X = someCall(...)` was never indexed as a symbol in TypeScript or JavaScript.

The symbol queries enumerate an allowlist of permitted right-hand-side node types for a top-level `const`/`let`, and `call_expression` was not on it. Everything built by a call was therefore absent from the index entirely: `forwardRef` and `memo` components, `styled()`, `createContext()`, zod schemas, factories and HOCs, and every Firebase `export const f = onCall(...)`.

JavaScript was worse. Its list also omitted `member_expression`, so even a plain `const Accordion = AccordionPrimitive.Root` alias yielded nothing.

This is the third instance of the same family, after #1214 (unparenthesized arrows) and #1012 (exported const literals), both fixed the same way.

## How

Widen both allowlists to admit call, function and class expressions plus the `await` / parenthesised / non-null wrappers around them, and bring the JavaScript list to parity with TypeScript apart from the two TS-only node types. The patterns stay anchored at `(program ...)`, so a module-internal `const x = useMemo(...)` still never reaches the index.

Admitting `call_expression` also admits `const svc = require('./svc')`, which is an import rather than a symbol. A tree-sitter predicate can only test a capture it can name, and the callee hides behind `await`, parentheses, a non-null assertion, an `as`/`satisfies` cast or a member pick, so the check lives beside the other CommonJS helpers as `declarator_value_is_module_ref` and unwraps those shells first.

That also closes two pre-existing leaks, both from node types the allowlist already permitted:

- `member_expression` made `const x = require('./svc').member` a symbol as well as an import
- `as_expression` made `const x = require('./svc') as Foo` a module-named symbol with no import edge at all

The member pick unwraps one level only, matching exactly what the CommonJS import patterns match. A deeper pick carries no import edge, so suppressing its symbol too would leave the file advertising neither a binding nor a dependency.

## Behavior

TS/JS files gain the symbols they should always have had. Downstream that restores enclosing-symbol attribution for call sites, unused-export detection, per-symbol health and `risk --target`.

Requires a re-index to take effect. Symbol kind for these bindings is unchanged here and still follows the constant/variable naming rule; classifying them by value is a separate change.

## Verification

13 of the new test cases fail on `main` and pass here. The remainder are guards that are green either way, holding the `(program ...)` anchor and the parity cases in place.

Measured against two real TypeScript trees:

| Repo | Symbols before | After | Lost | Import edges lost |
|---|---|---|---|---|
| Roo-Code (1560 files) | 5223 | 5643 | 0 | 0 |
| cline (2408 files) | 16873 | 17848 | 0 | 0 |

The additions were inspected rather than counted: zod schemas, shadcn components, memoized components, real exported API. The largest single-file delta is +40 on a schema barrel that genuinely exports 40 schemas.

Full parser, ingestion, dead-code, analysis and distill unit suites pass (3445), as does `tests/integration/test_ts_dead_code.py`. `ruff check` clean, and mypy reports no new errors in the changed files.