### PR TITLE
fix(cli): stop uninstall reporting a half-refused removal as clean

### DIFF
--- a/packages/cli/src/repowise/cli/agent_targets/targets/claude_code.py
+++ b/packages/cli/src/repowise/cli/agent_targets/targets/claude_code.py
@@ -470,7 +470,10 @@ class ClaudeCodeTarget:
                 result.record(desktop, FileAction.KEPT, desktop_leftover)
             elif desktop_removed:
                 result.record(desktop, FileAction.REMOVED)
-        removed = desktop_removed or removed
+        # Deliberately not folded into `removed`. That accumulator feeds the
+        # settings.json row below, so once the Desktop config got its own row a
+        # Desktop-only removal reported settings.json as `removed` too, over a
+        # file that in the common case does not even exist.
 
         # Asked of the file, not inferred from the three booleans. Each of them
         # returns False for "nothing of ours was here", "could not parse" and

--- a/packages/cli/src/repowise/cli/agent_targets/targets/codex.py
+++ b/packages/cli/src/repowise/cli/agent_targets/targets/codex.py
@@ -472,15 +472,15 @@ def remove_server_config(repo_path: Path, *, drop_hooks_feature: bool) -> FileWr
     # flow lands in exactly that shape.
     changed = (has_server and not server_refused) or (has_feature and not feature_refused)
     if not changed:
+        left = []
+        if server_refused:
+            left.append("the repowise server entry")
+        if feature_refused:
+            left.append("features.hooks")
         return FileWrite(
             path=config_path,
             action=FileAction.KEPT,
-            reason=(
-                "the repowise entry uses a key spelling this remover cannot match; "
-                "delete it by hand"
-            )
-            if server_refused
-            else "features.hooks holds a value this remover cannot cut; delete it by hand",
+            reason=f"{' and '.join(left)} could not be removed; delete by hand",
         )
 
     try:
@@ -517,20 +517,26 @@ def remove_server_config(repo_path: Path, *, drop_hooks_feature: bool) -> FileWr
                 reason="the entry was still present after the write",
             )
 
-    # Something went, and something else was declined. Both halves belong in
-    # the report: a bare REMOVED here would be true of the server table and
-    # silently false of the flag.
-    if feature_refused:
+    # Something moved and something else was declined. The row is KEPT, not
+    # REMOVED, and the action is what matters rather than the reason: the runner
+    # counts leftovers and picks the exit code from the action alone, so a
+    # REMOVED row carrying a "left in place" sentence was counted as clean.
+    # `uninstall --all` exited 0 under "everything selected is gone" while
+    # Codex went on launching our MCP server from an entry still in the file.
+    #
+    # Both halves are named when both were refused. The KEPT head and the
+    # REMOVED tail used to disagree about which one to report, so a run that
+    # declined both mentioned only the server.
+    if server_refused or feature_refused:
+        left = []
+        if server_refused:
+            left.append("the repowise server entry")
+        if feature_refused:
+            left.append("features.hooks")
         return FileWrite(
             path=config_path,
-            action=FileAction.REMOVED,
-            reason="features.hooks was left in place; its value is one this remover cannot cut",
-        )
-    if server_refused:
-        return FileWrite(
-            path=config_path,
-            action=FileAction.REMOVED,
-            reason="the repowise server entry was left in place; delete it by hand",
+            action=FileAction.KEPT,
+            reason=f"{' and '.join(left)} could not be removed; delete by hand",
         )
     return FileWrite(path=config_path, action=FileAction.REMOVED)
 
@@ -559,7 +565,21 @@ def _config_parse_refusal(repo_path: Path) -> str | None:
 
 
 def _user_hooks_leftover_reason() -> str | None:
-    """Why ``~/.codex/hooks.json`` still has us in it, read from disk. None when clean."""
+    """Why ``~/.codex/hooks.json`` still has us in it, read from disk. None when clean.
+
+    Scoped to **exactly what the remover removes**, which is the rewrite hook.
+    Probing for any command containing "repowise" made the two halves disagree:
+    the probe flagged a hook the remover does not touch, so the row reported
+    ``KEPT`` on every run and the machine could never be made clean. Any hook
+    the user wrote that merely mentions ``repowise distill`` or
+    ``repowise update`` triggered it.
+
+    The Claude Code side is broad because its uninstall is broad, removing the
+    rewrite hook and the augment hooks and the MCP entry. Codex's user-scope
+    uninstall removes the rewrite hook, so this asks about the rewrite hook.
+    """
+    from repowise.cli.editor_integrations.codex_config import _is_rewrite_hook
+
     path = user_hooks_path()
     if not path.exists():
         return None
@@ -567,11 +587,11 @@ def _user_hooks_leftover_reason() -> str | None:
         doc = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, ValueError):
         try:
-            if b"repowise" not in path.read_bytes().lower():
+            if b"repowise-rewrite" not in path.read_bytes().lower():
                 return None
         except OSError:
             return None
-        return "the file could not be read and still mentions repowise"
+        return "the file could not be read and still mentions our rewrite hook"
     hooks = doc.get("hooks") if isinstance(doc, dict) else None
     if not isinstance(hooks, dict):
         return None
@@ -581,9 +601,8 @@ def _user_hooks_leftover_reason() -> str | None:
         for entry in entries:
             if not isinstance(entry, dict) or not isinstance(entry.get("hooks"), list):
                 continue
-            for hook in entry["hooks"]:
-                if isinstance(hook, dict) and "repowise" in str(hook.get("command", "")):
-                    return "one of our hooks was still present after the write"
+            if any(_is_rewrite_hook(hook) for hook in entry["hooks"]):
+                return "our rewrite hook was still present after the write"
     return None
 
 

--- a/tests/unit/cli/test_toml_removal.py
+++ b/tests/unit/cli/test_toml_removal.py
@@ -228,6 +228,45 @@ def test_a_feature_value_we_cannot_cut_does_not_abandon_the_server_removal(
     assert '"a",' in body
 
 
+def test_a_half_refused_removal_is_not_reported_as_clean(tmp_path: Path) -> None:
+    """The action is what the runner counts, so it has to carry the bad news.
+
+    A ``REMOVED`` row with a "left in place" reason was counted as clean, so
+    ``uninstall --all`` exited 0 under "everything selected is gone" while Codex
+    went on launching our MCP server from an entry still in the file. The reason
+    text was accurate and nothing read it.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    # The inline spelling `remove_table`'s regex cannot match, beside a feature
+    # flag that removes cleanly, so one half succeeds and one half does not.
+    _write(
+        repo,
+        '[mcp_servers]\nrepowise = { command = "repowise" }\n[features]\nhooks = true\n',
+    )
+
+    write = remove_server_config(repo, drop_hooks_feature=True)
+
+    assert write.action is FileAction.KEPT
+    assert write.reason and "server entry" in write.reason
+
+
+def test_both_refusals_are_named_not_just_the_first(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _write(
+        repo,
+        '[mcp_servers]\nrepowise = { command = "repowise" }\n'
+        '[features]\nhooks = [\n  "a",\n]\n',
+    )
+
+    write = remove_server_config(repo, drop_hooks_feature=True)
+
+    assert write.action is FileAction.KEPT
+    assert "server entry" in (write.reason or "")
+    assert "features.hooks" in (write.reason or "")
+
+
 def test_one_row_per_file(tmp_path: Path) -> None:
     """Two passes over config.toml put two rows for one path in the report."""
     from repowise.cli.agent_targets.registry import get_target

--- a/tests/unit/cli/test_uninstall_cmd.py
+++ b/tests/unit/cli/test_uninstall_cmd.py
@@ -479,6 +479,14 @@ def test_every_kept_row_carries_a_reason(repo: Path) -> None:
         '{\n  // a comment\n  "mcpServers": {"repowise": {}}\n}\n', encoding="utf-8"
     )
     (repo / ".codex" / "config.toml").write_text("bad = = toml [[[\n", encoding="utf-8")
+    (repo / ".vscode" / "extensions.json").write_text(
+        '{\n  // a comment\n  "recommendations": ["repowise-dev.repowise"]\n}\n', encoding="utf-8"
+    )
+    # Claude Code was the sixth target and the only one this scenario never made
+    # refuse, so its reason wiring and both its leftover probes were unpinned.
+    (Path.home() / ".claude" / "settings.json").write_text(
+        '{\n  // a comment\n  "mcpServers": {"repowise": {}}\n}\n', encoding="utf-8"
+    )
 
     payload = _payload(["uninstall", str(repo), "--all"])
 
@@ -487,7 +495,7 @@ def test_every_kept_row_carries_a_reason(repo: Path) -> None:
     assert len({r["group"] for r in kept}) > 1, kept
     # Every target that can refuse here does, so a reverted reason in any one of
     # them turns this red rather than only the three that happened to be wired.
-    for expected in ("OpenCode", "Hermes", "Codex", "Cursor", "VS Code"):
+    for expected in ("OpenCode", "Hermes", "Codex", "Cursor", "VS Code", "Claude Code"):
         assert any(expected in label for label in labels), (expected, sorted(labels))
     assert all(r["reason"] for r in kept), [r for r in kept if not r["reason"]]
 


### PR DESCRIPTION
Follow-up to #1467. Four defects found reviewing that work after it merged; the
first is a false success of exactly the kind `repowise uninstall` exists to
prevent.

## 1. A half-refused removal was reported as clean

`remove_server_config` applies two independent edits to `.codex/config.toml`, the
server table and `features.hooks`. When one succeeded and the other was declined
it returned `REMOVED` with a reason naming what had been left behind.

Nothing reads that reason. `Outcome.exit_code` and `.leftovers` key on the
**action** alone, so the row counted as clean:

```
# .codex/config.toml using the inline spelling remove_table cannot match:
#   [mcp_servers]
#   repowise = { command = "repowise", args = ["mcp"] }
repowise uninstall <repo> --all --format json
# -> exit 0, "complete": true, action "removed",
#    reason "the repowise server entry was left in place; delete it by hand"
#    and the entry is still in the file
```

The command printed "Everything selected is gone" while Codex went on launching
our MCP server. A second run correctly said `kept`, so it converged, but run one
was a false success.

Any refusal now makes the row `KEPT`. Both halves are named when both were
refused: the `KEPT` head reported only the server and the `REMOVED` tail reported
only the feature, so a run that declined both mentioned one.

## 2. The codex hooks probe outran its remover, so it never converged

`_user_hooks_leftover_reason` flagged any hook whose command contained
`"repowise"`, under any event. `uninstall_codex_rewrite_hook` removes only the
rewrite hook. So a hook the remover does not touch was reported on every run:

```
run1: removed=True   leftover='one of our hooks was still present after the write'
run2: removed=False  leftover='one of our hooks was still present after the write'
run3: removed=False  leftover='one of our hooks was still present after the write'
```

`KEPT` and exit 3 forever, with no way to make the machine clean. A user hook
mentioning `repowise distill` or `repowise update` was enough to trigger it.

The probe is now scoped to exactly what the remover removes. Claude Code's
equivalent stays broad because its uninstall is broad, removing the rewrite hook,
the augment hooks and the MCP entry; the two are meant to differ, and previously
did not.

## 3. The settings.json row claimed a removal it had not made

Giving the Claude Desktop config its own row left the `removed` accumulator
shared, so a Desktop-only removal reported `~/.claude/settings.json` as `removed`
as well, over a file that in the common case does not exist. Over-reporting
rather than hiding a leftover, but the same honesty standard running the other
way.

## 4. The reason test covered five of six targets

`test_every_kept_row_carries_a_reason` never made Claude Code refuse, so its
reason wiring and both its leftover probes were unpinned, as was vscode's
`extensions.json` reason. Mutation-checked: reverting any of those left the suite
green. The scenario now makes all six refuse.

## Testing

Two new tests pin the false-success case and the both-refused reason. 69 tests in
`test_uninstall_cmd.py` and `test_toml_removal.py`, full CLI suite 2098 passed,
`ruff check .` clean.
