### PR TITLE
fix(chat): align get_context include schema with MCP/CLI

### DIFF
--- a/packages/server/src/repowise/server/chat_tools.py
+++ b/packages/server/src/repowise/server/chat_tools.py
@@ -47,7 +47,11 @@ _TOOL_SCHEMAS: list[dict[str, Any]] = [
     },
     {
         "name": "get_context",
-        "description": "Get documentation, ownership, freshness, and decisions for one or more files, modules, or symbols.",
+        "description": (
+            "Triage card for files/modules/symbols: docs, freshness, hotspot bit, "
+            "signatures. Opt into full_doc, ownership, last_change, callers/callees, "
+            "metrics, community, decisions, health, or skeleton (body-elided source)."
+        ),
         "parameters": {
             "type": "object",
             "properties": {
@@ -61,20 +65,31 @@ _TOOL_SCHEMAS: list[dict[str, Any]] = [
                     "items": {
                         "type": "string",
                         "enum": [
-                            "docs",
                             "full_doc",
                             "ownership",
                             "last_change",
-                            "decisions",
-                            "freshness",
-                            "source",
                             "callers",
                             "callees",
                             "metrics",
                             "community",
+                            "decisions",
+                            "health",
+                            "skeleton",
                         ],
                     },
-                    "description": "Data blocks to include. Default: docs + freshness.",
+                    "description": (
+                        "Opt-in blocks (docs + freshness are always on): "
+                        "full_doc | ownership | last_change | callers | callees | "
+                        "metrics | community | decisions | health | skeleton."
+                    ),
+                },
+                "compact": {
+                    "type": "boolean",
+                    "description": (
+                        "Default true. False adds structure, imports, and docstrings "
+                        "to the triage card."
+                    ),
+                    "default": True,
                 },
                 "repo": {"type": "string", "description": "Repository identifier."},
             },

--- a/tests/unit/server/test_chat_tool_registry.py
+++ b/tests/unit/server/test_chat_tool_registry.py
@@ -24,3 +24,22 @@ def test_chat_dead_code_schema_default_matches_risk_cap() -> None:
 
     params = get_tool_registry()["get_dead_code"].parameters["properties"]["min_confidence"]
     assert params["default"] == RISK_CAP_CONFIDENCE
+
+
+def test_chat_get_context_include_matches_cli_blocks() -> None:
+    """Chat schema must advertise the same include blocks MCP/CLI accept.
+
+    A stale enum that listed docs/freshness/source and omitted skeleton/health
+    made the chat model request a no-op ``source`` block and never ask for
+    skeleton or health — both of which get_context actually serves.
+    """
+    from repowise.cli.commands.context_cmd import _INCLUDE_BLOCKS
+    from repowise.server.chat_tools import get_tool_registry
+
+    props = get_tool_registry()["get_context"].parameters["properties"]
+    enum = props["include"]["items"]["enum"]
+    assert set(enum) == set(_INCLUDE_BLOCKS)
+    assert "compact" in props
+    assert props["compact"]["default"] is True
+    for bogus in ("docs", "freshness", "source"):
+        assert bogus not in enum


### PR DESCRIPTION
## Summary
- Chat `get_context` schema listed `docs`/`freshness`/`source` and omitted `skeleton`/`health`, so the model could request a no-op `source` block and never ask for blocks MCP already serves.
- Align the include enum with CLI `_INCLUDE_BLOCKS`, advertise `compact`, and pin the match with a registry drift test.

## Test plan
- [x] `pytest tests/unit/server/test_chat_tool_registry.py`
- [x] In web chat, ask for a file skeleton / health block and confirm the model can pass `include=["skeleton"]` / `include=["health"]`