### PR TITLE
fix(ui): render get_why MCP wire format in chat artifacts

### DIFF
--- a/packages/types/src/chat.ts
+++ b/packages/types/src/chat.ts
@@ -172,19 +172,59 @@ export interface GraphPathArtifact {
   data: GraphPathArtifactData;
 }
 
-/** `get_why` — decision register search results / health dashboard. */
+/** `get_why` — decision register search / path lookup / health dashboard. */
 export interface DecisionsArtifactData {
-  mode: "health" | "search";
+  mode: "health" | "search" | "path";
   query?: string;
+  path?: string;
+  summary?: string;
+  /** Health mode: counters from `get_decision_health_summary`. */
+  counts?: Record<string, number>;
+  /** @deprecated Legacy chat fixture field; prefer `counts`. */
   total_decisions?: number;
+  /** @deprecated Legacy chat fixture field; unused by MCP wire format. */
   by_source?: Record<string, number>;
-  decisions?: Array<{ title: string; status?: string }>;
+  stale_decisions?: Array<{
+    title: string;
+    status?: string;
+    affected_files?: string[];
+    staleness_score?: number;
+  }>;
+  proposed_awaiting_review?: Array<{
+    title: string;
+    source?: string;
+    confidence?: number;
+  }>;
+  ungoverned_hotspots?: Array<string | { file_path?: string; path?: string }>;
+  /** Search/path mode: governing or matched decisions (MCP wire). */
+  decisions?: Array<{
+    title: string;
+    status?: string;
+    decision?: string;
+    rationale?: string;
+    affected_files?: string[];
+  }>;
+  /**
+   * @deprecated Legacy chat fixture shape. MCP search/path return `decisions`.
+   * Renderers still accept this for stored conversations.
+   */
   results?: Array<{
     title: string;
     decision: string;
     rationale?: string;
     affected_files?: string[];
   }>;
+  origin_story?: {
+    first_commit?: { date?: string; author?: string; message?: string };
+    primary_author?: string;
+    [k: string]: unknown;
+  };
+  alignment?: {
+    score?: number;
+    label?: string;
+    summary?: string;
+    [k: string]: unknown;
+  };
 }
 export interface DecisionsArtifact {
   type: "decisions";

--- a/packages/ui/__tests__/chat/artifacts.test.tsx
+++ b/packages/ui/__tests__/chat/artifacts.test.tsx
@@ -129,6 +129,29 @@ describe("chat artifact renderers", () => {
     expect(screen.getByText("Use SSE for chat")).toBeInTheDocument();
   });
 
+  it("DecisionsRenderer health mode reads MCP counts and stale rows", () => {
+    render(
+      <DecisionsRenderer
+        data={{
+          mode: "health",
+          summary: "12 active · 2 stale · 1 proposed · 3 ungoverned hotspots",
+          counts: { active: 12, stale: 2, proposed: 1 },
+          stale_decisions: [
+            {
+              title: "Prefer SSE",
+              affected_files: ["packages/server/src/chat.py"],
+            },
+          ],
+          proposed_awaiting_review: [{ title: "Drop Redis", source: "commit" }],
+          ungoverned_hotspots: ["src/hot.ts"],
+        }}
+      />,
+    );
+    expect(screen.getByText("12")).toBeInTheDocument();
+    expect(screen.getByText("Prefer SSE")).toBeInTheDocument();
+    expect(screen.getByText("Drop Redis")).toBeInTheDocument();
+  });
+
   it("DecisionsRenderer search mode renders matches with affected files", () => {
     render(
       <DecisionsRenderer
@@ -149,6 +172,48 @@ describe("chat artifact renderers", () => {
     expect(screen.getByText("LRU artifact cache")).toBeInTheDocument();
     expect(
       screen.getByText("app/services/artifact_service.py"),
+    ).toBeInTheDocument();
+  });
+
+  it("DecisionsRenderer search mode reads MCP decisions array", () => {
+    render(
+      <DecisionsRenderer
+        data={{
+          mode: "search",
+          query: "auth",
+          decisions: [
+            {
+              title: "JWT sessions",
+              decision: "Use signed cookies.",
+              affected_files: ["packages/server/auth.py"],
+            },
+          ],
+        }}
+      />,
+    );
+    expect(screen.getByText("JWT sessions")).toBeInTheDocument();
+    expect(screen.getByText("packages/server/auth.py")).toBeInTheDocument();
+  });
+
+  it("DecisionsRenderer path mode shows governing decisions", () => {
+    render(
+      <DecisionsRenderer
+        data={{
+          mode: "path",
+          path: "packages/ui/src/chat/artifacts.tsx",
+          decisions: [
+            {
+              title: "Typed chat artifacts",
+              status: "active",
+              decision: "One renderer per tool.",
+            },
+          ],
+        }}
+      />,
+    );
+    expect(screen.getByText("Typed chat artifacts")).toBeInTheDocument();
+    expect(
+      screen.getByText((_, el) => el?.textContent === '"packages/ui/src/chat/artifacts.tsx"'),
     ).toBeInTheDocument();
   });
 

--- a/packages/ui/__tests__/chat/source-citations.test.tsx
+++ b/packages/ui/__tests__/chat/source-citations.test.tsx
@@ -66,6 +66,32 @@ describe("extractSources", () => {
     // Badge hides rather than falling back to the unbounded raw score.
     expect(sources[0]?.confidence).toBeUndefined();
   });
+
+  it("cites files from get_why health stale_decisions", () => {
+    const sources = extractSources(
+      [
+        {
+          id: "why1",
+          name: "get_why",
+          arguments: {},
+          status: "done",
+          result: {
+            mode: "health",
+            stale_decisions: [
+              {
+                title: "Prefer SSE",
+                affected_files: ["packages/server/src/chat.py"],
+              },
+            ],
+          },
+        },
+      ],
+      "repo1",
+    );
+
+    expect(sources).toHaveLength(1);
+    expect(sources[0]?.targetPath).toBe("packages/server/src/chat.py");
+  });
 });
 
 describe("SourceCitations render", () => {

--- a/packages/ui/src/chat/artifacts.tsx
+++ b/packages/ui/src/chat/artifacts.tsx
@@ -326,14 +326,107 @@ export function GraphPathRenderer({ data }: { data: GraphPathArtifactData }) {
 // Decisions
 // ---------------------------------------------------------------------------
 
+function decisionRows(
+  data: DecisionsArtifactData,
+): Array<{
+  title: string;
+  status?: string;
+  decision?: string;
+  rationale?: string;
+  affected_files?: string[];
+}> {
+  // MCP search/path emit `decisions`; older chat fixtures used `results`.
+  return (data.decisions ?? data.results ?? []) as Array<{
+    title: string;
+    status?: string;
+    decision?: string;
+    rationale?: string;
+    affected_files?: string[];
+  }>;
+}
+
+function DecisionCards({
+  rows,
+}: {
+  rows: Array<{
+    title: string;
+    status?: string;
+    decision?: string;
+    rationale?: string;
+    affected_files?: string[];
+  }>;
+}) {
+  return (
+    <div className="space-y-3">
+      {rows.map((r, i) => (
+        <div
+          key={`${r.title}:${i}`}
+          className="rounded-lg border border-[var(--color-border-default)] p-3 space-y-1.5"
+        >
+          <h3 className="text-xs font-medium text-[var(--color-text-primary)]">
+            {r.title}
+            {r.status && (
+              <span className="ml-1.5 text-[10px] font-normal text-[var(--color-text-tertiary)]">
+                ({r.status})
+              </span>
+            )}
+          </h3>
+          {r.decision && (
+            <p className="text-xs text-[var(--color-text-secondary)] leading-relaxed">
+              {r.decision}
+            </p>
+          )}
+          {r.rationale && (
+            <p className="text-xs text-[var(--color-text-tertiary)] leading-relaxed">
+              {r.rationale}
+            </p>
+          )}
+          {r.affected_files && r.affected_files.length > 0 && (
+            <div className="flex flex-wrap gap-1 pt-1">
+              {r.affected_files.slice(0, 6).map((f) => (
+                <FilePathChip key={f} path={f} />
+              ))}
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
 export function DecisionsRenderer({ data }: { data: DecisionsArtifactData }) {
   if (data.mode === "health") {
+    const counts = data.counts ?? {};
+    const active =
+      counts.active ??
+      counts.total ??
+      data.total_decisions ??
+      0;
+    const stale = data.stale_decisions ?? [];
+    const proposed = data.proposed_awaiting_review ?? [];
+    const hotspots = data.ungoverned_hotspots ?? [];
+    const legacyRecent = data.decisions ?? [];
+
     return (
       <div className="space-y-4">
-        <StatRow
-          label="Decisions"
-          value={(data.total_decisions ?? 0).toLocaleString()}
-        />
+        {data.summary && (
+          <p className="text-xs text-[var(--color-text-secondary)]">{data.summary}</p>
+        )}
+        <div className="grid grid-cols-2 gap-2">
+          <StatRow label="Active" value={Number(active).toLocaleString()} />
+          <StatRow
+            label="Stale"
+            value={Number(counts.stale ?? stale.length).toLocaleString()}
+          />
+          <StatRow
+            label="Proposed"
+            value={Number(counts.proposed ?? proposed.length).toLocaleString()}
+          />
+          <StatRow
+            label="Ungoverned"
+            value={hotspots.length.toLocaleString()}
+          />
+        </div>
         {data.by_source && Object.keys(data.by_source).length > 0 && (
           <div>
             <SectionTitle icon={Layers}>By source</SectionTitle>
@@ -348,11 +441,40 @@ export function DecisionsRenderer({ data }: { data: DecisionsArtifactData }) {
             </div>
           </div>
         )}
-        {data.decisions && data.decisions.length > 0 && (
+        {stale.length > 0 && (
+          <div>
+            <SectionTitle icon={AlertTriangle}>Stale decisions</SectionTitle>
+            <ul className="space-y-1">
+              {stale.slice(0, 8).map((d, i) => (
+                <li key={i} className="text-xs text-[var(--color-text-secondary)]">
+                  <span className="truncate">{d.title}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+        {proposed.length > 0 && (
+          <div>
+            <SectionTitle icon={Sparkles}>Proposed</SectionTitle>
+            <ul className="space-y-1">
+              {proposed.slice(0, 8).map((d, i) => (
+                <li key={i} className="text-xs text-[var(--color-text-secondary)]">
+                  <span className="truncate">{d.title}</span>
+                  {d.source && (
+                    <span className="ml-1.5 text-[10px] text-[var(--color-text-tertiary)]">
+                      ({d.source})
+                    </span>
+                  )}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+        {legacyRecent.length > 0 && stale.length === 0 && proposed.length === 0 && (
           <div>
             <SectionTitle icon={Sparkles}>Recent</SectionTitle>
             <ul className="space-y-1">
-              {data.decisions.map((d, i) => (
+              {legacyRecent.map((d, i) => (
                 <li key={i} className="text-xs text-[var(--color-text-secondary)]">
                   <span className="truncate">{d.title}</span>
                   {d.status && (
@@ -369,49 +491,42 @@ export function DecisionsRenderer({ data }: { data: DecisionsArtifactData }) {
     );
   }
 
-  // search mode
-  if (!data.results || data.results.length === 0) {
+  const rows = decisionRows(data);
+  const heading =
+    data.mode === "path"
+      ? data.path ?? data.query
+      : data.query;
+
+  if (rows.length === 0) {
     return (
       <p className="text-xs text-[var(--color-text-tertiary)]">
-        No matching decisions for {data.query ? `"${data.query}"` : "this query"}.
+        No matching decisions
+        {heading ? ` for "${heading}"` : " for this query"}.
       </p>
     );
   }
+
   return (
     <div className="space-y-3">
-      {data.query && (
+      {heading && (
         <p className="text-xs text-[var(--color-text-tertiary)]">
-          Matches for{" "}
+          {data.mode === "path" ? "Governing" : "Matches for"}{" "}
           <span className="font-mono text-[var(--color-text-secondary)]">
-            "{data.query}"
+            "{heading}"
           </span>
         </p>
       )}
-      {data.results.map((r, i) => (
-        <div
-          key={`${r.title}:${i}`}
-          className="rounded-lg border border-[var(--color-border-default)] p-3 space-y-1.5"
-        >
-          <h3 className="text-xs font-medium text-[var(--color-text-primary)]">
-            {r.title}
-          </h3>
-          <p className="text-xs text-[var(--color-text-secondary)] leading-relaxed">
-            {r.decision}
-          </p>
-          {r.rationale && (
-            <p className="text-xs text-[var(--color-text-tertiary)] leading-relaxed">
-              {r.rationale}
-            </p>
-          )}
-          {r.affected_files && r.affected_files.length > 0 && (
-            <div className="flex flex-wrap gap-1 pt-1">
-              {r.affected_files.slice(0, 6).map((f) => (
-                <FilePathChip key={f} path={f} />
-              ))}
-            </div>
-          )}
-        </div>
-      ))}
+      {data.alignment?.summary && (
+        <p className="text-xs text-[var(--color-text-secondary)]">
+          {data.alignment.summary}
+        </p>
+      )}
+      <DecisionCards rows={rows} />
+      {data.origin_story?.primary_author && (
+        <p className="text-[10px] text-[var(--color-text-tertiary)]">
+          Primary author: {String(data.origin_story.primary_author)}
+        </p>
+      )}
     </div>
   );
 }

--- a/packages/ui/src/chat/source-citations.tsx
+++ b/packages/ui/src/chat/source-citations.tsx
@@ -101,7 +101,9 @@ export function extractSources(
       const decisions = (result.decisions as Array<Record<string, unknown>>)
         ?? (result.matching_decisions as Array<Record<string, unknown>>)
         ?? [];
-      for (const d of decisions) {
+      const stale = (result.stale_decisions as Array<Record<string, unknown>>) ?? [];
+      const rows = [...decisions, ...stale];
+      for (const d of rows) {
         const affectedFiles = (d.affected_files as string[]) ?? [];
         for (const filePath of affectedFiles.slice(0, 3)) {
           const pageId = `file_page:${filePath}`;


### PR DESCRIPTION
## Summary
- Chat `DecisionsRenderer` expected `results` / `total_decisions` / `by_source`, but MCP `get_why` returns `decisions`, `counts`, `stale_decisions`, and a `path` mode — so View Artifact was empty or wrong for all three modes.
- Align types + renderer with the MCP wire format (keep legacy fixture shapes), and cite files from health-mode `stale_decisions`.

## Test plan
- [x] `npm test -- --run __tests__/chat/artifacts.test.tsx __tests__/chat/source-citations.test.tsx` in `packages/ui`
- [x] In web chat, call get_why with no query (health), a natural-language query (search), and a file path (path); open View Artifact for each