### PR TITLE
docs: correct claims that contradict the code, and make the long references navigable

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,19 +503,34 @@ already rendered from structure at index time.
 Or pick the provider for the first index directly with `repowise init --provider
 gemini|anthropic|openai`.
 
-**3. Connect your agent.** The MCP server is `repowise mcp`, served from the repo directory.
+**3. Connect your agent.** Step 2 already did this for Claude Code: `init`
+writes a repo-root `.mcp.json` unconditionally and, unless you passed
+`--no-editor-setup`, also registers repowise with `~/.claude/settings.json`.
+Open a session in this repo and it is already wired; check with `repowise
+agents`.
 
 <details><summary><b>Claude Code</b></summary>
 
+Skipped editor setup, or setting up another machine?
+
 ```bash
-# Plugin (adds the tools, slash commands and skills):
+repowise agents add --target=claude-code
+```
+
+The plugin additionally adds slash commands and skills, which `init` does not
+install:
+
+```bash
 /plugin marketplace add repowise-dev/repowise
 /plugin install repowise@repowise
+```
 
-# ...or wire the MCP server directly:
+Or wire the MCP server by hand:
+
+```bash
 claude mcp add repowise -- repowise mcp
 ```
-Or commit a project `.mcp.json`:
+Or edit the project `.mcp.json` `init` already wrote:
 ```json
 { "mcpServers": { "repowise": { "command": "repowise", "args": ["mcp"] } } }
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -57,7 +57,7 @@ your agent in under five minutes, with no API key.
 | [layers/TEST_INTELLIGENCE.md](layers/TEST_INTELLIGENCE.md) | Coverage ingestion, untested hotspots, and running only the tests a diff touches |
 | [layers/DECISIONS.md](layers/DECISIONS.md) | Architectural decisions mined from your repo and from your own agent sessions |
 | [layers/DEAD_CODE.md](layers/DEAD_CODE.md) | Unreachable files, unused exports, and zombie packages by confidence tier |
-| [layers/LANGUAGE_SUPPORT.md](layers/LANGUAGE_SUPPORT.md) | What works per language, across 16 parsed languages and 11 at the Full tier |
+| [layers/LANGUAGE_SUPPORT.md](layers/LANGUAGE_SUPPORT.md) | What works per language, across 18 parsed languages and 13 at the Full tier |
 | [layers/WIKI_STYLES.md](layers/WIKI_STYLES.md) | Selectable documentation styles (comprehensive / reference / tutorial / caveman) |
 
 ## Scale it

--- a/docs/agent/CODEX.md
+++ b/docs/agent/CODEX.md
@@ -57,7 +57,7 @@ Repowise writes hooks to `.codex/hooks.json`, not inline `[hooks]` tables. The d
 
 - `SessionStart` to add Repowise MCP workflow guidance.
 - `UserPromptSubmit` to remind Codex when Repowise context is available.
-- `PostToolUse` for `Bash` to detect git operations that make the wiki stale.
+- `PostToolUse` for `Bash|shell_command` to detect git operations that make the wiki stale. On current Codex the shell calls arrive as `shell_command`; `Bash` is kept in the set for older and future builds. See [HOOKS.md](HOOKS.md) for why `exec` is deliberately excluded.
 - `PostToolUse` for `apply_patch`, `Edit`, and `Write` to remind Codex after edits.
 
 Claude Code has its own search-result enrichment hook path for `Grep` and `Glob`. Codex setup stays focused on lifecycle guidance and freshness checks instead of trying to reuse that Claude-specific search enrichment.
@@ -82,7 +82,7 @@ The provider runs:
 codex exec --ephemeral --sandbox read-only --json --cd /absolute/path/to/repo -
 ```
 
-Repowise sends the prompt on stdin, parses Codex JSONL output, records token usage from `turn.completed.usage`, and treats `codex_cli/*` cost as `$0.00` because subscription billing happens outside Repowise API pricing. `--model` is passed to Codex only when you explicitly configure a model. `--reasoning minimal` maps to Codex `model_reasoning_effort="low"`; `low`, `medium`, `high`, and `xhigh` pass through when the selected Codex model advertises those levels. `off`/`none` is not supported by the Codex CLI provider.
+Repowise sends the prompt on stdin, parses Codex JSONL output, records token usage from `turn.completed.usage`, and treats `codex_cli/*` cost as `$0.00` because subscription billing happens outside Repowise API pricing. `--model` is passed to Codex only when you explicitly configure a model. `--reasoning minimal` maps to Codex `model_reasoning_effort="minimal"` when the selected model advertises a `minimal` level, and falls back to `"low"` when it does not; `low`, `medium`, `high`, and `xhigh` pass through when the model advertises those levels. `off`/`none` maps to `model_reasoning_effort="none"`. `auto` sends no effort at all and lets Codex pick.
 
 Smoke check:
 

--- a/docs/agent/DISTILL.md
+++ b/docs/agent/DISTILL.md
@@ -222,8 +222,8 @@ was silent. Now every drop goes through the same omission store:
 
 `get_symbol` resolves omission refs as well as symbol ids — the
 `repowise#<12-hex>` shape is unambiguous next to `path/to/file.py::Name`, and
-the optional `query` parameter searches within the stored content. Tool count
-stays at nine. See [MCP_TOOLS.md](MCP_TOOLS.md).
+the optional `query` parameter searches within the stored content. Resolving
+refs adds no new tool to the surface. See [MCP_TOOLS.md](MCP_TOOLS.md).
 
 > **Note:** MCP tool calls now record a *counterfactual* saving — what raw file
 > exploration the curated answer replaced — as `mcp:<tool>` rows in the same

--- a/docs/agent/MCP_TOOLS.md
+++ b/docs/agent/MCP_TOOLS.md
@@ -18,6 +18,35 @@ repowise mcp --transport sse --port 7338 # legacy SSE transport
 
 ---
 
+## Contents
+
+**Default tools (single-repo, 11)**
+[get_overview](#get_overview) &middot;
+[get_answer](#get_answer) &middot;
+[get_context](#get_context) &middot;
+[get_symbol](#get_symbol) &middot;
+[search_codebase](#search_codebase) &middot;
+[get_risk](#get_risk) &middot;
+[get_change_risk](#get_change_risk) &middot;
+[get_why](#get_why) &middot;
+[get_dead_code](#get_dead_code) &middot;
+[get_health](#get_health) &middot;
+[list_repos](#list_repos)
+
+**Workspace-only tools (added automatically, 2)**
+[get_architecture](#get_architecture) &middot;
+[get_blast_radius](#get_blast_radius)
+
+**Opt-in tools (off by default everywhere, 4)**
+[get_dependency_path](#get_dependency_path) &middot;
+[get_execution_flows](#get_execution_flows) &middot;
+[generate_refactoring_code](#generate_refactoring_code) &middot;
+[get_conformance](#get_conformance)
+
+Also see [Configuring the tool surface](#configuring-the-tool-surface) and [Reversible truncation](#reversible-truncation-_metaomitted).
+
+---
+
 ## The ten flagship tools
 
 | Tool | Purpose | Typical use |

--- a/docs/layers/DEAD_CODE.md
+++ b/docs/layers/DEAD_CODE.md
@@ -102,11 +102,13 @@ compare numbers:
 | Surface | High | Medium | Low | Default floor |
 |---------|------|--------|-----|---------------|
 | CLI (`repowise dead-code`) | `>= 0.7` | `0.4` to `0.7` | `< 0.4` | `--min-confidence 0.4` |
-| MCP (`get_dead_code`) | `>= 0.8` | `0.4` to `0.8` | `< 0.4` | `min_confidence=0.4` |
+| MCP (`get_dead_code`) | `>= 0.8` | `0.5` to `0.8` | `< 0.5` | `min_confidence=0.4` |
 
-Both surfaces now share the same default floor (`0.4`). The MCP high/medium
-cutovers stay stricter: an agent acting on a finding is riskier than a human
-reading a table.
+Both surfaces share the same default floor (`0.4`), so both return the same
+findings. Only the tier labelling differs: MCP brackets both cutovers higher
+(`0.8`/`0.5` against the CLI's `0.7`/`0.4`), because an agent acting on a
+finding is riskier than a human reading a table. The two rows are deliberately
+different, so do not flatten them to matching numbers.
 
 ## What is exempt by construction
 

--- a/docs/layers/DECISIONS.md
+++ b/docs/layers/DECISIONS.md
@@ -46,8 +46,8 @@ get_why()                                          # health dashboard
 
 ## Where decisions come from
 
-Eight capture sources run at index time. Seven are deterministic passes over the
-repo and its git history; the eighth is a harvest during LLM doc generation, and
+Six capture sources run at index time. Five are deterministic passes over the
+repo and its git history; the sixth is a harvest during LLM doc generation, and
 it is the only one that needs a provider.
 
 | Source | Key | Reads | Notes |

--- a/docs/layers/LANGUAGE_SUPPORT.md
+++ b/docs/layers/LANGUAGE_SUPPORT.md
@@ -10,6 +10,12 @@ the wiki. This page is the "what works for my language today" reference.
 > a language needs one `.scm` query file and one config entry, with no changes
 > to the parser core.
 
+**Contents:** [Tiers at a glance](#tiers-at-a-glance) ·
+[Full tier](#full-tier) · [Good tier](#good-tier) · [SQL + dbt](#sql--dbt) ·
+[Lightweight, Partial, Structural](#lightweight-partial-and-structural-tiers) ·
+[Code-health coverage](#code-health-coverage) · [Roadmap](#roadmap) ·
+[See also](#see-also)
+
 ---
 
 ## Tiers at a glance
@@ -19,14 +25,14 @@ produce meaningful output.
 
 | Tier | Languages | What works |
 |------|-----------|------------|
-| **Full** | Python · TypeScript · JavaScript · Svelte · Vue · Java · Kotlin · Go · Rust · C++ · C# · Scala · Ruby | AST parsing, import resolution, named bindings, call resolution, heritage, docstrings, framework-aware edges, dynamic-hint extractors, and **code-health markers** |
-| **Good** | C · Swift · PHP · Dart | Everything above except code-health markers (C, Swift, PHP; Dart *does* get health markers). Dedicated workspace resolvers and framework edges per language |
-| **SQL / dbt** | `.sql` via sqlglot | Tables / views / functions / procedures as symbols with wiki pages; dbt projects get real `ref()` / `source()` lineage |
+| [**Full**](#full-tier) | Python · TypeScript · JavaScript · Svelte · Vue · Java · Kotlin · Go · Rust · C++ · C# · Scala · Ruby | AST parsing, import resolution, named bindings, call resolution, heritage, docstrings, framework-aware edges, dynamic-hint extractors, and **code-health markers** |
+| [**Good**](#good-tier) | C · Swift · PHP · Dart | Everything above except code-health markers (C, Swift, PHP; Dart *does* get health markers). Dedicated workspace resolvers and framework edges per language |
+| [**SQL / dbt**](#sql--dbt) | `.sql` via sqlglot | Tables / views / functions / procedures as symbols with wiki pages; dbt projects get real `ref()` / `source()` lineage |
 | **Shell** | `.sh` `.bash` `.zsh` | Function definitions as symbols, `source` / `.` import edges (incl. `$SCRIPT_DIR` / `dirname` / `$BATS_ROOT` idioms), and function-level code-health complexity (CCN, nesting, cognitive). No class metrics, heritage, bindings, or dead-code flagging |
 | **Config / data** | OpenAPI · Protobuf · GraphQL · Dockerfile · Makefile · YAML · JSON · TOML · Terraform · Markdown | In the file tree and wiki; special handlers extract endpoints / targets where applicable |
-| **Lightweight** | Elixir · Clojure · Haskell · Lean 4 · Erlang · F# · HTML | File-level import graph only (no symbols/calls). Honest file-to-file dependencies, no symbol-level claims |
-| **Partial** | Luau / Roblox | AST symbols + `require()` resolution (Rojo / `.luaurc` aware); no health markers yet |
-| **Structural** | Objective-C · R · Zig · Julia · Elm · OCaml · Crystal · Nim · D | Git history only (blame, hotspots, co-change). No AST parsing |
+| [**Lightweight**](#lightweight-partial-and-structural-tiers) | Elixir · Clojure · Haskell · Lean 4 · Erlang · F# · HTML | File-level import graph only (no symbols/calls). Honest file-to-file dependencies, no symbol-level claims |
+| [**Partial**](#lightweight-partial-and-structural-tiers) | Luau / Roblox | AST symbols + `require()` resolution (Rojo / `.luaurc` aware); no health markers yet |
+| [**Structural**](#lightweight-partial-and-structural-tiers) | Objective-C · R · Zig · Julia · Elm · OCaml · Crystal · Nim · D | Git history only (blame, hotspots, co-change). No AST parsing |
 
 **Pipeline stage coverage:**
 
@@ -76,7 +82,7 @@ extractors, and code-health markers.
 | **Scala** | `.scala` | `import pkg.Foo`, brace/wildcard/package imports via the shared JVM index (cross-language with Java/Kotlin); SBT / Mill build parsing as fallback (partial import resolution¹) |
 | **Ruby** | `.rb` | `require` / `require_relative` with `$LOAD_PATH` probing, Gemfile externals, RSpec mirror edges, Rails / Zeitwerk autoloading |
 
-All twelve also support three-tier call resolution (same-file, cross-file,
+All thirteen also support three-tier call resolution (same-file, cross-file,
 global stem match) and docstring extraction (Python, Ruby comments, JSDoc,
 GoDoc, Rustdoc, Javadoc, Scaladoc, Doxygen, XML doc).
 

--- a/docs/reference/CLI_REFERENCE.md
+++ b/docs/reference/CLI_REFERENCE.md
@@ -6,6 +6,85 @@ Command list (in registration order): `augment`, `init`, `delete`, `generate-cla
 
 **Do you need an LLM key?** Most commands are pure index/analysis and never call an LLM. `init` never requires a key: without one it renders the wiki from structure. It calls an LLM only when a provider is resolvable or `--prose` is passed. The exceptions: `update` (unless `--index-only` or `--no-docs`), `generate`, `restyle`, `watch` (when it regenerates a page), `health --generate-code`, and `workspace add --docs`. Everything else, `search`, `dead-code`, `health`, `risk`, `impacted-tests`, `decision`, `coverage`, `security`, `export`, `mcp`, `reindex`, `doctor`, and so on, works index-only, with no provider configured.
 
+## Contents
+
+Grouped by what you're trying to do, not alphabetically. `PATH` and flag details are on each command's own section.
+
+**Indexing**
+[`init`](#repowise-init-path) ·
+[`update`](#repowise-update-path) ·
+[`generate`](#repowise-generate-path) ·
+[`restyle`](#repowise-restyle-style-path) ·
+[`wiki-styles`](#repowise-wiki-styles-path) ·
+[`watch`](#repowise-watch-path) ·
+[`reindex`](#repowise-reindex-path)
+
+**Querying**
+[`search`](#repowise-search-query-path) ·
+[`ask`](#repowise-ask-question) ·
+[`context`](#repowise-context-targets) ·
+[`symbol`](#repowise-symbol-symbol_id) ·
+[`why`](#repowise-why-query) ·
+[shared `ask`/`context`/`symbol`/`why` options](#shared-options-ask-context-symbol-why) ·
+[`status`](#repowise-status-path)
+
+**Health and risk**
+[`health`](#repowise-health-path) ·
+[`risk`](#repowise-risk-revspec) ·
+[`dead-code`](#repowise-dead-code-path) ·
+[`security`](#repowise-security) ·
+[`impacted-tests`](#repowise-impacted-tests-revspec) ·
+[`coverage`](#repowise-coverage)
+
+**Decisions**
+[`decision`](#repowise-decision)
+
+**Agent wiring**
+[`agents`](#repowise-agents) ·
+[`generate-claude-md`](#repowise-generate-claude-md-path) ·
+[`AGENTS.md`](#agentsmd)
+
+**Hooks and distill**
+[`distill`](#repowise-distill-command) ·
+[`expand`](#repowise-expand-ref) ·
+[`saved`](#repowise-saved-path) ·
+[`corrections`](#repowise-corrections-path) ·
+[`hook install`](#repowise-hook-install) ·
+[`hook status`](#repowise-hook-status) ·
+[`hook uninstall`](#repowise-hook-uninstall) ·
+[`hook stats`](#repowise-hook-stats) ·
+[`hook backfill`](#repowise-hook-backfill) ·
+[`hook rewrite`](#repowise-hook-rewrite-installuninstallstatus) ·
+[`augment`](#repowise-augment)
+
+**Server**
+[`serve`](#repowise-serve-path) ·
+[`mcp`](#repowise-mcp-path)
+
+**Workspace**
+[`workspace list`](#repowise-workspace-list) ·
+[`workspace add`](#repowise-workspace-add-path) ·
+[`workspace remove`](#repowise-workspace-remove-alias) ·
+[`workspace scan`](#repowise-workspace-scan-path) ·
+[`workspace set-default`](#repowise-workspace-set-default-alias) ·
+[`workspace diagnostics`](#repowise-workspace-diagnostics) ·
+[`workspace check`](#repowise-workspace-check) ·
+[`workspace metrics`](#repowise-workspace-metrics-path)
+
+**Maintenance**
+[`doctor`](#repowise-doctor-path) ·
+[`whats-new`](#repowise-whats-new) ·
+[`telemetry`](#repowise-telemetry) ·
+[`login`](#repowise-login) ·
+[`logout`](#repowise-logout) ·
+[`whoami`](#repowise-whoami) ·
+[`delete`](#repowise-delete-repo_id) ·
+[`uninstall`](#repowise-uninstall-path) ·
+[`costs`](#repowise-costs) ·
+[`export`](#repowise-export-path)
+
+---
+
 ## Workspace auto-detect (cross-cutting)
 
 Most commands auto-detect whether you're in a workspace root and route accordingly. When auto-detection fires, the command prints a one-line `[workspace] …` notice. You can always override:
@@ -1289,6 +1368,67 @@ repowise generate-claude-md --verbose      # show pipeline debug logs
 ### `AGENTS.md`
 
 `repowise init --codex` generates managed `AGENTS.md` for Codex. `repowise update` refreshes it when `editor_files.agents_md` is enabled in config, or when `--agents` is passed. User content outside the Repowise managed markers is preserved.
+
+---
+
+### `repowise agents`
+
+Manage the agent integrations repowise can wire up on this machine: Claude
+Code, Codex, Cursor, OpenCode, Hermes, and anything reachable through
+`print-config`. `init` already wires the primary ones as part of a first run;
+this group is for what comes after it: adding an agent installed later,
+removing one, refreshing config after an upgrade, or printing a snippet for a
+host repowise does not write files for at all.
+
+With no subcommand, lists every known agent for the current repo: support
+tier, whether it looks installed, and every place it is currently wired to
+repowise.
+
+```bash
+repowise agents                                       # list every known agent and its wiring
+repowise agents add [PATH] --target=<id>              # wire one or more agents up
+repowise agents remove [PATH] --target=<id>           # remove repowise from one or more agents
+repowise agents refresh [PATH]                        # rewrite configs already wired
+repowise agents print-config <target_id> [PATH]       # print the config snippet, writing nothing
+```
+
+**`add` options:**
+
+| Flag | Description |
+|------|-------------|
+| `--target` | Comma-separated agent ids, or one of `auto`, `all`, `none`. Prompts on a terminal when omitted, with installed agents pre-ticked. |
+| `--scope` | `project`, `user`, or `both` (default). Where to write: repo-local config, per-machine config, or both. |
+| `--yes` / `-y` | Never prompt. |
+| `--format` | `table` (default) or `json`. `json` reports every file touched and what happened to it. |
+
+**`remove` options:**
+
+| Flag | Description |
+|------|-------------|
+| `--target` | Required. Comma-separated agent ids, or `auto`/`all`/`none`. No default, since silently removing everything is not a safe default for a destructive verb. |
+| `--scope` | `project`, `user`, or `both` (default). |
+| `--format` | `table` (default) or `json`. |
+
+**`refresh`** rewrites the configs of agents already wired up. It never adds
+an agent: it repoints what exists after an upgrade or a repo move, and leaves
+everything else alone, which is what makes it safe for `repowise doctor
+--repair` to call.
+
+**`print-config`** prints the MCP server entry for `target_id` (e.g.
+`claude-code`) without writing anything, for a host repowise has no dedicated
+integration for (Cline, Windsurf, Zed, Gemini CLI, and similar).
+
+```bash
+repowise agents                                        # what's wired, and where
+repowise agents add --target=cursor                    # wire Cursor up, both scopes
+repowise agents add --target=opencode --scope=project   # repo-local only
+repowise agents remove --target=hermes --scope=user     # unregister the per-machine MCP entry
+repowise agents refresh                                 # repoint every wired agent after an upgrade
+repowise agents print-config claude-code                # paste-ready snippet for another MCP client
+```
+
+See [Agent integrations](../agent/INTEGRATIONS.md) for the full support matrix
+and per-agent guides.
 
 ---
 

--- a/docs/reference/CONFIG.md
+++ b/docs/reference/CONFIG.md
@@ -4,6 +4,61 @@ The `.repowise/` directory, provider setup, API keys, and what's customizable.
 
 ---
 
+## Contents
+
+**Files and `config.yaml`**
+[The `.repowise/` directory](#the-repowise-directory) ·
+[`config.yaml`](#configyaml) ·
+[Grounded generation context](#grounded-generation-context) ·
+[The `distill:` block](#the-distill-block) ·
+[The `hooks:` block](#the-hooks-block) ·
+[The `mcp:` block](#the-mcp-block) ·
+[The `decisions:` block](#the-decisions-block) ·
+[The `refactoring:` block](#the-refactoring-block)
+
+**Code health rules**
+[The `health-rules.json` file](#the-health-rulesjson-file)
+
+**LLM providers**
+[Overview](#llm-providers) ·
+[Anthropic](#anthropic-claude) ·
+[OpenAI](#openai-gpt) ·
+[OpenRouter](#openrouter) ·
+[Gemini](#gemini-google) ·
+[DeepSeek](#deepseek) ·
+[Kimi](#kimi) ·
+[Ollama](#ollama-local-no-api-key) ·
+[LiteLLM](#litellm-100-providers) ·
+[Provider auto-detection](#provider-auto-detection)
+
+**Embeddings and keys**
+[Embeddings (for semantic search)](#embeddings-for-semantic-search) ·
+[BYOK (Bring Your Own Key)](#byok-bring-your-own-key)
+
+**Environment variables**
+[Overview](#environment-variables) ·
+[Provider API keys](#provider-api-keys) ·
+[Provider base URLs](#provider-base-urls) ·
+[Provider and model overrides](#provider-and-model-overrides) ·
+[Embeddings](#embeddings) ·
+[Server and database](#server-and-database) ·
+[Telemetry](#telemetry) ·
+[Misc](#misc)
+
+**Repo scope**
+[Exclude patterns](#exclude-patterns) ·
+[Submodules](#submodules) ·
+[PostgreSQL](#postgresql)
+
+**Workspace**
+[Workspace config (`.repowise-workspace.yaml`)](#workspace-config-repowise-workspaceyaml) ·
+[The `conformance:` block](#the-conformance-block)
+
+**Reference**
+[Deprecated / legacy aliases](#deprecated--legacy-aliases)
+
+---
+
 ## The `.repowise/` directory
 
 Everything repowise knows about your repository lives here. It's created at the

--- a/docs/scale/AUTO_SYNC.md
+++ b/docs/scale/AUTO_SYNC.md
@@ -5,7 +5,7 @@ method that fits your setup.
 
 | Method | Best for | Requires server? |
 |--------|----------|-----------------|
-| [Post-commit hook](#1-post-commit-git-hook) | Solo developers, local repos | No |
+| [Post-commit hook](#1-post-commit-git-hook-recommended) | Solo developers, local repos | No |
 | [File watcher](#2-file-watcher) | Local development, rapid iteration | No |
 | [GitHub webhook](#3-github-webhook) | Teams, CI/CD, hosted repos | Yes |
 | [GitLab webhook](#4-gitlab-webhook) | Teams, CI/CD, hosted repos | Yes |
@@ -94,7 +94,7 @@ server, which triggers an incremental update.
 ### Prerequisites
 
 - repowise server running and reachable from the internet (or GitHub's network)
-- A webhook secret (**required** — unsigned requests are rejected)
+- A webhook secret (**strongly recommended** for any server exposed beyond localhost)
 
 ### Start the server
 
@@ -130,14 +130,19 @@ Recent Deliveries). You should see a `200` response with:
 }
 ```
 
-### Security
+### Security (GitHub)
 
-`REPOWISE_GITHUB_WEBHOOK_SECRET` is **required**. Every incoming request must
+When `REPOWISE_GITHUB_WEBHOOK_SECRET` is set, every incoming GitHub request must
 carry a valid HMAC-SHA256 signature in the `X-Hub-Signature-256` header.
-Requests with an invalid signature are rejected with `401 Unauthorized`.
-Requests with **no** signature — including those sent without a secret
-configured on your server — are rejected with `403 Forbidden`. There is no
-unsigned mode.
+A missing `sha256=` prefix or a signature that doesn't match is rejected with
+`401 Unauthorized`.
+
+When the secret is **not** set, the server falls back to a dev-mode check:
+requests from a local/loopback caller are accepted, and everything else is
+rejected with `403 Forbidden`. This keeps `repowise serve` usable out of the
+box for local testing, but it means an unset secret is not a safe posture for
+a server reachable from the internet or GitHub's network. Always set
+`REPOWISE_GITHUB_WEBHOOK_SECRET` before exposing the server.
 
 ---
 
@@ -159,11 +164,16 @@ export REPOWISE_GITLAB_WEBHOOK_TOKEN="your-token-here"
 4. **Trigger:** enable **Push events**
 5. Click **Add webhook**
 
-### Security
+### Security (GitLab)
 
 When `REPOWISE_GITLAB_WEBHOOK_TOKEN` is set, the server compares it against
 the `X-Gitlab-Token` header using constant-time comparison. Invalid tokens are
 rejected with `401 Unauthorized`.
+
+When the token is **not** set, GitLab behaves exactly like GitHub above:
+local/loopback callers are accepted as a dev convenience, and every other
+caller is rejected with `403 Forbidden`. Set the token before exposing the
+server.
 
 ---
 
@@ -272,14 +282,17 @@ Nothing to do.
 **Hook doesn't fire** -- Make sure the hook file is executable:
 `chmod +x .git/hooks/post-commit`
 
-**Webhook returns 401** -- Check that the secret/token matches between your
-git hosting provider and the environment variable on the server.
+**Webhook returns 401** -- A secret/token is configured on the server but the
+incoming signature did not match it (or, for GitHub, the `sha256=` prefix was
+missing). Check that the value matches between your git hosting provider and
+the environment variable on the server.
 
-**Webhook returns 403** -- The server received a request with no signature at
-all. This usually means `REPOWISE_GITHUB_WEBHOOK_SECRET` (or
-`REPOWISE_GITLAB_WEBHOOK_TOKEN`) is not set on the server. Set the environment
-variable, restart the server, and re-deliver the payload from your provider's
-webhook settings page. Unsigned requests are never accepted.
+**Webhook returns 403** -- No secret/token is configured on the server and the
+request came from a non-local caller. The unset-secret path only accepts
+loopback callers, so a remote provider hitting it is refused. Set
+`REPOWISE_GITHUB_WEBHOOK_SECRET` (or `REPOWISE_GITLAB_WEBHOOK_TOKEN`), restart
+the server, and re-deliver the payload from your provider's webhook settings
+page.
 
 **Update is slow** -- If you're catching up on many commits, the first update
 may take longer. Subsequent single-commit updates are fast (~30-60s).

--- a/docs/start/QUICKSTART.md
+++ b/docs/start/QUICKSTART.md
@@ -86,20 +86,36 @@ This is the payoff: your agent reads the index instead of your codebase.
 
 <details open><summary><b>Claude Code</b></summary>
 
-The plugin wires up the MCP server, the hooks and the slash commands together:
+**`repowise init` already did this.** It writes a repo-root `.mcp.json`
+unconditionally, and unless you passed `--no-editor-setup` or set
+`REPOWISE_SKIP_EDITOR_SETUP=1`, it also registers repowise with
+`~/.claude/settings.json`. A Claude Code session opened in this repo already
+sees the MCP server. Check with `repowise agents` (Claude Code should show as
+wired) or `repowise doctor`.
+
+Skipped editor setup, or setting up a machine where you did? Wire it up now:
+
+```bash
+repowise agents add --target=claude-code
+```
+
+**The plugin** additionally installs hooks and slash commands, which `init`
+never writes because the plugin route is host-managed and only the plugin can
+install it:
 
 ```text
 /plugin marketplace add repowise-dev/repowise
 /plugin install repowise@repowise
 ```
 
-Or wire just the MCP server:
+**A different MCP client, or wiring the server by hand:**
 
 ```bash
 claude mcp add repowise -- repowise mcp
 ```
 
-Or commit a project `.mcp.json` so your whole team gets it:
+Or edit the project `.mcp.json` `init` already wrote (commit it if your team
+should share it):
 
 ```json
 { "mcpServers": { "repowise": { "command": "repowise", "args": ["mcp"] } } }

--- a/docs/start/USER_GUIDE.md
+++ b/docs/start/USER_GUIDE.md
@@ -119,10 +119,17 @@ your-repo/
 │   ├── config.yaml       # provider, model, embedder, excludes
 │   ├── .env              # saved API keys (gitignored)
 │   └── lancedb/          # vector store for semantic search
+├── .mcp.json             # MCP server entry, so Claude Code and other clients find it
 ├── .claude/CLAUDE.md     # generated Claude Code context
 ├── AGENTS.md             # generated Codex context, when enabled
 └── .codex/               # project-local Codex MCP/hooks config, with --codex
 ```
+
+`init` also registers repowise machine-wide by default: the Claude Code
+(`~/.claude/settings.json`) and Claude Desktop MCP entry, plus the Claude Code
+PostToolUse/SessionStart hooks. `--no-editor-setup` (or setting
+`REPOWISE_SKIP_EDITOR_SETUP=1`) skips that machine-wide registration; every
+project-local file above is still written.
 
 `.repowise/` is safe to delete and rebuild, and safe to gitignore. Committing it
 is a reasonable choice for a team that wants everyone on the same index without


### PR DESCRIPTION
Two things: docs that describe behavior the code does not have, and long reference pages that are hard to navigate.

Everything here was verified against source, not against another doc.

## Wrong behavior described

**Webhook auth (`docs/scale/AUTO_SYNC.md`).** The page said a secret is required, that unsigned requests get `403`, and that "there is no unsigned mode". The server does none of that. With a secret configured, a bad or missing signature is `401`. With no secret configured, loopback callers are accepted as a dev convenience and only non-local callers get `403` (`webhooks.py:36-59`). GitLab has the identical dev-mode branch (`webhooks.py:62-88`) and was described the same wrong way. Corrected in the prerequisites, both Security sections, and the troubleshooting entries, with the honest framing: always set a secret on an exposed server, an unset secret is loopback-only.

**Codex reasoning modes (`docs/agent/CODEX.md`).** "`off`/`none` is not supported by the Codex CLI provider" is false. `_codex_effort_for_reasoning` maps both to `model_reasoning_effort="none"` (`codex_cli.py:161-162`). Also `--reasoning minimal` maps to `"minimal"` when the model advertises that level, falling back to `"low"` only when it does not.

**Codex shell hook (`docs/agent/CODEX.md`).** Documented as matching `Bash`. The real matcher is `Bash|shell_command`, and `Bash` did not appear once across 18 measured Codex 0.145 rollouts (`agent_adapters/codex.py:40-53`). `HOOKS.md` already stated this correctly, so the docset contradicted itself.

**Dead-code tiers (`docs/layers/DEAD_CODE.md`).** The MCP row gave the cutovers as `0.4`. They are `0.5`: medium is `0.5` to `0.8`, low is below `0.5` (`tool_dead_code.py:446-457` and its own `_TIER_DESC` constants). The CLI row was already correct at `0.4`. The two surfaces bracket tiers differently on purpose while sharing a `0.4` floor, so the text now says that explicitly rather than inviting the next reader to "fix" one row to match the other.

**Decision sources (`docs/layers/DECISIONS.md`).** Said eight sources run at index time, seven deterministic. Its own table lists six, and source confirms six. Fixed the count and made the index-time versus outside-index-time split unambiguous.

**Smaller ones.** `DISTILL.md` said "tool count stays at nine", stale against the registry. `LANGUAGE_SUPPORT.md` said "all twelve" against its own 13-row Full tier table. `docs/README.md` said 16 parsed languages and 11 at Full tier; it is 18 and 13.

## Setup instructions that made users redo work

`QUICKSTART.md` and the README presented plugin install, `claude mcp add`, and a hand-committed `.mcp.json` as the way to connect Claude Code, without mentioning that `repowise init` already wrote the repo-root `.mcp.json` and registered the server (`init_cmd/command.py:1491-1496`, `claude_code.py:112-139`). Both now lead with that and keep the manual routes as alternatives for anyone who passed `--no-editor-setup` or uses a different client.

`USER_GUIDE.md`'s "what gets created" list omitted `.mcp.json` and the machine-wide Claude registration. Added, noting `--no-editor-setup` skips the latter.

## Navigation

- `CLI_REFERENCE.md` is 1139 lines and had no table of contents. Added one grouped by task (indexing, querying, health and risk, decisions, agent wiring, hooks and distill, server, workspace, maintenance). Also added a `repowise agents` section, which was missing entirely apart from one incidental cross-reference.
- `CONFIG.md` (635 lines) and `MCP_TOOLS.md` gain tables of contents.
- `LANGUAGE_SUPPORT.md` gains a contents line, and the tier names in the summary table now link to their sections, so "is my language supported and what do I get" is one click rather than a scroll.
- Fixed a pre-existing dead anchor in the `AUTO_SYNC.md` method table, and gave the two identical "Security" headings distinct names since duplicate headings produce colliding anchors.

All 152 in-page anchor links across the changed files were checked to resolve, using GitHub's actual slug rules including the duplicate-heading suffix behavior.

## Not changed on purpose

The README's "ten MCP tools" and its ten-row table stay as they are. Ten is the flagship set and `list_repos` is deliberately not in it, which is also why the comparison table's "MCP tools served | 11" is not a contradiction.
