### PR TITLE
fix(ui): render get_risk MCP dict targets in chat artifacts

### DIFF
--- a/packages/types/src/chat.ts
+++ b/packages/types/src/chat.ts
@@ -127,7 +127,10 @@ export interface ContextArtifact {
 
 /** `get_risk` / `get_change_risk` — modification or commit-range risk report. */
 export interface RiskTargetRow {
-  file_path: string;
+  /** Path key; optional on MCP dict values that use `target` instead. */
+  file_path?: string;
+  /** MCP per-target id when `targets` is a path-keyed object. */
+  target?: string;
   /** MCP `get_risk` hotspot score (0–100 churn percentile). */
   hotspot_score?: number;
   /** Legacy chat fixture field. */
@@ -144,9 +147,7 @@ export interface RiskReportArtifactData {
    * MCP `get_risk` returns a path-keyed object; legacy fixtures used an array.
    * Renderers normalize either shape.
    */
-  targets?:
-    | RiskTargetRow[]
-    | Record<string, RiskTargetRow & { target?: string }>;
+  targets?: RiskTargetRow[] | Record<string, RiskTargetRow>;
   global_hotspots?: Array<{
     /** MCP wire. */
     file_path?: string;

--- a/packages/types/src/chat.ts
+++ b/packages/types/src/chat.ts
@@ -126,14 +126,44 @@ export interface ContextArtifact {
 }
 
 /** `get_risk` / `get_change_risk` — modification or commit-range risk report. */
+export interface RiskTargetRow {
+  file_path: string;
+  /** MCP `get_risk` hotspot score (0–100 churn percentile). */
+  hotspot_score?: number;
+  /** Legacy chat fixture field. */
+  churn_percentile?: number;
+  is_hotspot?: boolean;
+  risk_type?: string;
+  trend?: string;
+  risk_summary?: string;
+  [k: string]: unknown;
+}
+
 export interface RiskReportArtifactData {
-  targets: Array<{
-    file_path: string;
+  /**
+   * MCP `get_risk` returns a path-keyed object; legacy fixtures used an array.
+   * Renderers normalize either shape.
+   */
+  targets?:
+    | RiskTargetRow[]
+    | Record<string, RiskTargetRow & { target?: string }>;
+  global_hotspots?: Array<{
+    /** MCP wire. */
+    file_path?: string;
+    hotspot_score?: number;
+    /** Legacy chat fixture. */
+    path?: string;
     churn_percentile?: number;
-    is_hotspot?: boolean;
-    [k: string]: unknown;
   }>;
-  global_hotspots: Array<{ path: string; churn_percentile: number }>;
+  /** `get_change_risk` live-git payload fields. */
+  ref?: string;
+  score?: number;
+  risk_percentile?: number | null;
+  review_priority?: string;
+  classification?: string;
+  warning?: string;
+  error?: string;
+  [k: string]: unknown;
 }
 export interface RiskReportArtifact {
   type: "risk_report";

--- a/packages/types/src/chat.ts
+++ b/packages/types/src/chat.ts
@@ -131,9 +131,12 @@ export interface RiskTargetRow {
   file_path?: string;
   /** MCP per-target id when `targets` is a path-keyed object. */
   target?: string;
-  /** MCP `get_risk` hotspot score (0–100 churn percentile). */
+  /**
+   * MCP `get_risk` hotspot score: a 0–1 fraction from
+   * `GitMetadata.churn_percentile` (rank / total), not 0–100.
+   */
   hotspot_score?: number;
-  /** Legacy chat fixture field. */
+  /** Same 0–1 fraction as `hotspot_score` (legacy fixture field name). */
   churn_percentile?: number;
   is_hotspot?: boolean;
   risk_type?: string;

--- a/packages/ui/__tests__/chat/artifacts.test.tsx
+++ b/packages/ui/__tests__/chat/artifacts.test.tsx
@@ -69,6 +69,47 @@ describe("chat artifact renderers", () => {
     expect(screen.getByText("src/other.ts")).toBeInTheDocument();
   });
 
+  it("RiskReportRenderer accepts MCP dict targets and hotspot_score", () => {
+    render(
+      <RiskReportRenderer
+        data={{
+          targets: {
+            "src/auth.py": {
+              target: "src/auth.py",
+              hotspot_score: 91,
+              risk_type: "churn-heavy",
+              trend: "increasing",
+            },
+          },
+          global_hotspots: [
+            { file_path: "src/db.py", hotspot_score: 85 },
+          ],
+        }}
+      />,
+    );
+    expect(screen.getByText("src/auth.py")).toBeInTheDocument();
+    expect(screen.getByText("hotspot")).toBeInTheDocument();
+    expect(screen.getByText("src/db.py")).toBeInTheDocument();
+    expect(screen.getByText(/91th pct/)).toBeInTheDocument();
+  });
+
+  it("RiskReportRenderer renders get_change_risk score cards", () => {
+    render(
+      <RiskReportRenderer
+        data={{
+          ref: "HEAD",
+          score: 7.2,
+          risk_percentile: 82,
+          review_priority: "Elevated",
+          classification: "Above typical recent changes.",
+        }}
+      />,
+    );
+    expect(screen.getByText("HEAD")).toBeInTheDocument();
+    expect(screen.getByText("Elevated")).toBeInTheDocument();
+    expect(screen.getByText("p82")).toBeInTheDocument();
+  });
+
   it("SearchResultsRenderer lists results with snippets", () => {
     render(
       <SearchResultsRenderer

--- a/packages/ui/__tests__/chat/artifacts.test.tsx
+++ b/packages/ui/__tests__/chat/artifacts.test.tsx
@@ -58,15 +58,18 @@ describe("chat artifact renderers", () => {
       <RiskReportRenderer
         data={{
           targets: [
-            { file_path: "src/hot.ts", churn_percentile: 99, is_hotspot: true },
+            // Wire scores are 0–1 fractions (rank / total), not 0–100.
+            { file_path: "src/hot.ts", churn_percentile: 0.99 },
           ],
-          global_hotspots: [{ path: "src/other.ts", churn_percentile: 88 }],
+          global_hotspots: [{ path: "src/other.ts", churn_percentile: 0.88 }],
         }}
       />,
     );
     expect(screen.getByText("src/hot.ts")).toBeInTheDocument();
     expect(screen.getByText("hotspot")).toBeInTheDocument();
     expect(screen.getByText("src/other.ts")).toBeInTheDocument();
+    expect(screen.getByText(/99th pct/)).toBeInTheDocument();
+    expect(screen.getByText("88th")).toBeInTheDocument();
   });
 
   it("RiskReportRenderer accepts MCP dict targets and hotspot_score", () => {
@@ -76,13 +79,14 @@ describe("chat artifact renderers", () => {
           targets: {
             "src/auth.py": {
               target: "src/auth.py",
-              hotspot_score: 91,
+              // No is_hotspot on the MCP row — badge comes from score >= 0.75.
+              hotspot_score: 0.91,
               risk_type: "churn-heavy",
               trend: "increasing",
             },
           },
           global_hotspots: [
-            { file_path: "src/db.py", hotspot_score: 85 },
+            { file_path: "src/db.py", hotspot_score: 0.85 },
           ],
         }}
       />,
@@ -91,6 +95,7 @@ describe("chat artifact renderers", () => {
     expect(screen.getByText("hotspot")).toBeInTheDocument();
     expect(screen.getByText("src/db.py")).toBeInTheDocument();
     expect(screen.getByText(/91th pct/)).toBeInTheDocument();
+    expect(screen.getByText("85th")).toBeInTheDocument();
   });
 
   it("RiskReportRenderer renders get_change_risk score cards", () => {

--- a/packages/ui/src/chat/artifacts.tsx
+++ b/packages/ui/src/chat/artifacts.tsx
@@ -178,12 +178,20 @@ export function ContextRenderer({ data }: { data: ContextArtifactData }) {
 
 type NormalizedRiskTarget = {
   file_path: string;
+  /** 0–1 fraction from MCP `hotspot_score` / `churn_percentile`. */
   score: number | null;
   is_hotspot: boolean;
   risk_type?: string;
   trend?: string;
   risk_summary?: string;
 };
+
+/** Same top-quartile cut `git_indexer/enrich.py` uses for `is_hotspot`. */
+const HOTSPOT_SCORE_THRESHOLD = 0.75;
+
+function formatHotspotPct(score: number): string {
+  return `${Math.round(score * 100)}th`;
+}
 
 function normalizeRiskTargets(data: RiskReportArtifactData): NormalizedRiskTarget[] {
   const raw = data.targets;
@@ -219,7 +227,10 @@ function normalizeRiskTargets(data: RiskReportArtifactData): NormalizedRiskTarge
       const out: NormalizedRiskTarget = {
         file_path: t.file_path,
         score,
-        is_hotspot: Boolean(t.is_hotspot) || (typeof score === "number" && score >= 80),
+        // MCP target rows omit `is_hotspot`; derive from the enrich.py cut.
+        is_hotspot:
+          Boolean(t.is_hotspot) ||
+          (typeof score === "number" && score >= HOTSPOT_SCORE_THRESHOLD),
       };
       if (typeof t.risk_type === "string") out.risk_type = t.risk_type;
       if (typeof t.trend === "string") out.trend = t.trend;
@@ -313,7 +324,7 @@ export function RiskReportRenderer({ data }: { data: RiskReportArtifactData }) {
                 </div>
                 {typeof t.score === "number" && (
                   <div className="text-[10px] text-[var(--color-text-tertiary)] mt-0.5 tabular-nums">
-                    Hotspot {Math.round(t.score)}th pct
+                    Hotspot {formatHotspotPct(t.score)} pct
                     {t.risk_type ? ` · ${t.risk_type}` : ""}
                     {t.trend ? ` · ${t.trend}` : ""}
                   </div>
@@ -342,7 +353,7 @@ export function RiskReportRenderer({ data }: { data: RiskReportArtifactData }) {
                   {h.path}
                 </span>
                 <span className="text-[10px] tabular-nums text-[var(--color-text-tertiary)]">
-                  {Math.round(h.score)}th
+                  {formatHotspotPct(h.score)}
                 </span>
               </div>
             ))}

--- a/packages/ui/src/chat/artifacts.tsx
+++ b/packages/ui/src/chat/artifacts.tsx
@@ -176,42 +176,152 @@ export function ContextRenderer({ data }: { data: ContextArtifactData }) {
 // Risk report
 // ---------------------------------------------------------------------------
 
+type NormalizedRiskTarget = {
+  file_path: string;
+  score: number | null;
+  is_hotspot: boolean;
+  risk_type?: string;
+  trend?: string;
+  risk_summary?: string;
+};
+
+function normalizeRiskTargets(data: RiskReportArtifactData): NormalizedRiskTarget[] {
+  const raw = data.targets;
+  if (!raw) return [];
+  const rows = Array.isArray(raw)
+    ? raw
+    : Object.entries(raw).map(([key, value]) => ({
+        file_path:
+          (value as { file_path?: string; target?: string }).file_path ??
+          (value as { target?: string }).target ??
+          key,
+        ...(value as object),
+      }));
+  return rows.map((t) => {
+    const score =
+      typeof t.hotspot_score === "number"
+        ? t.hotspot_score
+        : typeof t.churn_percentile === "number"
+          ? t.churn_percentile
+          : null;
+    return {
+      file_path: t.file_path,
+      score,
+      is_hotspot: Boolean(t.is_hotspot) || (typeof score === "number" && score >= 80),
+      risk_type: typeof t.risk_type === "string" ? t.risk_type : undefined,
+      trend: typeof t.trend === "string" ? t.trend : undefined,
+      risk_summary:
+        typeof t.risk_summary === "string" ? t.risk_summary : undefined,
+    };
+  });
+}
+
+function normalizeGlobalHotspots(data: RiskReportArtifactData): Array<{
+  path: string;
+  score: number;
+}> {
+  return (data.global_hotspots ?? [])
+    .map((h) => {
+      const path = h.file_path ?? h.path ?? "";
+      const score =
+        typeof h.hotspot_score === "number"
+          ? h.hotspot_score
+          : typeof h.churn_percentile === "number"
+            ? h.churn_percentile
+            : null;
+      if (!path || score === null) return null;
+      return { path, score };
+    })
+    .filter((h): h is { path: string; score: number } => h !== null);
+}
+
 export function RiskReportRenderer({ data }: { data: RiskReportArtifactData }) {
+  // get_change_risk returns a live-git score card, not per-file targets.
+  if (data.error || data.ref || data.review_priority || data.risk_percentile != null) {
+    const pct =
+      typeof data.risk_percentile === "number"
+        ? Math.round(data.risk_percentile)
+        : null;
+    return (
+      <div className="space-y-3">
+        {data.error && (
+          <p className="text-xs text-[var(--color-warning)]">{String(data.error)}</p>
+        )}
+        {data.ref && (
+          <StatRow label="Change" value={String(data.ref)} />
+        )}
+        {data.review_priority && (
+          <StatRow label="Review priority" value={String(data.review_priority)} />
+        )}
+        {pct !== null && <StatRow label="Risk percentile" value={`p${pct}`} />}
+        {typeof data.score === "number" && (
+          <StatRow label="Score" value={data.score.toFixed(1)} />
+        )}
+        {data.classification && (
+          <p className="text-xs text-[var(--color-text-secondary)]">
+            {String(data.classification)}
+          </p>
+        )}
+        {data.warning && (
+          <p className="text-xs text-[var(--color-text-tertiary)]">{String(data.warning)}</p>
+        )}
+      </div>
+    );
+  }
+
+  const targets = normalizeRiskTargets(data);
+  const hotspots = normalizeGlobalHotspots(data);
+
+  if (targets.length === 0 && hotspots.length === 0) {
+    return (
+      <p className="text-xs text-[var(--color-text-tertiary)]">No risk data.</p>
+    );
+  }
+
   return (
     <div className="space-y-4">
-      <div>
-        <SectionTitle icon={ShieldAlert}>Targets</SectionTitle>
-        <div className="space-y-1.5">
-          {data.targets.map((t, i) => (
-            <div
-              key={`${t.file_path}:${i}`}
-              className="rounded-lg border border-[var(--color-border-default)] p-2.5"
-            >
-              <div className="flex items-center justify-between gap-2">
-                <span className="font-mono text-xs text-[var(--color-text-primary)] truncate">
-                  {t.file_path}
-                </span>
-                {t.is_hotspot && (
-                  <span className="inline-flex items-center gap-1 rounded bg-[var(--color-warning)]/10 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wider text-[var(--color-warning)]">
-                    <AlertTriangle className="h-2.5 w-2.5" /> hotspot
+      {targets.length > 0 && (
+        <div>
+          <SectionTitle icon={ShieldAlert}>Targets</SectionTitle>
+          <div className="space-y-1.5">
+            {targets.map((t, i) => (
+              <div
+                key={`${t.file_path}:${i}`}
+                className="rounded-lg border border-[var(--color-border-default)] p-2.5"
+              >
+                <div className="flex items-center justify-between gap-2">
+                  <span className="font-mono text-xs text-[var(--color-text-primary)] truncate">
+                    {t.file_path}
                   </span>
+                  {t.is_hotspot && (
+                    <span className="inline-flex items-center gap-1 rounded bg-[var(--color-warning)]/10 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wider text-[var(--color-warning)]">
+                      <AlertTriangle className="h-2.5 w-2.5" /> hotspot
+                    </span>
+                  )}
+                </div>
+                {typeof t.score === "number" && (
+                  <div className="text-[10px] text-[var(--color-text-tertiary)] mt-0.5 tabular-nums">
+                    Hotspot {Math.round(t.score)}th pct
+                    {t.risk_type ? ` · ${t.risk_type}` : ""}
+                    {t.trend ? ` · ${t.trend}` : ""}
+                  </div>
+                )}
+                {t.risk_summary && (
+                  <p className="text-[10px] text-[var(--color-text-secondary)] mt-1 line-clamp-2">
+                    {t.risk_summary}
+                  </p>
                 )}
               </div>
-              {typeof t.churn_percentile === "number" && (
-                <div className="text-[10px] text-[var(--color-text-tertiary)] mt-0.5 tabular-nums">
-                  Churn {Math.round(t.churn_percentile)}th pct
-                </div>
-              )}
-            </div>
-          ))}
+            ))}
+          </div>
         </div>
-      </div>
+      )}
 
-      {data.global_hotspots.length > 0 && (
+      {hotspots.length > 0 && (
         <div>
           <SectionTitle icon={Activity}>Top global hotspots</SectionTitle>
           <div className="space-y-1">
-            {data.global_hotspots.slice(0, 5).map((h, i) => (
+            {hotspots.slice(0, 5).map((h, i) => (
               <div
                 key={`${h.path}:${i}`}
                 className="flex items-center justify-between gap-2 text-xs"
@@ -220,7 +330,7 @@ export function RiskReportRenderer({ data }: { data: RiskReportArtifactData }) {
                   {h.path}
                 </span>
                 <span className="text-[10px] tabular-nums text-[var(--color-text-tertiary)]">
-                  {Math.round(h.churn_percentile)}th
+                  {Math.round(h.score)}th
                 </span>
               </div>
             ))}

--- a/packages/ui/src/chat/artifacts.tsx
+++ b/packages/ui/src/chat/artifacts.tsx
@@ -188,32 +188,44 @@ type NormalizedRiskTarget = {
 function normalizeRiskTargets(data: RiskReportArtifactData): NormalizedRiskTarget[] {
   const raw = data.targets;
   if (!raw) return [];
-  const rows = Array.isArray(raw)
-    ? raw
+
+  const rows: Array<{
+    file_path: string;
+    hotspot_score?: number;
+    churn_percentile?: number;
+    is_hotspot?: boolean;
+    risk_type?: string;
+    trend?: string;
+    risk_summary?: string;
+  }> = Array.isArray(raw)
+    ? raw.map((t) => ({
+        ...t,
+        file_path: t.file_path ?? t.target ?? "",
+      }))
     : Object.entries(raw).map(([key, value]) => ({
-        file_path:
-          (value as { file_path?: string; target?: string }).file_path ??
-          (value as { target?: string }).target ??
-          key,
-        ...(value as object),
+        ...value,
+        file_path: value.file_path ?? value.target ?? key,
       }));
-  return rows.map((t) => {
-    const score =
-      typeof t.hotspot_score === "number"
-        ? t.hotspot_score
-        : typeof t.churn_percentile === "number"
-          ? t.churn_percentile
-          : null;
-    return {
-      file_path: t.file_path,
-      score,
-      is_hotspot: Boolean(t.is_hotspot) || (typeof score === "number" && score >= 80),
-      risk_type: typeof t.risk_type === "string" ? t.risk_type : undefined,
-      trend: typeof t.trend === "string" ? t.trend : undefined,
-      risk_summary:
-        typeof t.risk_summary === "string" ? t.risk_summary : undefined,
-    };
-  });
+
+  return rows
+    .filter((t) => t.file_path.length > 0)
+    .map((t) => {
+      const score =
+        typeof t.hotspot_score === "number"
+          ? t.hotspot_score
+          : typeof t.churn_percentile === "number"
+            ? t.churn_percentile
+            : null;
+      const out: NormalizedRiskTarget = {
+        file_path: t.file_path,
+        score,
+        is_hotspot: Boolean(t.is_hotspot) || (typeof score === "number" && score >= 80),
+      };
+      if (typeof t.risk_type === "string") out.risk_type = t.risk_type;
+      if (typeof t.trend === "string") out.trend = t.trend;
+      if (typeof t.risk_summary === "string") out.risk_summary = t.risk_summary;
+      return out;
+    });
 }
 
 function normalizeGlobalHotspots(data: RiskReportArtifactData): Array<{


### PR DESCRIPTION
## Summary
- Chat `RiskReportRenderer` assumed `targets` was an array with `file_path` / `churn_percentile`, but MCP `get_risk` returns a path-keyed object with `hotspot_score` — View Artifact threw (`targets.map is not a function`) or showed blank hotspot rows.
- Normalize array/dict shapes, map `file_path`/`hotspot_score`, and render the `get_change_risk` live-git score card (same `risk_report` artifact type).

## Test plan
- [x] `npm test -- --run __tests__/chat/artifacts.test.tsx` in `packages/ui`
- [x] In web chat, run get_risk on a file and get_change_risk on HEAD; open View Artifact for both