### PR TITLE
fix(tests): stop the suite repointing the developer's global editor config

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,6 +45,38 @@ def _no_telemetry_network(tmp_path_factory: pytest.TempPathFactory):
     mp.undo()
 
 
+@pytest.fixture(scope="session", autouse=True)
+def _no_real_editor_setup():
+    """Guarantee no test repoints the developer's real global editor config.
+
+    ``repowise init`` (and ``doctor``'s self-heal path) defaults to
+    ``--editor-setup`` on, which rewrites the *global*, machine-wide MCP
+    server registration (e.g. ``~/.claude/settings.json``) to point at
+    whatever repo path was just indexed. A test that drives the real CLI
+    against a ``tmp_path`` fixture repo — e.g.
+    ``tests/integration/test_cli.py``'s lock/watcher tests, which call
+    ``init`` through ``CliRunner`` in-process rather than mocking it out —
+    was doing exactly that: it repointed the developer's actual Claude Code
+    MCP entry at a pytest temp directory that gets wiped on reboot, breaking
+    every other project's ``repowise`` MCP tools until the *next*
+    ``doctor``/``update`` run happened to self-heal it back (and even then,
+    an already-running Claude Code session keeps using the stale spawn
+    command it cached at connect time, since it has no reason to re-read
+    the file mid-session).
+
+    ``REPOWISE_SKIP_EDITOR_SETUP`` is the exact env var editor_setup.py and
+    doctor's self-heal migrations already gate on — set once, for the whole
+    session, so no test (present or future) can hit this by omission the
+    way the lock/watcher tests did.
+    """
+    from _pytest.monkeypatch import MonkeyPatch
+
+    mp = MonkeyPatch()
+    mp.setenv("REPOWISE_SKIP_EDITOR_SETUP", "1")
+    yield
+    mp.undo()
+
+
 @pytest.fixture(autouse=True)
 def _isolate_structlog_config():
     """Restore structlog's global configuration after every test.

--- a/tests/unit/cli/test_agent_target_baseline.py
+++ b/tests/unit/cli/test_agent_target_baseline.py
@@ -190,6 +190,13 @@ def baseline_env(tmp_path_factory, monkeypatch):
     monkeypatch.setenv("HOMEPATH", str(home)[len(home.drive) :])
     monkeypatch.setattr(Path, "home", lambda: home)
 
+    # The session-wide guard in conftest.py stops every test writing global
+    # editor config. This baseline exists to capture exactly those writes, and
+    # the redirects above (including ``Path.home``) mean they land in the fake
+    # home, so it opts out — otherwise the user scope loses the Claude Desktop
+    # entry and the golden no longer matches.
+    monkeypatch.delenv("REPOWISE_SKIP_EDITOR_SETUP", raising=False)
+
     # Claude Desktop only registers when its config directory already exists,
     # so create it — the baseline should cover that write where the platform
     # supports it at all.

--- a/tests/unit/cli/test_augment_hook_perf.py
+++ b/tests/unit/cli/test_augment_hook_perf.py
@@ -46,9 +46,16 @@ def _fake_home(tmp_path: Path) -> dict[str, str]:
     finds anything to migrate, and ``Path.home()`` reads ``USERPROFILE`` on
     Windows and ``HOME`` elsewhere. Both are redirected. What is under test is
     the import graph, which is identical either way.
+
+    ``REPOWISE_SKIP_EDITOR_SETUP`` is dropped rather than inherited: the
+    session-wide guard in ``conftest.py`` sets it for every test, but this one
+    measures the *default* user's import graph. Under that variable the stamp is
+    never written, so every call falls through to the ``is_editor_setup_disabled``
+    check and imports ``editor_setup`` — the exact thing this asserts against.
     """
     env = dict(os.environ)
     env["HOME"] = env["USERPROFILE"] = str(tmp_path)
+    env.pop("REPOWISE_SKIP_EDITOR_SETUP", None)
     return env
 
 

--- a/tests/unit/cli/test_editor_setup.py
+++ b/tests/unit/cli/test_editor_setup.py
@@ -282,6 +282,7 @@ def test_the_rewrite_hook_answer_decides_every_replacing_surface(
     """
     from repowise.cli.commands.init_cmd._interactive import offer_distill_rewrite_hook
 
+    monkeypatch.delenv("REPOWISE_SKIP_EDITOR_SETUP", raising=False)
     (tmp_path / ".repowise").mkdir()
     monkeypatch.setattr(
         "repowise.cli.agent_adapters.claude_code.ClaudeCodeAdapter.install_rewrite_hook",


### PR DESCRIPTION
## Summary

Running the test suite on a real machine repoints the developer's **global** editor config at a pytest temp directory.

`repowise init` defaults `--editor-setup` on, and its own help says why that matters: "there is one global 'repowise' MCP key, so a second init would otherwise repoint it at this repo." `tests/integration/test_cli.py` drives that same `init` through `CliRunner` in-process against `tmp_path` fixture repos at ~10 call sites, passing neither `--no-editor-setup` nor `REPOWISE_SKIP_EDITOR_SETUP`.

So a local `pytest tests/` rewrites `~/.claude/settings.json` to spawn repowise from a temp directory that gets wiped later, breaking the MCP integration for every other project until a subsequent `doctor`/`update` happens to self-heal it. An already-running editor session keeps the stale spawn command it cached at connect time.

Integration tests are push-to-main only in CI, so this is invisible there and lands on whoever runs the full suite locally.

## Change

A session-scoped autouse fixture in `tests/conftest.py` sets `REPOWISE_SKIP_EDITOR_SETUP=1` for the whole run. That is the exact variable `editor_setup.py` and doctor's self-heal migrations already gate on, so there are no production code changes.

Three suites opt back out, because they exist to exercise the writes the guard suppresses. All of them redirect `HOME` first, so the writes land in a fake home:

- `test_editor_setup.py` — one test asserts on the unset state.
- `test_agent_target_baseline.py` — `baseline_env` redirects `HOME`, `USERPROFILE`, `HOMEDRIVE`, `HOMEPATH` and `Path.home`, and the golden covers the Claude Desktop entry that the guard suppresses.
- `test_augment_hook_perf.py` — builds its subprocess env from `os.environ`, so the guard leaked into a test measuring the *default* user's import graph. Under the variable the version stamp is never written, so every call falls through to the `is_editor_setup_disabled` check and imports `editor_setup` and `agent_targets.types`, which is the precise import that test asserts against.

## Credit

The `conftest.py` guard is cherry-picked from @Laex's work in #1353, where it was found and fixed while adding Object Pascal support. It is unrelated to that language work and fixes something that bites every contributor, so it lands on its own ahead of it. The two extra opt-outs are follow-up.

## Test plan

- [x] `tests/unit/cli` — 2098 passed, 2 skipped, 0 failed (2 failed before the opt-outs)
- [x] Verified the guard is live in-session and absent on the parent commit: a probe asserting `REPOWISE_SKIP_EDITOR_SETUP == "1"` passes with the fix and fails `assert None == '1'` without it
- [x] `ruff check .` clean

## Follow-up, not in this PR

`run_editor_migrations` reads the version stamp first so the per-tool-call path imports nothing, then falls through to `is_editor_setup_disabled()` on a stamp miss. The stamp is written only after migrations complete, and under `REPOWISE_SKIP_EDITOR_SETUP` the function returns before writing it. So anyone who sets that variable in real use (CI, sandboxes) never has a stamp, always takes the fallthrough, and pays the ~13ms `editor_setup` import the stamp exists to avoid. Pre-existing; worth its own issue.
