### PR TITLE
ci: make the internal prerelease publish idempotent

### DIFF
--- a/.github/workflows/publish-internal.yml
+++ b/.github/workflows/publish-internal.yml
@@ -11,10 +11,16 @@ name: Publish internal prereleases
 # (`publish.yml`) only fires on `v*` tags and is unaffected.
 #
 # Triggers:
-#   - push to `next` (auto)
+#   - push to `main` (auto), so a merged PR publishes itself
 #   - workflow_dispatch (manual, for re-publishes)
 #
-# Triggers on push to `main` so merged PRs automatically publish.
+# Publishing is idempotent. The version is derived from the commit SHA, so
+# republishing one is by definition a no-op, and each step skips when the
+# version is already on the registry. Without that, anything that delivers a
+# second push event for a SHA already published (a duplicate webhook, a re-run,
+# a manual dispatch on an already-built commit) turns main red on a 409 with
+# nothing actually wrong. `cancel-in-progress` is deliberately not the fix: it
+# would kill a real publish mid-flight when the next merge lands.
 
 on:
   push:
@@ -70,7 +76,11 @@ jobs:
         run: |
           npm pkg set version="$VERSION"
           npm pkg delete private
-          npm publish
+          if npm view "@repowise-dev/types@$VERSION" version >/dev/null 2>&1; then
+            echo "@repowise-dev/types@$VERSION is already published, skipping"
+          else
+            npm publish
+          fi
 
       - name: Publish @repowise-dev/ui
         working-directory: packages/ui
@@ -81,12 +91,16 @@ jobs:
           npm pkg set version="$VERSION"
           npm pkg set dependencies.@repowise-dev/types="$VERSION"
           npm pkg delete private
-          npm publish
+          if npm view "@repowise-dev/ui@$VERSION" version >/dev/null 2>&1; then
+            echo "@repowise-dev/ui@$VERSION is already published, skipping"
+          else
+            npm publish
+          fi
 
       - name: Summary
         run: |
           {
-            echo "### Published"
+            echo "### Available on GitHub Packages"
             echo ""
             echo "- \`@repowise-dev/types@${{ steps.ver.outputs.version }}\`"
             echo "- \`@repowise-dev/ui@${{ steps.ver.outputs.version }}\`"


### PR DESCRIPTION
## What went wrong

Merging #1102 delivered **two `push` events on `main` for the identical SHA**, two seconds apart:

| Run | Created | Result |
|---|---|---|
| [31695679658](https://github.com/repowise-dev/repowise/actions/runs/31695679658) | 11:28:48 | success, published `@repowise-dev/types` and `@repowise-dev/ui` at `0.0.0-internal.41fc388` |
| [31695682113](https://github.com/repowise-dev/repowise/actions/runs/31695682113) | 11:28:50 | failure, `npm error 409 Conflict - Cannot publish over existing version` |

The second run did exactly what the first had finished two seconds earlier. Both packages were on the registry the whole time, so nothing downstream was ever broken. Main just went red on a no-op.

The CI workflow saw the same duplicate and dropped its older run, because it sets `cancel-in-progress: true`. This workflow sets `false`, so the duplicate queued and then ran.

## The fix

The version is derived from the commit SHA, so republishing one is by definition a no-op. Each publish step now checks the registry first and skips when the version is already there.

That covers more than this one incident: a duplicate webhook delivery, a re-run of a completed job, and a `workflow_dispatch` on a commit that already published all become no-ops instead of failures.

## Why not `cancel-in-progress: true`

It would have swallowed this particular pair, but it is the wrong tool for a publish job. It would kill a genuine in-flight publish the moment the next merge lands, which is a worse failure than the one it prevents: a half-published pair where `types` went out and `ui` did not. The concurrency group stays serialized exactly as it was.

## Also

The header comment claimed the workflow triggers on pushes to `next`, two lines above the block that triggers it on `main`. Corrected.

## Verification

YAML parses, step list unchanged (8 steps, same names). The behaviour change is only reachable on a push to `main`, so it proves itself on the first merge after this one: the publish should run normally, and a duplicate event should log a skip instead of failing.
