### PR TITLE
release: v0.42.0 — one seam for every agent, and three new ones

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "name": "repowise",
       "source": "./plugins/claude-code",
       "description": "Codebase intelligence for Claude Code. Indexes your repo into five layers (Graph, Git, Docs, Decisions, Code Health) and gives Claude deep understanding of architecture, ownership, hotspots, decisions, and defect risk — fewer greps, fewer file reads, lower cost per query.",
-      "version": "0.41.0",
+      "version": "0.42.0",
       "category": "productivity",
       "keywords": [
         "codebase",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,56 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.42.0] — 2026-08-13
+
+repowise shipped real integrations for exactly three agents — Claude Code, Codex and VS Code — with no cheap way to add a fourth. The wiring lived in four unrelated places, each carrying its own copy of what a given agent needs, and the two plugins had already forked from one another with nothing detecting the skew. This cycle puts every agent behind one descriptor seam and then proves it by adding three: **Cursor, OpenCode and Hermes**. A new `repowise agents` command group lists what is wired, adds and removes targets, and prints a config snippet for hosts we write nothing for. A support tier is derived from what a target actually wires rather than declared, so the docs cannot claim more than the code delivers.
+
+The seam paid for itself immediately in a place that was not the point of it. Removal was never really implemented: `init` wrote to six surfaces and nothing took them away, so uninstalling repowise left MCP servers registered, hooks firing, and instruction blocks in files repowise did not own. There is a `repowise uninstall` now, and every removal path reports what it actually removed instead of calling a half-refused removal clean.
+
+The other theme is a group of correctness fixes in ingestion and retrieval that all have the same shape: a signal was being read as something it is not. Co-change partners were being served as dependency edges, so "what does this import" answered with files that merely change alongside it. A TS/JS binding was classified by its name rather than its value. Large source files were dropped silently. Dead code called runtime-loaded web assets safe to delete.
+
+### Added
+- **`repowise agents`.** Lists every agent repowise knows, with its support tier, whether it looks installed, and every place it is currently wired — including duplicates, because "configured" is the wrong answer when the truth is "configured three times". Subcommands `add`, `remove`, `refresh` and `print-config`, each with `--format json` that reports what changed, so an agent can wire itself up and read back the result. (#1448)
+- **Cursor, OpenCode and Hermes as agent targets.** Each is a descriptor file and a registry line. Cursor writes `.cursor/mcp.json` (it does not read `.vscode/mcp.json`) plus a rules file; OpenCode and Hermes read the same host-neutral `AGENTS.md` that Codex does, so the instruction block is shared rather than owned. Hermes also writes YAML and registers into its toolset list. (#1457, #1459, #1460)
+- **`repowise uninstall`.** Removes repowise from everything it wired: MCP registrations, hooks, instruction-file blocks, and the local index, in either scope. Shared surfaces are left alone while another agent still reads them, and the user is told who. (#1467)
+- **Codex slash commands**, built from the same shared source as the skills rather than forked a second time. A Codex plugin manifest has no slot for commands, so they install from package data into `~/.codex/prompts/`; Claude Code gets its commands from the plugin and never from `init`. Both hosts' skills now render from one body, with a drift report when they diverge. (#1450)
+- **A generated agent support matrix** in the docs, built from the registry so it cannot drift from the code. The published MCP tool count is generated from the same place — six artifacts had been asserting a number that was wrong. (#1455)
+
+### Changed
+- **The three existing integrations were rewritten onto the new seam, not extended.** Claude Code, Codex and VS Code all resolve through one `AgentTarget` protocol with composable format helpers rather than a base class, because the targets genuinely differ: Codex writes a TOML server table, a TOML feature flag and a JSON hooks file for one install; VS Code writes two JSON files, one of which may carry comments. Every file the old path wrote is reproduced byte for byte. (#1446)
+- **When a host-managed plugin is already registered, direct wiring stands down.** Claude Code is reachable both through its plugin and by repowise writing the config, and the host merges both without complaint — leaving two process spawns per matched tool call and a duplicate set of tool schemas resident in every session. Measured on a live machine: three repowise MCP servers at once, roughly 36 tool schemas for one product. (#1446)
+- **A dead-code CLI walkthrough** was added to the examples. (#1384)
+
+### Fixed
+- **`get_risk` and `get_context` no longer serve co-change partners as dependencies.** Both read a graph edge set that mixed the two, so a file that merely changes alongside another was reported as importing it. Dependency edges are read on their own now. (#1462, #1470)
+- **Large source files are indexed instead of silently dropped**, and when one genuinely is too large to parse, the run says so and counts it rather than leaving a gap the user cannot see. (#1443, #1237)
+- **TS/JS bindings are classified by their value, not their name.** A `const` whose value is a call was not indexed at all, and a binding was typed from its identifier, so factory results and configured instances went missing from the graph. (#1468, #1469)
+- **TypeScript workspace members resolve from `pnpm-workspace.yaml`**, not only from the `package.json` `workspaces` field, so pnpm monorepos link across packages. (#1454)
+- **Files are decoded as UTF-8 rather than the platform locale**, which on Windows silently mangled any source with non-ASCII bytes. (#1466)
+- **`get_answer` caps its confidence when a cited symbol body was truncated**, instead of reporting high confidence on a partial read, and validates the withheld `symbol_id` it hands back. It also stops reading backtick strings as code. (#1444, #1445, #1451, #1461)
+- **Reachability is answered in one place.** Two callers each had their own notion of "is this file reachable", so the overview page could contradict the dead-code pass about the same file. Barrel files also rank down rather than dominating. (#1487, #1464)
+- **Dead code stops calling runtime-loaded web assets safe to delete**, and the CLI now indicates when low-confidence findings are being hidden rather than presenting a filtered list as the whole answer. (#1463, #1434)
+- **Deterministic structural wiki pages are localized.** With `--language` set, the model-written pages were translated while every structural page stayed English, so a non-English wiki was mixed. (#1092, #1102)
+- **Orientation entry points rank the same way on every surface** — the CLI, the MCP tools and the web UI each had their own ordering. (#1488)
+- **Concept pages stay local and are named for the directory they are actually under.** Unrelated top-level directories could be merged into one concept group, which then took a name from neither. (#1280, #1465)
+- **`repowise mcp` keeps an older index readable** instead of failing on the first query, and caps confidence on a truncated symbol lookup. (#1458)
+- **MCP tools emit `index_behind` and `embedder_degraded` when false**, not only when true. A caller cannot distinguish "not degraded" from "this build does not report it" when the key is simply absent. (#1449)
+- **A failing CLI command names the real error** rather than a generic wrapper, and pytest runs are flagged. (#1447)
+- **Webhooks match repositories by normalized URL** instead of a `contains` prefix, which matched the wrong repo when one name was a prefix of another. (#1440)
+- **The test suite no longer repoints the developer's global editor config.** Running the suite could overwrite the real `~/.claude` MCP registration, breaking the developer's own tooling. (#1481)
+
+### Documentation
+- The documentation layer has its own reference, with the wiki style guidance folded into it. (#1493)
+- Claims that contradicted the code were corrected across the reference docs, and the long ones were made navigable. (#1479)
+
+### Plugins
+- Claude Code plugin at 0.42.0; Codex plugin to 0.5.0 — both skill sets now render from one shared source (#1450).
+
+### Internal
+- The internal prerelease publish is idempotent, so a re-run no longer fails on an already-published version. (#1494)
+
+---
+
 ## [0.41.0] — 2026-08-11
 
 This cycle closes the gap between what an agent can ask over MCP and what it can ask from a terminal. `get_answer`, `get_context`, `get_symbol` and `get_why` had no CLI form at all, so anyone driving repowise from a shell or a CI job could search the wiki but could not ask it a question, read a triage card, pull one verified symbol body, or ask why the code is shaped the way it is. Those four are commands now. `search` and `risk` were rebuilt as thin adapters over the same tool functions, so a CLI answer and an MCP answer are the same answer, and thirteen more commands gained a machine-readable mode under one flag spelling.

--- a/packages/cli/src/repowise/cli/__init__.py
+++ b/packages/cli/src/repowise/cli/__init__.py
@@ -16,4 +16,4 @@ from repowise.cli._stdio import _ensure_utf8_stdio
 # is already UTF-8.
 _ensure_utf8_stdio()
 
-__version__ = "0.41.0"
+__version__ = "0.42.0"

--- a/packages/core/src/repowise/core/__init__.py
+++ b/packages/core/src/repowise/core/__init__.py
@@ -6,4 +6,4 @@ generation engine. This is the heart of repowise — all other packages depend o
 Namespace package: repowise.core is part of the repowise namespace.
 """
 
-__version__ = "0.41.0"
+__version__ = "0.42.0"

--- a/packages/core/src/repowise/core/upgrade/_data/CHANGELOG.md
+++ b/packages/core/src/repowise/core/upgrade/_data/CHANGELOG.md
@@ -9,6 +9,56 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.42.0] — 2026-08-13
+
+repowise shipped real integrations for exactly three agents — Claude Code, Codex and VS Code — with no cheap way to add a fourth. The wiring lived in four unrelated places, each carrying its own copy of what a given agent needs, and the two plugins had already forked from one another with nothing detecting the skew. This cycle puts every agent behind one descriptor seam and then proves it by adding three: **Cursor, OpenCode and Hermes**. A new `repowise agents` command group lists what is wired, adds and removes targets, and prints a config snippet for hosts we write nothing for. A support tier is derived from what a target actually wires rather than declared, so the docs cannot claim more than the code delivers.
+
+The seam paid for itself immediately in a place that was not the point of it. Removal was never really implemented: `init` wrote to six surfaces and nothing took them away, so uninstalling repowise left MCP servers registered, hooks firing, and instruction blocks in files repowise did not own. There is a `repowise uninstall` now, and every removal path reports what it actually removed instead of calling a half-refused removal clean.
+
+The other theme is a group of correctness fixes in ingestion and retrieval that all have the same shape: a signal was being read as something it is not. Co-change partners were being served as dependency edges, so "what does this import" answered with files that merely change alongside it. A TS/JS binding was classified by its name rather than its value. Large source files were dropped silently. Dead code called runtime-loaded web assets safe to delete.
+
+### Added
+- **`repowise agents`.** Lists every agent repowise knows, with its support tier, whether it looks installed, and every place it is currently wired — including duplicates, because "configured" is the wrong answer when the truth is "configured three times". Subcommands `add`, `remove`, `refresh` and `print-config`, each with `--format json` that reports what changed, so an agent can wire itself up and read back the result. (#1448)
+- **Cursor, OpenCode and Hermes as agent targets.** Each is a descriptor file and a registry line. Cursor writes `.cursor/mcp.json` (it does not read `.vscode/mcp.json`) plus a rules file; OpenCode and Hermes read the same host-neutral `AGENTS.md` that Codex does, so the instruction block is shared rather than owned. Hermes also writes YAML and registers into its toolset list. (#1457, #1459, #1460)
+- **`repowise uninstall`.** Removes repowise from everything it wired: MCP registrations, hooks, instruction-file blocks, and the local index, in either scope. Shared surfaces are left alone while another agent still reads them, and the user is told who. (#1467)
+- **Codex slash commands**, built from the same shared source as the skills rather than forked a second time. A Codex plugin manifest has no slot for commands, so they install from package data into `~/.codex/prompts/`; Claude Code gets its commands from the plugin and never from `init`. Both hosts' skills now render from one body, with a drift report when they diverge. (#1450)
+- **A generated agent support matrix** in the docs, built from the registry so it cannot drift from the code. The published MCP tool count is generated from the same place — six artifacts had been asserting a number that was wrong. (#1455)
+
+### Changed
+- **The three existing integrations were rewritten onto the new seam, not extended.** Claude Code, Codex and VS Code all resolve through one `AgentTarget` protocol with composable format helpers rather than a base class, because the targets genuinely differ: Codex writes a TOML server table, a TOML feature flag and a JSON hooks file for one install; VS Code writes two JSON files, one of which may carry comments. Every file the old path wrote is reproduced byte for byte. (#1446)
+- **When a host-managed plugin is already registered, direct wiring stands down.** Claude Code is reachable both through its plugin and by repowise writing the config, and the host merges both without complaint — leaving two process spawns per matched tool call and a duplicate set of tool schemas resident in every session. Measured on a live machine: three repowise MCP servers at once, roughly 36 tool schemas for one product. (#1446)
+- **A dead-code CLI walkthrough** was added to the examples. (#1384)
+
+### Fixed
+- **`get_risk` and `get_context` no longer serve co-change partners as dependencies.** Both read a graph edge set that mixed the two, so a file that merely changes alongside another was reported as importing it. Dependency edges are read on their own now. (#1462, #1470)
+- **Large source files are indexed instead of silently dropped**, and when one genuinely is too large to parse, the run says so and counts it rather than leaving a gap the user cannot see. (#1443, #1237)
+- **TS/JS bindings are classified by their value, not their name.** A `const` whose value is a call was not indexed at all, and a binding was typed from its identifier, so factory results and configured instances went missing from the graph. (#1468, #1469)
+- **TypeScript workspace members resolve from `pnpm-workspace.yaml`**, not only from the `package.json` `workspaces` field, so pnpm monorepos link across packages. (#1454)
+- **Files are decoded as UTF-8 rather than the platform locale**, which on Windows silently mangled any source with non-ASCII bytes. (#1466)
+- **`get_answer` caps its confidence when a cited symbol body was truncated**, instead of reporting high confidence on a partial read, and validates the withheld `symbol_id` it hands back. It also stops reading backtick strings as code. (#1444, #1445, #1451, #1461)
+- **Reachability is answered in one place.** Two callers each had their own notion of "is this file reachable", so the overview page could contradict the dead-code pass about the same file. Barrel files also rank down rather than dominating. (#1487, #1464)
+- **Dead code stops calling runtime-loaded web assets safe to delete**, and the CLI now indicates when low-confidence findings are being hidden rather than presenting a filtered list as the whole answer. (#1463, #1434)
+- **Deterministic structural wiki pages are localized.** With `--language` set, the model-written pages were translated while every structural page stayed English, so a non-English wiki was mixed. (#1092, #1102)
+- **Orientation entry points rank the same way on every surface** — the CLI, the MCP tools and the web UI each had their own ordering. (#1488)
+- **Concept pages stay local and are named for the directory they are actually under.** Unrelated top-level directories could be merged into one concept group, which then took a name from neither. (#1280, #1465)
+- **`repowise mcp` keeps an older index readable** instead of failing on the first query, and caps confidence on a truncated symbol lookup. (#1458)
+- **MCP tools emit `index_behind` and `embedder_degraded` when false**, not only when true. A caller cannot distinguish "not degraded" from "this build does not report it" when the key is simply absent. (#1449)
+- **A failing CLI command names the real error** rather than a generic wrapper, and pytest runs are flagged. (#1447)
+- **Webhooks match repositories by normalized URL** instead of a `contains` prefix, which matched the wrong repo when one name was a prefix of another. (#1440)
+- **The test suite no longer repoints the developer's global editor config.** Running the suite could overwrite the real `~/.claude` MCP registration, breaking the developer's own tooling. (#1481)
+
+### Documentation
+- The documentation layer has its own reference, with the wiki style guidance folded into it. (#1493)
+- Claims that contradicted the code were corrected across the reference docs, and the long ones were made navigable. (#1479)
+
+### Plugins
+- Claude Code plugin at 0.42.0; Codex plugin to 0.5.0 — both skill sets now render from one shared source (#1450).
+
+### Internal
+- The internal prerelease publish is idempotent, so a re-run no longer fails on an already-published version. (#1494)
+
+---
+
 ## [0.41.0] — 2026-08-11
 
 This cycle closes the gap between what an agent can ask over MCP and what it can ask from a terminal. `get_answer`, `get_context`, `get_symbol` and `get_why` had no CLI form at all, so anyone driving repowise from a shell or a CI job could search the wiki but could not ask it a question, read a triage card, pull one verified symbol body, or ask why the code is shaped the way it is. Those four are commands now. `search` and `risk` were rebuilt as thin adapters over the same tool functions, so a CLI answer and an MCP answer are the same answer, and thirteen more commands gained a machine-readable mode under one flag spelling.

--- a/packages/server/src/repowise/server/__init__.py
+++ b/packages/server/src/repowise/server/__init__.py
@@ -7,4 +7,4 @@ Provides:
     - Background job scheduler (APScheduler)
 """
 
-__version__ = "0.41.0"
+__version__ = "0.42.0"

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "repowise",
   "description": "Codebase intelligence for Claude Code. Indexes your codebase into five layers (Graph, Git, Docs, Decisions, Code Health) and exposes them through eleven task-shaped MCP tools — so Claude understands architecture, ownership, hotspots, why code is built the way it is, and where the defect risk lives.",
-  "version": "0.41.0",
+  "version": "0.42.0",
   "author": {
     "name": "Repowise",
     "email": "hello@repowise.dev",

--- a/plugins/claude-code/CHANGELOG.md
+++ b/plugins/claude-code/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the Repowise Claude Code plugin are documented here.
 
+## 0.42.0
+
+### Changed
+- The six skills now render from a source shared with the Codex plugin rather
+  than being maintained as two hand-kept copies that had already drifted in
+  wording, headings and one directory name. A drift report fails when the two
+  hosts diverge (#1450).
+
 ## 0.41.0
 
 ### Added

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "Repowise codebase intelligence for Codex.",
   "author": {
     "name": "Repowise",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "repowise"
-version = "0.41.0"
+version = "0.42.0"
 description = "The codebase intelligence layer for your AI coding agent — dependency graph, git history, dead code, decisions, and code health, exposed over MCP"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/server.json
+++ b/server.json
@@ -8,12 +8,12 @@
     "source": "github"
   },
   "websiteUrl": "https://www.repowise.dev",
-  "version": "0.41.0",
+  "version": "0.42.0",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "repowise",
-      "version": "0.41.0",
+      "version": "0.42.0",
       "transport": {
         "type": "stdio"
       },

--- a/uv.lock
+++ b/uv.lock
@@ -3051,7 +3051,7 @@ wheels = [
 
 [[package]]
 name = "repowise"
-version = "0.41.0"
+version = "0.42.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Cuts v0.42.0 from `origin/main` at 6d5e5178. Bump + changelog only; no behaviour change in this diff.

## What shipped this cycle

36 commits since v0.41.0. The theme is the agent layer: every integration now sits behind one descriptor seam, proved by rewriting the existing three (Claude Code, Codex, VS Code) onto it rather than extending around them, then adding **Cursor, OpenCode and Hermes** as a descriptor file each. A `repowise agents` group lists, adds, removes, refreshes and prints config. `repowise uninstall` closes the removal gap — `init` wrote six surfaces and nothing took them away.

Alongside that, a set of fixes that share a shape: a signal read as something it is not. Co-change partners served as dependency edges, TS/JS bindings typed by name instead of value, large files dropped silently, runtime-loaded web assets called safe to delete.

## Version bump

| File | |
|---|---|
| `pyproject.toml`, `packages/{cli,core,server}/**/__init__.py` | 0.41.0 → 0.42.0 |
| `uv.lock` | self-entry moved via `uv lock` |
| `.claude-plugin/marketplace.json`, `plugins/claude-code/.claude-plugin/plugin.json` | 0.42.0 |
| `server.json` (both `version` and `packages[0].version`) | 0.42.0 |
| `plugins/codex/.codex-plugin/plugin.json` | 0.4.1 → **0.5.0** |

The Codex plugin rides its own line and moves only when it ships changes. It shipped changes: all six skills now render from the source shared with the Claude plugin (#1450) instead of being a hand-kept copy that had already drifted in wording, headings and one directory name.

## Test plan

- [x] Drift grep — no `0.41.0` remaining in any tracked manifest
- [x] `tests/unit/test_release_manifests.py` — 8 passed
- [x] Plugin + agent-matrix drift guards — 106 passed across `test_agent_matrix`, `test_claude_plugin`, `test_codex_plugin`, `test_bundled_changelog_sync`, `test_release_manifests`
- [x] `ruff check .` clean
- [x] `uv build --wheel` → `repowise-0.42.0-py3-none-any.whl`; 93 command modules, `serve_cmd` present, 54 `.scm`/`.j2`, bundled changelog, 36 `agent_targets` modules packaged
- [x] `npm ci && npm run build --workspace packages/web` — green, standalone `server.js` emitted, workspace-package code compiled into the route chunks
- [x] MCP tool-surface parity — every tool name referenced by the plugin is in the live `list_tools()`; `get_architecture_diagram` appears only in the plugin changelog documenting its removal
- [x] Cold index of `test-repos/microdot` both ways on the release code: keyless `--no-prose` (183 files, 1,217 symbols, 188 pages, 19.7s, $0) and `--prose` via OpenAI (1m20s, $0.02)
- [x] `<!-- mcp-name: dev.repowise/repowise -->` still on line 1 of `README.md`
- [ ] Tag `v0.42.0` on `main` after merge, push, watch `publish.yml`
- [ ] Publish `server.json` to the MCP registry (`mcp-publisher publish`) once PyPI serves 0.42.0
- [ ] Final gate: install `repowise==0.42.0` from PyPI into a throwaway venv and cold-index microdot

## Known, not blocking

On the prose run, 3 of 6 subsystem pages were rejected by the `supplied_context` artifact guard — the default `gpt-5.4-nano` writing prose addressed to the prompter. `--resume` recovered one; two failed again identically and kept their structural placeholders. The guard behaved as designed. Moving the default model and reassessing what a rejection should cost is filed for next cycle.

The README's "ten task-shaped MCP tools" is deliberate and correct — it is the flagship count (default single-repo surface minus `list_repos`), narrower than the seventeen registered. `scripts/gen_agent_matrix.py` derives it and the golden test enforces it.
