### PR TITLE
refactor(answer): split get_answer into named stages

### DIFF
--- a/packages/server/src/repowise/server/mcp_server/tool_answer/answer.py
+++ b/packages/server/src/repowise/server/mcp_server/tool_answer/answer.py
@@ -174,10 +174,10 @@ from repowise.server.mcp_server.tool_answer.symbols import (
     _hydrate_symbols_for_hits,
     _read_repo_text,
     _read_symbol_source,
+    attach_truncation_contract,
     build_homonym_union_bodies,
     is_symbol_lookup_question,
     union_defers_to_synthesis,
-    withheld_definitions,
 )
 from repowise.server.mcp_server.tool_answer.synthesis import (
     _hash_question,
@@ -527,6 +527,29 @@ def _is_readable_path(target: str) -> bool:
     return bool(ext) and ext.isalnum() and len(ext) <= 6
 
 
+def _repo_root(ctx) -> Path | None:
+    """The checkout root as a Path, or None when the context carries no path.
+
+    Every live source read in this module is anchored on it, and a context
+    without a path is the repo-less case those reads must skip rather than
+    guess at.
+    """
+    return Path(str(ctx.path)) if getattr(ctx, "path", None) else None
+
+
+def _top_two_score_ratio(hits: list[dict]) -> float:
+    """The top hit's retrieval score over the runner-up's.
+
+    The separator both the confidence grade and :func:`_retrieval_quality` are
+    built on, kept in one place because they must agree on what "dominant"
+    measures. A lone hit has nothing to be ambiguous against, so it is infinitely
+    dominant; no hits at all is zero.
+    """
+    if len(hits) >= 2:
+        return hits[0].get("score", 0.0) / (hits[1].get("score", 0.0) or 1e-9)
+    return float("inf") if hits else 0.0
+
+
 async def _first_resolvable_id(
     ids: list[str], ctx, repository, exclude_spec
 ) -> str | None:
@@ -549,7 +572,7 @@ async def _first_resolvable_id(
     evidence the id is fabricated. Only a positive read that does not contain
     the name, with no index row either, disqualifies one.
     """
-    repo_root = Path(str(ctx.path)) if getattr(ctx, "path", None) else None
+    repo_root = _repo_root(ctx)
     for sid in ids:
         file_part, name_part = parse_symbol_id(sid)
         if not file_part or not name_part:
@@ -569,6 +592,29 @@ async def _first_resolvable_id(
     return None
 
 
+def _rationale_anchors(h: dict) -> list[tuple[str, int | None]]:
+    """One ``(path, near-line)`` pair per reason this hit is worth scanning.
+
+    A concept-anchored file leads: it was selected precisely because its comment
+    explains the question, and the grep match line is the best near-line boost
+    available. Each anchored or question-matched symbol then contributes the
+    same path again at its own definition line, so a file with several matches
+    is repeated as many times as it has reasons, which is the weighting the
+    scan below orders on.
+    """
+    path = h.get("target_path")
+    if not path:
+        return []
+    anchors: list[tuple[str, int | None]] = []
+    if h.get("_concept_anchored"):
+        anchors.append((path, h.get("_concept_near_line")))
+    for s in (h.get("_anchor_symbols") or []) + [
+        s for s in (h.get("symbols") or []) if s.get("_matched")
+    ]:
+        anchors.append((path, s.get("start_line")))
+    return anchors
+
+
 def _gather_code_rationale(ctx, hits: list[dict], fallback_targets: list[str], question: str):
     """Mine in-code rationale comments for a low-confidence answer.
 
@@ -585,24 +631,11 @@ def _gather_code_rationale(ctx, hits: list[dict], fallback_targets: list[str], q
     candidates: list[str] = []
     near_lines: dict[str, int] = {}
     for h in hits or []:
-        path = h.get("target_path")
-        if not path:
-            continue
-        # A concept-anchored file leads: it was selected precisely because its
-        # comment explains the question, and the grep match line is the best
-        # near-line boost we have.
-        if h.get("_concept_anchored"):
+        for path, near_line in _rationale_anchors(h):
             candidates.append(path)
-            cl = h.get("_concept_near_line")
-            if cl and path not in near_lines:
-                near_lines[path] = cl
-        for s in (h.get("_anchor_symbols") or []) + [
-            s for s in (h.get("symbols") or []) if s.get("_matched")
-        ]:
-            candidates.append(path)
-            sl = s.get("start_line")
-            if sl and path not in near_lines:
-                near_lines[path] = sl
+            # First mention of a path wins its near-line boost.
+            if near_line and path not in near_lines:
+                near_lines[path] = near_line
     candidates.extend(p for p in (fallback_targets or []) if p)
     try:
         return _mine_rationale(repo_root, candidates, question, near_lines=near_lines)
@@ -620,28 +653,31 @@ def _drop_already_surfaced(rationale: list[dict], *surfaced: list[dict]) -> list
     drop any mined comment whose ``(path, line-range)`` overlaps an entry already
     surfaced. Entries without a ``(path, lines)`` pair are ignored.
     """
-    occupied: list[tuple[str, int, int]] = []
-    for entries in surfaced:
-        for e in entries or []:
-            path = e.get("path")
-            lines = e.get("lines")
-            if path and isinstance(lines, (list, tuple)) and len(lines) == 2:
-                occupied.append((path, lines[0], lines[1]))
+    occupied = [span for entries in surfaced for span in map(_line_span, entries or []) if span]
     if not occupied:
         return rationale
-    kept: list[dict] = []
-    for r in rationale:
-        path = r.get("path")
-        lines = r.get("lines")
-        if (
-            path
-            and isinstance(lines, (list, tuple))
-            and len(lines) == 2
-            and any(p == path and not (lines[1] < s or lines[0] > e) for p, s, e in occupied)
-        ):
-            continue
-        kept.append(r)
-    return kept
+    return [r for r in rationale if not _overlaps_any(_line_span(r), occupied)]
+
+
+def _line_span(entry: dict) -> tuple[str, int, int] | None:
+    """The ``(path, start, end)`` an entry occupies, or None if it names none.
+
+    Entries without a usable ``(path, lines)`` pair cannot be compared for
+    overlap in either direction, so they neither occupy space nor get dropped.
+    """
+    path = entry.get("path")
+    lines = entry.get("lines")
+    if path and isinstance(lines, (list, tuple)) and len(lines) == 2:
+        return (path, lines[0], lines[1])
+    return None
+
+
+def _overlaps_any(span: tuple[str, int, int] | None, occupied: list[tuple[str, int, int]]) -> bool:
+    """Whether ``span`` shares a file and any line with something already shown."""
+    if span is None:
+        return False
+    path, start, end = span
+    return any(p == path and not (end < s or start > e) for p, s, e in occupied)
 
 
 def _gather_body_candidates(
@@ -676,29 +712,57 @@ def _gather_body_candidates(
         if not path:
             continue
         for s in h.get("_anchor_symbols") or []:
-            name = s.get("name")
-            if not name:
-                continue
-            if name not in anchor_names if anchor_names is not None else name not in answer_text:
-                continue
-            kind = s.get("kind")
-            kind_rank = 0 if kind in ("function", "method") else 1
-            candidates.append((0, kind_rank, s.get("start_line") or 0, path, s))
+            if _selection_names(s.get("name"), answer_text, anchor_names):
+                candidates.append((0, _kind_rank(s), s.get("start_line") or 0, path, s))
+        # Tier 1 exists to catch a symbol only the PROSE names, so it has
+        # nothing to do in the degraded mode that has no prose.
         if anchor_names is not None:
             continue
         for s in h.get("symbols") or []:
-            name = s.get("name")
-            if not name or len(name) < 3 or not s.get("_matched"):
-                continue
-            if name not in answer_text:
-                continue
-            kind = s.get("kind")
-            if kind not in ("function", "method", "class", "interface"):
-                continue
-            kind_rank = 0 if kind in ("function", "method") else 1
-            candidates.append((1, kind_rank, s.get("start_line") or 0, path, s))
+            if _is_named_definition(s, answer_text):
+                candidates.append((1, _kind_rank(s), s.get("start_line") or 0, path, s))
     candidates.sort(key=lambda t: (t[0], t[1], t[2]))
     return candidates
+
+
+def _selection_names(name: str | None, answer_text: str, anchor_names: set[str] | None) -> bool:
+    """Whether the text that selects bodies names this symbol.
+
+    Two selection texts, one predicate: normally the synthesised answer decides
+    which definitions are worth inlining, but the degraded path has no prose, so
+    ``anchor_names`` puts the question's own identifiers in its place. Note the
+    difference in kind: ``anchor_names`` is an exact set membership, the answer
+    text a substring match.
+    """
+    if not name:
+        return False
+    return name in anchor_names if anchor_names is not None else name in answer_text
+
+
+def _kind_rank(s: dict) -> int:
+    """0 for a callable, 1 for a container.
+
+    Within a tier a function or method outranks the class that holds it, so
+    "explain the extract_all method of DecisionExtractor" serves extract_all
+    rather than the 1,300-line class head.
+    """
+    return 0 if s.get("kind") in ("function", "method") else 1
+
+
+def _is_named_definition(s: dict, answer_text: str) -> bool:
+    """Whether a hydrated symbol is a definition the answer actually names.
+
+    Requires a name long enough that substring containment means something (a
+    1-2 character constant would "appear" in almost any answer), the
+    question-match the hydrator recorded, and a kind that has a body worth
+    inlining. Constants stay in ``quotes``: their body IS the assignment line.
+    """
+    name = s.get("name")
+    if not name or len(name) < 3 or not s.get("_matched"):
+        return False
+    if name not in answer_text:
+        return False
+    return s.get("kind") in ("function", "method", "class", "interface")
 
 
 def _retrieval_quality(hits: list[dict], agreement_dominant: bool) -> str:
@@ -715,10 +779,7 @@ def _retrieval_quality(hits: list[dict], agreement_dominant: bool) -> str:
     and "high" has to mean the same thing to a keyless caller as to a keyed one
     or the field is worth less than nothing.
     """
-    if len(hits) >= 2:
-        ratio = hits[0].get("score", 0.0) / (hits[1].get("score", 0.0) or 1e-9)
-    else:
-        ratio = float("inf") if hits else 0.0
+    ratio = _top_two_score_ratio(hits)
     top_score = hits[0].get("score", 0.0) if hits else 0.0
     dominant_grade = ratio >= _DOMINANCE_RATIO or agreement_dominant
     if dominant_grade and top_score >= _HIGH_CONFIDENCE_SCORE_FLOOR:
@@ -771,22 +832,102 @@ def _build_symbol_bodies(
             "lines": [start, end_served],
             "source": body,
         }
-        if sym_end > end_served:
-            entry["truncated"] = True
-            entry["continuation"] = f"{path}:{end_served + 1}-{sym_end}"
-            # Say WHAT was withheld, not just that something was. A bare
-            # truncated flag plus a get_symbol pointer was followed zero times
-            # across the agent runs measured, so the consumer needs the names in
-            # hand to decide whether it is missing anything it cares about, and
-            # to continue inside this tool rather than falling back to Read.
-            withheld = withheld_definitions(repo_root, entry["continuation"])
-            if withheld:
-                entry["withheld_symbols"] = withheld
+        attach_truncation_contract(
+            entry, indexed_end=sym_end, end_served=end_served, repo_root=repo_root
+        )
         symbol_bodies.append(entry)
         seen.add((path, name))
         if tier == 0:
             served_named_body = True
     return symbol_bodies, served_named_body
+
+
+def _data_shape_prose(grounded: dict, citations: list[str]) -> tuple[str, str]:
+    """The ``answer`` and ``note`` for a mined data shape, by how it was grounded.
+
+    A documented shape is authoritative and says so (cite it, no verification
+    Read). A usage-mined shape is the keys consumers actually pull off the value,
+    which may be a subset of what is stored, so it asks to be verified.
+    """
+    ident = grounded["identifier"]
+    fields = grounded["fields"]
+    sources = grounded["sources"]
+    also_accessed = grounded.get("also_accessed") or []
+    field_list = ", ".join(f"`{f}`" for f in fields)
+
+    if grounded["grounding"] != "docstring":
+        first = sources[0]
+        return (
+            f"Each entry in `{ident}` is accessed with {len(fields)} key(s): "
+            f"{field_list}. These are the keys consumers actually pull off the "
+            f"parsed value (e.g. {first['file']}:{first['line']}); this is mined "
+            "from usage, not a declared schema, so verify if you need the full set.",
+            "Grounded in the key accesses mined from consumer source (no "
+            "documented shape was found). Medium confidence: these are the keys "
+            "the code reads, which may be a subset of the stored fields.",
+        )
+
+    doc_src = next((s for s in sources if s["kind"] == "docstring"), None)
+    where = f"{doc_src['file']}:{doc_src['line']}" if doc_src else citations[0]
+    if not also_accessed:
+        return (
+            f"Each entry in `{ident}` has {len(fields)} field(s): {field_list}. "
+            f"This is the documented shape at {where}; cite it directly, no "
+            "verification Read needed.",
+            "Grounded in the documented field shape mined from source (the "
+            "quoted keys in the docstring/comment at the cited line). "
+            "data_shape.sources lists every field's origin line.",
+        )
+
+    # The doc lists the declared shape, but consumers read alias key(s) it omits
+    # (a legacy fallback). Surface them: telling the agent "no Read needed" while
+    # hiding a key it must handle would be a confidently-incomplete answer.
+    alias_list = ", ".join(f"`{a['field']}`" for a in also_accessed)
+    first_alias = also_accessed[0]
+    return (
+        f"Each entry in `{ident}` has {len(fields)} documented field(s): "
+        f"{field_list} (documented shape at {where}). Consumers also read "
+        f"{alias_list} as a fallback (e.g. {first_alias['file']}:"
+        f"{first_alias['line']}) - an alias the docstring omits, so handle "
+        f"{alias_list} too if you touch this.",
+        "Grounded in the documented field shape, plus alias key(s) "
+        "consumers read beside a documented field that the docstring "
+        "omits (see data_shape.also_accessed). The documented fields are "
+        "authoritative; the aliases are real keys the code defends against.",
+    )
+
+
+def _is_question_named_body_cut_by_us(entry: dict, question_ids: set[str]) -> bool:
+    """Whether this body is the question's own symbol, cut because WE ran out of lines.
+
+    ``truncated`` alone is not trustworthy enough to demote on. It is set by
+    comparing the INDEXED end line against what was read, while the read clamps
+    to the end of the live file, so a symbol whose stored end overshoots (an
+    unsupported language or a syntax error leaves the bounds unverified, and a
+    file that shrank since indexing does it too) is served WHOLE and still
+    flagged. Requiring the served span to have reached the line cap says the cut
+    was ours, which is the only case where something was really withheld.
+    """
+    if not (entry.get("truncated") and entry.get("continuation")):
+        return False
+    if entry.get("name") not in question_ids:
+        return False
+    return entry["lines"][1] - entry["lines"][0] + 1 >= _INLINE_BODY_MAX_LINES
+
+
+def _is_enclosing_continuation(entry: dict, implicated: set[str]) -> bool:
+    """Whether this body simply continues past the cut, rather than losing a symbol.
+
+    A withheld entry carrying the served body's OWN name is the enclosing symbol
+    continuing past the cut, not something that never arrived. Calling that "not
+    served" is wrong about the payload directly above the note, and sends the
+    caller to get_symbol for a body they already hold most of. The accurate
+    pointer is the ``continuation`` the entry already carries.
+    """
+    name = entry.get("name")
+    if not (entry.get("continuation") and name in implicated):
+        return False
+    return any(s.get("name") == name for s in (entry.get("withheld_symbols") or []))
 
 
 def _build_data_shape_payload(grounded: dict, t0: float, repository) -> dict:
@@ -801,54 +942,7 @@ def _build_data_shape_payload(grounded: dict, t0: float, repository) -> dict:
     sources = grounded["sources"]
     also_accessed = grounded.get("also_accessed") or []
     citations = sorted({s["file"] for s in sources})
-    field_list = ", ".join(f"`{f}`" for f in fields)
-    doc_src = next((s for s in sources if s["kind"] == "docstring"), None)
-    if grounded["grounding"] == "docstring":
-        where = f"{doc_src['file']}:{doc_src['line']}" if doc_src else citations[0]
-        if also_accessed:
-            # The doc lists the declared shape, but consumers read alias key(s)
-            # it omits (a legacy fallback). Surface them: telling the agent "no
-            # Read needed" while hiding a key it must handle would be a
-            # confidently-incomplete answer.
-            alias_list = ", ".join(f"`{a['field']}`" for a in also_accessed)
-            first_alias = also_accessed[0]
-            answer = (
-                f"Each entry in `{ident}` has {len(fields)} documented field(s): "
-                f"{field_list} (documented shape at {where}). Consumers also read "
-                f"{alias_list} as a fallback (e.g. {first_alias['file']}:"
-                f"{first_alias['line']}) - an alias the docstring omits, so handle "
-                f"{alias_list} too if you touch this."
-            )
-            note = (
-                "Grounded in the documented field shape, plus alias key(s) "
-                "consumers read beside a documented field that the docstring "
-                "omits (see data_shape.also_accessed). The documented fields are "
-                "authoritative; the aliases are real keys the code defends against."
-            )
-        else:
-            answer = (
-                f"Each entry in `{ident}` has {len(fields)} field(s): {field_list}. "
-                f"This is the documented shape at {where}; cite it directly, no "
-                "verification Read needed."
-            )
-            note = (
-                "Grounded in the documented field shape mined from source (the "
-                "quoted keys in the docstring/comment at the cited line). "
-                "data_shape.sources lists every field's origin line."
-            )
-    else:
-        first = sources[0]
-        answer = (
-            f"Each entry in `{ident}` is accessed with {len(fields)} key(s): "
-            f"{field_list}. These are the keys consumers actually pull off the "
-            f"parsed value (e.g. {first['file']}:{first['line']}); this is mined "
-            "from usage, not a declared schema, so verify if you need the full set."
-        )
-        note = (
-            "Grounded in the key accesses mined from consumer source (no "
-            "documented shape was found). Medium confidence: these are the keys "
-            "the code reads, which may be a subset of the stored fields."
-        )
+    answer, note = _data_shape_prose(grounded, citations)
     payload: dict = {
         "answer": answer,
         "citations": citations,
@@ -871,6 +965,34 @@ def _build_data_shape_payload(grounded: dict, t0: float, repository) -> dict:
         ),
     }
     return payload
+
+
+def _no_answer_payload(note: str, *, repository, t0: float) -> dict:
+    """The reply for a post-retrieval gate that has nothing to answer with.
+
+    Two gates end this way and both mean the same thing: retrieval ran, and the
+    honest reply is "not this" plus what to do instead. The qualified-miss guard
+    refuses to substitute a same-named symbol from another file; the no-hits
+    guard has no candidates at all. ``note`` is the only part that differs, and
+    it carries the redirect.
+
+    Both callers still wrap this in :func:`_with_candidates`, which is what keeps
+    the ranked shortlist travelling with every post-retrieval return.
+    """
+    return {
+        "answer": "",
+        "citations": [],
+        "confidence": "low",
+        "note": note,
+        "fallback_targets": [],
+        "retrieval": [],
+        "_meta": _build_meta(
+            timing_ms=(time.perf_counter() - t0) * 1000,
+            hint=_answer_hint("low", 0),
+            repository=repository,
+            targets=[],
+        ),
+    }
 
 
 def _with_candidates(payload: dict, resolved_pool: list[dict]) -> dict:
@@ -902,6 +1024,43 @@ def _with_candidates(payload: dict, resolved_pool: list[dict]) -> dict:
     if candidates:
         payload["candidates"] = candidates
     return payload
+
+
+def _degraded_summary(reason: str, symbol_bodies: list[dict], served: int) -> str:
+    """The ``answer`` sentence a synthesis-less payload states about itself.
+
+    Assembled from what the payload actually carries, so it can never claim more
+    than it has, and it invents no prose about the question itself, that being
+    precisely the part that needs a provider. Three cases, best evidence first:
+    bodies in hand, a ranked retrieval, or nothing.
+    """
+    if symbol_bodies:
+        names = ", ".join(f"`{b['name']}`" for b in symbol_bodies)
+        # Never say "full" over a body the payload itself flags as cut. The
+        # entry carries `truncated` and a `continuation` two keys away, so the
+        # claim is refutable from inside the same response.
+        cut = any(b.get("truncated") for b in symbol_bodies)
+        return (
+            f"No synthesized prose ({reason}), but the evidence is here: "
+            f"`symbol_bodies` carries the live source of {names}, read from the "
+            "current checkout"
+            + (", cut at the line cap where noted; see `continuation`. " if cut else " in full. ")
+            + "Answer from that; `retrieval`, `fallback_targets` and `candidates` "
+            "cover the wider question."
+        )
+    if served:
+        return (
+            f"No synthesized prose ({reason}), but retrieval succeeded and this "
+            f"payload is usable: {served} ranked "
+            f"{'hit' if served == 1 else 'hits'} in `retrieval`, the files to open "
+            "in `fallback_targets`, and the wider ranked shortlist in `candidates`. "
+            "Read those rather than starting a fresh search."
+        )
+    return (
+        f"No synthesized prose ({reason}), and retrieval matched nothing for "
+        "this question. Rephrase with an identifier or path from the codebase, "
+        "or search directly."
+    )
 
 
 async def _degraded_payload(
@@ -960,7 +1119,7 @@ async def _degraded_payload(
     retrievals were genuinely weak in both arms and still grade "weak".
     """
     retrieval_quality = _retrieval_quality(hits, agreement_dominant)
-    repo_root = Path(str(ctx.path)) if getattr(ctx, "path", None) else None
+    repo_root = _repo_root(ctx)
     symbol_bodies, _served_named_body = _build_symbol_bodies(
         _gather_body_candidates(hits, "", anchor_names=question_ids or set()),
         repo_root,
@@ -971,39 +1130,7 @@ async def _degraded_payload(
     # discarding this reply.
     citations = list(dict.fromkeys(b["path"] for b in symbol_bodies))
 
-    served = len(hits)
-    if symbol_bodies:
-        _names = ", ".join(f"`{b['name']}`" for b in symbol_bodies)
-        # Never say "full" over a body the payload itself flags as cut. The
-        # entry carries `truncated` and a `continuation` two keys away, so the
-        # claim is refutable from inside the same response.
-        _cut = any(b.get("truncated") for b in symbol_bodies)
-        summary = (
-            f"No synthesized prose ({reason}), but the evidence is here: "
-            f"`symbol_bodies` carries the live source of {_names}, read from the "
-            "current checkout"
-            + (
-                ", cut at the line cap where noted; see `continuation`. "
-                if _cut
-                else " in full. "
-            )
-            + "Answer from that; `retrieval`, `fallback_targets` and `candidates` "
-            "cover the wider question."
-        )
-    elif served:
-        summary = (
-            f"No synthesized prose ({reason}), but retrieval succeeded and this "
-            f"payload is usable: {served} ranked "
-            f"{'hit' if served == 1 else 'hits'} in `retrieval`, the files to open "
-            "in `fallback_targets`, and the wider ranked shortlist in `candidates`. "
-            "Read those rather than starting a fresh search."
-        )
-    else:
-        summary = (
-            f"No synthesized prose ({reason}), and retrieval matched nothing for "
-            "this question. Rephrase with an identifier or path from the codebase, "
-            "or search directly."
-        )
+    summary = _degraded_summary(reason, symbol_bodies, len(hits))
 
     payload: dict = {
         "answer": summary,
@@ -1311,7 +1438,7 @@ async def get_answer(
     homonyms: dict = {"union": {}, "qualified_miss": []}
     if question_ids:
         with contextlib.suppress(Exception):
-            _anchor_root = Path(str(ctx.path)) if getattr(ctx, "path", None) else None
+            _anchor_root = _repo_root(ctx)
             async with get_session(ctx.session_factory) as session:
                 hits, homonyms = await _anchor_symbol_hits(
                     session,
@@ -1404,28 +1531,17 @@ async def get_answer(
     if homonyms.get("qualified_miss"):
         missed = homonyms["qualified_miss"]
         return _with_candidates(
-            {
-                "answer": "",
-                "citations": [],
-                "confidence": "low",
-                "note": (
-                    f"No indexed definition matches the qualified name(s) {missed}. "
-                    "The base name is defined elsewhere, but not under the "
-                    "class/module you named, so this is not returning a same-named "
-                    "symbol from another file, to avoid a confidently-wrong answer. "
-                    'Re-check the qualifier, or call search_codebase mode="symbol" '
-                    "on the base name to see every definition. The files retrieval "
-                    "ranked for this question are in candidates."
-                ),
-                "fallback_targets": [],
-                "retrieval": [],
-                "_meta": _build_meta(
-                    timing_ms=(time.perf_counter() - t0) * 1000,
-                    hint=_answer_hint("low", 0),
-                    repository=repository,
-                    targets=[],
-                ),
-            },
+            _no_answer_payload(
+                f"No indexed definition matches the qualified name(s) {missed}. "
+                "The base name is defined elsewhere, but not under the "
+                "class/module you named, so this is not returning a same-named "
+                "symbol from another file, to avoid a confidently-wrong answer. "
+                'Re-check the qualifier, or call search_codebase mode="symbol" '
+                "on the base name to see every definition. The files retrieval "
+                "ranked for this question are in candidates.",
+                repository=repository,
+                t0=t0,
+            ),
             resolved_pool,
         )
 
@@ -1455,7 +1571,7 @@ async def get_answer(
     if union_groups and _flag_on(_UNION_MECHANISM_DEFER_ENV) and _is_mechanism_question(question):
         union_groups = {}
     if union_groups:
-        repo_root = Path(str(ctx.path)) if getattr(ctx, "path", None) else None
+        repo_root = _repo_root(ctx)
         union_bodies, more_defs = build_homonym_union_bodies(repo_root, union_groups)
         if union_bodies:
             names = sorted(union_groups)
@@ -1542,26 +1658,15 @@ async def get_answer(
         # retrieval goes through ``_with_candidates``" is what stops the next
         # reordering of this function quietly re-opening the hole.
         return _with_candidates(
-            {
-                "answer": "",
-                "citations": [],
-                "confidence": "low",
-                "fallback_targets": [],
-                "retrieval": [],
-                "note": (
-                    "No wiki hits for this question. Rephrase around the code "
-                    'concept, or use search_codebase (mode="symbol" for an '
-                    'identifier, mode="path" for a file name); if the question '
-                    "names a file, call get_context on it directly. Grep only "
-                    "if those come back empty too."
-                ),
-                "_meta": _build_meta(
-                    timing_ms=(time.perf_counter() - t0) * 1000,
-                    hint=_answer_hint("low", 0),
-                    repository=repository,
-                    targets=[],
-                ),
-            },
+            _no_answer_payload(
+                "No wiki hits for this question. Rephrase around the code "
+                'concept, or use search_codebase (mode="symbol" for an '
+                'identifier, mode="path" for a file name); if the question '
+                "names a file, call get_context on it directly. Grep only "
+                "if those come back empty too.",
+                repository=repository,
+                t0=t0,
+            ),
             resolved_pool,
         )
 
@@ -1868,7 +1973,7 @@ async def get_answer(
     # even when synthesis hedges. The confidence gate below reads this to avoid
     # the "low, go Read" label that contradicts a payload already holding the
     # answer (2026-07-11 dogfood).
-    repo_root = Path(str(ctx.path)) if getattr(ctx, "path", None) else None
+    repo_root = _repo_root(ctx)
     symbol_bodies, served_named_body = _build_symbol_bodies(
         _gather_body_candidates(hits, answer_text), repo_root
     )
@@ -1876,12 +1981,7 @@ async def get_answer(
     # Compute confidence from the dominance ratio (top hit vs second hit).
     # The dominance ratio is a more reliable separator than absolute BM25
     # thresholds, which tend to label most retrievals "high" indiscriminately.
-    if len(hits) >= 2:
-        _top = hits[0].get("score", 0.0)
-        _second = hits[1].get("score", 0.0) or 1e-9
-        _ratio = _top / _second
-    else:
-        _ratio = float("inf") if hits else 0.0
+    _ratio = _top_two_score_ratio(hits)
     _top_score = hits[0].get("score", 0.0) if hits else 0.0
     # Agreement lifts the RRF-compressed ratio: a consensus top hit (both
     # retrievers rank it at/near #1) grades dominant even though its fused
@@ -2064,14 +2164,7 @@ async def get_answer(
     # to have hit the line cap says the cut was ours, which is the only case
     # where something was really withheld.
     named_body_cut = next(
-        (
-            b
-            for b in symbol_bodies
-            if b.get("truncated")
-            and b.get("continuation")
-            and b.get("name") in question_ids
-            and b["lines"][1] - b["lines"][0] + 1 >= _INLINE_BODY_MAX_LINES
-        ),
+        (b for b in symbol_bodies if _is_question_named_body_cut_by_us(b, question_ids)),
         None,
     )
     lookup_body_truncated = (
@@ -2244,13 +2337,7 @@ async def get_answer(
             # valid get_symbol id in its own right ("path.py:174-221").
             # Measured: 7 instances on 5 of 6 corpus trees.
             _implicated = set(withheld_implicated)
-            _continuing = [
-                b
-                for b in symbol_bodies
-                if b.get("continuation")
-                and b.get("name") in _implicated
-                and any(s.get("name") == b.get("name") for s in (b.get("withheld_symbols") or []))
-            ]
+            _continuing = [b for b in symbol_bodies if _is_enclosing_continuation(b, _implicated)]
             _continuing_names = {b["name"] for b in _continuing}
             _absent = [n for n in withheld_implicated if n not in _continuing_names]
             # Only advertise an id get_symbol can actually answer. The scanner

--- a/packages/server/src/repowise/server/mcp_server/tool_answer/answer.py
+++ b/packages/server/src/repowise/server/mcp_server/tool_answer/answer.py
@@ -53,6 +53,7 @@ import logging
 import os
 import time
 from pathlib import Path
+from typing import NamedTuple
 
 from sqlalchemy import delete, select
 
@@ -506,6 +507,177 @@ def _cache_entry_expired(created_at) -> bool:
 
     ts = created_at if created_at.tzinfo else created_at.replace(tzinfo=UTC)
     return (datetime.now(UTC) - ts) > timedelta(days=_ANSWER_CACHE_TTL_DAYS)
+
+
+def _cached_payload_paths(payload: dict) -> list:
+    """Every file path a cached row mentions.
+
+    Read twice: once to decide whether the row references a path that has since
+    been excluded, and once as the ``_meta`` targets of the served reply.
+    """
+    return [
+        *(payload.get("citations") or []),
+        *(payload.get("fallback_targets") or []),
+        # "path" is the serialized key; "target_path" survives in rows cached
+        # before the clean retrieval view existed.
+        *(h.get("path") or h.get("target_path") for h in (payload.get("retrieval") or [])),
+        *(g.get("file") for g in (payload.get("best_guesses") or [])),
+    ]
+
+
+def _cache_bypass_reason(
+    payload: dict, created_at, repository, exclude_spec, cached_paths: list
+) -> str | None:
+    """Why this cached row must not be served, or None when it is good to serve.
+
+    Each reason is logged where it is decided, with its own values, so the log
+    says why a caller got a fresh synthesis rather than merely that it did.
+
+    * schema: payloads from a pre-rework code path do not carry the fields the
+      current consumer expects. Serving them masks every later improvement until
+      the row happens to expire, so bypass silently and let the next write
+      upgrade the row.
+    * hedged: the retrieval and symbol pipeline has been upgraded since, so give
+      synthesis another shot with the new context rather than pinning a bad
+      answer.
+    * empty: older versions cached gated empty-answer payloads, which pinned a
+      retrieval miss until TTL. The write side no longer does this; the check
+      retires the rows that predate the fix.
+    * excluded: a row cached before ``exclude_patterns`` changed may reference a
+      now-excluded file in its fields or in its prose. Re-synthesize rather than
+      scrub the fields and leave the prose dangling.
+    * commit / TTL: a row synthesised against a previous index may cite moved
+      code or stale values. The TTL covers pre-stamping rows and gitless repos,
+      where there is no commit to compare.
+    """
+    cached_version = payload.get("_schema_version", 1)
+    if cached_version < _ANSWER_SCHEMA_VERSION:
+        _log.info(
+            "Bypassing cache entry at schema v%s (current v%s)",
+            cached_version,
+            _ANSWER_SCHEMA_VERSION,
+        )
+        return "schema"
+    if _answer_is_hedged(payload.get("answer", "")):
+        _log.info("Bypassing hedged cache entry for re-synthesis")
+        return "hedged"
+    if not (payload.get("answer") or "").strip():
+        _log.info("Bypassing cached empty-answer (gated) entry")
+        return "empty"
+    if any(is_excluded(p, exclude_spec) for p in cached_paths):
+        _log.info("Bypassing cache entry referencing a now-excluded path")
+        return "excluded"
+    current_commit = getattr(repository, "head_commit", None)
+    cached_commit = payload.get("_indexed_commit")
+    if cached_commit and current_commit and cached_commit != current_commit:
+        _log.info(
+            "Bypassing cache entry from commit %s (repo now at %s)",
+            cached_commit,
+            current_commit,
+        )
+        return "stale-commit"
+    if _cache_entry_expired(created_at):
+        _log.info("Bypassing cache entry past the %d-day TTL", _ANSWER_CACHE_TTL_DAYS)
+        return "expired"
+    return None
+
+
+async def _serve_cached_answer(
+    *, ctx, question: str, repository, repo_id, qhash: str, exclude_spec, t0: float
+) -> dict | None:
+    """The cached answer for this question, or None to synthesize a fresh one.
+
+    None covers every reason a row must not be served: no row at all, a row
+    :func:`_cache_bypass_reason` rejects, and any failure reading one. A row
+    that will not parse is not a reason to fail the call; the next write
+    replaces it.
+    """
+    async with get_session(ctx.session_factory) as session:
+        res = await session.execute(
+            select(AnswerCache).where(
+                AnswerCache.repository_id == repo_id,
+                AnswerCache.question_hash == qhash,
+            )
+        )
+        cached = res.scalar_one_or_none()
+    if cached is None:
+        return None
+    with contextlib.suppress(Exception):
+        payload = _json.loads(cached.payload_json)
+        cached_paths = _cached_payload_paths(payload)
+        if _cache_bypass_reason(
+            payload, cached.created_at, repository, exclude_spec, cached_paths
+        ):
+            return None
+        # Cache-internal fields never reach the consumer (response keys must not
+        # start with "_" except _meta).
+        payload.pop("_indexed_commit", None)
+        payload.pop("_schema_version", None)
+        payload["_meta"] = _build_meta(
+            timing_ms=(time.perf_counter() - t0) * 1000,
+            cached=True,
+            hint=_answer_hint(
+                payload.get("confidence", "low"),
+                len(payload.get("retrieval", [])),
+            ),
+            repository=repository,
+            targets=[p for p in cached_paths if isinstance(p, str) and p],
+        )
+        _apply_lean_high(payload, question)
+        _trim_served_payload(payload)
+        # Serve-time, on this path as well as the fresh one: the episode is read
+        # on every call and never cached into an answer, so a disagreement
+        # cannot be frozen into a row and served after it has been superseded.
+        await _attach_episode(
+            payload,
+            question=question,
+            repo_path=getattr(ctx, "path", None),
+            repo_name=getattr(repository, "name", None),
+        )
+        return payload
+    return None
+
+
+async def _write_answer_cache(
+    payload: dict, *, ctx, question: str, repository, repo_id, qhash: str, provider
+) -> None:
+    """Persist this answer as the cache row for the question (upsert).
+
+    Best-effort: a cache failure must never block the response, but it must be
+    LOGGED rather than suppressed. A plain INSERT under a blanket suppress
+    violated ``uq_answer_cache_q`` on every bypass-and-resynthesize round and
+    failed silently, so hedged and stale rows were never upgraded.
+    Delete-then-insert in one transaction is the dialect-agnostic upsert, and
+    the stamped ``_indexed_commit`` is what the read-side freshness check reads.
+
+    The row is a shallow copy taken here, so anything the caller attaches to the
+    payload after this point reaches the caller and never the cache.
+    """
+    cache_payload = dict(payload)
+    cache_payload["_schema_version"] = _ANSWER_SCHEMA_VERSION
+    commit_now = getattr(repository, "head_commit", None)
+    if commit_now:
+        cache_payload["_indexed_commit"] = commit_now
+    try:
+        async with get_session(ctx.session_factory) as session:
+            await session.execute(
+                delete(AnswerCache).where(
+                    AnswerCache.repository_id == repo_id,
+                    AnswerCache.question_hash == qhash,
+                )
+            )
+            row = AnswerCache(
+                repository_id=repo_id,
+                question_hash=qhash,
+                question=question.strip(),
+                payload_json=_json.dumps(cache_payload, default=_json_default),
+                provider_name=getattr(provider, "provider_name", "") or "",
+                model_name=getattr(provider, "model_name", "") or "",
+            )
+            session.add(row)
+            await session.commit()
+    except Exception as exc:
+        _log.warning("get_answer cache write failed: %s", exc)
 
 
 def _is_readable_path(target: str) -> bool:
@@ -1214,181 +1386,30 @@ async def _degraded_next_action(
     )
 
 
-@mcp.tool()
-async def get_answer(
-    question: str,
-    scope: str | None = None,
-    repo: str | None = None,
-) -> dict:
-    """Synthesised answer with citations and a calibrated trust signal.
+class _Retrieved(NamedTuple):
+    """What retrieval resolved, before any decision about how to answer.
 
-    The single entry point for questions: "how does X work" / "where is Y" /
-    "why is Z". It runs the full hybrid retrieval internally (no prior
-    search_codebase call needed) and answers in one round-trip.
-    confidence=high is content-grounded (value + citation-source + frame
-    gates): cite it directly, no verification Read needed. A "why" answer
-    whose named mechanism is absent from the retrieved source is downgraded
-    to medium (the rationale may be conflated). Low confidence returns
-    best_guesses with one-line justifications instead of an empty answer.
-    retrieval_quality separately rates the retrieval that fed synthesis.
-    When the answer names a function/method/class, ``symbol_bodies`` carries
-    its full live body — read that instead of a follow-up get_symbol.
-    ``episodes``, when present, is a dated fact recorded about this checkout
-    that bears on the question — evidence beside the answer, not a correction
-    of it. Weigh it against the answer; ``still_true`` says how current it is.
-
-    Args:
-        question: developer question.
-        scope: optional path-prefix filter (e.g. "src/pkg/").
-        repo: usually omitted.
+    ``hits`` is capped for the response payload; ``resolved_pool`` is the
+    same ranking before the cap, which is what ``candidates`` is built from.
     """
-    if repo == "all":
-        return _unsupported_repo_all("get_answer")
 
-    t0 = time.perf_counter()
-    ctx = await _resolve_repo_context(repo)
-    exclude_spec = _get_exclude_spec(ctx.path)
+    hits: list[dict]
+    resolved_pool: list[dict]
+    question_ids: set[str]
+    homonyms: dict
+    flow_paths: list[list[str]]
 
-    if not question or not question.strip():
-        return {
-            "answer": "",
-            "citations": [],
-            "confidence": "low",
-            "fallback_targets": [],
-            "retrieval": [],
-            "error": "question is required",
-            "_meta": _build_meta(timing_ms=(time.perf_counter() - t0) * 1000),
-        }
 
-    async with get_session(ctx.session_factory) as session:
-        repository = await _get_repo(session)
-        repo_id = repository.id
+async def _run_retrieval_pipeline(
+    question: str, ctx, *, scope: str | None, exclude_spec, repo_id
+) -> _Retrieved:
+    """Run every retrieval, ranking and enrichment stage, in order.
 
-    # --- Data-shape fast path ----------------------------------------------
-    # "what fields does each entry in <blob> contain" is answered by mining the
-    # field set straight from source (a documented {...} shape, else consistent
-    # key accesses) instead of gating to a best_guesses pointer list — the exact
-    # payload that triggers the agent's Read/get_symbol drill. Runs before the
-    # cache and retrieval: it's deterministic from live source, cheap, and reads
-    # the field set directly (retrieval scatters across every file that touches
-    # the blob and misses the one file that documents it). Returns None (falls
-    # through) unless the fields are genuinely grounded, so it can never invent a
-    # shape.
-    ds_ids = _extract_question_identifiers(question)
-    if _is_data_shape_question(question, ds_ids):
-        grounded = await asyncio.to_thread(mine_data_shape, getattr(ctx, "path", None), ds_ids)
-        if grounded is not None:
-            return _build_data_shape_payload(grounded, t0, repository)
-
-    # --- Cache lookup --------------------------------------------------------
-    # Scope: ignore the (rare) `scope` argument in the cache key for now;
-    # scoped queries are uncommon and including scope would balloon hit rate
-    # variance. We hash on (repo_id, normalized_question) only.
-    qhash = _hash_question(question)
-    cache_disabled = _cache_disabled()
-    cached = None
-    if not cache_disabled:
-        async with get_session(ctx.session_factory) as session:
-            res = await session.execute(
-                select(AnswerCache).where(
-                    AnswerCache.repository_id == repo_id,
-                    AnswerCache.question_hash == qhash,
-                )
-            )
-            cached = res.scalar_one_or_none()
-    if cached is not None:
-        with contextlib.suppress(Exception):
-            payload = _json.loads(cached.payload_json)
-            # Schema bypass: payloads from a pre-rework code path don't carry
-            # the fields the current consumer expects (retrieval_quality,
-            # best_guesses, calibrated confidence). Returning them masks every
-            # subsequent improvement until the cache happens to expire. Bypass
-            # silently so the next write upgrades the row.
-            cached_version = payload.get("_schema_version", 1)
-            schema_stale = cached_version < _ANSWER_SCHEMA_VERSION
-            # Bypass-on-hedged: if the cached answer hedged, the retrieval +
-            # symbol pipeline has since been upgraded (question-aware symbol
-            # promotion, source-body excerpts). Give synthesis another shot
-            # with the new context rather than pinning the bad answer.
-            hedged_cache = _answer_is_hedged(payload.get("answer", ""))
-            # Bypass-on-empty: older versions cached gated (empty-answer)
-            # payloads, so a retrieval miss got pinned until TTL and every
-            # later improvement to the miss path was invisible. The write
-            # side no longer caches empty answers; this read-side check
-            # retires rows that predate that fix.
-            empty_cache = not (payload.get("answer") or "").strip()
-            # A row cached before exclude_patterns changed may reference a
-            # now-excluded file — in its fields or its prose. Re-synthesize
-            # rather than scrub the fields and leave the prose dangling.
-            cached_paths = [
-                *(payload.get("citations") or []),
-                *(payload.get("fallback_targets") or []),
-                # "path" is the serialized key; "target_path" survives in
-                # rows cached before the clean retrieval view existed.
-                *(h.get("path") or h.get("target_path") for h in (payload.get("retrieval") or [])),
-                *(g.get("file") for g in (payload.get("best_guesses") or [])),
-            ]
-            excluded_cache = any(is_excluded(p, exclude_spec) for p in cached_paths)
-            # Freshness: a row synthesised against a previous index may cite
-            # moved code or stale values. The write path stamps the repo's
-            # head commit into the persisted payload; a mismatch (or a row
-            # past the hard TTL, for pre-stamping rows and gitless repos)
-            # forces re-synthesis.
-            current_commit = getattr(repository, "head_commit", None)
-            cached_commit = payload.get("_indexed_commit")
-            stale_commit = bool(
-                cached_commit and current_commit and cached_commit != current_commit
-            )
-            expired = _cache_entry_expired(cached.created_at)
-            if schema_stale:
-                _log.info(
-                    "Bypassing cache entry at schema v%s (current v%s)",
-                    cached_version,
-                    _ANSWER_SCHEMA_VERSION,
-                )
-            elif hedged_cache:
-                _log.info("Bypassing hedged cache entry for re-synthesis")
-            elif empty_cache:
-                _log.info("Bypassing cached empty-answer (gated) entry")
-            elif excluded_cache:
-                _log.info("Bypassing cache entry referencing a now-excluded path")
-            elif stale_commit:
-                _log.info(
-                    "Bypassing cache entry from commit %s (repo now at %s)",
-                    cached_commit,
-                    current_commit,
-                )
-            elif expired:
-                _log.info("Bypassing cache entry past the %d-day TTL", _ANSWER_CACHE_TTL_DAYS)
-            else:
-                # Cache-internal fields never reach the consumer (response
-                # keys must not start with "_" except _meta).
-                payload.pop("_indexed_commit", None)
-                payload.pop("_schema_version", None)
-                payload["_meta"] = _build_meta(
-                    timing_ms=(time.perf_counter() - t0) * 1000,
-                    cached=True,
-                    hint=_answer_hint(
-                        payload.get("confidence", "low"),
-                        len(payload.get("retrieval", [])),
-                    ),
-                    repository=repository,
-                    targets=[p for p in cached_paths if isinstance(p, str) and p],
-                )
-                _apply_lean_high(payload, question)
-                _trim_served_payload(payload)
-                # Serve-time, on this path as well as the fresh one: the
-                # episode is read on every call and never cached into an
-                # answer, so a disagreement cannot be frozen into a row and
-                # served after the episode has been superseded.
-                await _attach_episode(
-                    payload,
-                    question=question,
-                    repo_path=getattr(ctx, "path", None),
-                    repo_name=getattr(repository, "name", None),
-                )
-                return payload
-
+    Everything here is about FINDING the material; nothing here decides what
+    the answer is. Each expansion stage is best-effort and suppressed on its
+    own, so one slow or broken backend costs its contribution and never the
+    call.
+    """
     # --- Retrieval pipeline ------------------------------------------------
     # Stages live in ``_answer_pipeline`` so each can evolve without
     # rereading the orchestrator: hybrid retrieval (FTS + vector + RRF) →
@@ -1522,29 +1543,19 @@ async def get_answer(
                 await _hydrate_candidate_defines(
                     session, repo_id, resolved_pool, question_ids=question_ids
                 )
+    return _Retrieved(hits, resolved_pool, question_ids, homonyms, flow_paths)
 
-    # --- Qualified-miss guard ----------------------------------------------
-    # The question qualified a symbol (``Parent.leaf``) but the exact-name scan
-    # found the leaf only under OTHER parents. Return not-found rather than
-    # synthesizing from a same-named symbol elsewhere: a precise query must
-    # never degrade to a confidently-wrong answer (CodeGraph #173).
-    if homonyms.get("qualified_miss"):
-        missed = homonyms["qualified_miss"]
-        return _with_candidates(
-            _no_answer_payload(
-                f"No indexed definition matches the qualified name(s) {missed}. "
-                "The base name is defined elsewhere, but not under the "
-                "class/module you named, so this is not returning a same-named "
-                "symbol from another file, to avoid a confidently-wrong answer. "
-                'Re-check the qualifier, or call search_codebase mode="symbol" '
-                "on the base name to see every definition. The files retrieval "
-                "ranked for this question are in candidates.",
-                repository=repository,
-                t0=t0,
-            ),
-            resolved_pool,
-        )
 
+def _union_answer_payload(
+    question: str, question_ids: set[str], homonyms: dict, ctx, repository, t0: float
+) -> dict | None:
+    """The answer-by-union reply, or None to let synthesis handle the question.
+
+    Returns None in three cases, all of which mean the union is not the
+    answer: no homonym group survived the defer rules, or the bodies could
+    not be read (no repo root, files gone), in which case falling through to
+    the normal gate path beats returning an empty union.
+    """
     # --- Answer-by-union (homonym exact-name lookup) -----------------------
     # The question named a symbol with N>=2 defs no qualifier disambiguates
     # (``_severity_for`` x 4). Instead of bailing to a best_guesses pointer list
@@ -1641,343 +1652,53 @@ async def get_answer(
             }
             if more_defs:
                 payload["more_definitions"] = more_defs
-            return _with_candidates(payload, resolved_pool)
+            return payload
         # Bodies unreadable (no repo root / files gone) — fall through to the
         # normal retrieval/gate path rather than returning an empty union.
+    return None
 
-    fallback_targets = [
-        h["target_path"]
-        for h in hits
-        if h.get("target_path") and _is_readable_path(h["target_path"])
-    ]
 
-    if not hits:
-        # Wrapped like every other post-retrieval return even though the pool is
-        # necessarily empty here (``resolved_pool`` is ``hits`` before the cap, so
-        # no hits means no pool). Keeping the invariant "every return after
-        # retrieval goes through ``_with_candidates``" is what stops the next
-        # reordering of this function quietly re-opening the hole.
-        return _with_candidates(
-            _no_answer_payload(
-                "No wiki hits for this question. Rephrase around the code "
-                'concept, or use search_codebase (mode="symbol" for an '
-                'identifier, mode="path" for a file name); if the question '
-                "names a file, call get_context on it directly. Grep only "
-                "if those come back empty too.",
-                repository=repository,
-                t0=t0,
-            ),
-            resolved_pool,
-        )
+class _Grade(NamedTuple):
+    """The confidence verdict, and every finding the notes are written from.
 
-    # Attach real page content to the top hits, once, for every retrieval —
-    # before anything downstream branches on how good the retrieval looks.
-    #
-    # This used to run only when retrieval was NOT dominant, and dominance is
-    # what earns high confidence: the more certain retrieval was, the less
-    # prose the model was given, so confident answers were the ones built from
-    # symbol names alone. Whatever replaces the code below, keep this
-    # unconditional. Two call sites under different conditions is what made
-    # that inversion possible, and the cost of enriching a hit that a later
-    # fast path never reads is one indexed SELECT over at most five rows.
-    hits_without_page_content = await _attach_page_excerpts(hits, ctx)
-    if hits_without_page_content:
-        _log.warning(
-            "get_answer: %d of %d top hits have no page content; those hits "
-            "reach synthesis as a one-line summary only",
-            hits_without_page_content,
-            min(len(hits), _PAGE_EXCERPT_HITS),
-        )
+    The gates do not just produce a label: each one that fires records WHAT
+    it objected to, and the payload builder turns that into the note and the
+    next action. Carrying the findings out beside the verdict is what keeps
+    the two in step.
+    """
 
-    # --- Retrieval dominance -----------------------------------------------
-    # ``dominant`` = retrieval clearly pointed at ONE page (the top hit
-    # outscores the rest). It no longer decides WHETHER to synthesize — under
-    # the always-synthesize default, synthesis runs for every retrieval so
-    # coverage matches a research assistant that answers every question (the
-    # pre-synthesis gate abstained on ~58%). It now feeds the confidence grade
-    # as a CEILING (a non-dominant retrieval is "answered, but verify", never
-    # "high") and gates the ambiguous-retrieval evidence folded into the reply.
-    #
-    # Two-tier test: at high retrieval quality (both scores excellent) close
-    # ratios are expected, so use an absolute gap; at lower quality the ratio
-    # gate flags genuinely ambiguous retrievals. Coverage (fraction of query
-    # terms in the top hit) biases ranking but is intentionally NOT a gate:
-    # natural-language questions rarely have all content terms in one page
-    # (typical 0.15-0.25), so a coverage threshold over-fires. Default dominant
-    # for a lone hit (nothing to be ambiguous against).
-    always_synthesize = _always_synthesize()
-    # Agreement dominance recovers the "both retrievers rank this #1" signal
-    # that RRF fusion compresses out of the numeric score. Computed once and
-    # OR'd into every place the ratio/gap gate decides dominance, so it can
-    # only LIFT a retrieval — never demote one the ratio already trusts.
-    # Read the vector leg's own recorded status rather than inferring it from
-    # `hits`, which is capped to 5 by here: "no _vec_rank in the top 5" is also
-    # what a timed-out, errored, scope-filtered or simply outranked vector leg
-    # looks like, and those must NOT fall back to the symbol leg.
-    agreement_dominant = (
-        _agreement_dominant(
-            hits,
-            vector_leg_keyless=(
-                _symbol_agreement_enabled() and _retrieval_legs().get("vector") == "keyless"
-            ),
-        )
-        if _agreement_confidence_enabled()
-        else False
-    )
-    dominant = True
-    if len(hits) >= 2:
-        top_score = hits[0].get("score", 0.0)
-        second_score = hits[1].get("score", 0.0) or 1e-9
-        if top_score >= 3.0:
-            dominant = (top_score - second_score) >= 0.5
-        else:
-            dominant = (top_score / second_score) >= _DOMINANCE_RATIO
-        dominant = dominant or agreement_dominant
+    confidence: str
+    hedged: bool
+    ratio: float
+    top_score: float
+    ungrounded_values: list[str]
+    frame_unsupported: list[str]
+    exclusivity_over_truncated: bool
+    withheld_implicated: list[str]
+    lookup_body_truncated: bool
+    named_body_cut: dict | None
 
-    if not always_synthesize and not dominant:
-        # Legacy abstain path (REPOWISE_ANSWER_ALWAYS_SYNTHESIZE=off): retrieval
-        # is ambiguous, so skip synthesis and hand back ranked excerpts +
-        # best_guesses for the agent to ground in.
-        #
-        # The excerpts those best_guesses carry were attached above. Agent-
-        # transcript evidence (context-tool bench, 2026-07-17): a pointers-only
-        # gated payload sends the agent into an 8-15 call Grep/Read spree that
-        # costs more than a bare agent — it paid for the tool call and still had
-        # to acquire all content natively. Excerpts turn the miss path into
-        # "pick one candidate, verify with at most one Read".
-        best_guesses = _build_best_guesses(hits)
-        # Mine source comments for rationale the wiki/decision corpus missed —
-        # turns "go Read these 5 files" into a cited why.
-        code_rationale = _gather_code_rationale(ctx, hits, fallback_targets, question)
-        has_excerpts = any("excerpt" in g for g in best_guesses)
-        gated: dict = {
-            "answer": "",
-            "citations": [],
-            "confidence": "low",
-            "retrieval_quality": "weak",
-            "best_guesses": best_guesses,
-            "next_action_hint": (
-                (
-                    f"Start from the excerpt of {best_guesses[0]['file']} — "
-                    "it scored highest; Read the file only to verify "
-                    "details the excerpt does not settle."
-                    if has_excerpts
-                    else f"Read {best_guesses[0]['file']} first — it scored "
-                    "highest but retrieval was ambiguous, so verify "
-                    "before answering."
-                )
-                if best_guesses
-                else (
-                    'Retry search_codebase with mode="symbol" or '
-                    'mode="path" on the key terms; Grep only if those '
-                    "miss too."
-                )
-            ),
-            "fallback_targets": fallback_targets,
-            "retrieval": [],
-            "note": (
-                "Multiple plausible candidates — synthesis skipped to "
-                "avoid anchoring on a wrong frame. Each best_guess entry "
-                "names why that file is in the running"
-                + (", and its excerpt carries that page's actual content." if has_excerpts else ".")
-            ),
-        }
-        if code_rationale:
-            gated["code_rationale"] = code_rationale
-            gated["note"] += (
-                " code_rationale carries rationale comments mined from the "
-                "candidate source — they may already answer the question."
-            )
-        gated["_meta"] = _build_meta(
-            timing_ms=(time.perf_counter() - t0) * 1000,
-            hint=_answer_hint("low", len(hits)),
-            repository=repository,
-            targets=fallback_targets,
-        )
-        return _with_candidates(gated, resolved_pool)
 
-    # Confidence is the only axis we gate on. We deliberately do NOT add a
-    # second gate keyed on question shape (e.g. relational questions
-    # containing connectives like "between", "and", "from"). Relational vs
-    # non-relational is the wrong axis to gate on: the hard relational
-    # failures already surface as low-dominance retrievals and are caught
-    # by the gate above, while a shape-based gate over-fires on confidently
-    # dominant relational questions and pushes cost back onto the agent's
-    # own reasoning loop.
+def _grade_answer(
+    *,
+    question: str,
+    question_ids: set[str],
+    answer_text: str,
+    hits: list[dict],
+    citations: list[str],
+    symbol_bodies: list[dict],
+    served_named_body: bool,
+    dominant: bool,
+    agreement_dominant: bool,
+) -> _Grade:
+    """Grade the synthesised answer through the gate cascade, in order.
 
-    # --- Value-extraction fast path ----------------------------------------
-    # Value-shaped question + a question-matched constant in the top hits →
-    # the verbatim assignment line (read live by the hydrator) IS the
-    # answer. Today this class of question costs a multi-call drill-down
-    # chain and synthesis sometimes invents the number; the fast path is one
-    # call, zero LLM cost, and cannot hallucinate. Not cached: extraction is
-    # cheap and must always reflect the current source.
-    if _is_value_question(question) and question_ids:
-        extraction = _extract_value_answer(hits, question_ids)
-        if extraction is not None:
-            top_score_fp = hits[0].get("score", 0.0) if hits else 0.0
-            answer_text = extraction["answer"]
-            if extraction.get("value_source"):
-                answer_text += "\n\n" + extraction["value_source"]
-            return _with_candidates(
-                {
-                    "answer": answer_text,
-                    "citations": [extraction["file"]],
-                    "confidence": "high",
-                    "retrieval_quality": (
-                        "high" if top_score_fp >= _HIGH_CONFIDENCE_SCORE_FLOOR else "partial"
-                    ),
-                    "grounding": "extracted",
-                    "fallback_targets": fallback_targets,
-                    "retrieval": [],
-                    "note": (
-                        "Extracted verbatim from the live source line — no LLM "
-                        "synthesis involved. Cite directly; no verification "
-                        "Read needed. candidates holds the files retrieval ranked, "
-                        "for the wider question the value sits inside."
-                    ),
-                    "_meta": _build_meta(
-                        timing_ms=(time.perf_counter() - t0) * 1000,
-                        hint=_answer_hint("high", len(hits)),
-                        repository=repository,
-                        targets=[extraction["file"], *fallback_targets],
-                    ),
-                },
-                resolved_pool,
-            )
-
-    # --- Synthesis (LLM) ---------------------------------------------------
-    provider = _resolve_provider_for_answer(getattr(ctx, "path", None))
-    if provider is None:
-        # Retrieval-only mode (no provider). Return the hits so the agent can
-        # at least skip the search_codebase step — but mark the degradation
-        # loudly: an arm/user should never need to diff payload shapes to
-        # notice synthesis is unplugged.
-        _log.warning(
-            "get_answer running WITHOUT synthesis: no LLM provider resolvable "
-            "(set REPOWISE_PROVIDER + its API key, or any supported API key)."
-        )
-        return await _degraded_payload(
-            reason="no-llm-provider",
-            note=(
-                "DEGRADED: no LLM provider configured (set REPOWISE_PROVIDER "
-                "+ API key). Synthesis is what is missing here, not retrieval."
-            ),
-            hits=hits,
-            fallback_targets=fallback_targets,
-            repository=repository,
-            t0=t0,
-            ctx=ctx,
-            question_ids=question_ids,
-            exclude_spec=exclude_spec,
-            agreement_dominant=agreement_dominant,
-            resolved_pool=resolved_pool,
-        )
-
-    # Decision fusion (why-shaped questions only) + structured prelude. Both
-    # layers are gated on signal: no ADRs for the top hits → no decisions
-    # block, no symbols / commits / decisions → no prelude. Empty layers are
-    # dropped before formatting, so the prompt never carries hollow scaffolding.
-    top_paths = [h["target_path"] for h in hits if h.get("target_path")]
-    decisions: list[dict] = []
-    if _is_why_question(question) and top_paths:
-        with contextlib.suppress(Exception):
-            decisions = await _fetch_relevant_decisions(ctx, repo_id, top_paths)
-    prelude = ""
-    with contextlib.suppress(Exception):
-        prelude = await _build_structured_prelude(hits, decisions, ctx, repo_id)
-
-    user_prompt = _USER_TEMPLATE.format(
-        question=question.strip(),
-        n=len(hits),
-        context=_build_context_block_v2(hits, prelude=prelude, decisions=decisions),
-    )
-
-    # The call budgets itself against what this provider actually needs. A
-    # remote API answers in single-digit seconds; an agent-CLI subprocess or a
-    # local model needs minutes, and the old flat 30s cancelled every one of
-    # those before it could return (#1119).
-    answer_text, failure_note = await synthesize(
-        provider,
-        _SYSTEM_PROMPT,
-        user_prompt,
-        session_factory=getattr(ctx, "session_factory", None),
-        repo_id=repo_id,
-    )
-    if failure_note is not None:
-        return await _degraded_payload(
-            reason="synthesis-failed",
-            note=failure_note,
-            hits=hits,
-            fallback_targets=fallback_targets,
-            repository=repository,
-            t0=t0,
-            ctx=ctx,
-            question_ids=question_ids,
-            exclude_spec=exclude_spec,
-            agreement_dominant=agreement_dominant,
-            resolved_pool=resolved_pool,
-        )
-
-    citations = [
-        h["target_path"] for h in hits if h["target_path"] and h["target_path"] in answer_text
-    ]
-    if not citations:
-        # Fall back to top-2 retrieval paths so the agent always has something to verify.
-        citations = fallback_targets[:2]
-
-    # Line-grounded quotes: for symbols the answer actually names, attach the
-    # verbatim source line(s) the hydrator read live from disk. An agent can
-    # publish a cited claim backed by a quote without any verification Read —
-    # the quote IS the verification.
-    quotes: list[dict] = []
-    for h in hits[:_ENRICH_TOP_N_HITS]:
-        for s in h.get("symbols") or []:
-            name = s.get("name")
-            # Require a name long enough that substring containment is
-            # meaningful — a 1-2 char constant (``T``, ``e``) would "appear"
-            # in almost any answer and attach an irrelevant quote.
-            if not name or len(name) < 3 or name not in answer_text:
-                continue
-            src = s.get("source_excerpt") or s.get("signature") or ""
-            if not src:
-                continue
-            quote_lines = src.splitlines()[:3]
-            start = s.get("start_line") or 0
-            quotes.append(
-                {
-                    "path": h.get("target_path"),
-                    "lines": [start, start + len(quote_lines) - 1],
-                    "quote": "\n".join(quote_lines),
-                }
-            )
-            if len(quotes) >= 5:
-                break
-        if len(quotes) >= 5:
-            break
-
-    # Inline symbol bodies: for the multi-line definitions (function / method
-    # / class) the answer actually names, surface the full body the hydrator
-    # already read live for synthesis. This collapses the get_answer ->
-    # get_symbol drill-down — the agent that asked "how does X work" gets X's
-    # body in the same call instead of a follow-up read. Constants stay in
-    # `quotes` (their body IS the one-line assignment); only definitions with
-    # a real body earn a block. `source` is the live body sliced at the
-    # indexed bounds; it is NOT bounds-verified, so the field stays distinct
-    # from get_symbol's `verified` contract. When the indexed body is longer
-    # than the hydrator's line cap, a `continuation` names the exact range
-    # read for the remainder (mirrors get_symbol).
-    # ``served_named_body`` is True once a tier-0 body (the exact symbol the
-    # question named, resolved by symbol anchoring) is inlined. Its full live
-    # body IS the ground truth, so a response carrying it is content-grounded
-    # even when synthesis hedges. The confidence gate below reads this to avoid
-    # the "low, go Read" label that contradicts a payload already holding the
-    # answer (2026-07-11 dogfood).
-    repo_root = _repo_root(ctx)
-    symbol_bodies, served_named_body = _build_symbol_bodies(
-        _gather_body_candidates(hits, answer_text), repo_root
-    )
-
+    One starting grade from retrieval dominance, then a run of gates that can
+    only demote it. Several are guarded on the answer still being at high, so
+    that one response cannot be pushed two levels for one problem. Read them
+    as a list of reasons not to trust the prose: the order is the order they
+    were added, and each comment says which failure it was built to catch.
+    """
     # Compute confidence from the dominance ratio (top hit vs second hit).
     # The dominance ratio is a more reliable separator than absolute BM25
     # thresholds, which tend to label most retrievals "high" indiscriminately.
@@ -2187,6 +1908,489 @@ async def get_answer(
     # non-dominance ceiling does not apply to it.
     if not dominant and not earn_high and confidence == "high":
         confidence = "medium"
+    return _Grade(
+        confidence=confidence,
+        hedged=hedged,
+        ratio=_ratio,
+        top_score=_top_score,
+        ungrounded_values=ungrounded_values,
+        frame_unsupported=frame_unsupported,
+        exclusivity_over_truncated=exclusivity_over_truncated,
+        withheld_implicated=withheld_implicated,
+        lookup_body_truncated=lookup_body_truncated,
+        named_body_cut=named_body_cut,
+    )
+
+
+@mcp.tool()
+async def get_answer(
+    question: str,
+    scope: str | None = None,
+    repo: str | None = None,
+) -> dict:
+    """Synthesised answer with citations and a calibrated trust signal.
+
+    The single entry point for questions: "how does X work" / "where is Y" /
+    "why is Z". It runs the full hybrid retrieval internally (no prior
+    search_codebase call needed) and answers in one round-trip.
+    confidence=high is content-grounded (value + citation-source + frame
+    gates): cite it directly, no verification Read needed. A "why" answer
+    whose named mechanism is absent from the retrieved source is downgraded
+    to medium (the rationale may be conflated). Low confidence returns
+    best_guesses with one-line justifications instead of an empty answer.
+    retrieval_quality separately rates the retrieval that fed synthesis.
+    When the answer names a function/method/class, ``symbol_bodies`` carries
+    its full live body — read that instead of a follow-up get_symbol.
+    ``episodes``, when present, is a dated fact recorded about this checkout
+    that bears on the question — evidence beside the answer, not a correction
+    of it. Weigh it against the answer; ``still_true`` says how current it is.
+
+    Args:
+        question: developer question.
+        scope: optional path-prefix filter (e.g. "src/pkg/").
+        repo: usually omitted.
+    """
+    if repo == "all":
+        return _unsupported_repo_all("get_answer")
+
+    t0 = time.perf_counter()
+    ctx = await _resolve_repo_context(repo)
+    exclude_spec = _get_exclude_spec(ctx.path)
+
+    if not question or not question.strip():
+        return {
+            "answer": "",
+            "citations": [],
+            "confidence": "low",
+            "fallback_targets": [],
+            "retrieval": [],
+            "error": "question is required",
+            "_meta": _build_meta(timing_ms=(time.perf_counter() - t0) * 1000),
+        }
+
+    async with get_session(ctx.session_factory) as session:
+        repository = await _get_repo(session)
+        repo_id = repository.id
+
+    # --- Data-shape fast path ----------------------------------------------
+    # "what fields does each entry in <blob> contain" is answered by mining the
+    # field set straight from source (a documented {...} shape, else consistent
+    # key accesses) instead of gating to a best_guesses pointer list — the exact
+    # payload that triggers the agent's Read/get_symbol drill. Runs before the
+    # cache and retrieval: it's deterministic from live source, cheap, and reads
+    # the field set directly (retrieval scatters across every file that touches
+    # the blob and misses the one file that documents it). Returns None (falls
+    # through) unless the fields are genuinely grounded, so it can never invent a
+    # shape.
+    ds_ids = _extract_question_identifiers(question)
+    if _is_data_shape_question(question, ds_ids):
+        grounded = await asyncio.to_thread(mine_data_shape, getattr(ctx, "path", None), ds_ids)
+        if grounded is not None:
+            return _build_data_shape_payload(grounded, t0, repository)
+
+    # --- Cache lookup --------------------------------------------------------
+    # Scope: ignore the (rare) `scope` argument in the cache key for now;
+    # scoped queries are uncommon and including scope would balloon hit rate
+    # variance. We hash on (repo_id, normalized_question) only.
+    qhash = _hash_question(question)
+    cache_disabled = _cache_disabled()
+    if not cache_disabled:
+        served = await _serve_cached_answer(
+            ctx=ctx,
+            question=question,
+            repository=repository,
+            repo_id=repo_id,
+            qhash=qhash,
+            exclude_spec=exclude_spec,
+            t0=t0,
+        )
+        if served is not None:
+            return served
+
+    retrieved = await _run_retrieval_pipeline(
+        question, ctx, scope=scope, exclude_spec=exclude_spec, repo_id=repo_id
+    )
+    hits = retrieved.hits
+    resolved_pool = retrieved.resolved_pool
+    question_ids = retrieved.question_ids
+    homonyms = retrieved.homonyms
+    flow_paths = retrieved.flow_paths
+
+    # --- Qualified-miss guard ----------------------------------------------
+    # The question qualified a symbol (``Parent.leaf``) but the exact-name scan
+    # found the leaf only under OTHER parents. Return not-found rather than
+    # synthesizing from a same-named symbol elsewhere: a precise query must
+    # never degrade to a confidently-wrong answer (CodeGraph #173).
+    if homonyms.get("qualified_miss"):
+        missed = homonyms["qualified_miss"]
+        return _with_candidates(
+            _no_answer_payload(
+                f"No indexed definition matches the qualified name(s) {missed}. "
+                "The base name is defined elsewhere, but not under the "
+                "class/module you named, so this is not returning a same-named "
+                "symbol from another file, to avoid a confidently-wrong answer. "
+                'Re-check the qualifier, or call search_codebase mode="symbol" '
+                "on the base name to see every definition. The files retrieval "
+                "ranked for this question are in candidates.",
+                repository=repository,
+                t0=t0,
+            ),
+            resolved_pool,
+        )
+
+    union_payload = _union_answer_payload(question, question_ids, homonyms, ctx, repository, t0)
+    if union_payload is not None:
+        return _with_candidates(union_payload, resolved_pool)
+
+    fallback_targets = [
+        h["target_path"]
+        for h in hits
+        if h.get("target_path") and _is_readable_path(h["target_path"])
+    ]
+
+    if not hits:
+        # Wrapped like every other post-retrieval return even though the pool is
+        # necessarily empty here (``resolved_pool`` is ``hits`` before the cap, so
+        # no hits means no pool). Keeping the invariant "every return after
+        # retrieval goes through ``_with_candidates``" is what stops the next
+        # reordering of this function quietly re-opening the hole.
+        return _with_candidates(
+            _no_answer_payload(
+                "No wiki hits for this question. Rephrase around the code "
+                'concept, or use search_codebase (mode="symbol" for an '
+                'identifier, mode="path" for a file name); if the question '
+                "names a file, call get_context on it directly. Grep only "
+                "if those come back empty too.",
+                repository=repository,
+                t0=t0,
+            ),
+            resolved_pool,
+        )
+
+    # Attach real page content to the top hits, once, for every retrieval —
+    # before anything downstream branches on how good the retrieval looks.
+    #
+    # This used to run only when retrieval was NOT dominant, and dominance is
+    # what earns high confidence: the more certain retrieval was, the less
+    # prose the model was given, so confident answers were the ones built from
+    # symbol names alone. Whatever replaces the code below, keep this
+    # unconditional. Two call sites under different conditions is what made
+    # that inversion possible, and the cost of enriching a hit that a later
+    # fast path never reads is one indexed SELECT over at most five rows.
+    hits_without_page_content = await _attach_page_excerpts(hits, ctx)
+    if hits_without_page_content:
+        _log.warning(
+            "get_answer: %d of %d top hits have no page content; those hits "
+            "reach synthesis as a one-line summary only",
+            hits_without_page_content,
+            min(len(hits), _PAGE_EXCERPT_HITS),
+        )
+
+    # --- Retrieval dominance -----------------------------------------------
+    # ``dominant`` = retrieval clearly pointed at ONE page (the top hit
+    # outscores the rest). It no longer decides WHETHER to synthesize — under
+    # the always-synthesize default, synthesis runs for every retrieval so
+    # coverage matches a research assistant that answers every question (the
+    # pre-synthesis gate abstained on ~58%). It now feeds the confidence grade
+    # as a CEILING (a non-dominant retrieval is "answered, but verify", never
+    # "high") and gates the ambiguous-retrieval evidence folded into the reply.
+    #
+    # Two-tier test: at high retrieval quality (both scores excellent) close
+    # ratios are expected, so use an absolute gap; at lower quality the ratio
+    # gate flags genuinely ambiguous retrievals. Coverage (fraction of query
+    # terms in the top hit) biases ranking but is intentionally NOT a gate:
+    # natural-language questions rarely have all content terms in one page
+    # (typical 0.15-0.25), so a coverage threshold over-fires. Default dominant
+    # for a lone hit (nothing to be ambiguous against).
+    always_synthesize = _always_synthesize()
+    # Agreement dominance recovers the "both retrievers rank this #1" signal
+    # that RRF fusion compresses out of the numeric score. Computed once and
+    # OR'd into every place the ratio/gap gate decides dominance, so it can
+    # only LIFT a retrieval — never demote one the ratio already trusts.
+    # Read the vector leg's own recorded status rather than inferring it from
+    # `hits`, which is capped to 5 by here: "no _vec_rank in the top 5" is also
+    # what a timed-out, errored, scope-filtered or simply outranked vector leg
+    # looks like, and those must NOT fall back to the symbol leg.
+    agreement_dominant = (
+        _agreement_dominant(
+            hits,
+            vector_leg_keyless=(
+                _symbol_agreement_enabled() and _retrieval_legs().get("vector") == "keyless"
+            ),
+        )
+        if _agreement_confidence_enabled()
+        else False
+    )
+    dominant = True
+    if len(hits) >= 2:
+        top_score = hits[0].get("score", 0.0)
+        second_score = hits[1].get("score", 0.0) or 1e-9
+        if top_score >= 3.0:
+            dominant = (top_score - second_score) >= 0.5
+        else:
+            dominant = (top_score / second_score) >= _DOMINANCE_RATIO
+        dominant = dominant or agreement_dominant
+
+    if not always_synthesize and not dominant:
+        # Legacy abstain path (REPOWISE_ANSWER_ALWAYS_SYNTHESIZE=off): retrieval
+        # is ambiguous, so skip synthesis and hand back ranked excerpts +
+        # best_guesses for the agent to ground in.
+        #
+        # The excerpts those best_guesses carry were attached above. Agent-
+        # transcript evidence (context-tool bench, 2026-07-17): a pointers-only
+        # gated payload sends the agent into an 8-15 call Grep/Read spree that
+        # costs more than a bare agent — it paid for the tool call and still had
+        # to acquire all content natively. Excerpts turn the miss path into
+        # "pick one candidate, verify with at most one Read".
+        best_guesses = _build_best_guesses(hits)
+        # Mine source comments for rationale the wiki/decision corpus missed —
+        # turns "go Read these 5 files" into a cited why.
+        code_rationale = _gather_code_rationale(ctx, hits, fallback_targets, question)
+        has_excerpts = any("excerpt" in g for g in best_guesses)
+        gated: dict = {
+            "answer": "",
+            "citations": [],
+            "confidence": "low",
+            "retrieval_quality": "weak",
+            "best_guesses": best_guesses,
+            "next_action_hint": (
+                (
+                    f"Start from the excerpt of {best_guesses[0]['file']} — "
+                    "it scored highest; Read the file only to verify "
+                    "details the excerpt does not settle."
+                    if has_excerpts
+                    else f"Read {best_guesses[0]['file']} first — it scored "
+                    "highest but retrieval was ambiguous, so verify "
+                    "before answering."
+                )
+                if best_guesses
+                else (
+                    'Retry search_codebase with mode="symbol" or '
+                    'mode="path" on the key terms; Grep only if those '
+                    "miss too."
+                )
+            ),
+            "fallback_targets": fallback_targets,
+            "retrieval": [],
+            "note": (
+                "Multiple plausible candidates — synthesis skipped to "
+                "avoid anchoring on a wrong frame. Each best_guess entry "
+                "names why that file is in the running"
+                + (", and its excerpt carries that page's actual content." if has_excerpts else ".")
+            ),
+        }
+        if code_rationale:
+            gated["code_rationale"] = code_rationale
+            gated["note"] += (
+                " code_rationale carries rationale comments mined from the "
+                "candidate source — they may already answer the question."
+            )
+        gated["_meta"] = _build_meta(
+            timing_ms=(time.perf_counter() - t0) * 1000,
+            hint=_answer_hint("low", len(hits)),
+            repository=repository,
+            targets=fallback_targets,
+        )
+        return _with_candidates(gated, resolved_pool)
+
+    # Confidence is the only axis we gate on. We deliberately do NOT add a
+    # second gate keyed on question shape (e.g. relational questions
+    # containing connectives like "between", "and", "from"). Relational vs
+    # non-relational is the wrong axis to gate on: the hard relational
+    # failures already surface as low-dominance retrievals and are caught
+    # by the gate above, while a shape-based gate over-fires on confidently
+    # dominant relational questions and pushes cost back onto the agent's
+    # own reasoning loop.
+
+    # --- Value-extraction fast path ----------------------------------------
+    # Value-shaped question + a question-matched constant in the top hits →
+    # the verbatim assignment line (read live by the hydrator) IS the
+    # answer. Today this class of question costs a multi-call drill-down
+    # chain and synthesis sometimes invents the number; the fast path is one
+    # call, zero LLM cost, and cannot hallucinate. Not cached: extraction is
+    # cheap and must always reflect the current source.
+    if _is_value_question(question) and question_ids:
+        extraction = _extract_value_answer(hits, question_ids)
+        if extraction is not None:
+            top_score_fp = hits[0].get("score", 0.0) if hits else 0.0
+            answer_text = extraction["answer"]
+            if extraction.get("value_source"):
+                answer_text += "\n\n" + extraction["value_source"]
+            return _with_candidates(
+                {
+                    "answer": answer_text,
+                    "citations": [extraction["file"]],
+                    "confidence": "high",
+                    "retrieval_quality": (
+                        "high" if top_score_fp >= _HIGH_CONFIDENCE_SCORE_FLOOR else "partial"
+                    ),
+                    "grounding": "extracted",
+                    "fallback_targets": fallback_targets,
+                    "retrieval": [],
+                    "note": (
+                        "Extracted verbatim from the live source line — no LLM "
+                        "synthesis involved. Cite directly; no verification "
+                        "Read needed. candidates holds the files retrieval ranked, "
+                        "for the wider question the value sits inside."
+                    ),
+                    "_meta": _build_meta(
+                        timing_ms=(time.perf_counter() - t0) * 1000,
+                        hint=_answer_hint("high", len(hits)),
+                        repository=repository,
+                        targets=[extraction["file"], *fallback_targets],
+                    ),
+                },
+                resolved_pool,
+            )
+
+    # --- Synthesis (LLM) ---------------------------------------------------
+    # Both ways synthesis can go missing return the same payload from the same
+    # evidence, so they name only what differs between them: why, and what to
+    # tell the caller.
+    async def _degrade(reason: str, note: str) -> dict:
+        return await _degraded_payload(
+            reason=reason,
+            note=note,
+            hits=hits,
+            fallback_targets=fallback_targets,
+            repository=repository,
+            t0=t0,
+            ctx=ctx,
+            question_ids=question_ids,
+            exclude_spec=exclude_spec,
+            agreement_dominant=agreement_dominant,
+            resolved_pool=resolved_pool,
+        )
+
+    provider = _resolve_provider_for_answer(getattr(ctx, "path", None))
+    if provider is None:
+        # Retrieval-only mode (no provider). Return the hits so the agent can
+        # at least skip the search_codebase step — but mark the degradation
+        # loudly: an arm/user should never need to diff payload shapes to
+        # notice synthesis is unplugged.
+        _log.warning(
+            "get_answer running WITHOUT synthesis: no LLM provider resolvable "
+            "(set REPOWISE_PROVIDER + its API key, or any supported API key)."
+        )
+        return await _degrade(
+            "no-llm-provider",
+            "DEGRADED: no LLM provider configured (set REPOWISE_PROVIDER "
+            "+ API key). Synthesis is what is missing here, not retrieval.",
+        )
+
+    # Decision fusion (why-shaped questions only) + structured prelude. Both
+    # layers are gated on signal: no ADRs for the top hits → no decisions
+    # block, no symbols / commits / decisions → no prelude. Empty layers are
+    # dropped before formatting, so the prompt never carries hollow scaffolding.
+    top_paths = [h["target_path"] for h in hits if h.get("target_path")]
+    decisions: list[dict] = []
+    if _is_why_question(question) and top_paths:
+        with contextlib.suppress(Exception):
+            decisions = await _fetch_relevant_decisions(ctx, repo_id, top_paths)
+    prelude = ""
+    with contextlib.suppress(Exception):
+        prelude = await _build_structured_prelude(hits, decisions, ctx, repo_id)
+
+    user_prompt = _USER_TEMPLATE.format(
+        question=question.strip(),
+        n=len(hits),
+        context=_build_context_block_v2(hits, prelude=prelude, decisions=decisions),
+    )
+
+    # The call budgets itself against what this provider actually needs. A
+    # remote API answers in single-digit seconds; an agent-CLI subprocess or a
+    # local model needs minutes, and the old flat 30s cancelled every one of
+    # those before it could return (#1119).
+    answer_text, failure_note = await synthesize(
+        provider,
+        _SYSTEM_PROMPT,
+        user_prompt,
+        session_factory=getattr(ctx, "session_factory", None),
+        repo_id=repo_id,
+    )
+    if failure_note is not None:
+        return await _degrade("synthesis-failed", failure_note)
+
+    citations = [
+        h["target_path"] for h in hits if h["target_path"] and h["target_path"] in answer_text
+    ]
+    if not citations:
+        # Fall back to top-2 retrieval paths so the agent always has something to verify.
+        citations = fallback_targets[:2]
+
+    # Line-grounded quotes: for symbols the answer actually names, attach the
+    # verbatim source line(s) the hydrator read live from disk. An agent can
+    # publish a cited claim backed by a quote without any verification Read —
+    # the quote IS the verification.
+    quotes: list[dict] = []
+    for h in hits[:_ENRICH_TOP_N_HITS]:
+        for s in h.get("symbols") or []:
+            name = s.get("name")
+            # Require a name long enough that substring containment is
+            # meaningful — a 1-2 char constant (``T``, ``e``) would "appear"
+            # in almost any answer and attach an irrelevant quote.
+            if not name or len(name) < 3 or name not in answer_text:
+                continue
+            src = s.get("source_excerpt") or s.get("signature") or ""
+            if not src:
+                continue
+            quote_lines = src.splitlines()[:3]
+            start = s.get("start_line") or 0
+            quotes.append(
+                {
+                    "path": h.get("target_path"),
+                    "lines": [start, start + len(quote_lines) - 1],
+                    "quote": "\n".join(quote_lines),
+                }
+            )
+            if len(quotes) >= 5:
+                break
+        if len(quotes) >= 5:
+            break
+
+    # Inline symbol bodies: for the multi-line definitions (function / method
+    # / class) the answer actually names, surface the full body the hydrator
+    # already read live for synthesis. This collapses the get_answer ->
+    # get_symbol drill-down — the agent that asked "how does X work" gets X's
+    # body in the same call instead of a follow-up read. Constants stay in
+    # `quotes` (their body IS the one-line assignment); only definitions with
+    # a real body earn a block. `source` is the live body sliced at the
+    # indexed bounds; it is NOT bounds-verified, so the field stays distinct
+    # from get_symbol's `verified` contract. When the indexed body is longer
+    # than the hydrator's line cap, a `continuation` names the exact range
+    # read for the remainder (mirrors get_symbol).
+    # ``served_named_body`` is True once a tier-0 body (the exact symbol the
+    # question named, resolved by symbol anchoring) is inlined. Its full live
+    # body IS the ground truth, so a response carrying it is content-grounded
+    # even when synthesis hedges. The confidence gate below reads this to avoid
+    # the "low, go Read" label that contradicts a payload already holding the
+    # answer (2026-07-11 dogfood).
+    repo_root = _repo_root(ctx)
+    symbol_bodies, served_named_body = _build_symbol_bodies(
+        _gather_body_candidates(hits, answer_text), repo_root
+    )
+
+    grade = _grade_answer(
+        question=question,
+        question_ids=question_ids,
+        answer_text=answer_text,
+        hits=hits,
+        citations=citations,
+        symbol_bodies=symbol_bodies,
+        served_named_body=served_named_body,
+        dominant=dominant,
+        agreement_dominant=agreement_dominant,
+    )
+    confidence = grade.confidence
+    hedged = grade.hedged
+    _ratio = grade.ratio
+    _top_score = grade.top_score
+    ungrounded_values = grade.ungrounded_values
+    frame_unsupported = grade.frame_unsupported
+    exclusivity_over_truncated = grade.exclusivity_over_truncated
+    withheld_implicated = grade.withheld_implicated
+    lookup_body_truncated = grade.lookup_body_truncated
+    named_body_cut = grade.named_body_cut
 
     retrieval_quality = _retrieval_quality(hits, agreement_dominant)
 
@@ -2484,39 +2688,16 @@ async def get_answer(
     if candidates:
         payload["candidates"] = candidates
 
-    # Persist to cache (upsert). Best-effort: cache failures must never block
-    # the response — but they must be LOGGED, not suppressed. A plain INSERT
-    # under a blanket suppress violated uq_answer_cache_q on every
-    # bypass-and-resynthesize round and failed silently, so hedged/stale rows
-    # were never upgraded. Delete-then-insert in one transaction is the
-    # dialect-agnostic upsert; the stamped _indexed_commit drives the
-    # read-side freshness check.
     if answer_text and not cache_disabled:
-        cache_payload = dict(payload)
-        cache_payload["_schema_version"] = _ANSWER_SCHEMA_VERSION
-        commit_now = getattr(repository, "head_commit", None)
-        if commit_now:
-            cache_payload["_indexed_commit"] = commit_now
-        try:
-            async with get_session(ctx.session_factory) as session:
-                await session.execute(
-                    delete(AnswerCache).where(
-                        AnswerCache.repository_id == repo_id,
-                        AnswerCache.question_hash == qhash,
-                    )
-                )
-                row = AnswerCache(
-                    repository_id=repo_id,
-                    question_hash=qhash,
-                    question=question.strip(),
-                    payload_json=_json.dumps(cache_payload, default=_json_default),
-                    provider_name=getattr(provider, "provider_name", "") or "",
-                    model_name=getattr(provider, "model_name", "") or "",
-                )
-                session.add(row)
-                await session.commit()
-        except Exception as exc:
-            _log.warning("get_answer cache write failed: %s", exc)
+        await _write_answer_cache(
+            payload,
+            ctx=ctx,
+            question=question,
+            repository=repository,
+            repo_id=repo_id,
+            qhash=qhash,
+            provider=provider,
+        )
 
     payload["_meta"] = _build_meta(
         timing_ms=(time.perf_counter() - t0) * 1000,
@@ -2538,12 +2719,11 @@ async def get_answer(
     # ``best_guesses`` outright), so the cut sees the finished payload and the
     # cached row keeps the shape its schema version promises.
     _trim_served_payload(payload)
-    # After the cache write above, deliberately. ``cache_payload`` is a shallow
-    # copy taken before this point, so the episode reaches the caller and never
-    # the cache row — which is why adding it needs no _ANSWER_SCHEMA_VERSION
-    # bump: a row written before this change and one written after are the same
-    # bytes, and bumping would invalidate every user's cache for a field that
-    # is not in it.
+    # After the cache write above, deliberately. That write copies the payload
+    # as it stood then, so the episode reaches the caller and never the cache
+    # row, which is why adding it needs no _ANSWER_SCHEMA_VERSION bump: a row
+    # written before this change and one written after are the same bytes, and
+    # bumping would invalidate every user's cache for a field that is not in it.
     await _attach_episode(
         payload,
         question=question,

--- a/packages/server/src/repowise/server/mcp_server/tool_answer/symbols.py
+++ b/packages/server/src/repowise/server/mcp_server/tool_answer/symbols.py
@@ -445,6 +445,41 @@ async def _anchor_symbol_hits(
     return hits, homonyms
 
 
+def attach_truncation_contract(
+    entry: dict, *, indexed_end: int, end_served: int, repo_root: Path | None
+) -> None:
+    """Mark an inlined body that was cut, and name what the cut withheld.
+
+    Every place that inlines a symbol body owes the consumer the same three
+    keys when the indexed body outruns what was served: ``truncated``, a
+    ``continuation`` naming the exact range holding the remainder, and the
+    ``withheld_symbols`` that range covers.
+
+    Say WHAT was withheld, not just that something was. A bare truncated flag
+    plus a get_symbol pointer was followed zero times across the agent runs
+    measured, so the consumer needs the names in hand to decide whether it is
+    missing anything it cares about, and to continue inside this tool rather
+    than falling back to Read.
+
+    Both callers need it for the same reason and one of them needs it more: the
+    homonym union payload returns BEFORE synthesis, so it is served in no-LLM
+    mode and never reaches any of the confidence gates. Held in one function
+    because two copies of this contract drifting apart is a live risk: the
+    truncation keys are read by the confidence cascade, and the two sites have
+    co-changed ten times.
+
+    ``indexed_end`` is the end line the index recorded, ``end_served`` the last
+    line actually inlined. A falsy ``indexed_end`` means the index recorded no
+    end, which can never be a cut.
+    """
+    if indexed_end > end_served:
+        entry["truncated"] = True
+        entry["continuation"] = f"{entry['path']}:{end_served + 1}-{indexed_end}"
+        withheld = withheld_definitions(repo_root, entry["continuation"])
+        if withheld:
+            entry["withheld_symbols"] = withheld
+
+
 def build_homonym_union_bodies(
     repo_root: Path | None,
     union_groups: dict[str, list[dict]],
@@ -503,16 +538,9 @@ def build_homonym_union_bodies(
                 "lines": [start, end_served],
                 "source": body,
             }
-            if end and end > end_served:
-                entry["truncated"] = True
-                entry["continuation"] = f"{path}:{end_served + 1}-{end}"
-                # Same treatment as the main answer path: say WHAT was withheld.
-                # This one matters more, not less — the union payload returns
-                # BEFORE synthesis, so it is served in no-LLM mode and it never
-                # reaches any of the confidence gates.
-                w = withheld_definitions(repo_root, entry["continuation"])
-                if w:
-                    entry["withheld_symbols"] = w
+            attach_truncation_contract(
+                entry, indexed_end=end, end_served=end_served, repo_root=repo_root
+            )
             symbol_bodies.append(entry)
             spent += len(body)
         else:

--- a/packages/server/src/repowise/server/mcp_server/tool_answer/symbols.py
+++ b/packages/server/src/repowise/server/mcp_server/tool_answer/symbols.py
@@ -470,9 +470,11 @@ def attach_truncation_contract(
 
     ``indexed_end`` is the end line the index recorded, ``end_served`` the last
     line actually inlined. A falsy ``indexed_end`` means the index recorded no
-    end, which can never be a cut.
+    end at all, which is never a cut: it is tested explicitly rather than left
+    to ``indexed_end > end_served``, which would only agree with it while
+    ``end_served`` stays non-negative.
     """
-    if indexed_end > end_served:
+    if indexed_end and indexed_end > end_served:
         entry["truncated"] = True
         entry["continuation"] = f"{entry['path']}:{end_served + 1}-{indexed_end}"
         withheld = withheld_definitions(repo_root, entry["continuation"])

--- a/tests/unit/server/mcp/test_answer_degraded_evidence.py
+++ b/tests/unit/server/mcp/test_answer_degraded_evidence.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
-from repowise.server.mcp_server.tool_answer import answer as answer_mod
+from repowise.server.mcp_server.tool_answer import symbols as symbols_mod
 from repowise.server.mcp_server.tool_answer.answer import _degraded_payload
 
 
@@ -141,7 +141,7 @@ async def test_degraded_hint_names_a_withheld_symbol_that_resolves(tmp_path, mon
     """When something really was not served, name it rather than the range."""
     ctx = _tree(tmp_path, body_lines=200)
     monkeypatch.setattr(
-        answer_mod,
+        symbols_mod,
         "withheld_definitions",
         lambda repo_root, cont: [
             {"name": "attr_150", "line": 151, "symbol_id": "src/flask/app.py::attr_150"}
@@ -162,7 +162,7 @@ async def test_degraded_hint_never_advertises_an_unresolvable_id(tmp_path, monke
     """
     ctx = _tree(tmp_path, body_lines=200)
     monkeypatch.setattr(
-        answer_mod,
+        symbols_mod,
         "withheld_definitions",
         lambda repo_root, cont: [
             {

--- a/tests/unit/server/mcp/test_answer_early_return_candidates.py
+++ b/tests/unit/server/mcp/test_answer_early_return_candidates.py
@@ -30,8 +30,11 @@ from repowise.server.mcp_server.tool_answer.answer import _with_candidates
 
 # Returns that route through this are covered: the helper attaches the block
 # itself. ``_degraded_payload`` is the shared shape for both synthesis-less
-# paths and calls ``_with_candidates`` internally.
-_COVERING_CALLS = {"_with_candidates", "_degraded_payload"}
+# paths and calls ``_with_candidates`` internally. ``_degrade`` is the local
+# binding of ``_degraded_payload`` inside ``get_answer``, which exists so the
+# two synthesis-less returns name only what differs between them; it forwards
+# ``resolved_pool`` like any other call to it.
+_COVERING_CALLS = {"_with_candidates", "_degraded_payload", "_degrade"}
 
 # The mainline return. It attaches ``candidates`` a few lines above itself
 # rather than through the helper, because it also has to build the block after

--- a/tests/unit/server/mcp/test_answer_withheld_id_validation.py
+++ b/tests/unit/server/mcp/test_answer_withheld_id_validation.py
@@ -26,6 +26,8 @@ from types import SimpleNamespace
 
 import pytest
 
+from repowise.server.mcp_server.tool_answer import symbols as symbols_mod
+
 
 def _patch_provider(monkeypatch, answer_mod, content: str):
     class _Provider:
@@ -144,7 +146,7 @@ async def test_an_id_that_resolves_to_nothing_is_not_advertised(
         answer_text="big_handler runs each step in order and returns the first.",
     )
 
-    real = answer_mod.withheld_definitions
+    real = symbols_mod.withheld_definitions
 
     def _fabricating(repo_root, continuation):
         out = list(real(repo_root, continuation))
@@ -159,7 +161,7 @@ async def test_an_id_that_resolves_to_nothing_is_not_advertised(
         )
         return out
 
-    monkeypatch.setattr(answer_mod, "withheld_definitions", _fabricating)
+    monkeypatch.setattr(symbols_mod, "withheld_definitions", _fabricating)
 
     result = await get_answer("how does big_handler use phantomThing on each step")
 
@@ -193,7 +195,7 @@ async def test_an_unreadable_file_does_not_disqualify_its_id(
         answer_text="big_handler runs each step in order and returns the first.",
     )
 
-    real = answer_mod.withheld_definitions
+    real = symbols_mod.withheld_definitions
 
     def _from_a_vanished_file(repo_root, continuation):
         out = list(real(repo_root, continuation))
@@ -208,7 +210,7 @@ async def test_an_unreadable_file_does_not_disqualify_its_id(
         )
         return out
 
-    monkeypatch.setattr(answer_mod, "withheld_definitions", _from_a_vanished_file)
+    monkeypatch.setattr(symbols_mod, "withheld_definitions", _from_a_vanished_file)
 
     result = await get_answer("how does big_handler use movedAway on each step")
 


### PR DESCRIPTION
`get_answer` was 792 NLOC at CCN 189, cognitive 282, with 18 sibling blocks at
one nesting level, in a file 19 others import. The stages were already there,
marked by comment banners. This names them.

Structure only. No gate moves, no condition changes, no payload field is added
or dropped, and every stage is called exactly where its code used to run.

## What moved

Five stages come out of `get_answer`, in call order:

| stage | takes |
|---|---|
| `_serve_cached_answer` | the cache read, the six bypass rules, the serve |
| `_run_retrieval_pipeline` | hybrid retrieval through symbol hydration, returning a `_Retrieved` |
| `_union_answer_payload` | answer-by-union, returning None to fall through |
| `_grade_answer` | the nine-gate confidence cascade, returning a `_Grade` |
| `_write_answer_cache` | the upsert |

A stage returns None to mean "not mine, fall through" and a payload to mean
"this is the answer". The boundaries fall where the answer-deciding authority
changes rather than where the code happens to be long: nothing in the retrieval
pipeline decides what the answer is, which is why it is one stage rather than
the eight banners it used to be. `_grade_answer` returns the gate findings as
well as the verdict, because the notes downstream are written from those
findings and the two drifting apart is how a payload comes to say "high
confidence" beside a truncated body.

Smaller extractions, all lifts of an existing block to a named function at the
same call order: `_repo_root` (five call sites), `_top_two_score_ratio`,
`_rationale_anchors`, `_line_span` / `_overlaps_any`, `_selection_names` /
`_kind_rank` / `_is_named_definition`, `_degraded_summary`, `_data_shape_prose`,
`_is_question_named_body_cut_by_us`, `_is_enclosing_continuation`.

## Duplication

Three real, all fixed:

* The truncation contract (`truncated` / `continuation` / `withheld_symbols`)
  existed twice, in `answer.py` and `symbols.py`, and the two copies have
  co-changed ten times. It is now `attach_truncation_contract` in `symbols.py`,
  which already owns body building and the withheld scan. Behaviour is
  preserved exactly, including the case where the index recorded no end line.
  The open D8 defect rides along unchanged: fixing it here would make the diff
  unreviewable.
* The two post-retrieval gates with nothing to answer with (qualified miss, no
  hits) share `_no_answer_payload`.
* The two synthesis-less returns share a local `_degrade` that names only the
  reason and the note.

Three were assessed and rejected as false positives. All three matched adjacent
`from ... import` statements, so there is nothing to extract, and hoisting
imports into a shared shim would be worse than the duplication it removed.

## Numbers

Measured with the same tree-sitter engine `get_health` uses, `origin/main` vs
this branch.

| | before | after |
|---|---|---|
| `get_answer` CCN | 189 | 98 |
| cognitive | 282 | 168 |
| NLOC | 792 | 519 |
| sibling blocks (bumpy road) | 18 | 8 |
| functions in file | 26 | 46 |

Sibling helpers came down too: `_gather_body_candidates` 20 to 12,
`_gather_code_rationale` 17 to 10, `_drop_already_surfaced` 15 to below the top
six.

The `brain_method` finding does not clear, and saying otherwise would be wrong:
it fires at NLOC 70 and CCN 9, which no orchestrator of this shape reaches.
`_grade_answer` at CCN 45 will raise it as a new finding of its own. What moved
is the magnitude, not the presence.

## How equivalence was checked

* The unit suite, run after every extraction rather than once at the end.
* A payload diff on the indexed corpus. Both sides run the same questions
  through five deterministic arms (no provider, synthesis failed, and stubbed
  synthesis texts shaped to reach the hedge, value and completeness gates), with
  the answer cache disabled so no arm reads another's row. Removing the LLM as a
  variable is the point: the synthesised prose moves between runs and every gate
  downstream reads it, so a real change would hide in that noise.
* Two adversarial reviews, one on the control flow and one on the helpers and
  the duplication unification, each asked to name the input that would produce a
  different payload.

The payload diff came back clean on 30 payloads except for one question, where
the two entries of `flow_path` are the same two paths in the opposite order.
That is pre-existing nondeterminism, demonstrated rather than assumed: running
the **same build twice** on that question produces both orderings, one each. It
lives in code this branch does not touch:
`_flow_path.py` builds its adjacency graph out of `set()`, walks it collecting
into `set()`, and finishes with `paths.sort(key=len)`, which is stable and so
leaves two equal-length paths in discovery order. Both paths here are one hop
from `rich/table.py`, so they tie, and the tie resolves on string set iteration
order, which moves with per-process hash randomization. Worth fixing with a
total order on the sort key, but not here: this branch changes no behaviour and
that would.

## Known, and deliberate

* `_no_answer_payload` normalises the key insertion order of the no-hits reply,
  which previously placed `note` after `retrieval`. Keys and values are
  unchanged; only the JSON byte order moves. Nothing in the tree reads payload
  key order.
* `withheld_definitions` is no longer referenced from `answer.py`, so
  `answer.withheld_definitions` is no longer a live patch point. The only
  non-test reference in the tree was the call that moved. Three tests now patch
  it on `symbols`, where the call lives; no test assertion changed.
* `test_answer_early_return_candidates` asserts over the source that no return
  after `resolved_pool` bypasses `_with_candidates`. `_degrade` is added to the
  set of names it recognises, since it is the local binding of
  `_degraded_payload` and forwards `resolved_pool` like any other call to it.
  The invariant is unchanged; the list of names that satisfy it grew by one.

## Next

The file has two `hidden_coupling` partners it co-changes with but does not
import: `tool_search.py` (8 co-changes, 62%) and `tool_context/targets.py`
(4, 50%). Both are out of scope here and are the next thing to look at.
