### PR TITLE
feat(providers): archive OpenCode generation sessions

### DIFF
--- a/packages/core/src/repowise/core/providers/llm/opencode.py
+++ b/packages/core/src/repowise/core/providers/llm/opencode.py
@@ -433,6 +433,9 @@ class OpenCodeProvider(BaseProvider):
             )
 
         content, usage, session_id = _parse_jsonl(stdout)
+        if session_id:
+            await _archive_opencode_session_best_effort(session_id)
+
         if not content:
             raise ProviderError(
                 "opencode",

--- a/packages/core/src/repowise/core/providers/llm/opencode.py
+++ b/packages/core/src/repowise/core/providers/llm/opencode.py
@@ -19,6 +19,8 @@ import os
 import re
 import shutil
 import subprocess
+import time
+from urllib import request
 from functools import lru_cache
 from pathlib import Path
 from typing import Any
@@ -41,6 +43,8 @@ _DEFAULT_MODEL_LABEL = "opencode/default"
 _EXEC_TIMEOUT_SECONDS = 600
 _CATALOG_TIMEOUT_SECONDS = 10
 _MAX_STDERR_CHARS = 1_000
+_OPENCODE_SERVER_URL = "http://127.0.0.1:4096"
+_ARCHIVE_TIMEOUT_SECONDS = 1
 
 _MODEL_NAME_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._/\-]*$")
 
@@ -101,9 +105,10 @@ def _combine_prompt(system_prompt: str, user_prompt: str) -> str:
     )
 
 
-def _parse_jsonl(stdout: str) -> tuple[str, dict[str, Any]]:
+def _parse_jsonl(stdout: str) -> tuple[str, dict[str, Any], str | None]:
     content_parts: list[str] = []
     usage: dict[str, Any] = {}
+    session_id: str | None = None
 
     for raw_line in stdout.splitlines():
         line = raw_line.strip()
@@ -113,6 +118,9 @@ def _parse_jsonl(stdout: str) -> tuple[str, dict[str, Any]]:
             event = json.loads(line)
         except json.JSONDecodeError:
             continue
+
+        if session_id is None and isinstance(event.get("sessionID"), str):
+            session_id = event["sessionID"]
 
         event_type = event.get("type")
         if event_type == "text":
@@ -136,7 +144,31 @@ def _parse_jsonl(stdout: str) -> tuple[str, dict[str, Any]]:
                     elif isinstance(value, (int, float)):
                         usage[key] = usage.get(key, 0) + int(value)
 
-    return "\n".join(content_parts), usage
+    return "\n".join(content_parts), usage, session_id
+
+
+def _archive_opencode_session(session_id: str) -> None:
+    body = json.dumps(
+        {
+            "metadata": {"source": "repowise"},
+            "time": {"archived": int(time.time() * 1000)},
+        }
+    ).encode("utf-8")
+    archive_request = request.Request(
+        f"{_OPENCODE_SERVER_URL}/session/{session_id}",
+        data=body,
+        headers={"Content-Type": "application/json"},
+        method="PATCH",
+    )
+    with request.urlopen(archive_request, timeout=_ARCHIVE_TIMEOUT_SECONDS):
+        pass
+
+
+async def _archive_opencode_session_best_effort(session_id: str) -> None:
+    try:
+        await asyncio.to_thread(_archive_opencode_session, session_id)
+    except Exception:
+        log.debug("opencode.session.archive_failed", session_id=session_id)
 
 
 def _tail(text: str, max_chars: int = _MAX_STDERR_CHARS) -> str:
@@ -400,7 +432,7 @@ class OpenCodeProvider(BaseProvider):
                 status_code=proc.returncode,
             )
 
-        content, usage = _parse_jsonl(stdout)
+        content, usage, session_id = _parse_jsonl(stdout)
         if not content:
             raise ProviderError(
                 "opencode",

--- a/packages/core/src/repowise/core/providers/llm/opencode.py
+++ b/packages/core/src/repowise/core/providers/llm/opencode.py
@@ -19,11 +19,10 @@ import os
 import re
 import shutil
 import subprocess
-import time
+import uuid
 from functools import lru_cache
 from pathlib import Path
 from typing import Any
-from urllib import request
 
 import structlog
 
@@ -43,8 +42,6 @@ _DEFAULT_MODEL_LABEL = "opencode/default"
 _EXEC_TIMEOUT_SECONDS = 600
 _CATALOG_TIMEOUT_SECONDS = 10
 _MAX_STDERR_CHARS = 1_000
-_OPENCODE_SERVER_URL = "http://127.0.0.1:4096"
-_ARCHIVE_TIMEOUT_SECONDS = 1
 
 _MODEL_NAME_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._/\-]*$")
 
@@ -105,10 +102,9 @@ def _combine_prompt(system_prompt: str, user_prompt: str) -> str:
     )
 
 
-def _parse_jsonl(stdout: str) -> tuple[str, dict[str, Any], str | None]:
+def _parse_jsonl(stdout: str) -> tuple[str, dict[str, Any]]:
     content_parts: list[str] = []
     usage: dict[str, Any] = {}
-    session_id: str | None = None
 
     for raw_line in stdout.splitlines():
         line = raw_line.strip()
@@ -118,9 +114,6 @@ def _parse_jsonl(stdout: str) -> tuple[str, dict[str, Any], str | None]:
             event = json.loads(line)
         except json.JSONDecodeError:
             continue
-
-        if session_id is None and isinstance(event.get("sessionID"), str):
-            session_id = event["sessionID"]
 
         event_type = event.get("type")
         if event_type == "text":
@@ -144,31 +137,7 @@ def _parse_jsonl(stdout: str) -> tuple[str, dict[str, Any], str | None]:
                     elif isinstance(value, (int, float)):
                         usage[key] = usage.get(key, 0) + int(value)
 
-    return "\n".join(content_parts), usage, session_id
-
-
-def _archive_opencode_session(session_id: str) -> None:
-    body = json.dumps(
-        {
-            "metadata": {"source": "repowise"},
-            "time": {"archived": int(time.time() * 1000)},
-        }
-    ).encode("utf-8")
-    archive_request = request.Request(
-        f"{_OPENCODE_SERVER_URL}/session/{session_id}",
-        data=body,
-        headers={"Content-Type": "application/json"},
-        method="PATCH",
-    )
-    with request.urlopen(archive_request, timeout=_ARCHIVE_TIMEOUT_SECONDS):
-        pass
-
-
-async def _archive_opencode_session_best_effort(session_id: str) -> None:
-    try:
-        await asyncio.to_thread(_archive_opencode_session, session_id)
-    except Exception:
-        log.debug("opencode.session.archive_failed", session_id=session_id)
+    return "\n".join(content_parts), usage
 
 
 def _tail(text: str, max_chars: int = _MAX_STDERR_CHARS) -> str:
@@ -360,6 +329,8 @@ class OpenCodeProvider(BaseProvider):
             "json",
             "--dir",
             str(self._repo_path),
+            "--title",
+            f"repowise_auto_{uuid.uuid4().hex}",
         ]
         if self._model:
             cmd.extend(["--model", self._model])
@@ -432,9 +403,7 @@ class OpenCodeProvider(BaseProvider):
                 status_code=proc.returncode,
             )
 
-        content, usage, session_id = _parse_jsonl(stdout)
-        if session_id:
-            await _archive_opencode_session_best_effort(session_id)
+        content, usage = _parse_jsonl(stdout)
 
         if not content:
             raise ProviderError(

--- a/packages/core/src/repowise/core/providers/llm/opencode.py
+++ b/packages/core/src/repowise/core/providers/llm/opencode.py
@@ -20,10 +20,10 @@ import re
 import shutil
 import subprocess
 import time
-from urllib import request
 from functools import lru_cache
 from pathlib import Path
 from typing import Any
+from urllib import request
 
 import structlog
 

--- a/tests/unit/test_providers/test_opencode_provider.py
+++ b/tests/unit/test_providers/test_opencode_provider.py
@@ -7,13 +7,13 @@ from __future__ import annotations
 
 import asyncio
 import json
+import re
 from typing import Any
 
 import pytest
 
 from repowise.core.providers.llm.base import GeneratedResponse, ProviderError
 from repowise.core.providers.llm.opencode import (
-    _archive_opencode_session,
     OpenCodeProvider,
     _parse_models_output,
     _validate_model_name,
@@ -220,6 +220,9 @@ async def test_generate_invokes_opencode_with_stdin(monkeypatch, tmp_path):
     assert "--dangerously-skip-permissions" not in args
     assert args[args.index("--dir") + 1] == str(tmp_path.resolve())
     assert args[args.index("--model") + 1] == "deepseek/deepseek-v4-pro"
+    assert re.fullmatch(
+        r"repowise_auto_[0-9a-f]{32}", args[args.index("--title") + 1]
+    )
     assert captured["kwargs"]["stdin"] == asyncio.subprocess.PIPE
     env = captured["kwargs"].get("env", {})
     assert "OPENCODE_CONFIG_CONTENT" in env
@@ -260,58 +263,6 @@ async def test_generate_parses_jsonl_tokens(monkeypatch, tmp_path):
     assert result.cached_tokens == 20
     assert result.usage["source"] == "opencode_run"
     assert "estimated" not in result.usage
-
-
-async def test_generate_archives_opencode_session(monkeypatch, tmp_path):
-    monkeypatch.setattr("shutil.which", lambda _cmd: "opencode")
-    archived_session_ids: list[str] = []
-
-    async def archive(session_id: str) -> None:
-        archived_session_ids.append(session_id)
-
-    async def fake_exec(*_args: str, **_kwargs: Any) -> FakeProcess:
-        return FakeProcess(stdout=_success_jsonl("OK"))
-
-    monkeypatch.setattr("asyncio.create_subprocess_exec", fake_exec)
-    monkeypatch.setattr(
-        "repowise.core.providers.llm.opencode._archive_opencode_session_best_effort",
-        archive,
-    )
-
-    await OpenCodeProvider(repo_path=tmp_path).generate("sys", "user")
-
-    assert archived_session_ids == ["s1"]
-
-
-def test_archive_opencode_session_tags_and_archives(monkeypatch):
-    captured: dict[str, Any] = {}
-
-    class Response:
-        def __enter__(self):
-            return self
-
-        def __exit__(self, *_args: Any) -> None:
-            return None
-
-    def urlopen(request, timeout: float):
-        captured["url"] = request.full_url
-        captured["body"] = json.loads(request.data.decode("utf-8"))
-        captured["timeout"] = timeout
-        return Response()
-
-    monkeypatch.setattr("time.time", lambda: 123.456)
-    monkeypatch.setattr("urllib.request.urlopen", urlopen)
-
-    _archive_opencode_session("ses_123")
-
-    assert captured == {
-        "url": "http://127.0.0.1:4096/session/ses_123",
-        "body": {
-            "metadata": {"source": "repowise"},
-            "time": {"archived": 123456},
-        },
-        "timeout": 1,
-    }
 
 
 async def test_generate_handles_jsonl_noise(monkeypatch, tmp_path):

--- a/tests/unit/test_providers/test_opencode_provider.py
+++ b/tests/unit/test_providers/test_opencode_provider.py
@@ -13,6 +13,7 @@ import pytest
 
 from repowise.core.providers.llm.base import GeneratedResponse, ProviderError
 from repowise.core.providers.llm.opencode import (
+    _archive_opencode_session,
     OpenCodeProvider,
     _parse_models_output,
     _validate_model_name,
@@ -259,6 +260,58 @@ async def test_generate_parses_jsonl_tokens(monkeypatch, tmp_path):
     assert result.cached_tokens == 20
     assert result.usage["source"] == "opencode_run"
     assert "estimated" not in result.usage
+
+
+async def test_generate_archives_opencode_session(monkeypatch, tmp_path):
+    monkeypatch.setattr("shutil.which", lambda _cmd: "opencode")
+    archived_session_ids: list[str] = []
+
+    async def archive(session_id: str) -> None:
+        archived_session_ids.append(session_id)
+
+    async def fake_exec(*_args: str, **_kwargs: Any) -> FakeProcess:
+        return FakeProcess(stdout=_success_jsonl("OK"))
+
+    monkeypatch.setattr("asyncio.create_subprocess_exec", fake_exec)
+    monkeypatch.setattr(
+        "repowise.core.providers.llm.opencode._archive_opencode_session_best_effort",
+        archive,
+    )
+
+    await OpenCodeProvider(repo_path=tmp_path).generate("sys", "user")
+
+    assert archived_session_ids == ["s1"]
+
+
+def test_archive_opencode_session_tags_and_archives(monkeypatch):
+    captured: dict[str, Any] = {}
+
+    class Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args: Any) -> None:
+            return None
+
+    def urlopen(request, timeout: float):
+        captured["url"] = request.full_url
+        captured["body"] = json.loads(request.data.decode("utf-8"))
+        captured["timeout"] = timeout
+        return Response()
+
+    monkeypatch.setattr("time.time", lambda: 123.456)
+    monkeypatch.setattr("urllib.request.urlopen", urlopen)
+
+    _archive_opencode_session("ses_123")
+
+    assert captured == {
+        "url": "http://127.0.0.1:4096/session/ses_123",
+        "body": {
+            "metadata": {"source": "repowise"},
+            "time": {"archived": 123456},
+        },
+        "timeout": 1,
+    }
 
 
 async def test_generate_handles_jsonl_noise(monkeypatch, tmp_path):


### PR DESCRIPTION
## Problem

When Repowise uses its OpenCode provider to generate documentation, it starts one headless `opencode run` per page. OpenCode persists each run as a normal top-level chat session, so a bulk generation creates a large number of distracting entries in the user's chat history even though the work was automated.

## Change

- Read the OpenCode session ID from the JSONL output already returned by `opencode run`.
- Tag the session as generated by Repowise and archive it after a successful run.
- Keep the archive request best-effort, so an unavailable OpenCode server never fails documentation generation.

This affects only the OpenCode provider because direct API providers do not create OpenCode history entries. Other agent CLIs would need their own provider-specific integration.

## Test Plan

- [ ] Tests pass (`pytest`) - not run locally; this contribution was created without cloning the repository.
- [ ] Lint passes (`ruff check .`) - not run locally; upstream CI should verify it.
- [x] Web build passes (`npm run build`) *(not applicable; Python-only change)*

## Checklist

- [x] My code follows the project's code style
- [x] I have added tests for new functionality
- [ ] All existing tests still pass
- [x] I have updated documentation if needed (not needed; internal provider behavior)