### PR TITLE
fix(providers): title OpenCode sessions from Repowise

### DIFF
--- a/packages/core/src/repowise/core/providers/llm/opencode.py
+++ b/packages/core/src/repowise/core/providers/llm/opencode.py
@@ -19,6 +19,7 @@ import os
 import re
 import shutil
 import subprocess
+import uuid
 from functools import lru_cache
 from pathlib import Path
 from typing import Any
@@ -328,6 +329,8 @@ class OpenCodeProvider(BaseProvider):
             "json",
             "--dir",
             str(self._repo_path),
+            "--title",
+            f"repowise_auto_{uuid.uuid4().hex}",
         ]
         if self._model:
             cmd.extend(["--model", self._model])

--- a/tests/unit/test_providers/test_opencode_provider.py
+++ b/tests/unit/test_providers/test_opencode_provider.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import re
 from typing import Any
 
 import pytest
@@ -219,6 +220,9 @@ async def test_generate_invokes_opencode_with_stdin(monkeypatch, tmp_path):
     assert "--dangerously-skip-permissions" not in args
     assert args[args.index("--dir") + 1] == str(tmp_path.resolve())
     assert args[args.index("--model") + 1] == "deepseek/deepseek-v4-pro"
+    assert re.fullmatch(
+        r"repowise_auto_[0-9a-f]{32}", args[args.index("--title") + 1]
+    )
     assert captured["kwargs"]["stdin"] == asyncio.subprocess.PIPE
     env = captured["kwargs"].get("env", {})
     assert "OPENCODE_CONFIG_CONTENT" in env


### PR DESCRIPTION
Adds a distinct generated title to each Repowise OpenCode CLI session. Uses OpenCode's supported `--title` option; no server integration or session archival logic.

Current generation with opencode run creates a bunch of orphan chats that clutter everything up. Minimal change is to tag them so users know they came from repowise generation. Further auto-archival or auto-deletion of those chats might be useful. 