### PR TITLE
fix(cli): preserve sync baseline when HEAD is unavailable

### DIFF
--- a/packages/cli/src/repowise/cli/commands/generate_cmd/command.py
+++ b/packages/cli/src/repowise/cli/commands/generate_cmd/command.py
@@ -356,7 +356,9 @@ def _write_state(repo_path: Path, state: dict, provider: Any, outcome: Any) -> N
     upgrade leaves a mixed wiki, so it keeps its current mode rather than
     over-claiming that everything is written.
     """
-    state["last_sync_commit"] = get_head_commit(repo_path)
+    head = get_head_commit(repo_path)
+    if head is not None:
+        state["last_sync_commit"] = head
     state["total_pages"] = outcome.total_pages
     state["provider"] = provider.provider_name
     state["model"] = provider.model_name

--- a/tests/unit/cli/test_commands.py
+++ b/tests/unit/cli/test_commands.py
@@ -2,16 +2,38 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
 import pytest
 from click.testing import CliRunner
 
 from repowise.cli import __version__
+from repowise.cli.commands.generate_cmd.command import _write_state
 from repowise.cli.main import cli
 
 
 @pytest.fixture
 def runner():
     return CliRunner()
+
+
+def test_generate_state_preserves_sync_commit_when_head_is_unavailable():
+    state = {"last_sync_commit": "known-good-commit"}
+    outcome = SimpleNamespace(total_pages=1, remaining_template_pages=0)
+    provider = SimpleNamespace(provider_name="mock", model_name="mock")
+
+    with (
+        patch(
+            "repowise.cli.commands.generate_cmd.command.get_head_commit",
+            return_value=None,
+        ),
+        patch("repowise.cli.commands.generate_cmd.command.save_state"),
+    ):
+        _write_state(Path("/tmp/not-a-git-repository"), state, provider, outcome)
+
+    assert state["last_sync_commit"] == "known-good-commit"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1507

## Summary

<!-- What does this PR do? Keep it to 1-3 bullet points. -->

- Preserve the existing `last_sync_commit` when `git rev-parse HEAD` is unavailable during `generate`.
- Add a regression test for the failed HEAD lookup path.

## Related Issues

<!-- Link any related issues: Fixes #123, Closes #456 -->

Closes #1507

## Test Plan

<!-- How did you verify this works? -->

- [x] Tests pass (`pytest`)
- [x] Lint passes (`ruff check .`)
- [ ] Web build passes (`npm run build`) (N/A: no frontend changes)

This change was prepared with AI assistance; the regression test was run locally and fails without the fix.

## Checklist

- [x] My code follows the project's code style
- [x] I have added tests for new functionality
- [x] All existing tests still pass
- [x] I have updated documentation if needed
