### PR TITLE
fix(security-scan): flag multi-line subprocess.*(... shell=True) calls

### DIFF
--- a/packages/core/src/repowise/core/analysis/security_scan.py
+++ b/packages/core/src/repowise/core/analysis/security_scan.py
@@ -40,7 +40,7 @@ _PATTERNS: list[tuple[re.Pattern, str, str]] = [
     (re.compile(r"password\s*=\s*['\"]"), "hardcoded_password", "high"),
     (re.compile(r"(?:api_?key|secret)\s*=\s*['\"]"), "hardcoded_secret", "high"),
     (re.compile(r'f[\'"].*SELECT.*\{.*\}'), "fstring_sql", "med"),
-    (re.compile(r"\.execute\(\s*[\'\"]\s*SELECT.*\+"), "concat_sql", "med"),
+    (re.compile(r'\.execute\(\s*[\'\"]\s*SELECT.*\+'), "concat_sql", "med"),
     (re.compile(r"verify\s*=\s*False"), "tls_verify_false", "med"),
     (re.compile(r"\bmd5\b|\bsha1\b"), "weak_hash", "low"),
 ]
@@ -53,19 +53,26 @@ _ANY_PATTERN = re.compile("|".join(f"(?:{p.pattern})" for p, _, _ in _PATTERNS))
 # Patterns whose calls legitimately span multiple physical lines: the opening
 # ``subprocess.<call>(`` lands on one line and ``shell=True`` on another. The
 # per-line loop can never see such a call (``.*`` stops at the newline), so it
-# gets an extra whole-source pass. The span is bounded so a ``subprocess.*``
-# call without a ``shell=`` does not swallow an unrelated ``shell=True``
-# dozens of lines later.
+# gets an extra whole-source pass.
+#
+# Continuation is restricted to the same physical line or a newline that is
+# followed by indentation (``(?:[^\n]|\n(?=[ \t]))``), so a closed
+# ``subprocess.run(...)`` cannot jump to a later ``os.popen(..., shell=True)``
+# on a column-0 line. The span is also capped (~200 chars) as a second bound.
 _SPANNING_PATTERNS: list[tuple[re.Pattern, str, str]] = [
     (
-        re.compile(r"subprocess\.[A-Za-z]+\([\s\S]{0,500}?shell\s*=\s*True"),
+        re.compile(
+            r"subprocess\.[A-Za-z]+\((?:[^\n]|\n(?=[ \t])){0,200}?shell\s*=\s*True"
+        ),
         "subprocess_shell_true",
         "high",
     ),
 ]
 
 # Symbol names that are informational security hotspots
-_SYMBOL_KEYWORDS = re.compile(r"\b(auth|token|password|jwt|session|crypto)\b", re.IGNORECASE)
+_SYMBOL_KEYWORDS = re.compile(
+    r"\b(auth|token|password|jwt|session|crypto)\b", re.IGNORECASE
+)
 
 # Patterns whose matches are genuine leaked credentials (as opposed to the
 # broader "code smell" patterns like os.system/eval). Full-history scans
@@ -206,7 +213,10 @@ class SecurityScanner:
             conflict_suffix = ""
         else:
             insert_prefix = "INSERT INTO security_findings "
-            conflict_suffix = " ON CONFLICT ON CONSTRAINT uq_security_finding_provenance DO NOTHING"
+            conflict_suffix = (
+                " ON CONFLICT ON CONSTRAINT uq_security_finding_provenance "
+                "DO NOTHING"
+            )
 
         inserted = 0
         for finding in findings:
@@ -217,7 +227,8 @@ class SecurityScanner:
                         + "(repository_id, file_path, kind, severity, snippet, line_number, "
                         "commit_sha, commit_at, detected_at) "
                         "VALUES (:repo_id, :file_path, :kind, :severity, :snippet, :line, "
-                        ":commit_sha, :commit_at, :detected_at)" + conflict_suffix
+                        ":commit_sha, :commit_at, :detected_at)"
+                        + conflict_suffix
                     ),
                     {
                         "repo_id": self._repo_id,

--- a/packages/core/src/repowise/core/analysis/security_scan.py
+++ b/packages/core/src/repowise/core/analysis/security_scan.py
@@ -40,7 +40,7 @@ _PATTERNS: list[tuple[re.Pattern, str, str]] = [
     (re.compile(r"password\s*=\s*['\"]"), "hardcoded_password", "high"),
     (re.compile(r"(?:api_?key|secret)\s*=\s*['\"]"), "hardcoded_secret", "high"),
     (re.compile(r'f[\'"].*SELECT.*\{.*\}'), "fstring_sql", "med"),
-    (re.compile(r'\.execute\(\s*[\'\"]\s*SELECT.*\+'), "concat_sql", "med"),
+    (re.compile(r"\.execute\(\s*[\'\"]\s*SELECT.*\+"), "concat_sql", "med"),
     (re.compile(r"verify\s*=\s*False"), "tls_verify_false", "med"),
     (re.compile(r"\bmd5\b|\bsha1\b"), "weak_hash", "low"),
 ]
@@ -50,10 +50,22 @@ _PATTERNS: list[tuple[re.Pattern, str, str]] = [
 # _PATTERNS matches, so findings are unchanged.
 _ANY_PATTERN = re.compile("|".join(f"(?:{p.pattern})" for p, _, _ in _PATTERNS))
 
+# Patterns whose calls legitimately span multiple physical lines: the opening
+# ``subprocess.<call>(`` lands on one line and ``shell=True`` on another. The
+# per-line loop can never see such a call (``.*`` stops at the newline), so it
+# gets an extra whole-source pass. The span is bounded so a ``subprocess.*``
+# call without a ``shell=`` does not swallow an unrelated ``shell=True``
+# dozens of lines later.
+_SPANNING_PATTERNS: list[tuple[re.Pattern, str, str]] = [
+    (
+        re.compile(r"subprocess\.[A-Za-z]+\([\s\S]{0,500}?shell\s*=\s*True"),
+        "subprocess_shell_true",
+        "high",
+    ),
+]
+
 # Symbol names that are informational security hotspots
-_SYMBOL_KEYWORDS = re.compile(
-    r"\b(auth|token|password|jwt|session|crypto)\b", re.IGNORECASE
-)
+_SYMBOL_KEYWORDS = re.compile(r"\b(auth|token|password|jwt|session|crypto)\b", re.IGNORECASE)
 
 # Patterns whose matches are genuine leaked credentials (as opposed to the
 # broader "code smell" patterns like os.system/eval). Full-history scans
@@ -107,6 +119,31 @@ class SecurityScanner:
                             "line": lineno,
                         }
                     )
+
+        # Whole-source pass for patterns that span physical lines
+        # (``subprocess.run(\n    ...,\n    shell=True,\n)``). The per-line
+        # loop above can never see the sink when the call opens on one line
+        # and ``shell=`` lands on another, so scan the full source once. The
+        # finding is reported on the line where the call starts, and a match
+        # the per-line pass already caught on that line is not duplicated.
+        for pattern, kind, severity in _SPANNING_PATTERNS:
+            for match in pattern.finditer(source):
+                start_line = source.count("\n", 0, match.start()) + 1
+                if any(f["kind"] == kind and f["line"] == start_line for f in findings):
+                    continue
+                line_start = source.rfind("\n", 0, match.start()) + 1
+                line_end = source.find("\n", match.start())
+                if line_end == -1:
+                    line_end = len(source)
+                snippet = source[line_start:line_end].strip()[:120]
+                findings.append(
+                    {
+                        "kind": kind,
+                        "severity": severity,
+                        "snippet": snippet,
+                        "line": start_line,
+                    }
+                )
 
         # Symbol-name scan (informational / low)
         for sym in symbols:
@@ -169,10 +206,7 @@ class SecurityScanner:
             conflict_suffix = ""
         else:
             insert_prefix = "INSERT INTO security_findings "
-            conflict_suffix = (
-                " ON CONFLICT ON CONSTRAINT uq_security_finding_provenance "
-                "DO NOTHING"
-            )
+            conflict_suffix = " ON CONFLICT ON CONSTRAINT uq_security_finding_provenance DO NOTHING"
 
         inserted = 0
         for finding in findings:
@@ -183,8 +217,7 @@ class SecurityScanner:
                         + "(repository_id, file_path, kind, severity, snippet, line_number, "
                         "commit_sha, commit_at, detected_at) "
                         "VALUES (:repo_id, :file_path, :kind, :severity, :snippet, :line, "
-                        ":commit_sha, :commit_at, :detected_at)"
-                        + conflict_suffix
+                        ":commit_sha, :commit_at, :detected_at)" + conflict_suffix
                     ),
                     {
                         "repo_id": self._repo_id,

--- a/tests/unit/analysis/test_security_scan.py
+++ b/tests/unit/analysis/test_security_scan.py
@@ -31,7 +31,10 @@ CLEAN = b"""def add(a, b):
 
 
 def _fake_result(files: dict[str, bytes]):
-    parsed = [SimpleNamespace(file_info=SimpleNamespace(path=p), symbols=[]) for p in files]
+    parsed = [
+        SimpleNamespace(file_info=SimpleNamespace(path=p), symbols=[])
+        for p in files
+    ]
     return SimpleNamespace(parsed_files=parsed, source_map=dict(files))
 
 
@@ -70,7 +73,9 @@ async def _rows(sf) -> list[tuple]:
 class TestScanFile:
     def test_line_patterns_fire_on_real_source(self) -> None:
         scanner = SecurityScanner(session=None, repo_id="r1")  # type: ignore[arg-type]
-        findings = asyncio.run(scanner.scan_file("a.py", SNIPPY.decode(), symbols=[]))
+        findings = asyncio.run(
+            scanner.scan_file("a.py", SNIPPY.decode(), symbols=[])
+        )
         kinds = {f["kind"] for f in findings}
         assert "hardcoded_password" in kinds
         assert "pickle_loads" in kinds
@@ -110,6 +115,18 @@ class TestScanFile:
     def test_subprocess_without_shell_does_not_fire(self) -> None:
         scanner = SecurityScanner(session=None, repo_id="r1")  # type: ignore[arg-type]
         source = 'subprocess.run(\n    ["git", "rev-parse", "HEAD"],\n    capture_output=True,\n)\n'
+        findings = asyncio.run(scanner.scan_file("a.py", source, symbols=[]))
+        hits = [f for f in findings if f["kind"] == "subprocess_shell_true"]
+        assert hits == []
+
+    def test_spanning_pass_does_not_jump_to_later_shell_true(self) -> None:
+        """A closed subprocess call must not claim a later column-0 shell=True."""
+        scanner = SecurityScanner(session=None, repo_id="r1")  # type: ignore[arg-type]
+        source = (
+            'subprocess.run(["ls"], capture_output=True)\n'
+            "\n"
+            "os.popen(cmd, shell=True)\n"
+        )
         findings = asyncio.run(scanner.scan_file("a.py", source, symbols=[]))
         hits = [f for f in findings if f["kind"] == "subprocess_shell_true"]
         assert hits == []
@@ -165,9 +182,13 @@ class TestPersistSecurityFindings:
             from repowise.core.persistence import get_session
 
             async with get_session(sf) as session:
-                await persist_security_findings(_fake_result({"a.py": SNIPPY}), session, "repo-1")
+                await persist_security_findings(
+                    _fake_result({"a.py": SNIPPY}), session, "repo-1"
+                )
             async with get_session(sf) as session:
-                await persist_security_findings(_fake_result({"a.py": CLEAN}), session, "repo-1")
+                await persist_security_findings(
+                    _fake_result({"a.py": CLEAN}), session, "repo-1"
+                )
             rows = await _rows(sf)
             await engine.dispose()
             return rows
@@ -188,7 +209,9 @@ class TestPersistSecurityFindings:
             sym = SimpleNamespace(name="auth", start_line=7)
             result = SimpleNamespace(
                 parsed_files=[
-                    SimpleNamespace(file_info=SimpleNamespace(path="auth.py"), symbols=[sym])
+                    SimpleNamespace(
+                        file_info=SimpleNamespace(path="auth.py"), symbols=[sym]
+                    )
                 ],
             )
             async with get_session(sf) as session:

--- a/tests/unit/analysis/test_security_scan.py
+++ b/tests/unit/analysis/test_security_scan.py
@@ -31,10 +31,7 @@ CLEAN = b"""def add(a, b):
 
 
 def _fake_result(files: dict[str, bytes]):
-    parsed = [
-        SimpleNamespace(file_info=SimpleNamespace(path=p), symbols=[])
-        for p in files
-    ]
+    parsed = [SimpleNamespace(file_info=SimpleNamespace(path=p), symbols=[]) for p in files]
     return SimpleNamespace(parsed_files=parsed, source_map=dict(files))
 
 
@@ -73,9 +70,7 @@ async def _rows(sf) -> list[tuple]:
 class TestScanFile:
     def test_line_patterns_fire_on_real_source(self) -> None:
         scanner = SecurityScanner(session=None, repo_id="r1")  # type: ignore[arg-type]
-        findings = asyncio.run(
-            scanner.scan_file("a.py", SNIPPY.decode(), symbols=[])
-        )
+        findings = asyncio.run(scanner.scan_file("a.py", SNIPPY.decode(), symbols=[]))
         kinds = {f["kind"] for f in findings}
         assert "hardcoded_password" in kinds
         assert "pickle_loads" in kinds
@@ -87,6 +82,37 @@ class TestScanFile:
         scanner = SecurityScanner(session=None, repo_id="r1")  # type: ignore[arg-type]
         findings = asyncio.run(scanner.scan_file("b.py", CLEAN.decode(), symbols=[]))
         assert findings == []
+
+    def test_single_line_subprocess_shell_true_is_flagged(self) -> None:
+        scanner = SecurityScanner(session=None, repo_id="r1")  # type: ignore[arg-type]
+        source = 'subprocess.run("rm -rf " + path, shell=True)\n'
+        findings = asyncio.run(scanner.scan_file("a.py", source, symbols=[]))
+        hits = [f for f in findings if f["kind"] == "subprocess_shell_true"]
+        assert len(hits) == 1
+        assert hits[0]["line"] == 1
+
+    def test_multiline_subprocess_shell_true_is_flagged(self) -> None:
+        scanner = SecurityScanner(session=None, repo_id="r1")  # type: ignore[arg-type]
+        source = 'subprocess.run(\n    "rm -rf " + path,\n    shell=True,\n)\n'
+        findings = asyncio.run(scanner.scan_file("a.py", source, symbols=[]))
+        hits = [f for f in findings if f["kind"] == "subprocess_shell_true"]
+        assert len(hits) == 1
+        assert hits[0]["line"] == 1
+
+    def test_multiline_popen_shell_true_is_flagged(self) -> None:
+        scanner = SecurityScanner(session=None, repo_id="r1")  # type: ignore[arg-type]
+        source = 'subprocess.Popen(\n    ["/bin/sh"],\n    shell=True,\n)\n'
+        findings = asyncio.run(scanner.scan_file("a.py", source, symbols=[]))
+        hits = [f for f in findings if f["kind"] == "subprocess_shell_true"]
+        assert len(hits) == 1
+        assert hits[0]["line"] == 1
+
+    def test_subprocess_without_shell_does_not_fire(self) -> None:
+        scanner = SecurityScanner(session=None, repo_id="r1")  # type: ignore[arg-type]
+        source = 'subprocess.run(\n    ["git", "rev-parse", "HEAD"],\n    capture_output=True,\n)\n'
+        findings = asyncio.run(scanner.scan_file("a.py", source, symbols=[]))
+        hits = [f for f in findings if f["kind"] == "subprocess_shell_true"]
+        assert hits == []
 
 
 class TestPersistSecurityFindings:
@@ -139,13 +165,9 @@ class TestPersistSecurityFindings:
             from repowise.core.persistence import get_session
 
             async with get_session(sf) as session:
-                await persist_security_findings(
-                    _fake_result({"a.py": SNIPPY}), session, "repo-1"
-                )
+                await persist_security_findings(_fake_result({"a.py": SNIPPY}), session, "repo-1")
             async with get_session(sf) as session:
-                await persist_security_findings(
-                    _fake_result({"a.py": CLEAN}), session, "repo-1"
-                )
+                await persist_security_findings(_fake_result({"a.py": CLEAN}), session, "repo-1")
             rows = await _rows(sf)
             await engine.dispose()
             return rows
@@ -166,9 +188,7 @@ class TestPersistSecurityFindings:
             sym = SimpleNamespace(name="auth", start_line=7)
             result = SimpleNamespace(
                 parsed_files=[
-                    SimpleNamespace(
-                        file_info=SimpleNamespace(path="auth.py"), symbols=[sym]
-                    )
+                    SimpleNamespace(file_info=SimpleNamespace(path="auth.py"), symbols=[sym])
                 ],
             )
             async with get_session(sf) as session:


### PR DESCRIPTION
Fixes #1506

## Problem

The pattern `subprocess\..*shell\s*=\s*True` is matched per physical line (`security_scan.py` line loop), and `.*` cannot cross a newline. Idiomatic multi-line calls:

```python
subprocess.run(
    "rm -rf " + path,
    shell=True,
)
```

produce zero `subprocess_shell_true` findings — the high-severity command-injection sink escapes detection.

## Fix

Add a whole-source pass for patterns that legitimately span physical lines:
- `subprocess\.[A-Za-z]+\([\s\S]{0,500}?shell\s*=\s*True` scanned over the full source once.
- The span is bounded (500 chars) so a `subprocess` call without `shell=` cannot swallow an unrelated `shell=True` later in the file.
- The finding is reported on the call's start line, and a match the per-line pass already caught on that line is not duplicated.

## Tests

Added 4 cases to `test_security_scan.py`: single-line `subprocess.run`, multi-line `subprocess.run`, multi-line `subprocess.Popen`, and a negative case (multi-line call without `shell=`). All pass.