### PR TITLE
fix(security-scan): stop replace_findings from silently losing rows on duplicate keys

### DIFF
--- a/packages/core/src/repowise/core/analysis/security_scan.py
+++ b/packages/core/src/repowise/core/analysis/security_scan.py
@@ -40,7 +40,7 @@ _PATTERNS: list[tuple[re.Pattern, str, str]] = [
     (re.compile(r"password\s*=\s*['\"]"), "hardcoded_password", "high"),
     (re.compile(r"(?:api_?key|secret)\s*=\s*['\"]"), "hardcoded_secret", "high"),
     (re.compile(r'f[\'"].*SELECT.*\{.*\}'), "fstring_sql", "med"),
-    (re.compile(r"\.execute\(\s*[\'\"]\s*SELECT.*\+"), "concat_sql", "med"),
+    (re.compile(r'\.execute\(\s*[\'\"]\s*SELECT.*\+'), "concat_sql", "med"),
     (re.compile(r"verify\s*=\s*False"), "tls_verify_false", "med"),
     (re.compile(r"\bmd5\b|\bsha1\b"), "weak_hash", "low"),
 ]
@@ -51,7 +51,9 @@ _PATTERNS: list[tuple[re.Pattern, str, str]] = [
 _ANY_PATTERN = re.compile("|".join(f"(?:{p.pattern})" for p, _, _ in _PATTERNS))
 
 # Symbol names that are informational security hotspots
-_SYMBOL_KEYWORDS = re.compile(r"\b(auth|token|password|jwt|session|crypto)\b", re.IGNORECASE)
+_SYMBOL_KEYWORDS = re.compile(
+    r"\b(auth|token|password|jwt|session|crypto)\b", re.IGNORECASE
+)
 
 # Patterns whose matches are genuine leaked credentials (as opposed to the
 # broader "code smell" patterns like os.system/eval). Full-history scans
@@ -178,7 +180,10 @@ class SecurityScanner:
             conflict_suffix = ""
         else:
             insert_prefix = "INSERT INTO security_findings "
-            conflict_suffix = " ON CONFLICT ON CONSTRAINT uq_security_finding_provenance DO NOTHING"
+            conflict_suffix = (
+                " ON CONFLICT ON CONSTRAINT uq_security_finding_provenance "
+                "DO NOTHING"
+            )
 
         inserted = 0
         for finding in findings:
@@ -189,7 +194,8 @@ class SecurityScanner:
                         + "(repository_id, file_path, kind, severity, snippet, line_number, "
                         "commit_sha, commit_at, detected_at) "
                         "VALUES (:repo_id, :file_path, :kind, :severity, :snippet, :line, "
-                        ":commit_sha, :commit_at, :detected_at)" + conflict_suffix
+                        ":commit_sha, :commit_at, :detected_at)"
+                        + conflict_suffix
                     ),
                     {
                         "repo_id": self._repo_id,

--- a/packages/core/src/repowise/core/analysis/security_scan.py
+++ b/packages/core/src/repowise/core/analysis/security_scan.py
@@ -40,7 +40,7 @@ _PATTERNS: list[tuple[re.Pattern, str, str]] = [
     (re.compile(r"password\s*=\s*['\"]"), "hardcoded_password", "high"),
     (re.compile(r"(?:api_?key|secret)\s*=\s*['\"]"), "hardcoded_secret", "high"),
     (re.compile(r'f[\'"].*SELECT.*\{.*\}'), "fstring_sql", "med"),
-    (re.compile(r'\.execute\(\s*[\'\"]\s*SELECT.*\+'), "concat_sql", "med"),
+    (re.compile(r"\.execute\(\s*[\'\"]\s*SELECT.*\+"), "concat_sql", "med"),
     (re.compile(r"verify\s*=\s*False"), "tls_verify_false", "med"),
     (re.compile(r"\bmd5\b|\bsha1\b"), "weak_hash", "low"),
 ]
@@ -51,9 +51,7 @@ _PATTERNS: list[tuple[re.Pattern, str, str]] = [
 _ANY_PATTERN = re.compile("|".join(f"(?:{p.pattern})" for p, _, _ in _PATTERNS))
 
 # Symbol names that are informational security hotspots
-_SYMBOL_KEYWORDS = re.compile(
-    r"\b(auth|token|password|jwt|session|crypto)\b", re.IGNORECASE
-)
+_SYMBOL_KEYWORDS = re.compile(r"\b(auth|token|password|jwt|session|crypto)\b", re.IGNORECASE)
 
 # Patterns whose matches are genuine leaked credentials (as opposed to the
 # broader "code smell" patterns like os.system/eval). Full-history scans
@@ -62,6 +60,17 @@ _SYMBOL_KEYWORDS = re.compile(
 # history. This positions history mode as complementary to gitleaks /
 # trufflehog rather than a noisy replacement.
 SECRET_KINDS: frozenset[str] = frozenset({"hardcoded_password", "hardcoded_secret"})
+
+
+def _is_missing_table_error(exc: Exception) -> bool:
+    """True when *exc* is a 'no such table' / 'does not exist' failure.
+
+    ``replace_findings`` runs against a DB that may not yet have migrated the
+    ``security_findings`` table (pre-migration indexing). Those failures are
+    expected and skipped silently; everything else is a real error.
+    """
+    message = str(exc).lower()
+    return "no such table" in message or "does not exist" in message
 
 
 class SecurityScanner:
@@ -169,10 +178,7 @@ class SecurityScanner:
             conflict_suffix = ""
         else:
             insert_prefix = "INSERT INTO security_findings "
-            conflict_suffix = (
-                " ON CONFLICT ON CONSTRAINT uq_security_finding_provenance "
-                "DO NOTHING"
-            )
+            conflict_suffix = " ON CONFLICT ON CONSTRAINT uq_security_finding_provenance DO NOTHING"
 
         inserted = 0
         for finding in findings:
@@ -183,8 +189,7 @@ class SecurityScanner:
                         + "(repository_id, file_path, kind, severity, snippet, line_number, "
                         "commit_sha, commit_at, detected_at) "
                         "VALUES (:repo_id, :file_path, :kind, :severity, :snippet, :line, "
-                        ":commit_sha, :commit_at, :detected_at)"
-                        + conflict_suffix
+                        ":commit_sha, :commit_at, :detected_at)" + conflict_suffix
                     ),
                     {
                         "repo_id": self._repo_id,
@@ -223,6 +228,14 @@ class SecurityScanner:
         ``scan --history`` are left intact. Uses raw SQL to stay independent of
         any ORM session state; silently skips if the table doesn't exist yet
         (pre-migration).
+
+        Re-running must never lose findings: two findings in one batch can
+        share a provenance key (e.g. two keyword symbols on the same line), and
+        a plain bulk INSERT would abort the whole batch at the first collision
+        — after the DELETE above already removed the file's prior rows. Rows
+        are therefore deduplicated in Python and inserted with the same
+        conflict-tolerant clauses as ``persist``, so a duplicate key is a no-op
+        rather than an abort.
         """
         chunk_size = 400  # SQLite parameter-limit headroom, same as the CRUD layer
 
@@ -258,16 +271,51 @@ class SecurityScanner:
                 for file_path, findings in findings_by_file.items()
                 for finding in findings
             ]
-            if rows:
+            # Two findings can collide on the unique provenance key
+            # (repository_id, file_path, kind, line_number, commit_sha) — e.g.
+            # two keyword symbols on the same line. Keeping only the first per
+            # key makes the batch insertable and lossless (the duplicates are
+            # redundant signals, not distinct rows).
+            seen: set[tuple[str, str, int]] = set()
+            deduped: list[dict] = []
+            for row in rows:
+                key = (row["file_path"], row["kind"], row["line"])
+                if key in seen:
+                    continue
+                seen.add(key)
+                deduped.append(row)
+
+            if deduped:
+                uses_sqlite = self._uses_sqlite()
+                insert_prefix = (
+                    "INSERT OR IGNORE INTO security_findings "
+                    if uses_sqlite
+                    else "INSERT INTO security_findings "
+                )
+                conflict_suffix = (
+                    ""
+                    if uses_sqlite
+                    else " ON CONFLICT ON CONSTRAINT uq_security_finding_provenance DO NOTHING"
+                )
                 await self._session.execute(
                     text(
-                        "INSERT INTO security_findings "
-                        "(repository_id, file_path, kind, severity, snippet, line_number, "
+                        insert_prefix
+                        + "(repository_id, file_path, kind, severity, snippet, line_number, "
                         "commit_sha, commit_at, detected_at) "
                         "VALUES (:repo_id, :file_path, :kind, :severity, :snippet, :line, "
-                        ":commit_sha, :commit_at, :detected_at)"
+                        ":commit_sha, :commit_at, :detected_at)" + conflict_suffix
                     ),
-                    rows,
+                    deduped,
                 )
-        except Exception:  # table may not exist pre-migration
-            return
+        except Exception as exc:
+            # Pre-migration, the table does not exist yet — silently skip (the
+            # historical contract for indexing against a not-yet-migrated DB).
+            # Any other failure is a real one and must not be swallowed: a
+            # silently dropped batch is how findings disappear.
+            if _is_missing_table_error(exc):
+                return
+            logger.exception(
+                "security_findings_replace_failed paths=%d rows=%d",
+                len(scanned_paths),
+                len(rows) if "rows" in locals() else 0,
+            )

--- a/tests/unit/analysis/test_security_scan.py
+++ b/tests/unit/analysis/test_security_scan.py
@@ -31,7 +31,10 @@ CLEAN = b"""def add(a, b):
 
 
 def _fake_result(files: dict[str, bytes]):
-    parsed = [SimpleNamespace(file_info=SimpleNamespace(path=p), symbols=[]) for p in files]
+    parsed = [
+        SimpleNamespace(file_info=SimpleNamespace(path=p), symbols=[])
+        for p in files
+    ]
     return SimpleNamespace(parsed_files=parsed, source_map=dict(files))
 
 
@@ -70,7 +73,9 @@ async def _rows(sf) -> list[tuple]:
 class TestScanFile:
     def test_line_patterns_fire_on_real_source(self) -> None:
         scanner = SecurityScanner(session=None, repo_id="r1")  # type: ignore[arg-type]
-        findings = asyncio.run(scanner.scan_file("a.py", SNIPPY.decode(), symbols=[]))
+        findings = asyncio.run(
+            scanner.scan_file("a.py", SNIPPY.decode(), symbols=[])
+        )
         kinds = {f["kind"] for f in findings}
         assert "hardcoded_password" in kinds
         assert "pickle_loads" in kinds
@@ -134,9 +139,13 @@ class TestPersistSecurityFindings:
             from repowise.core.persistence import get_session
 
             async with get_session(sf) as session:
-                await persist_security_findings(_fake_result({"a.py": SNIPPY}), session, "repo-1")
+                await persist_security_findings(
+                    _fake_result({"a.py": SNIPPY}), session, "repo-1"
+                )
             async with get_session(sf) as session:
-                await persist_security_findings(_fake_result({"a.py": CLEAN}), session, "repo-1")
+                await persist_security_findings(
+                    _fake_result({"a.py": CLEAN}), session, "repo-1"
+                )
             rows = await _rows(sf)
             await engine.dispose()
             return rows
@@ -157,7 +166,9 @@ class TestPersistSecurityFindings:
             sym = SimpleNamespace(name="auth", start_line=7)
             result = SimpleNamespace(
                 parsed_files=[
-                    SimpleNamespace(file_info=SimpleNamespace(path="auth.py"), symbols=[sym])
+                    SimpleNamespace(
+                        file_info=SimpleNamespace(path="auth.py"), symbols=[sym]
+                    )
                 ],
             )
             async with get_session(sf) as session:

--- a/tests/unit/analysis/test_security_scan.py
+++ b/tests/unit/analysis/test_security_scan.py
@@ -31,10 +31,7 @@ CLEAN = b"""def add(a, b):
 
 
 def _fake_result(files: dict[str, bytes]):
-    parsed = [
-        SimpleNamespace(file_info=SimpleNamespace(path=p), symbols=[])
-        for p in files
-    ]
+    parsed = [SimpleNamespace(file_info=SimpleNamespace(path=p), symbols=[]) for p in files]
     return SimpleNamespace(parsed_files=parsed, source_map=dict(files))
 
 
@@ -73,9 +70,7 @@ async def _rows(sf) -> list[tuple]:
 class TestScanFile:
     def test_line_patterns_fire_on_real_source(self) -> None:
         scanner = SecurityScanner(session=None, repo_id="r1")  # type: ignore[arg-type]
-        findings = asyncio.run(
-            scanner.scan_file("a.py", SNIPPY.decode(), symbols=[])
-        )
+        findings = asyncio.run(scanner.scan_file("a.py", SNIPPY.decode(), symbols=[]))
         kinds = {f["kind"] for f in findings}
         assert "hardcoded_password" in kinds
         assert "pickle_loads" in kinds
@@ -139,13 +134,9 @@ class TestPersistSecurityFindings:
             from repowise.core.persistence import get_session
 
             async with get_session(sf) as session:
-                await persist_security_findings(
-                    _fake_result({"a.py": SNIPPY}), session, "repo-1"
-                )
+                await persist_security_findings(_fake_result({"a.py": SNIPPY}), session, "repo-1")
             async with get_session(sf) as session:
-                await persist_security_findings(
-                    _fake_result({"a.py": CLEAN}), session, "repo-1"
-                )
+                await persist_security_findings(_fake_result({"a.py": CLEAN}), session, "repo-1")
             rows = await _rows(sf)
             await engine.dispose()
             return rows
@@ -166,9 +157,7 @@ class TestPersistSecurityFindings:
             sym = SimpleNamespace(name="auth", start_line=7)
             result = SimpleNamespace(
                 parsed_files=[
-                    SimpleNamespace(
-                        file_info=SimpleNamespace(path="auth.py"), symbols=[sym]
-                    )
+                    SimpleNamespace(file_info=SimpleNamespace(path="auth.py"), symbols=[sym])
                 ],
             )
             async with get_session(sf) as session:
@@ -179,3 +168,64 @@ class TestPersistSecurityFindings:
 
         rows = asyncio.run(_run())
         assert ("auth.py", "security_sensitive_symbol", 7) in rows
+
+    def test_replace_findings_duplicate_key_does_not_lose_rows(self, tmp_path: Path) -> None:
+        """Two findings sharing a provenance key must not abort the batch and
+        drop the file's other rows (regression for the bulk-INSERT abort that
+        swallowed IntegrityError and silently truncated the insert)."""
+        from repowise.core.analysis.security_scan import SecurityScanner
+        from repowise.core.persistence import get_session
+
+        async def _run():
+            engine, sf = await _fresh_session_factory(tmp_path)
+            async with get_session(sf) as session:
+                scanner = SecurityScanner(session, "repo-1")
+                await scanner.replace_findings(
+                    {
+                        "a.py": [
+                            {"kind": "hardcoded_password", "severity": "high", "line": 1},
+                            {"kind": "security_sensitive_symbol", "severity": "low", "line": 7},
+                            {"kind": "security_sensitive_symbol", "severity": "low", "line": 7},
+                        ],
+                    },
+                    ["a.py"],
+                )
+            rows = await _rows(sf)
+            await engine.dispose()
+            return rows
+
+        rows = asyncio.run(_run())
+        assert sorted(rows) == [
+            ("a.py", "hardcoded_password", 1),
+            ("a.py", "security_sensitive_symbol", 7),
+        ]
+
+    def test_replace_findings_rescan_keeps_prior_and_new_rows(self, tmp_path: Path) -> None:
+        """Re-running replace_findings over the same file must yield the same
+        full row set — duplicates on the provenance key are no-ops, never a
+        partial insert."""
+        from repowise.core.analysis.security_scan import SecurityScanner
+        from repowise.core.persistence import get_session
+
+        async def _run():
+            engine, sf = await _fresh_session_factory(tmp_path)
+            findings = {
+                "a.py": [
+                    {"kind": "hardcoded_password", "severity": "high", "line": 1},
+                    {"kind": "security_sensitive_symbol", "severity": "low", "line": 7},
+                    {"kind": "security_sensitive_symbol", "severity": "low", "line": 7},
+                ],
+            }
+            for _ in range(2):
+                async with get_session(sf) as session:
+                    scanner = SecurityScanner(session, "repo-1")
+                    await scanner.replace_findings(findings, ["a.py"])
+            rows = await _rows(sf)
+            await engine.dispose()
+            return rows
+
+        rows = asyncio.run(_run())
+        assert sorted(rows) == [
+            ("a.py", "hardcoded_password", 1),
+            ("a.py", "security_sensitive_symbol", 7),
+        ]


### PR DESCRIPTION
Fixes #1483

## Problem

`replace_findings` is a delete-then-bulk-insert with no conflict clause on the bulk INSERT and a blanket `except Exception: return` around the whole method. When two findings in one batch collide on the unique provenance key `(repository_id, file_path, kind, line_number, commit_sha)` (e.g. two `security_sensitive_symbol` findings on the same line, or symbols without `start_line` collapsing to line 0), the INSERT raises `IntegrityError`, which is swallowed, and the batch inserts only up to the offending row. Because the DELETE already ran, the file loses both its previously stored findings and most of the new ones — silently.

## Fix

- Deduplicate rows in Python by provenance key before the INSERT (duplicates are redundant signals, not distinct rows).
- Use the same conflict-tolerant clauses as the sibling `persist()`: `INSERT OR IGNORE` on SQLite, `ON CONFLICT ... DO NOTHING` on Postgres.
- Narrow the blanket `except Exception: return`: pre-migration `no such table` failures still skip silently (the historical contract); any other failure is now logged via `logger.exception` instead of dropping the batch.

## Tests

Added two cases to `test_security_scan.py`:
- duplicate-key batch inserts exactly one row per provenance key (no partial insert),
- re-running replace_findings over the same file yields the identical full row set.

All 8 scanner tests + 10 history tests pass.