### PR TITLE
fix(update-lock): never report 'acquired' with no lock file on disk

### DIFF
--- a/packages/core/src/repowise/core/update_lock.py
+++ b/packages/core/src/repowise/core/update_lock.py
@@ -97,9 +97,24 @@ def try_acquire_update_lock(repo_path: Path, target_commit: str | None) -> dict[
             with contextlib.suppress(OSError):
                 tmp_path.unlink(missing_ok=True)
         return None
-    # Lost the create race twice in a row: someone else just acquired a
-    # fresh lock — report it. A still-unreadable lock degrades to acquired.
-    return read_update_lock(repo_path)
+    # Both create attempts lost a race against a stale lock that was then
+    # unlinked. Rather than falling through to a bare ``read_update_lock``
+    # — which can return ``None`` ("acquired") with *no lock file on disk*,
+    # letting a caller proceed without holding the lock — make one final
+    # exclusive create. Winner: return ``None`` (owned). Loser: report the
+    # fresh winner. Still-unreadable degrades to acquired, as everywhere.
+    try:
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        tmp_path.write_text(data, encoding="utf-8")
+        os.link(tmp_path, lock_path)
+    except FileExistsError:
+        return read_update_lock(repo_path)
+    except OSError:
+        return None
+    finally:
+        with contextlib.suppress(OSError):
+            tmp_path.unlink(missing_ok=True)
+    return None
 
 
 def release_update_lock(repo_path: Path) -> None:

--- a/tests/unit/cli/test_update_lock.py
+++ b/tests/unit/cli/test_update_lock.py
@@ -85,6 +85,44 @@ def test_acquire_replaces_stale_lock(tmp_path: Path) -> None:
     assert payload["pid"] == os.getpid()
 
 
+def test_loop_exhaustion_never_returns_acquired_without_a_lock_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Regression: after two lost create-races against a stale lock, the
+    caller must not be handed ``None`` ("acquired") with no lock file on disk.
+
+    Both initial ``os.link`` calls raise ``FileExistsError`` against a stale
+    lock, exactly the interleaving that used to fall through to a bare
+    ``read_update_lock`` and return ``None`` with nothing on disk — letting a
+    concurrent update race on the same index. The function must make one final
+    exclusive create so ``None`` always implies the caller owns a lock.
+    """
+    _write_lock(
+        tmp_path,
+        {"pid": _dead_pid(), "target_commit": "crashed", "started_at": time.time()},
+    )
+
+    real_link = os.link
+    link_calls = 0
+
+    def _failing_link(src: str | os.PathLike, dst: str | os.PathLike) -> None:
+        nonlocal link_calls
+        link_calls += 1
+        if link_calls <= 2:
+            raise FileExistsError(f"[Errno 17] File exists: '{dst}'")
+        real_link(src, dst)
+
+    monkeypatch.setattr(os, "link", _failing_link)
+
+    assert helpers.try_acquire_update_lock(tmp_path, "fresh") is None
+    assert (tmp_path / ".repowise" / ".update.lock").exists()
+    payload = helpers.read_update_lock(tmp_path)
+    assert payload is not None
+    assert payload["target_commit"] == "fresh"
+    assert payload["pid"] == os.getpid()
+    assert link_calls == 3
+
+
 def test_release_then_reacquire(tmp_path: Path) -> None:
     assert helpers.try_acquire_update_lock(tmp_path, "one") is None
     helpers.release_update_lock(tmp_path)


### PR DESCRIPTION
Fixes #1503

## Problem

`try_acquire_update_lock` retries the exclusive `os.link` twice. If both attempts hit `FileExistsError` and the existing lock reads as stale each time, the stale lock is unlinked and the loop falls through to `return read_update_lock(repo_path)`. If no other process re-creates the lock in that window, this returns `None` — which every caller treats as **"lock acquired"** — while **no lock file exists on disk**. A concurrent update then also "acquires", and two updates race on one index (the exact interleaving the lock exists to serialize).

## Fix

After both retries lose against a stale lock, make one final exclusive create:
- winner returns `None` (owned, lock file on disk),
- loser reports the fresh winner's payload,
- still-unreadable degrades to acquired, as everywhere.

`None` now always implies the caller owns a lock file.

## Tests

Added `test_loop_exhaustion_never_returns_acquired_without_a_lock_file`: forces the first two `os.link` calls to raise `FileExistsError` against a stale lock, then asserts the acquire returns `None` *and* a lock file with our PID exists on disk. All 20 lock tests pass.