### PR TITLE
fix(init): make --test-run actually limit generation to top 10 files

### DIFF
--- a/packages/cli/src/repowise/cli/commands/init_cmd/command.py
+++ b/packages/cli/src/repowise/cli/commands/init_cmd/command.py
@@ -263,6 +263,7 @@ def _run_generation_phase(
     skip_infra: bool,
     embedder_name_resolved: str,
     resume: bool,
+    test_run: bool,
 ) -> tuple[bool, bool]:
     """Run the LLM generation phase for a single-repo init.
 
@@ -391,6 +392,7 @@ def _run_generation_phase(
         embedder_name_resolved=embedder_name_resolved,
         resume=resume,
         verbose=True,
+        test_run=test_run,
     )
     return False, False
 
@@ -1396,6 +1398,7 @@ def init_command(
             # file. Resuming against it would skip the entire model run and
             # say nothing, so a template wiki is never a run to continue.
             resume=resume and _prior_docs_mode != "deterministic",
+            test_run=test_run,
         )
         if gen_stop:
             return

--- a/packages/cli/src/repowise/cli/commands/init_cmd/generation.py
+++ b/packages/cli/src/repowise/cli/commands/init_cmd/generation.py
@@ -251,6 +251,7 @@ def run_repo_generation(
     embedder_name_resolved: str,
     resume: bool,
     verbose: bool,
+    test_run: bool = False,
 ) -> list[Any]:
     """Generate wiki pages for one repo and enrich its knowledge graph.
 
@@ -350,6 +351,7 @@ def run_repo_generation(
                     if getattr(result, "knowledge_graph_result", None) is not None
                     else None
                 ),
+                test_run=test_run,
             )
         )
 

--- a/packages/cli/src/repowise/cli/commands/init_cmd/workspace.py
+++ b/packages/cli/src/repowise/cli/commands/init_cmd/workspace.py
@@ -163,6 +163,7 @@ def _run_workspace_generation(
         embedder_name_resolved=embedder_name_resolved,
         resume=resume,
         verbose=False,
+        test_run=test_run,
     )
 
 

--- a/packages/core/src/repowise/core/pipeline/orchestrator.py
+++ b/packages/core/src/repowise/core/pipeline/orchestrator.py
@@ -32,7 +32,7 @@ from repowise.core.pipeline.progress import (
 )
 from repowise.core.registry import HookProgressCallback
 
-from .phases._common import _phase_done
+from .phases._common import TEST_RUN_FILE_LIMIT, _phase_done, limit_to_top_pagerank
 from .phases.analysis import (
     _run_dead_code_analysis,
     _run_decision_extraction,
@@ -440,19 +440,12 @@ async def run_pipeline(
                 f"→ Git: {git_summary.files_indexed:,} files indexed{_hotspot_msg}",
             )
 
-    # Test-run: limit to top 10 files by PageRank
+    # Test-run: limit to top 10 files by PageRank (shared helper with
+    # ``run_generation`` so the two paths cannot drift).
     if test_run and generate_docs:
-        try:
-            import networkx as nx
-
-            ranks = nx.pagerank(graph_builder.graph())
-        except Exception:
-            ranks = {}
-        parsed_files = sorted(
-            parsed_files,
-            key=lambda pf: ranks.get(pf.file_info.path, 0),
-            reverse=True,
-        )[:10]
+        parsed_files = limit_to_top_pagerank(
+            parsed_files, graph_builder, n=TEST_RUN_FILE_LIMIT
+        )
         if progress:
             progress.on_message("warning", f"Test run: limiting to {len(parsed_files)} files")
 

--- a/packages/core/src/repowise/core/pipeline/phases/_common.py
+++ b/packages/core/src/repowise/core/pipeline/phases/_common.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import contextlib
+from typing import Any
 
 from repowise.core.pipeline.progress import ProgressCallback
 
@@ -17,3 +18,31 @@ def _phase_done(progress: ProgressCallback | None, phase: str) -> None:
     if callable(fn):
         with contextlib.suppress(Exception):
             fn(phase)
+
+
+def limit_to_top_pagerank(
+    parsed_files: list[Any],
+    graph_builder: Any,
+    n: int = 10,
+) -> list[Any]:
+    """Return the *n* highest-PageRank files from *parsed_files*.
+
+    Shared by the orchestrator's in-pipeline generation path and
+    ``run_generation`` (init's separate generation phase), so ``--test-run``
+    cannot drift between two copies of the same truncation.
+    """
+    try:
+        import networkx as nx
+
+        ranks = nx.pagerank(graph_builder.graph())
+    except Exception:
+        ranks = {}
+    return sorted(
+        parsed_files,
+        key=lambda pf: ranks.get(pf.file_info.path, 0),
+        reverse=True,
+    )[:n]
+
+
+#: Default ``--test-run`` file cap (highest-PageRank files).
+TEST_RUN_FILE_LIMIT = 10

--- a/packages/core/src/repowise/core/pipeline/phases/generation.py
+++ b/packages/core/src/repowise/core/pipeline/phases/generation.py
@@ -45,6 +45,7 @@ async def run_generation(
     kg_data: dict | None = None,
     only_page_ids: set[str] | None = None,
     preserved_page_ids: set[str] | None = None,
+    test_run: bool = False,
 ) -> list[Any]:
     """Run LLM-powered page generation.
 
@@ -61,6 +62,10 @@ async def run_generation(
     ``preserved_page_ids`` is an out-parameter filled by a ``resume`` run with
     the ids it skipped because a prior run already wrote them. Persistence
     needs it to keep those pages out of the stale sweep.
+
+    ``test_run`` limits generation to the top 10 files by PageRank, so a quick
+    validation run can exercise the whole generation path without paying for a
+    full index's worth of pages.
     """
     from repowise.core.generation import (
         ContextAssembler,
@@ -82,6 +87,26 @@ async def run_generation(
     base_config = generation_config if generation_config is not None else GenerationConfig()
     config = replace(base_config, max_concurrency=concurrency)
     assembler = ContextAssembler(config)
+
+    # Test-run: limit to top 10 files by PageRank for a fast validation run.
+    # Applied here rather than in the orchestrator so it works whether the
+    # pipeline ran with generate_docs=True or generation happened in a later,
+    # separate phase (init's generate_docs=False flow) — the flag's documented
+    # purpose is to cap the *generation* work, and this is where that happens.
+    if test_run:
+        try:
+            import networkx as nx
+
+            ranks = nx.pagerank(graph_builder.graph())
+        except Exception:
+            ranks = {}
+        parsed_files = sorted(
+            parsed_files,
+            key=lambda pf: ranks.get(pf.file_info.path, 0),
+            reverse=True,
+        )[:10]
+        if progress:
+            progress.on_message("warning", f"Test run: limiting to {len(parsed_files)} files")
 
     # Resolve embedder and vector store
     embedder_impl = embedder if embedder is not None else KeylessEmbedder()

--- a/packages/core/src/repowise/core/pipeline/phases/generation.py
+++ b/packages/core/src/repowise/core/pipeline/phases/generation.py
@@ -15,7 +15,7 @@ import structlog
 from repowise.core.generation.models import count_stub_fallbacks
 from repowise.core.pipeline.progress import ProgressCallback
 
-from ._common import _phase_done
+from ._common import TEST_RUN_FILE_LIMIT, _phase_done, limit_to_top_pagerank
 
 logger = structlog.get_logger(__name__)
 
@@ -89,22 +89,14 @@ async def run_generation(
     assembler = ContextAssembler(config)
 
     # Test-run: limit to top 10 files by PageRank for a fast validation run.
-    # Applied here rather than in the orchestrator so it works whether the
+    # Applied here rather than only in the orchestrator so it works whether the
     # pipeline ran with generate_docs=True or generation happened in a later,
     # separate phase (init's generate_docs=False flow) — the flag's documented
     # purpose is to cap the *generation* work, and this is where that happens.
     if test_run:
-        try:
-            import networkx as nx
-
-            ranks = nx.pagerank(graph_builder.graph())
-        except Exception:
-            ranks = {}
-        parsed_files = sorted(
-            parsed_files,
-            key=lambda pf: ranks.get(pf.file_info.path, 0),
-            reverse=True,
-        )[:10]
+        parsed_files = limit_to_top_pagerank(
+            parsed_files, graph_builder, n=TEST_RUN_FILE_LIMIT
+        )
         if progress:
             progress.on_message("warning", f"Test run: limiting to {len(parsed_files)} files")
 

--- a/tests/unit/pipeline/test_run_generation_test_run.py
+++ b/tests/unit/pipeline/test_run_generation_test_run.py
@@ -1,0 +1,104 @@
+"""``run_generation`` honours ``test_run`` by limiting the file set.
+
+Regression anchor for #1505: ``--test-run`` was forwarded end-to-end but never
+consumed, because the orchestrator's truncation branch was gated on
+``test_run and generate_docs`` and init always runs the pipeline with
+``generate_docs=False``, delegating generation to a later phase. The top-10
+PageRank cap belongs in the generation entry itself, so it works regardless of
+how the pipeline got there.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from repowise.core.pipeline.phases.generation import run_generation
+
+
+class _StubGenerator:
+    """Records the parsed_files it was asked to generate, then returns pages."""
+
+    def __init__(self) -> None:
+        self.parsed_files: list | None = None
+
+    async def generate_all(self, parsed_files, *args, **kwargs) -> list:
+        self.parsed_files = list(parsed_files)
+        return []
+
+
+@pytest.fixture(autouse=True)
+def _stub_generator(monkeypatch: pytest.MonkeyPatch) -> _StubGenerator:
+    stub = _StubGenerator()
+    monkeypatch.setattr(
+        "repowise.core.generation.PageGenerator",
+        lambda *a, **k: stub,
+    )
+    return stub
+
+
+def _parsed_files(n: int) -> list:
+    files = []
+    for i in range(n):
+        files.append(SimpleNamespace(file_info=SimpleNamespace(path=f"pkg/mod_{i}.py")))
+    return files
+
+
+def _graph_builder_for(paths: list[str]):
+    """A bare GraphBuilder whose graph has a node per file (pagerank on a
+    graph with no edges is uniform, so ranking never drops any file before
+    the cap)."""
+    import networkx as nx
+
+    from repowise.core.ingestion.graph import builder as _builder_mod
+
+    g = nx.DiGraph()
+    for p in paths:
+        g.add_node(p)
+    b = object.__new__(_builder_mod.GraphBuilder)
+    b._graph = g
+    return b
+
+
+async def test_test_run_limits_generation_to_top_10_files(
+    _stub_generator: _StubGenerator, tmp_path: pytest.TempPathFactory
+) -> None:
+    paths = [f"pkg/mod_{i}.py" for i in range(15)]
+    await run_generation(
+        repo_path=tmp_path,
+        parsed_files=_parsed_files(15),
+        source_map={},
+        graph_builder=_graph_builder_for(paths),
+        repo_structure=SimpleNamespace(),
+        git_meta_map={},
+        llm_client=SimpleNamespace(),
+        embedder=None,
+        vector_store=None,
+        concurrency=1,
+        progress=None,
+        test_run=True,
+    )
+    assert _stub_generator.parsed_files is not None
+    assert len(_stub_generator.parsed_files) == 10
+
+
+async def test_no_test_run_generates_every_file(
+    _stub_generator: _StubGenerator, tmp_path: pytest.TempPathFactory
+) -> None:
+    paths = [f"pkg/mod_{i}.py" for i in range(15)]
+    await run_generation(
+        repo_path=tmp_path,
+        parsed_files=_parsed_files(15),
+        source_map={},
+        graph_builder=_graph_builder_for(paths),
+        repo_structure=SimpleNamespace(),
+        git_meta_map={},
+        llm_client=SimpleNamespace(),
+        embedder=None,
+        vector_store=None,
+        concurrency=1,
+        progress=None,
+    )
+    assert _stub_generator.parsed_files is not None
+    assert len(_stub_generator.parsed_files) == 15


### PR DESCRIPTION
Fixes #1505

## Problem

`--test-run` is documented as "Limit generation to top 10 files by PageRank for quick validation" but was a silent no-op. The only consumer was gated on `test_run and generate_docs` in the orchestrator (`orchestrator.py:444`), and init always runs the pipeline with `generate_docs=False` (generation happens in a separate phase afterwards). The flag was forwarded end-to-end and never consumed; a user selecting "test run" got a full generation.

## Fix

Move the top-10 PageRank cap into `run_generation` itself — the single entry both init paths converge on:
- `run_generation` gains a `test_run` parameter and truncates `parsed_files` to the top 10 by PageRank before generating.
- Threaded through `run_repo_generation` (single-repo `_run_generation_phase` and workspace `_run_workspace_generation`).
- The deterministic template renderers keep `test_run=False` — they're free and fast, so the cap only matters on the paid LLM path.

## Tests

New `tests/unit/pipeline/test_run_generation_test_run.py` stubs `PageGenerator` and asserts `test_run=True` hands it exactly 10 files (from 15), and the default passes all 15. All related init/generation tests pass (67).