### PR TITLE
fix: generate no longer clobbers last_sync_commit with None

### DIFF
--- a/packages/cli/src/repowise/cli/commands/generate_cmd/command.py
+++ b/packages/cli/src/repowise/cli/commands/generate_cmd/command.py
@@ -356,7 +356,13 @@ def _write_state(repo_path: Path, state: dict, provider: Any, outcome: Any) -> N
     upgrade leaves a mixed wiki, so it keeps its current mode rather than
     over-claiming that everything is written.
     """
-    state["last_sync_commit"] = get_head_commit(repo_path)
+    # Only stamp the base commit when git actually resolves HEAD. get_head_commit
+    # returns None on any git failure; unconditionally overwriting last_sync_commit
+    # with None would clobber the previously recorded base, so the next `update`
+    # treats the repo as never-indexed and hard-fails (update_cmd base_ref None).
+    head = get_head_commit(repo_path)
+    if head is not None:
+        state["last_sync_commit"] = head
     state["total_pages"] = outcome.total_pages
     state["provider"] = provider.provider_name
     state["model"] = provider.model_name

--- a/tests/unit/cli/test_generate_state_keep_last_sync_commit.py
+++ b/tests/unit/cli/test_generate_state_keep_last_sync_commit.py
@@ -1,0 +1,61 @@
+"""``generate`` must not clobber ``last_sync_commit`` with ``None``.
+
+Regression anchor for #1507: ``_write_state`` unconditionally set
+``state["last_sync_commit"] = get_head_commit(repo_path)``. ``get_head_commit``
+returns ``None`` on any git failure, which wiped the previously recorded base
+commit; the next ``repowise update`` then saw ``last_sync_commit`` as ``None``
+and hard-failed as if the repo had never been indexed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from repowise.cli.commands.generate_cmd import command as gen_mod
+from repowise.cli.commands.generate_cmd.command import _write_state
+
+
+def _outcome() -> SimpleNamespace:
+    return SimpleNamespace(total_pages=5, remaining_template_pages=0)
+
+
+def _provider() -> SimpleNamespace:
+    return SimpleNamespace(provider_name="openai", model_name="gpt-4o")
+
+
+def _state(**overrides: object) -> dict:
+    state: dict = {
+        "last_sync_commit": "original-sha",
+        "total_pages": 1,
+        "docs_mode": "llm",
+        "provider": "openai",
+        "model": "gpt-4o",
+    }
+    state.update(overrides)
+    return state
+
+
+def test_git_failure_preserves_existing_last_sync_commit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    state = _state()
+    monkeypatch.setattr(gen_mod, "get_head_commit", lambda _p: None)
+
+    _write_state(tmp_path, state, _provider(), _outcome())
+
+    assert state["last_sync_commit"] == "original-sha"
+    assert state["total_pages"] == 5
+
+
+def test_git_success_stamps_new_last_sync_commit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    state = _state()
+    monkeypatch.setattr(gen_mod, "get_head_commit", lambda _p: "new-sha")
+
+    _write_state(tmp_path, state, _provider(), _outcome())
+
+    assert state["last_sync_commit"] == "new-sha"


### PR DESCRIPTION
## Summary

`repowise generate` clobbered the persisted base commit. `_write_state` unconditionally set `state["last_sync_commit"] = get_head_commit(repo_path)`, and `get_head_commit` returns `None` on any git failure (workspace/update.py). When HEAD resolution failed, the previously recorded base was overwritten with `None`.

The next `repowise update` reads `last_sync_commit` (directly or as the fallback for `last_docs_commit`) as its `base_ref`; a `None` there triggers the hard failure at update_cmd/command.py:714 that reports the repo as never indexed — even though it was fully indexed and generated before.

## Fix

In `_write_state`, only stamp `last_sync_commit` when git actually resolves HEAD; otherwise preserve the existing value.

## Tests

- New `tests/unit/cli/test_generate_state_keep_last_sync_commit.py`:
  - git failure → `last_sync_commit` keeps its prior value (and `total_pages` still updates);
  - git success → new SHA is stamped.
- Related generate/update suites still pass (40 tests).

Closes #1507
