### PR TITLE
refactor(entry-points): give the execution-start candidacy rule one owner

### DIFF
--- a/packages/core/src/repowise/core/analysis/kg_curation.py
+++ b/packages/core/src/repowise/core/analysis/kg_curation.py
@@ -36,7 +36,7 @@ from repowise.core.generation.entry_points import (
     CONVENTIONAL_ENTRY_STEMS as _CONVENTIONAL_ENTRY_STEMS,
 )
 from repowise.core.generation.entry_points import (
-    is_glue_leaf,
+    not_an_execution_start,
     rank_entry_points,
 )
 from repowise.core.generation.layers import (
@@ -66,12 +66,6 @@ _FIXTURE_CAMEL_RES = _LANG_REGISTRY.camel_fixture_res_by_extension()
 # Test-project dir suffixes (.Tests/.Specs) — when present, the suite's
 # face must come from inside one.
 _TEST_PROJECT_DIR_SUFFIXES: tuple[str, ...] = _LANG_REGISTRY.test_dir_suffixes()
-# Config/markup/data + infra languages — a server.json or a Dockerfile
-# describes or wires the system, it is never where execution starts, so it
-# never belongs on the orientation entry-point list.
-_NON_CODE_ENTRY_LANGUAGES: frozenset[str] = (
-    _LANG_REGISTRY.config_languages() | _LANG_REGISTRY.infra_languages()
-)
 
 # Honest-degradation thresholds. Density = (imports + tested_by)
 # edges per dominant-language file — the same definition the validation
@@ -873,13 +867,6 @@ def _curate_entry_points(
     except Exception:  # pragma: no cover - defensive
         betweenness = {}
 
-    def _not_an_execution_start(path: str, language: str) -> bool:
-        # Config/data files (server.json) describe the system and deep
-        # generic-glue leaves (a resolver's index.py) dispatch within it —
-        # neither is where a reader enters. Barrel demotion is handled
-        # separately (it mutates tags), so this covers only candidacy.
-        return language in _NON_CODE_ENTRY_LANGUAGES or is_glue_leaf(path)
-
     candidates: list[tuple[str, float, float]] = []
     for node in kg.nodes:
         nid = node.get("id", "")
@@ -902,7 +889,7 @@ def _curate_entry_points(
                 new_tags.append("barrel")
             node["tags"] = new_tags
             continue
-        if _not_an_execution_start(path, language):
+        if not_an_execution_start(path, language):
             continue
         candidates.append((path, pagerank.get(path, 0.0), betweenness.get(path, 0.0)))
 
@@ -919,7 +906,7 @@ def _curate_entry_points(
             pf = pf_by_path.get(path)
             if pf is not None and _is_barrel(pf):
                 continue
-            if _not_an_execution_start(path, language):
+            if not_an_execution_start(path, language):
                 continue
             candidates.append((path, pagerank.get(path, 0.0), betweenness.get(path, 0.0)))
 

--- a/packages/core/src/repowise/core/generation/entry_points.py
+++ b/packages/core/src/repowise/core/generation/entry_points.py
@@ -42,6 +42,13 @@ SHALLOW_ENTRY_DEPTH = 1
 # no DB / graph / LLM dependency.
 CONVENTIONAL_ENTRY_STEMS: frozenset[str] = _LANG_REGISTRY.entry_filename_stems() - GLUE_STEMS
 
+# Config/markup/data + infra languages — a server.json or a Dockerfile describes
+# or wires the system, it is never where execution starts, so it never belongs
+# on the orientation entry-point list.
+NON_CODE_ENTRY_LANGUAGES: frozenset[str] = (
+    _LANG_REGISTRY.config_languages() | _LANG_REGISTRY.infra_languages()
+)
+
 
 def entry_point_depth(path: str) -> int:
     """Directory depth — 0 for a root file, 1 for one level deep, etc."""
@@ -59,6 +66,24 @@ def is_glue_leaf(path: str) -> bool:
         PurePosixPath(path).stem.lower() in GLUE_STEMS
         and entry_point_depth(path) > SHALLOW_ENTRY_DEPTH
     )
+
+
+def not_an_execution_start(path: str, language: str) -> bool:
+    """True for a file that cannot be where a reader enters the system.
+
+    Config/data files (``server.json``) describe the system and deep
+    generic-glue leaves (a resolver's ``index.py``) dispatch within it —
+    neither is an execution start.
+
+    **Not the whole candidacy rule.** Callers apply their own further
+    exclusions beside this one: the knowledge-graph curator drops adjacent
+    layers, support paths and re-export barrels itself, and
+    :func:`~repowise.core.generation.tour.score_entry_points` withholds its
+    entry bonuses over a *wider* language set (it adds unnormalized aliases
+    from older indexes). This owns only the two conditions above, so that
+    the curator and the wiki surfaces answer them the same way.
+    """
+    return language in NON_CODE_ENTRY_LANGUAGES or is_glue_leaf(path)
 
 
 def _name_bucket(path: str, conventional_stems: frozenset[str]) -> int:
@@ -144,7 +169,7 @@ def orientation_entry_points(repo_structure: Any, *, limit: int | None = None) -
     candidacy is the larger defect. ``repo_structure.entry_points`` carries
     ``.github/workflows/main.yml``, ``README.md`` and test files, so some
     repos lead with one whatever the order. The knowledge-graph curator drops
-    those (``kg_curation._not_an_execution_start``) and the wiki surfaces do
+    those (:func:`not_an_execution_start`) and the wiki surfaces do
     not; sharing that rule is the follow-up. Same for the heuristic's own
     false positives: ``app`` is a generic entry stem, so a React
     ``src/components/App.tsx`` is published as an execution entry point, as is

--- a/tests/unit/generation/test_entry_points.py
+++ b/tests/unit/generation/test_entry_points.py
@@ -7,6 +7,7 @@ from repowise.core.generation.entry_points import (
     entry_point_depth,
     entry_point_rank_key,
     is_glue_leaf,
+    not_an_execution_start,
     rank_entry_points,
 )
 
@@ -33,6 +34,33 @@ def test_is_glue_leaf_only_for_deep_generic_stems():
     assert not is_glue_leaf("src/index.ts")
     # Non-generic stems are never glue leaves, however deep.
     assert not is_glue_leaf("a/b/c/d/main.py")
+
+
+def test_not_an_execution_start_is_language_or_glue_leaf():
+    # Config/data and infra languages describe or wire the system.
+    assert not_an_execution_start("api/server.json", "json")
+    assert not_an_execution_start("deploy/Dockerfile", "dockerfile")
+    # Deep generic-glue leaves dispatch within it.
+    assert not_an_execution_start("core/ingestion/resolvers/dotnet/index.py", "python")
+    # A real code entry is neither, at any depth.
+    assert not not_an_execution_start("src/main.py", "python")
+    assert not not_an_execution_start("a/b/c/d/main.py", "python")
+    # Only a *shallow* glue stem survives candidacy. A monorepo package barrel
+    # is dropped here even though ``orientation_entry_points`` keeps it by
+    # ranking it last — candidacy and ordering answer different questions.
+    assert not not_an_execution_start("src/index.ts", "typescript")
+    assert not_an_execution_start("packages/cli/src/index.ts", "typescript")
+
+
+def test_the_curator_calls_the_shared_rule_not_a_copy():
+    # The curator's output is unchanged *by construction* only while it holds
+    # this exact object; a re-inlined copy reopens the divergence the lift
+    # closed. Scope, honestly: this pins the module binding, not the two call
+    # sites. A copy that left the import in place still passes here — ruff's
+    # unused-import rule is what catches that half.
+    from repowise.core.analysis import kg_curation
+
+    assert kg_curation.not_an_execution_start is not_an_execution_start
 
 
 def test_glue_leaf_never_outranks_a_real_entry():


### PR DESCRIPTION
`_not_an_execution_start` lived as a closure inside `_curate_entry_points`,
so the knowledge-graph curator privately owned a rule the wiki surfaces also
need. It moves to module scope in `generation/entry_points.py`, next to the
ranking that already shares its vocabulary, and the curator imports it.

`_NON_CODE_ENTRY_LANGUAGES` moves with it. The curator was its only reader,
so leaving it behind would have split the rule across two modules rather
than consolidating it.

## No behaviour change

The same rule runs at the same two call sites on the same input, so the
curated entry-point list is identical by construction:

- both call sites keep their arguments and their nesting;
- the language registry is a static spec list, so the registry-derived sets
  are time-invariant and do not depend on when the module is imported;
- `kg_curation` already imported `generation/entry_points`, so there is no
  new import cycle and no new evaluation window.

`test_the_curator_calls_the_shared_rule_not_a_copy` pins the binding, since
that identity is what the "by construction" claim rests on. Its docstring
records what it does *not* cover: a re-inlined copy that left the import in
place would still pass it, and ruff's unused-import rule is what catches
that half.

## The name overclaims, so the docstring corrects it

This is only part of candidacy at its call site, and reading the name alone
would suggest otherwise. The curator applies its adjacent-layer,
support-path and re-export-barrel exclusions itself, and
`tour.score_entry_points` withholds its entry bonuses over a *wider*
language set — it adds unnormalized aliases (`md`, `yml`, `txt`, ...) that
older indexes can still carry. The docstring names both so the next reader
does not assume this function is the whole rule.

## Verification

- `tests/unit`: 12,543 passed, 4 skipped, 0 failed
- `tests/integration`: the generation, ingestion and deterministic-generation
  files, 72 passed
- `ruff check .` clean; mypy unchanged against the base commit
- Performance is unchanged by construction: same rule, same call sites, same
  per-node work. The only difference is a module-level function instead of a
  closure rebuilt on each `_curate_entry_points` call.
