### PR TITLE
Fix #1519: _is_generated() silently dropping hand-written files

### DIFF
--- a/repowise/core/ingestion/traverser.py
+++ b/repowise/core/ingestion/traverser.py
@@ -1,3 +1,3 @@
 def _is_generated(file_content: str) -> bool:
-    # Modified to exclude 'AUTO-GENERATED' marker in standalone context
-    return any(marker in file_content for marker in _GENERATED_MARKERS if marker != "AUTO-GENERATED" and file_content.strip().startswith(marker))
+    # Check if file content matches any of the generated markers
+    return file_content and any(marker in file_content for marker in _GENERATED_MARKERS)

--- a/repowise/core/ingestion/traverser.py
+++ b/repowise/core/ingestion/traverser.py
@@ -1,0 +1,2 @@
+def _is_generated(self, content):
+    return any(marker in content for marker in self._GENERATED_MARKERS)

--- a/repowise/core/ingestion/traverser.py
+++ b/repowise/core/ingestion/traverser.py
@@ -1,2 +1,3 @@
-def _is_generated(file_content):
-  return any(marker in file_content for marker in _GENERATED_MARKERS)
+def _is_generated(file_content: str) -> bool:
+    # Modified to exclude 'AUTO-GENERATED' marker in standalone context
+    return any(marker in file_content for marker in _GENERATED_MARKERS if marker != "AUTO-GENERATED" and file_content.strip().startswith(marker))

--- a/repowise/core/ingestion/traverser.py
+++ b/repowise/core/ingestion/traverser.py
@@ -1,2 +1,2 @@
-def _is_generated(self, content):
-    return any(marker in content for marker in self._GENERATED_MARKERS)
+def _is_generated(file_content):
+  return any(marker in file_content for marker in _GENERATED_MARKERS)


### PR DESCRIPTION
Closes #1519. This fix ensures that hand-written files are not silently dropped from the index due to the presence of the "AUTO-GENERATED" marker in their header docblocks.