### PR TITLE
Add declined finding lifecycle

### DIFF
--- a/src/findings/disposition.ts
+++ b/src/findings/disposition.ts
@@ -1,0 +1,34 @@
+export type FindingDisposition = "open" | "accepted" | "declined";
+
+export interface Finding {
+  id: string;
+  fingerprint: string;
+  disposition: FindingDisposition;
+  [key: string]: unknown;
+}
+
+const terminalDispositions = new Set<FindingDisposition>(["accepted", "declined"]);
+
+/** Preserve a reviewer's decision when an analysis re-discovers a finding. */
+export function reconcileFinding(existing: Finding | undefined, discovered: Finding): Finding {
+  if (!existing) return discovered;
+
+  if (existing.disposition === "declined" && discovered.disposition === "open") {
+    return { ...existing, disposition: existing.disposition };
+  }
+
+  return {
+    ...discovered,
+    id: existing.id,
+    disposition: terminalDispositions.has(existing.disposition)
+      ? existing.disposition
+      : discovered.disposition,
+  };
+}
+
+export function setDisposition(
+  finding: Finding,
+  disposition: FindingDisposition,
+): Finding {
+  return { ...finding, disposition };
+}

--- a/src/main/java/com/repowise/analysis/Disposition.java
+++ b/src/main/java/com/repowise/analysis/Disposition.java
@@ -1,0 +1,11 @@
+public enum Disposition { OPEN, DECLINED, ACCEPTED }
+
+public class DispositionManager { 
+	private Disposition currentDisposition;
+	public void updateDisposition(Disposition newDisposition) {
+		currentDisposition = newDisposition;
+	}
+	public Disposition getDisposition() {
+		return currentDisposition;
+	}
+}

--- a/src/main/java/com/repowise/dev/repowise/model/Issue.java
+++ b/src/main/java/com/repowise/dev/repowise/model/Issue.java
@@ -1,0 +1,1 @@
+public enum Disposition { OPEN, DECLINED, ACCEPTED }

--- a/src/main/resources/finding-disposition/lifecycle.js
+++ b/src/main/resources/finding-disposition/lifecycle.js
@@ -1,0 +1,6 @@
+module.exports = {
+  'declined': {
+    'description': 'Declined finding, will not be re-suggested',
+    'lifecycle': 'declined'
+  }
+};


### PR DESCRIPTION
Closes #1535. Add a 'declined' lifecycle to findings to prevent re-suggestion on every analysis run.