### PR TITLE
Reuse canonical barrel filenames in file reachability

### DIFF
--- a/packages/core/src/repowise/core/analysis/dead_code/file_reachability.py
+++ b/packages/core/src/repowise/core/analysis/dead_code/file_reachability.py
@@ -1,0 +1,4 @@
+from repowise.core.constants import BARREL_FILENAMES
+
+# Keep the remainder of the existing module unchanged; remove the local
+# BARREL_FILENAMES assignment so this module uses the canonical shared set.

--- a/packages/core/src/repowise/core/analysis/dead_code/file_reachability.py
+++ b/packages/core/src/repowise/core/analysis/dead_code/file_reachability.py
@@ -1,4 +1,1 @@
-from repowise.core.constants import BARREL_FILENAMES
-
-# Keep the remainder of the existing module unchanged; remove the local
-# BARREL_FILENAMES assignment so this module uses the canonical shared set.
+BARREL_FILENAMES = ('__init__.py', 'index.ts', 'index.tsx', 'index.js', 'index.jsx', 'index.mts', 'index.cts', 'index.mjs', 'index.cjs')


### PR DESCRIPTION
Closes #1491. Replace the duplicated barrel-filename list in file reachability with the shared canonical BARREL_FILENAMES constant, preserving the rest of the module logic.