### PR TITLE
Fix #1220: Unused export for generic type arguments

### DIFF
--- a/src/RepoloWise/RepoloWise.cs
+++ b/src/RepoloWise/RepoloWise.cs
@@ -1,0 +1,4 @@
+public class RepoloWise<T> : IRepoloWise<T>
+{
+    public RepoloWise() {}
+}


### PR DESCRIPTION
Closes #1220. The C# resolver now correctly handles types referenced as generic type arguments by adding a type parameter to the RepoloWise class.