### PR TITLE
Fix dead-code analyzer marking live code as unused

### DIFF
--- a/rules/dynamic-import.js
+++ b/rules/dynamic-import.js
@@ -1,0 +1,21 @@
+const rule = {
+  meta: {
+    messages: {
+      unused: 'Unused dynamic import() target'
+    }
+  },
+  create(context) {
+    return {
+      'import()': {
+        exit(node) {
+          if (node.type === 'CallExpression' && node.arguments[0].type === 'Identifier') {
+            context.report({
+              node: node, 
+              messageId: 'unused'
+            });
+          }
+        }
+      }
+    };
+  }
+};


### PR DESCRIPTION
Closes #1534. Update rules/dynamic-import.js to handle dynamic import() targets flagged as unused at confidence 1.0.