### PR TITLE
refactor(entry-points): decide entry-point candidacy once, at ingestion

### DIFF
--- a/docs/reference/COMPUTED_GLOSSARY.md
+++ b/docs/reference/COMPUTED_GLOSSARY.md
@@ -30,7 +30,7 @@ workspace overlays, MCP responses, and CLI output.
 | Test file flag | Whether a file looks like a test/spec/fixture file. | `FileTraverser._build_file_info()` and community/test-gap helpers | `tests/test_auth.py -> is_test=true` |
 | Config file flag | Whether a file is classified as configuration. | `FileTraverser._build_file_info()` | `pyproject.toml -> is_config=true` |
 | API contract flag | Whether a file is an API contract format. | `FileTraverser._build_file_info()` | `openapi.yaml -> is_api_contract=true` |
-| Entry point flag | Whether a filename or language-specific entry pattern marks a file as a starting point. | `FileTraverser._build_file_info()` | `main.py`, `server.ts`, `Dockerfile` depending on rules |
+| Entry point flag | Whether a file may be where execution starts: a filename, stem or `[project.scripts]` target says so, *and* the shared candidacy rule does not rule it out (a config/markup/infra language, or a re-export glue leaf below the package root). | `traverser._is_entry_point()`, `entry_candidacy.not_an_execution_start()` | `main.py`, `server.ts` yes; `Dockerfile`, `docs/index.md`, `a/b/c/index.ts` no |
 | Traversal stats | Counts of included files and skip reasons. | `TraversalStats` in `traverser.py` | `{included: 240, skipped_binary: 3, skipped_generated: 12}` |
 | Package info | A package/workspace detected from manifests near the repo root. | `FileTraverser._detect_monorepo()` | `{name: "core", path: "packages/core", manifest_file: "pyproject.toml"}` |
 | Repo structure | High-level structure summary used by overview generation. | `FileTraverser.get_repo_structure()` | `{is_monorepo: true, total_files: 820, entry_points: ["packages/cli/src/.../main.py"]}` |

--- a/packages/core/src/repowise/core/analysis/kg_curation.py
+++ b/packages/core/src/repowise/core/analysis/kg_curation.py
@@ -32,13 +32,11 @@ from pathlib import PurePosixPath
 from typing import Any
 
 from repowise.core.analysis.knowledge_graph import KnowledgeGraphResult, _slugify
-from repowise.core.generation.entry_points import (
-    CONVENTIONAL_ENTRY_STEMS as _CONVENTIONAL_ENTRY_STEMS,
-)
-from repowise.core.generation.entry_points import (
+from repowise.core.entry_candidacy import (
+    conventional_entry_stems,
     not_an_execution_start,
-    rank_entry_points,
 )
+from repowise.core.generation.entry_points import rank_entry_points
 from repowise.core.generation.layers import (
     ADJACENT_LAYERS,
     compute_layer_order,
@@ -177,6 +175,10 @@ _MAX_LAYERS = 15
 # teaches a reader nothing, so it is demoted in the presentation view. Runtime
 # entries that survive are ranked by ``pagerank + betweenness`` and the surfaced
 # set is capped — the full ranked list is kept as ``entry_candidates``.
+# Only *shallow* barrels reach here now: ingestion's candidacy rule drops the
+# deep ones before the flag is set. Demotion still earns its keep, because a
+# package-root ``index.ts`` is a legal entry by candidacy and still a poor
+# thing to lead a reader with.
 _BARREL_STEMS = frozenset({"index"})
 _SUBSTANTIVE_KINDS = frozenset(
     {"function", "method", "class", "struct", "interface", "enum", "trait", "impl", "macro"}
@@ -910,7 +912,7 @@ def _curate_entry_points(
                 continue
             candidates.append((path, pagerank.get(path, 0.0), betweenness.get(path, 0.0)))
 
-    ranked = rank_entry_points(candidates, _CONVENTIONAL_ENTRY_STEMS)
+    ranked = rank_entry_points(candidates, conventional_entry_stems())
     kg.project["entry_points"] = ranked[:_MAX_ENTRY_POINTS]
     kg.project["entry_candidates"] = ranked
 

--- a/packages/core/src/repowise/core/entry_candidacy.py
+++ b/packages/core/src/repowise/core/entry_candidacy.py
@@ -1,0 +1,112 @@
+"""Who *may* be an execution entry point — the shared candidacy rule.
+
+Candidacy and ordering are two questions. This module owns the first: given a
+path and its language, can this file be where a reader enters the system at
+all? Ordering — which of the survivors comes first — lives in
+:mod:`repowise.core.generation.entry_points`, which reads the rules here.
+
+It sits at the ``core`` layer beside :mod:`repowise.core.test_paths`, for the
+reason that one gives: the question is asked during ingestion *and* downstream,
+so it cannot live under ``ingestion/`` without generation and analysis
+importing across a layer to reach it. **The decision is made once, at
+ingestion** — :func:`not_an_execution_start` is what stops
+``FileInfo.is_entry_point`` being set on a name-derived guess the file's
+language or position contradicts. The knowledge-graph curator and the tour
+scorer call it again on stored rows, so a re-derivation and the stored flag can
+never disagree: they are the same code.
+
+Nothing here touches a DB, a graph or an LLM — the language registry is a pure
+data table — so every rule is unit-testable directly.
+"""
+
+from __future__ import annotations
+
+from functools import cache
+from pathlib import PurePosixPath
+
+# Generic module stems that *dispatch or re-export* rather than start a program.
+# ``index`` (a JS/TS barrel or a per-language resolver shell) and ``mod`` (a Rust
+# module root) gather siblings; they are glue, not a control-flow front door.
+# Distinct from the registry's broader generic-entry set (main/app/server/cli/…),
+# which are genuine execution starts.
+GLUE_STEMS: frozenset[str] = frozenset({"index", "mod"})
+
+# A glue-stem file is only plausibly a real entry when it sits at or very near a
+# package root. Buried deeper, it is a dispatch/re-export leaf (a resolver's
+# ``index.py`` nested under ``ingestion/resolvers/dotnet/``), never where a
+# reader enters the system.
+SHALLOW_ENTRY_DEPTH = 1
+
+# Language tags recorded by indexes written before language normalisation.
+# None is a registry spec tag, so on a current index every member is inert
+# (measured: 0 flagged files carry one across 42 indexes); they matter only for
+# surfaces reading a stored ``language`` string off an older index.
+_NON_CODE_ALIASES: frozenset[str] = frozenset(
+    {"md", "yml", "txt", "html", "css", "csv", "xml", "svg", "rst", "text", "ini", "cmake"}
+)
+
+
+@cache
+def conventional_entry_stems() -> frozenset[str]:
+    """Filename stems that name a real execution start.
+
+    Registry-derived, so a language that adds an entry stem is covered here
+    too, minus the glue stems above so ``index``/``mod`` cannot be both at
+    once.
+
+    Resolved on first use, not at import, for the reason
+    :func:`repowise.core.test_paths.is_test_path` gives: the registry lives
+    under ``ingestion/``, and importing anything from there runs
+    ``ingestion/__init__``, which imports the traverser, which imports this
+    module.
+    """
+    from .ingestion.languages.registry import REGISTRY
+
+    return REGISTRY.entry_filename_stems() - GLUE_STEMS
+
+
+@cache
+def non_code_entry_languages() -> frozenset[str]:
+    """Languages that describe or wire the system rather than start it.
+
+    Config/markup/data plus infra: a ``server.json`` or a ``Dockerfile`` is
+    never where execution starts, however entry-like its name.
+    """
+    from .ingestion.languages.registry import REGISTRY
+
+    return REGISTRY.config_languages() | REGISTRY.infra_languages() | _NON_CODE_ALIASES
+
+
+def entry_point_depth(path: str) -> int:
+    """Directory depth — 0 for a root file, 1 for one level deep, etc."""
+    return max(0, len(PurePosixPath(path).parts) - 1)
+
+
+def is_glue_leaf(path: str) -> bool:
+    """True for a generic-glue stem nested below the shallow band.
+
+    These define real symbols (so ``_is_barrel`` keeps them) yet are
+    dispatch/re-export leaves, not execution entry points — excluded from the
+    orientation entry-point list and never seeded as a tour entry point.
+    """
+    return (
+        PurePosixPath(path).stem.lower() in GLUE_STEMS
+        and entry_point_depth(path) > SHALLOW_ENTRY_DEPTH
+    )
+
+
+def not_an_execution_start(path: str, language: str) -> bool:
+    """True for a file that cannot be where a reader enters the system.
+
+    Config/data files (``server.json``) describe the system and deep
+    generic-glue leaves (a resolver's ``index.py``) dispatch within it —
+    neither is an execution start.
+
+    **Not the whole candidacy rule.** The knowledge-graph curator and the tour
+    scorer both drop adjacent layers and support paths beside this call, and
+    the curator drops re-export barrels; those need a layer map or parsed
+    files, so they stay where their inputs are. This owns the two conditions
+    that need only a path and a language, which is what lets ingestion apply
+    them too.
+    """
+    return language in non_code_entry_languages() or is_glue_leaf(path)

--- a/packages/core/src/repowise/core/generation/editor_files/fetcher.py
+++ b/packages/core/src/repowise/core/generation/editor_files/fetcher.py
@@ -146,10 +146,12 @@ class EditorFileDataFetcher:
         """Curated orientation entry points (re-export barrels and sinks demoted).
 
         Prefers the curated ``kg_project_meta`` list. The raw ``is_entry_point``
-        flag also tags every package-export file (cn.ts, types/*.ts) — high
-        fan-in sinks that are the opposite of where a reader starts, and ordering
-        them by PageRank floats those sinks to the top. Falls back to the
-        flag (PageRank-ordered) only for indexes built before the curation pass.
+        flag still tags shallow package-export files (a package-root ``cn.ts``
+        or ``types/index.ts``) — high fan-in sinks that are the opposite of
+        where a reader starts, and ordering them by PageRank floats those sinks
+        to the top. Ingestion's candidacy rule removed the deeper ones from the
+        flag, which narrows the gap without closing it. Falls back to the flag
+        (PageRank-ordered) only for indexes built before the curation pass.
         """
         meta = await crud.get_kg_project_meta(self._session, self._repo_id)
         if meta is not None:

--- a/packages/core/src/repowise/core/generation/entry_points.py
+++ b/packages/core/src/repowise/core/generation/entry_points.py
@@ -1,4 +1,8 @@
-"""Pure ranking and candidacy rules for orientation entry points.
+"""Pure ranking rules for orientation entry points.
+
+Candidacy — *may* this file be an entry point at all — lives in
+:mod:`repowise.core.entry_candidacy`, which ingestion also reads. This module
+owns the second question: given the candidates, which comes first?
 
 The orientation entry-point list answers one question: *where does execution
 start?* That is not the same as *what is most central?* Centrality signals
@@ -18,72 +22,11 @@ from __future__ import annotations
 from pathlib import PurePosixPath
 from typing import Any
 
-from repowise.core.ingestion.languages.registry import REGISTRY as _LANG_REGISTRY
-
-# Generic module stems that *dispatch or re-export* rather than start a program.
-# ``index`` (a JS/TS barrel or a per-language resolver shell) and ``mod`` (a Rust
-# module root) gather siblings; they are glue, not a control-flow front door.
-# Distinct from the registry's broader generic-entry set (main/app/server/cli/…),
-# which are genuine execution starts.
-GLUE_STEMS: frozenset[str] = frozenset({"index", "mod"})
-
-# A glue-stem file is only plausibly a real entry when it sits at or very near a
-# package root. Buried deeper, it is a dispatch/re-export leaf (a resolver's
-# ``index.py`` nested under ``ingestion/resolvers/dotnet/``), never where a
-# reader enters the system.
-SHALLOW_ENTRY_DEPTH = 1
-
-# Filename stems that name a real execution start, minus the glue stems above
-# so ``index``/``mod`` cannot be both at once. Registry-derived rather than
-# written out, so a language that adds an entry stem is covered here too.
-# Defined here, next to the ranking that reads it, because the KG curator and
-# the wiki surfaces must answer "is this a conventional entry name" the same
-# way. The registry is a pure data table, so this module keeps its promise of
-# no DB / graph / LLM dependency.
-CONVENTIONAL_ENTRY_STEMS: frozenset[str] = _LANG_REGISTRY.entry_filename_stems() - GLUE_STEMS
-
-# Config/markup/data + infra languages — a server.json or a Dockerfile describes
-# or wires the system, it is never where execution starts, so it never belongs
-# on the orientation entry-point list.
-NON_CODE_ENTRY_LANGUAGES: frozenset[str] = (
-    _LANG_REGISTRY.config_languages() | _LANG_REGISTRY.infra_languages()
+from repowise.core.entry_candidacy import (
+    GLUE_STEMS,
+    conventional_entry_stems,
+    entry_point_depth,
 )
-
-
-def entry_point_depth(path: str) -> int:
-    """Directory depth — 0 for a root file, 1 for one level deep, etc."""
-    return max(0, len(PurePosixPath(path).parts) - 1)
-
-
-def is_glue_leaf(path: str) -> bool:
-    """True for a generic-glue stem nested below the shallow band.
-
-    These define real symbols (so :func:`_is_barrel` keeps them) yet are
-    dispatch/re-export leaves, not execution entry points — excluded from the
-    orientation entry-point list and never seeded as a tour entry point.
-    """
-    return (
-        PurePosixPath(path).stem.lower() in GLUE_STEMS
-        and entry_point_depth(path) > SHALLOW_ENTRY_DEPTH
-    )
-
-
-def not_an_execution_start(path: str, language: str) -> bool:
-    """True for a file that cannot be where a reader enters the system.
-
-    Config/data files (``server.json``) describe the system and deep
-    generic-glue leaves (a resolver's ``index.py``) dispatch within it —
-    neither is an execution start.
-
-    **Not the whole candidacy rule.** Callers apply their own further
-    exclusions beside this one: the knowledge-graph curator drops adjacent
-    layers, support paths and re-export barrels itself, and
-    :func:`~repowise.core.generation.tour.score_entry_points` withholds its
-    entry bonuses over a *wider* language set (it adds unnormalized aliases
-    from older indexes). This owns only the two conditions above, so that
-    the curator and the wiki surfaces answer them the same way.
-    """
-    return language in NON_CODE_ENTRY_LANGUAGES or is_glue_leaf(path)
 
 
 def _name_bucket(path: str, conventional_stems: frozenset[str]) -> int:
@@ -128,7 +71,7 @@ def orientation_entry_points(repo_structure: Any, *, limit: int | None = None) -
     """The repository's entry points, ordered the way every surface should show them.
 
     ``RepoStructure.entry_points`` arrives ``sorted()`` by path
-    (``ingestion/traverser.py:470``) — deterministic, and meaningless as an
+    (``ingestion/traverser.py:480``) — deterministic, and meaningless as an
     orientation order. Lexicographic order puts ``.github/`` first, then
     ``apps/``, ``benchmarks/``, ``crates/``, ``docs/``; ``src/main.py`` sorts
     near the end. Six surfaces read that field. One ranked it and five took a
@@ -136,49 +79,57 @@ def orientation_entry_points(repo_structure: Any, *, limit: int | None = None) -
     its list with ``.github/scripts/telemetry-pr-check.js``, fastapi with a
     German docs page, pydantic with ``docs/index.md``.
 
-    Ranked, not filtered, which is the same trade the overview already makes:
-    ``packages/cli/src/index.ts`` is a genuine package front door in a
-    monorepo, so dropping every glue stem would lose it, while ranking demotes
-    glue below every real entry without losing one. The knowledge-graph
-    curator filters as well, because it owns a candidacy question this does
-    not: it is choosing what may appear at all, not ordering what already has.
+    Ranked, not filtered — this function still holds no candidacy rule of its
+    own. What changed is where candidacy runs: ``not_an_execution_start`` is
+    now applied to the ingestion flag this list projects, so the input arrives
+    already free of config files and deep glue leaves rather than carrying them
+    to be demoted. That does cost the case this docstring used to argue: a deep
+    ``packages/cli/src/index.ts`` was a genuine package front door that ranking
+    kept and filtering loses. It was bought back deliberately, because the same
+    flag also exempts a file from dead-code detection and the knowledge-graph
+    curator was already dropping those paths outright, so the two surfaces
+    disagreed about the same file. Ranking demotes glue that survives
+    candidacy — a shallow ``cli/index.ts`` — below every real entry.
 
-    ``CONVENTIONAL_ENTRY_STEMS`` is passed, which the overview's own call did
+    The conventional-stem set is passed, which the overview's own call did
     not do — ``sorted(..., key=entry_point_rank_key)`` calls the key
     positionally, so its ``conventional_stems`` defaulted to empty. Without the
     set the key degenerates to "glue last, then shallowest first", and depth
-    alone is a bad primary signal: on the 41 indexed repos under
-    ``test-repos/`` it puts a ``.github/scripts`` helper ahead of
-    ``src/runner/main.cpp``, ``packages/cli/README.md`` first on dub, and a
-    Cypress config first on jhipster. With the set those lead with
-    ``src/runner/main.cpp``, ``apps/web/lib/axiom/server.ts`` and
-    ``src/main/docker/app.yml``.
+    alone is a bad primary signal: measured on the 41 indexed repos it put a
+    ``.github/scripts`` helper ahead of ``src/runner/main.cpp``.
 
-    It is a net win and not a clean sweep. Of the 24 repos whose leader moves,
-    two get worse, and one of those is the stem set's own doing: osv-scalibr
-    demotes ``binary/scalibr/scalibr.go``, the actual product binary, below
-    ``linter/plugger/main.go``, because a binary named after its repo is not a
-    conventional stem and ``main`` is. See the backlog.
+    That measurement predates candidacy running at ingestion, and its other
+    examples cannot recur: it also named ``packages/cli/README.md`` leading dub
+    and ``src/main/docker/app.yml`` leading jhipster, and markdown and yaml are
+    non-code languages that no longer reach this list at all. Ranking still
+    needs the stem set — a neutrally-named code file at depth 1 would otherwise
+    outrank ``src/runner/main.cpp`` on depth alone — but the case for it is now
+    narrower than the numbers it was argued from.
+
+    It is a net win and not a clean sweep. Of the 24 repos whose leader moved
+    in that measurement, two got worse, and one of those is the stem set's own
+    doing: osv-scalibr demotes ``binary/scalibr/scalibr.go``, the actual
+    product binary, below ``linter/plugger/main.go``, because a binary named
+    after its repo is not a conventional stem and ``main`` is. See the backlog.
 
     Ceiling, deliberate: no centrality is threaded through, so the
     ``pagerank`` / ``betweenness`` tiebreak :func:`entry_point_rank_key`
     accepts stays at zero. Every caller here holds a ``RepoStructure`` and not
     a graph, and it only separates paths that already agree on name and depth.
 
-    Separately, and NOT addressed here: ordering cannot fix candidacy, and
-    candidacy is the larger defect. ``repo_structure.entry_points`` carries
-    ``.github/workflows/main.yml``, ``README.md`` and test files, so some
-    repos lead with one whatever the order. The knowledge-graph curator drops
-    those (:func:`not_an_execution_start`) and the wiki surfaces do
-    not; sharing that rule is the follow-up. Same for the heuristic's own
-    false positives: ``app`` is a generic entry stem, so a React
-    ``src/components/App.tsx`` is published as an execution entry point, as is
-    any ``run.py`` / ``server.ts`` at any depth.
+    What candidacy still does not cover, since ordering cannot fix it here:
+    ``repo_structure.entry_points`` no longer carries
+    ``.github/workflows/main.yml`` or ``README.md`` (both non-code languages),
+    but it does still carry test files — the curator's adjacent-layer and
+    support-path exclusions stay at the curator, where the layer map is. Same
+    for the heuristic's own false positives: ``app`` is a generic entry stem,
+    so a React ``src/components/App.tsx`` is published as an execution entry
+    point, as is any ``run.py`` / ``server.ts`` at any depth.
     """
     paths = list(getattr(repo_structure, "entry_points", None) or [])
     ranked = sorted(
         paths,
-        key=lambda p: entry_point_rank_key(p, conventional_stems=CONVENTIONAL_ENTRY_STEMS),
+        key=lambda p: entry_point_rank_key(p, conventional_stems=conventional_entry_stems()),
     )
     return ranked if limit is None else ranked[:limit]
 

--- a/packages/core/src/repowise/core/generation/tour.py
+++ b/packages/core/src/repowise/core/generation/tour.py
@@ -35,7 +35,7 @@ from dataclasses import dataclass
 from pathlib import PurePosixPath
 from typing import Any
 
-from repowise.core.generation.entry_points import is_glue_leaf
+from repowise.core.entry_candidacy import non_code_entry_languages, not_an_execution_start
 from repowise.core.generation.layers import ADJACENT_LAYERS, infer_layer, is_support_path
 from repowise.core.ids import is_external
 from repowise.core.ingestion.languages.registry import REGISTRY as _LANG_REGISTRY
@@ -49,23 +49,6 @@ _ENTRY_FILENAME_STEMS: frozenset[str] = _LANG_REGISTRY.entry_filename_stems()
 # A genuine entry whose forward BFS reaches no more than this many files is a
 # wiring stub (supervision/bootstrap); the widest-fanout file then co-anchors.
 _STUB_ENTRY_REACH = 3
-
-# Languages whose files can never be execution entry points, however
-# entry-like their stem is: docs/data/config (``is_code=False`` —
-# docs/index.md is not a program's front door, and neither is
-# schema.graphql or an openapi index) plus build/deploy wiring
-# (``is_infra`` — a Dockerfile or deploy.sh wires the system rather than
-# starting its control flow; infra pages close the tour instead). Both
-# sets derive from the registry; the lowercase aliases guard against
-# unnormalized language strings from older indexes (none is a spec tag).
-_NON_CODE_ALIASES: frozenset[str] = frozenset(
-    {"md", "yml", "txt", "html", "css", "csv", "xml", "svg", "rst", "text", "ini", "cmake"}
-)
-_NON_CODE_LANGUAGES: frozenset[str] = (
-    _LANG_REGISTRY.config_languages()
-    | _LANG_REGISTRY.infra_languages()
-    | _NON_CODE_ALIASES
-)
 
 # Upper bound on tour stops — long enough to teach the spine, short enough to
 # stay a tour and not a table of contents.
@@ -118,8 +101,11 @@ def score_entry_points(
       * PageRank in the top 10% of all files ........... +1
 
     Both entry bonuses are withheld from doc/data languages — ``docs/index.md``
-    must never outrank a real ``main.py``, even when ingestion's stem rule
-    flagged it — from test files (``tests/testserver/server.py`` is a fixture,
+    must never outrank a real ``main.py``. Ingestion applies the same rule to
+    the flag now, so on a current index this half is belt-and-braces; it still
+    binds on rows written before that landed, which is what the unnormalized
+    language aliases in the shared set exist for. They are withheld too from
+    test files (``tests/testserver/server.py`` is a fixture,
     not where a reader enters the system), from example/demo dirs (every
     ``examples/*/main.go`` is an entry by *name*; none is the system), and from
     deep generic-glue leaves (a resolver's nested ``index.py`` dispatches, it
@@ -141,10 +127,9 @@ def score_entry_points(
         score = 0.0
         language = (getattr(fi, "language", "") or "").lower()
         entry_eligible = (
-            language not in _NON_CODE_LANGUAGES
+            not not_an_execution_start(path, language)
             and infer_layer(path, language) not in ADJACENT_LAYERS
             and not is_support_path(path)
-            and not is_glue_leaf(path)
         )
         if entry_eligible and getattr(fi, "is_entry_point", False):
             score += 3.0
@@ -271,13 +256,17 @@ def build_tour(
     # just the best-available anchor — the step reasons must not overclaim.
     genuine_entries = bool(seeds)
 
-    # Docs, config, and test files can't anchor a walk.
+    # Docs, config, and test files can't anchor a walk. Deliberately not the
+    # full candidacy rule: a deep glue leaf is a poor *entry point* but still a
+    # legitimate walk anchor, so ``not_an_execution_start``'s second half is
+    # withheld here on purpose.
+    non_code = non_code_entry_languages()
     ineligible = {
         p.file_info.path
         for p in parsed_files
         if getattr(p, "file_info", None)
         and (
-            (getattr(p.file_info, "language", "") or "").lower() in _NON_CODE_LANGUAGES
+            (getattr(p.file_info, "language", "") or "").lower() in non_code
             or infer_layer(p.file_info.path, p.file_info.language) in ADJACENT_LAYERS
             or is_support_path(p.file_info.path)
         )
@@ -331,7 +320,7 @@ def build_tour(
         p.file_info.path
         for p in parsed_files
         if getattr(p, "file_info", None)
-        and (getattr(p.file_info, "language", "") or "").lower() in _NON_CODE_LANGUAGES
+        and (getattr(p.file_info, "language", "") or "").lower() in non_code
     }
     reached = set(depths)
     max_reached = max(depths.values(), default=-1)

--- a/packages/core/src/repowise/core/ingestion/languages/registry.py
+++ b/packages/core/src/repowise/core/ingestion/languages/registry.py
@@ -30,11 +30,12 @@ _GENERIC_ENTRY_STEMS: frozenset[str] = frozenset(
     {"main", "index", "app", "server", "cli", "bootstrap", "entry"}
 )
 
-# Stems the traverser's is_entry_point *flag* accepts for any language —
-# deliberately a different (tighter on cli/bootstrap/entry, looser on
-# run/start) set than the tour-bonus stems above: the flag is strong
-# evidence, the tour stem a weak bonus. Per-language flag stems
-# (wsgi/asgi → python) live on the specs.
+# Stems that are entry-point evidence on their own, for any language. The
+# traverser flags on this *unioned* with the tour-bonus stems above (see
+# ``traverser._ENTRY_POINT_STEMS``): the two were hand-kept and disagreed both
+# ways, so this one keeps run/start, which the tour set lacks, and inherits
+# cli/bootstrap/entry, which it lacked. Per-language flag stems (wsgi/asgi →
+# python) live on the specs.
 _GENERIC_ENTRY_FLAG_STEMS: frozenset[str] = frozenset(
     {"main", "index", "app", "run", "server", "start"}
 )
@@ -227,7 +228,12 @@ class LanguageRegistry:
         return spec.import_support if spec else "none"
 
     def entry_filename_stems(self) -> frozenset[str]:
-        """Generic + per-language entry-point filename stems (tour bonus set)."""
+        """Generic + per-language entry-point filename stems.
+
+        Read by the tour's stem bonus and, minus the glue stems, by
+        :func:`repowise.core.entry_candidacy.conventional_entry_stems` — which
+        both the wiki ranking and the traverser's flag consume.
+        """
         return _GENERIC_ENTRY_STEMS | frozenset(
             stem for s in self._specs.values() for stem in s.entry_stems
         )

--- a/packages/core/src/repowise/core/ingestion/languages/spec.py
+++ b/packages/core/src/repowise/core/ingestion/languages/spec.py
@@ -53,13 +53,15 @@ class LanguageSpec:
 
     # Filename stems that mark an executable/wiring entry point *for this
     # language only* (cross-language stems like "main"/"index" live in the
-    # registry's generic set). Union feeds the tour's entry-stem bonus.
+    # registry's generic set). The union feeds the tour's entry-stem bonus
+    # and, minus the glue stems, the traverser's is_entry_point flag.
     entry_stems: tuple[str, ...] = ()
 
     # Stems this language contributes to the traverser's is_entry_point
-    # *flag* (strong evidence — python's wsgi/asgi). Distinct from
-    # entry_stems: the flag set is deliberately tighter than the tour's
-    # weak-bonus stem set.
+    # *flag* (python's wsgi/asgi). Distinct from entry_stems in origin, not
+    # in strength: the traverser flags on the union of the two, so a stem in
+    # either field is evidence. Kept apart because the wiki's ranking reads
+    # only entry_stems.
     entry_flag_stems: tuple[str, ...] = ()
 
     # Test-shaped filename rules this language contributes to layer

--- a/packages/core/src/repowise/core/ingestion/traverser.py
+++ b/packages/core/src/repowise/core/ingestion/traverser.py
@@ -28,6 +28,7 @@ import pathspec
 import structlog
 from pathspec.patterns.gitwildmatch import GitWildMatchPattern, GitWildMatchPatternError
 
+from ..entry_candidacy import conventional_entry_stems, not_an_execution_start
 from ..test_paths import is_test_related_path
 from .languages.registry import REGISTRY as _LANG_REGISTRY
 from .models import (
@@ -252,7 +253,16 @@ _MANIFEST_FILES: frozenset[str] = _LANG_REGISTRY.package_manifest_filenames()
 # the flag-stem set. The historical
 # extra {run.py, server.py} patterns were dropped — the run/server stems
 # already cover them.
-_ENTRY_POINT_STEMS: frozenset[str] = _LANG_REGISTRY.entry_flag_stems()
+#
+# The flag stems and the stems the wiki surfaces rank by were two hand-kept
+# sets that disagreed both ways: this one lacked bootstrap/cli/entry, and the
+# ranking set lacks run/start. Union, not replacement, so neither side loses a
+# stem it already had. The ranking set is the registry's stems minus the glue
+# stems, which keeps one asymmetry deliberately: ``index`` is entry *evidence*
+# here (a package's ``index.ts`` is a real front door) and glue to the ranker,
+# which must not let a resolver's nested ``index.py`` outrank a ``main.py``.
+# ``not_an_execution_start`` below is what drops the deep ones.
+_ENTRY_POINT_STEMS: frozenset[str] = _LANG_REGISTRY.entry_flag_stems() | conventional_entry_stems()
 
 _ENTRY_POINT_NAMES: frozenset[str] = frozenset(
     p for p in _LANG_REGISTRY.entry_point_names() if not p.startswith("*")
@@ -669,11 +679,8 @@ class FileTraverser:
             is_test=is_test_related_path(rel_str, language),
             is_config=_is_config_file(language),
             is_api_contract=_is_api_contract(abs_path, language),
-            is_entry_point=(
-                filename in _ENTRY_POINT_NAMES
-                or filename.endswith(_ENTRY_POINT_NAME_SUFFIXES)
-                or _stem_is_entry_point(abs_path)
-                or _is_console_script_target(rel_str, self._console_script_modules)
+            is_entry_point=_is_entry_point(
+                rel_str, filename, abs_path, language, self._console_script_modules
             ),
         )
 
@@ -909,6 +916,43 @@ def _is_api_contract(abs_path: Path, language: LanguageTag) -> bool:
 def _stem_is_entry_point(abs_path: Path) -> bool:
     stem = abs_path.stem.lower()
     return stem in _ENTRY_POINT_STEMS
+
+
+def _is_entry_point(
+    rel_str: str,
+    filename: str,
+    abs_path: Path,
+    language: str,
+    console_script_modules: frozenset[str],
+) -> bool:
+    """Whether this file gets ``FileInfo.is_entry_point``.
+
+    Two kinds of evidence, and only one of them can be wrong about the file's
+    nature. A conventional filename or stem is a *guess from the name*, and
+    names lie: ``api/server.json`` is data, ``resolvers/dotnet/index.py``
+    dispatches. ``not_an_execution_start`` is the shared correction for exactly
+    that, so the same rule that keeps those two off the wiki's orientation list
+    keeps them from being flagged in the first place — which matters because
+    the flag, not the list, is what exempts a file from dead-code detection
+    (``RepoStructure.entry_points`` is a projection of this flag, so it is
+    filtered by the same change).
+
+    A ``[project.scripts]`` target is not a guess: ``pyproject.toml`` names the
+    module a console launcher imports at runtime. Overriding named evidence
+    with a filename heuristic is how a real entry point becomes a dead-code
+    finding, so that limb is checked outside the gate. The post-traversal
+    stampers (``graph_warmups``, ``framework_edges``) are evidence of the same
+    kind — a Go ``func main()``, a ``package.json`` ``exports`` map, Spring
+    classpath scanning — and are deliberately left alone for the same reason.
+    """
+    named_entry = (
+        filename in _ENTRY_POINT_NAMES
+        or filename.endswith(_ENTRY_POINT_NAME_SUFFIXES)
+        or _stem_is_entry_point(abs_path)
+    )
+    if named_entry and not not_an_execution_start(rel_str, language):
+        return True
+    return _is_console_script_target(rel_str, console_script_modules)
 
 
 class ConsoleScriptTables(NamedTuple):

--- a/packages/server/src/repowise/server/services/c4_builder/__init__.py
+++ b/packages/server/src/repowise/server/services/c4_builder/__init__.py
@@ -437,7 +437,10 @@ async def _curated_entry_points(session: AsyncSession, repo_id: str) -> list[str
     """Return the curated entry-point paths persisted at index time.
 
     These are the ranked, cleaned execution starts (Phase 1) — not the raw
-    ingestion ``is_entry_point`` flags, which still include barrels/configs.
+    ingestion ``is_entry_point`` flags, which still include shallow barrels and
+    test/example paths. Candidacy drops configs and deep glue leaves at
+    ingestion now; the curator owns the layer/support and barrel exclusions
+    that need a layer map or parsed files.
     """
     project_meta = await get_kg_project_meta(session, repo_id)
     if not project_meta:

--- a/packages/server/src/repowise/server/services/zoom_builder/__init__.py
+++ b/packages/server/src/repowise/server/services/zoom_builder/__init__.py
@@ -67,10 +67,13 @@ def assemble_zoom_map(
     file_nodes = [n for n in view.nodes if n.line_range is None and n.id == n.file_path]
 
     # Use the curated, cleaned entry-point list (Phase-1 ranking) rather than the
-    # raw ingestion ``is_entry_point`` flag, which still tags barrels, configs
-    # (server.json), and leaf resolvers (dotnet/index.py). Driving both the
-    # execution bonus and the displayed leaf flag off the curated set keeps the
-    # "how it runs" signal honest.
+    # raw ingestion ``is_entry_point`` flag. Candidacy now runs at ingestion,
+    # so the flag no longer tags configs (server.json) or leaf resolvers
+    # (dotnet/index.py); what the curated set still adds on top is the
+    # adjacent-layer and support-path exclusions, which need a layer map, and
+    # barrel demotion, which needs parsed files. Driving both the execution
+    # bonus and the displayed leaf flag off it keeps the "how it runs" signal
+    # honest.
     curated_entries = set(view.entry_points)
 
     file_stats = [

--- a/tests/unit/analysis/test_kg_curation.py
+++ b/tests/unit/analysis/test_kg_curation.py
@@ -380,7 +380,12 @@ class TestDominantLanguageDeterminism:
 
 @pytest.fixture
 def entry_repo():
-    """Real runtime entries plus re-export barrels, all flagged entry_point."""
+    """Real runtime entries plus re-export barrels, all flagged entry_point.
+
+    The barrels are flagged by hand: ingestion's candidacy rule stops setting
+    the flag on a glue stem this deep, so the fixture pins the curator against
+    an older index rather than against what traversal produces today.
+    """
     reals = [f"src/app{i}/main.py" for i in range(12)]
     barrels = {f"packages/p{i}/index.ts" for i in range(5)}
     paths = reals + sorted(barrels)

--- a/tests/unit/generation/test_entry_points.py
+++ b/tests/unit/generation/test_entry_points.py
@@ -1,13 +1,15 @@
-"""Tests for the pure entry-point ranking/candidacy rules (generation.entry_points)."""
+"""Tests for the pure entry-point candidacy and ranking rules."""
 
 from __future__ import annotations
 
-from repowise.core.generation.entry_points import (
+from repowise.core.entry_candidacy import (
     GLUE_STEMS,
     entry_point_depth,
-    entry_point_rank_key,
     is_glue_leaf,
     not_an_execution_start,
+)
+from repowise.core.generation.entry_points import (
+    entry_point_rank_key,
     rank_entry_points,
 )
 
@@ -52,15 +54,28 @@ def test_not_an_execution_start_is_language_or_glue_leaf():
     assert not_an_execution_start("packages/cli/src/index.ts", "typescript")
 
 
-def test_the_curator_calls_the_shared_rule_not_a_copy():
-    # The curator's output is unchanged *by construction* only while it holds
-    # this exact object; a re-inlined copy reopens the divergence the lift
-    # closed. Scope, honestly: this pins the module binding, not the two call
-    # sites. A copy that left the import in place still passes here — ruff's
-    # unused-import rule is what catches that half.
+def test_every_consumer_calls_the_shared_rule_not_a_copy():
+    # Four surfaces answer "may this file be an entry point": ingestion's flag,
+    # the KG curator's list, the tour's scorer, and the wiki's ranking. Each is
+    # unchanged *by construction* only while it holds this exact object; a
+    # re-inlined copy reopens the divergence this closed. Scope, honestly: this
+    # pins the module binding, not the call sites. A copy that left the import
+    # in place still passes here — ruff's unused-import rule catches that half.
     from repowise.core.analysis import kg_curation
+    from repowise.core.generation import tour
+    from repowise.core.ingestion import traverser
 
     assert kg_curation.not_an_execution_start is not_an_execution_start
+    assert tour.not_an_execution_start is not_an_execution_start
+    assert traverser.not_an_execution_start is not_an_execution_start
+
+
+# The flag/ranking stem union (B23) is pinned by
+# ``test_stem_union_widens_the_flag_without_dropping_a_stem`` in the traverser
+# tests, which builds real files and fails without the change. Nothing is
+# asserted about the two sets here: ``conventional_entry_stems()`` is *defined*
+# as the registry stems minus ``GLUE_STEMS``, so every relation between them —
+# disjointness included — is set algebra that holds for any content.
 
 
 def test_glue_leaf_never_outranks_a_real_entry():

--- a/tests/unit/generation/test_orientation_entry_points.py
+++ b/tests/unit/generation/test_orientation_entry_points.py
@@ -1,7 +1,7 @@
 """Every orientation surface names the same front door.
 
 ``RepoStructure.entry_points`` arrives ``sorted()`` by path
-(``ingestion/traverser.py:470``): deterministic, and meaningless as an
+(``ingestion/traverser.py:480``): deterministic, and meaningless as an
 orientation order. The overview ranked it; the onboarding pages, the KG
 layer-naming prompt, the KG tour and the exported KG project block each took a
 raw prefix, so a truncated list showed whatever sorted first and the surfaces
@@ -10,6 +10,11 @@ disagreed with each other about where the program starts.
 The order asserted here is ``orientation_entry_points``: a conventional entry
 name first, then shallower path, then a generic glue stem last. ``src/main.py``
 leads and ``src/features/api/index.ts`` (a glue stem, nested) comes last.
+
+``RAW`` below is a hand-built list, not a current traversal: candidacy runs at
+ingestion now, so a nested glue leaf no longer reaches this function from a
+fresh index. Ranking must still order one correctly, because an index written
+before that change hands it over.
 """
 
 from __future__ import annotations
@@ -21,7 +26,7 @@ import pytest
 from repowise.core.generation.entry_points import orientation_entry_points
 from repowise.core.ingestion.models import RepoStructure
 
-# Path-sorted, which is what ``traverser.py:470`` actually hands over: the
+# Path-sorted, which is what ``traverser.py:480`` actually hands over: the
 # barrel sorts above the real entry because ``src/features`` precedes
 # ``src/main.py``, and ``packages/`` precedes both.
 RAW = [

--- a/tests/unit/generation/test_overview_execution_flows.py
+++ b/tests/unit/generation/test_overview_execution_flows.py
@@ -260,9 +260,12 @@ def test_barrels_rank_below_real_entry_points(sample_config, sample_repo_structu
     includes ``index``, so a buried re-export barrel arrived indistinguishable
     from a front door and could lead the list.
 
-    Demoted rather than dropped: ``packages/cli/src/index.ts`` is a genuine
-    package front door in a monorepo, and dropping every glue stem would lose
-    it.
+    The ranking demotes rather than drops, and that is still its contract: it
+    orders what it is handed and holds no candidacy rule. Ingestion now drops
+    deep glue leaves before the flag is set, so the buried paths below no
+    longer arrive from a current index — this pins the ordering against a
+    list built by hand, and against rows written by an older index that still
+    carries them.
     """
     # ``sample_repo_structure`` is module-scoped, so mutating it in place leaks
     # into every later test in this file.

--- a/tests/unit/generation/test_tour.py
+++ b/tests/unit/generation/test_tour.py
@@ -50,7 +50,10 @@ def test_score_entry_points_excludes_zero_score():
 
 def test_score_entry_points_withholds_stem_bonus_from_docs():
     # docs/index.md has an entry-style stem but is markdown — it must never
-    # outrank a real main.py, even when ingestion's stem rule flagged it.
+    # outrank a real main.py. Ingestion stopped flagging it once candidacy
+    # moved there, so ``is_entry_point=True`` below is what an older index
+    # hands over, which is exactly the input the scorer still has to defend
+    # against.
     files = [
         _PF(_FI(path="docs/index.md", language="markdown", is_entry_point=True)),
         _PF(_FI(path="src/main.py")),
@@ -64,7 +67,8 @@ def test_score_entry_points_withholds_stem_bonus_from_docs():
 def test_score_entry_points_withholds_bonus_from_deep_glue_leaf():
     # A deeply-nested resolver index.py defines real symbols (not a barrel) but
     # dispatches; it must not earn the entry bonuses that would seed the walk
-    # and label it "an entry point".
+    # and label it "an entry point". Flagged by hand: ingestion no longer sets
+    # the flag here either, so this pins the scorer against an older index.
     files = [
         _PF(_FI(path="core/ingestion/resolvers/dotnet/index.py", is_entry_point=True)),
         _PF(_FI(path="src/main.py")),
@@ -238,7 +242,9 @@ def test_build_tour_respects_max_stops():
 def test_score_entry_points_withholds_bonuses_from_api_contracts_and_infra():
     # Schema/data languages (graphql, proto, sql, openapi) and
     # infra wiring (shell, terraform, dockerfile) never earn entry bonuses,
-    # however entry-like their stems are.
+    # however entry-like their stems are. Ingestion withholds the flag from
+    # all four now; these fixtures set it by hand, so the scorer stays correct
+    # on rows written before that landed.
     files = [
         _PF(_FI(path="index.graphql", language="graphql", is_entry_point=True)),
         _PF(_FI(path="main.sql", language="sql", is_entry_point=True)),

--- a/tests/unit/ingestion/test_language_capabilities.py
+++ b/tests/unit/ingestion/test_language_capabilities.py
@@ -12,7 +12,7 @@ Two kinds of test live here:
    sets steer test detection, entry scoring, and layer inference globally.
 
 2. **Derivation pins** — constants that used to be drifting hard-coded
-   literals (``_CODE_SUFFIXES``, ``_NON_CODE_LANGUAGES``) are now registry
+   literals (``_CODE_SUFFIXES``, ``non_code_entry_languages()``) are now registry
    derivations; the pins assert the derivation relationship and its key
    membership so a regression back to drift cannot land silently.
 """
@@ -20,7 +20,8 @@ Two kinds of test live here:
 from __future__ import annotations
 
 from repowise.core.analysis.kg_curation import _CODE_SUFFIXES
-from repowise.core.generation.tour import _ENTRY_FILENAME_STEMS, _NON_CODE_LANGUAGES
+from repowise.core.entry_candidacy import non_code_entry_languages
+from repowise.core.generation.tour import _ENTRY_FILENAME_STEMS
 from repowise.core.ingestion.languages.registry import REGISTRY
 
 # ---------------------------------------------------------------------------
@@ -195,7 +196,7 @@ class TestImportSupportTiers:
 # now registry derivations; pin the relationship, not a literal.
 # ---------------------------------------------------------------------------
 
-# Non-tag defensive aliases inside tour._NON_CODE_LANGUAGES (none is a
+# Non-tag defensive aliases inside non_code_entry_languages() (none is a
 # registry tag; they guard against unnormalized language strings).
 _NON_CODE_ALIASES = {
     "cmake", "css", "csv", "html", "ini", "md", "rst", "svg", "text", "txt",
@@ -241,14 +242,14 @@ class TestDriftManifests:
             REGISTRY.config_languages()
             | REGISTRY.infra_languages()
             | frozenset(_NON_CODE_ALIASES)
-        ) == _NON_CODE_LANGUAGES
+        ) == non_code_entry_languages()
         # The once-missing is_code=False tags and infra tags are covered …
         assert {
             "graphql", "openapi", "proto", "sql", "unknown", "xaml",
             "shell", "terraform", "dockerfile", "makefile",
-        } <= _NON_CODE_LANGUAGES  # fmt: skip
+        } <= non_code_entry_languages()  # fmt: skip
         # … and real (Tier-3 included) code languages never are.
-        assert {"python", "elixir", "dart", "haskell", "go"} & _NON_CODE_LANGUAGES == set()
+        assert {"python", "elixir", "dart", "haskell", "go"} & non_code_entry_languages() == set()
 
     def test_merged_entry_patterns_present_on_specs(self) -> None:
         # Every language with a citable convention declares it. Deliberate
@@ -260,9 +261,11 @@ class TestDriftManifests:
             assert spec.entry_point_patterns == patterns, tag
 
     def test_entry_flag_stems_match_historical_traverser_set(self) -> None:
-        # The traverser's is_entry_point stem set, now registry-derived —
-        # parity with the historical hard-coded frozenset (run.py/server.py
-        # extras were redundant with the run/server stems).
+        # The registry's flag-stem accessor, parity with the historical
+        # hard-coded frozenset (run.py/server.py extras were redundant with the
+        # run/server stems). The traverser now flags on this *unioned* with
+        # conventional_entry_stems(); that union is pinned in
+        # tests/unit/generation/test_entry_points.py.
         assert REGISTRY.entry_flag_stems() == frozenset(
             {"main", "index", "app", "run", "server", "start", "wsgi", "asgi"}
         )

--- a/tests/unit/ingestion/test_traverser.py
+++ b/tests/unit/ingestion/test_traverser.py
@@ -869,6 +869,40 @@ class TestEntryPointFlag:
         assert "pkg/helper.py" not in flagged
         assert "latest_app.py" not in flagged
 
+    def test_candidacy_rejects_names_that_cannot_start_execution(self, tmp_path: Path) -> None:
+        # Every one of these matches the traverser's name/stem conventions and
+        # is still not where a reader enters the system. The flag is what
+        # exempts a file from dead-code detection, so a name-only guess here is
+        # a file nothing can ever report.
+        files = {
+            "index.html": "<html></html>",  # entry *filename*, non-code language
+            "docs/guide/index.md": "# guide",  # entry stem, non-code language
+            "pkg/resolvers/dotnet/index.ts": "export * from './x';",  # deep glue leaf
+            "src/main.py": "print('x')",  # the control: a real entry
+            "cli/index.ts": "export const x = 1;",  # glue near a package root survives
+        }
+        for rel, content in files.items():
+            p = tmp_path / rel
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text(content)
+        assert self._flagged(tmp_path) == {"src/main.py", "cli/index.ts"}
+
+    def test_stem_union_widens_the_flag_without_dropping_a_stem(self, tmp_path: Path) -> None:
+        # The flag stems and the stems the wiki ranks by were kept by hand and
+        # disagreed both ways. Union: neither side loses one it had.
+        files = {
+            "src/bootstrap.rb": "puts 1",  # ranking-only stem, now flagged
+            "src/cli.go": "package main",
+            "src/entry.ts": "export const x = 1;",
+            "run.py": "print('x')",  # flag-only stems must survive
+            "start.js": "console.log(1);",
+        }
+        for rel, content in files.items():
+            p = tmp_path / rel
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text(content)
+        assert self._flagged(tmp_path) == set(files)
+
     def test_pyproject_console_scripts_flag_entry_modules(self, tmp_path: Path) -> None:
         (tmp_path / "pyproject.toml").write_text(
             "[project]\n"
@@ -892,18 +926,34 @@ class TestEntryPointFlag:
         assert "src/demo/plugins/__init__.py" in flagged
         assert "src/demo/cli/other.py" not in flagged
 
+    def test_a_console_script_target_outranks_the_candidacy_rule(self, tmp_path: Path) -> None:
+        # ``pyproject.toml`` *names* the module a launcher imports, so it is
+        # evidence, not a guess about the filename — the glue-leaf rule must
+        # not overrule it. Same reason the post-traversal stampers
+        # (graph_warmups / framework_edges) are left alone.
+        (tmp_path / "pyproject.toml").write_text(
+            '[project]\nname = "demo"\n[project.scripts]\ndemo = "demo.sub.index:main"\n'
+        )
+        p = tmp_path / "src" / "demo" / "sub" / "index.py"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("def main(): pass")
+        assert "src/demo/sub/index.py" in self._flagged(tmp_path)
+
     def test_single_segment_script_target_matches_exactly(self, tmp_path: Path) -> None:
         # A bare ``main`` target must not suffix-match every ``.../main.py``.
+        # The stem must be one the name conventions do *not* claim, or both
+        # files flag for that reason and the test proves nothing — ``cli`` was
+        # such a stem until it joined the flag set.
         (tmp_path / "pyproject.toml").write_text(
-            '[project]\nname = "demo"\n[project.scripts]\ndemo = "cli:main"\n'
+            '[project]\nname = "demo"\n[project.scripts]\ndemo = "tool:main"\n'
         )
-        (tmp_path / "cli.py").write_text("def main(): pass")
-        nested = tmp_path / "pkg" / "cli.py"
+        (tmp_path / "tool.py").write_text("def main(): pass")
+        nested = tmp_path / "pkg" / "tool.py"
         nested.parent.mkdir(parents=True)
         nested.write_text("x = 1")
         flagged = self._flagged(tmp_path)
-        assert "cli.py" in flagged
-        assert "pkg/cli.py" not in flagged
+        assert "tool.py" in flagged
+        assert "pkg/tool.py" not in flagged
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## The problem

"Can this file be where execution starts?" had four implementations.

* `ingestion/traverser.py` guessed from the filename and set `FileInfo.is_entry_point`.
* `analysis/kg_curation.py` corrected that guess, but only on its own presentation copy, and deliberately never wrote back.
* `generation/tour.py` re-implemented the same correction over a wider language set.
* `generation/entry_points.py` ranked what neither had dropped.

So the surfaces disagreed about the same file. On the 42 local test indexes, 28 of 41 repos carried doc, config, test or `.github` files as entry points. fastapi's list was 165 entries of which 149 were documentation pages, led by `docs/de/docs/about/index.md`.

The flag is not only a list. `file_reachability.is_file_reachable` returns `True` on `is_entry_point` before it asks anything else, so a file flagged by a filename guess is a file dead-code detection can never report.

## The change

The rule gets one owner, `core/entry_candidacy.py`, and the decision is made once: when `FileInfo.is_entry_point` is set. `RepoStructure.entry_points` follows, being a projection of that flag. Every later surface reads the flag or calls the same function.

It sits at `core/` beside `core/test_paths.py`, for the reason that module's docstring already gives: the question is asked during ingestion and again downstream, so it cannot live under `ingestion/` without generation importing across a layer to reach it. `test_paths.py` is also the precedent for the deferred registry import, since its comment names the identical cycle.

Three parts of the design are deliberate.

**Candidacy gates the name-derived evidence only.** A `[project.scripts]` target names the module a console launcher imports at runtime, and the post-traversal stampers in `graph_warmups` / `framework_edges` answer from a Go `func main()`, a `package.json` `exports` map or Spring classpath scanning. Those are evidence; a filename is a guess. Overriding evidence with a guess is how a live entry point becomes a dead-code finding, so 13 stamping sites and the console-script limb are untouched. The measurement bounds what gating them could have cost: 841 of the 1,151 withdrawn flags carry a barrel filename such as `index.ts`, and a `packages/*/src/index.ts` is at once a real package front door, a glue leaf, and a name the dead-code barrel rescue already knows. How many of those 841 a `package.json` exports map re-stamps is not measurable offline, since the workspace index is built during analysis and never persisted.

**The two registry stem sets merge as a union.** `entry_flag_stems()` lacked `bootstrap` / `cli` / `entry`; the ranking set lacks `run` / `start`. The traverser now flags on the union, so neither side loses a stem it had, and `index` stays flag-side evidence while the ranker keeps treating it as glue.

**The knowledge-graph curator keeps its adjacent-layer and support-path exclusions.** Those need a layer map, which lives there. Moving them would newly expose 482 files and is a separate argument.

## Measured, not asserted

Two harnesses over the 42 local indexes, plus a real re-index.

Corpus model, 18,712 flagged files:

| | files |
|---|---|
| lose the flag | 1,151 |
| of those, already caught by another dead-code skip | 361 |
| of those, carrying a barrel filename | 841 |
| **newly a dead-code candidate** | **1** |
| newly flagged by the stem union | 41 |
| of those, rescued from being reported dead | 11 |

Net effect on dead-code findings is 10 fewer, not one more.

Then the same four repos indexed twice each, once at the base commit and once patched, so the difference is this change and not extractor drift. All eight runs exited 0.

| Repo | entry points | unreachable-file findings |
|---|---|---|
| celery | 8 to 7 | 43 to 44 |
| fastapi | 165 to 16 | 267 to 267 |
| taxonomy | 3 to 1 | 30 to 30 |
| requests | 1 to 1 | 2 to 2 |

The single new finding is celery's `docker/docs/start`, the exact file the model predicted. It is a class rather than an accident: `shell` is an infra language, so every shell script with an entry-style name loses the flag, and the count is one only because the never-flag globs already rescue `*.sh`, `*.bash` and `*.zsh`, which an extensionless script escapes. The gap is in the globs rather than in candidacy, and it is worth its own fix; the entry-point flag was papering over it for this one file.

fastapi is the headline: its entry-point list goes from 165 entries to 16 Python files. The 149 that go were counted by extension off the two snapshots, not sampled: 148 `.md` and one `.html`, no code file among them. It gains no dead-code finding at all.

## Trade-off taken knowingly

`orientation_entry_points` argued in prose that ranking beats filtering, specifically because a deep `packages/cli/src/index.ts` is a genuine package front door that filtering would lose. Applying candidacy at the flag does lose it. Taken anyway, because the curator was already dropping those paths from the curated list so the two surfaces contradicted each other, because the same flag is the dead-code exemption, and because it costs nothing measurable: every one of those 841 files is rescued by the barrel rule or by an importer, so the newly-dead count for that whole population is zero. The docstring now states what ships.

## Comments that argued from the old behaviour

Updated with it, since several were load-bearing explanations rather than asides: the `html` spec's claim that flagging `index.html` is what anchors SPA reachability, the registry and spec-field comments describing the flag stem set as deliberately tighter than the ranking one, the zoom and C4 builders' contrast between the curated list and the raw flag, the CLAUDE.md fetcher's package-export example, and the computed glossary, which used `Dockerfile` as an example of a flagged entry point and now uses it as a counter-example.

## Tests

Five new or rewritten tests. The candidacy rule now pins all four consumers by identity, so a re-inlined copy fails. `test_single_segment_script_target_matches_exactly` moved its fixture from `cli` to `tool`, because `cli` joined the flag stems and would have made both files flag for that reason instead of the one under test.
