### PR TITLE
fix(analysis): align barrel filename definitions with file_reachability (#1491)

### DIFF
--- a/packages/core/src/repowise/core/analysis/dead_code/file_reachability.py
+++ b/packages/core/src/repowise/core/analysis/dead_code/file_reachability.py
@@ -68,6 +68,7 @@ BARREL_FILENAMES: frozenset[str] = frozenset(
         "index.cts",
         "index.mjs",
         "index.cjs",
+        "mod.rs",
     }
 )
 

--- a/packages/core/src/repowise/core/analysis/dead_code/file_reachability.py
+++ b/packages/core/src/repowise/core/analysis/dead_code/file_reachability.py
@@ -289,6 +289,8 @@ def is_file_reachable(
         return True
     if path in rescues.whitelist:
         return True
+    # BARREL_FILENAMES entries are strictly lowercase matching standard file-system conventions
+    # (e.g. index.ts, __init__.py, mod.rs).
     if PurePosixPath(path).name in BARREL_FILENAMES:
         return True
     # Bundler ``resolve.alias`` targets are reached through the aliased package

--- a/packages/core/src/repowise/core/analysis/health/refactoring/split_file.py
+++ b/packages/core/src/repowise/core/analysis/health/refactoring/split_file.py
@@ -51,6 +51,7 @@ from __future__ import annotations
 from collections import Counter, defaultdict
 from typing import Any
 
+from ...dead_code.file_reachability import BARREL_FILENAMES
 from ....test_paths import is_test_related_path
 from .models import RefactoringContext, RefactoringSuggestion
 from .registry import RefactoringDetector, effort_bucket, register
@@ -124,7 +125,7 @@ def _is_generated_path(path: str) -> bool:
         or ".generated." in base
         or base.endswith(".min.js")
         # Barrel / package-init re-export files: nothing of substance to split.
-        or base in ("__init__.py", "index.ts", "index.js", "mod.rs")
+        or base in BARREL_FILENAMES
     )
 
 

--- a/packages/core/src/repowise/core/analysis/health/refactoring/split_file.py
+++ b/packages/core/src/repowise/core/analysis/health/refactoring/split_file.py
@@ -51,8 +51,8 @@ from __future__ import annotations
 from collections import Counter, defaultdict
 from typing import Any
 
-from ...dead_code.file_reachability import BARREL_FILENAMES
 from ....test_paths import is_test_related_path
+from ...dead_code.file_reachability import BARREL_FILENAMES
 from .models import RefactoringContext, RefactoringSuggestion
 from .registry import RefactoringDetector, effort_bucket, register
 

--- a/tests/unit/test_no_barrel_filename_copies.py
+++ b/tests/unit/test_no_barrel_filename_copies.py
@@ -5,9 +5,7 @@ import pathlib
 
 import pytest
 
-from repowise.core.analysis.dead_code.file_reachability import BARREL_FILENAMES
 from repowise.core.analysis.health.refactoring.split_file import _is_generated_path
-
 
 _KNOWN: frozenset[str] = frozenset(
     {
@@ -23,12 +21,14 @@ _BARREL_MARKERS = {"__init__.py", "index.ts", "index.js", "mod.rs"}
 
 
 def _check_assignment(node: ast.AST) -> list[str]:
-    if isinstance(node, ast.Assign):
-        if any(isinstance(target, ast.Name) and target.id == "BARREL_FILENAMES" for target in node.targets):
-            return ["BARREL_FILENAMES"]
-    elif isinstance(node, ast.AnnAssign):
-        if isinstance(node.target, ast.Name) and node.target.id == "BARREL_FILENAMES":
-            return ["BARREL_FILENAMES"]
+    if (isinstance(node, ast.Assign) and any(
+        isinstance(target, ast.Name) and target.id == "BARREL_FILENAMES" for target in node.targets
+    )) or (
+        isinstance(node, ast.AnnAssign)
+        and isinstance(node.target, ast.Name)
+        and node.target.id == "BARREL_FILENAMES"
+    ):
+        return ["BARREL_FILENAMES"]
     return []
 
 

--- a/tests/unit/test_no_barrel_filename_copies.py
+++ b/tests/unit/test_no_barrel_filename_copies.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import ast
+import pathlib
+
+import pytest
+
+from repowise.core.analysis.dead_code.file_reachability import BARREL_FILENAMES
+from repowise.core.analysis.health.refactoring.split_file import _is_generated_path
+
+
+_KNOWN: frozenset[str] = frozenset(
+    {
+        "packages/core/src/repowise/core/entry_candidacy.py",
+        "packages/core/src/repowise/core/ingestion/tsconfig_resolver.py",
+        "packages/server/src/repowise/server/services/c4_builder/architecture.py",
+    }
+)
+
+_PACKAGES = pathlib.Path(__file__).resolve().parents[2] / "packages"
+_HOME = "packages/core/src/repowise/core/analysis/dead_code/file_reachability.py"
+_BARREL_MARKERS = {"__init__.py", "index.ts", "index.js", "mod.rs"}
+
+
+def _check_assignment(node: ast.AST) -> list[str]:
+    if isinstance(node, ast.Assign):
+        if any(isinstance(target, ast.Name) and target.id == "BARREL_FILENAMES" for target in node.targets):
+            return ["BARREL_FILENAMES"]
+    elif isinstance(node, ast.AnnAssign):
+        if isinstance(node.target, ast.Name) and node.target.id == "BARREL_FILENAMES":
+            return ["BARREL_FILENAMES"]
+    return []
+
+
+def _check_literals(node: ast.AST) -> list[str]:
+    if not isinstance(node, ast.Tuple | ast.Set | ast.List):
+        return []
+    str_elts = {
+        elt.value
+        for elt in node.elts
+        if isinstance(elt, ast.Constant) and isinstance(elt.value, str)
+    }
+    matched = str_elts & _BARREL_MARKERS
+    if len(matched) >= 2:
+        return [f"literal {sorted(matched)}"]
+    return []
+
+
+def _analyze_file(path: pathlib.Path) -> list[str]:
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+    except (SyntaxError, UnicodeDecodeError):
+        return []
+
+    hits: list[str] = []
+    for node in ast.walk(tree):
+        hits.extend(_check_assignment(node))
+        hits.extend(_check_literals(node))
+    return sorted(set(hits))
+
+
+def _offenders() -> dict[str, list[str]]:
+    found: dict[str, list[str]] = {}
+    for path in _PACKAGES.rglob("*.py"):
+        rel = path.relative_to(_PACKAGES.parents[0]).as_posix()
+        if rel == _HOME:
+            continue
+        hits = _analyze_file(path)
+        if hits:
+            found[rel] = hits
+    return found
+
+
+def test_no_new_barrel_filename_copies() -> None:
+    offenders = {p: hits for p, hits in _offenders().items() if p not in _KNOWN}
+    assert not offenders, (
+        "New inline barrel-filename definition(s) outside file_reachability.py:\n"
+        + "\n".join(f"  {p}: {', '.join(hits)}" for p, hits in sorted(offenders.items()))
+    )
+
+
+@pytest.mark.parametrize(
+    "path, expected",
+    [
+        ("src/index.ts", True),
+        ("src/index.tsx", True),
+        ("src/index.js", True),
+        ("src/index.jsx", True),
+        ("src/index.mts", True),
+        ("src/index.cts", True),
+        ("src/index.mjs", True),
+        ("src/index.cjs", True),
+        ("pkg/__init__.py", True),
+        ("src/mod.rs", True),
+        ("src/utils.ts", False),
+        ("src/component.tsx", False),
+    ],
+)
+def test_split_file_is_generated_path_covers_all_barrels(path: str, expected: bool) -> None:
+    assert _is_generated_path(path) is expected

--- a/tests/unit/test_no_barrel_filename_copies.py
+++ b/tests/unit/test_no_barrel_filename_copies.py
@@ -17,13 +17,27 @@ _KNOWN: frozenset[str] = frozenset(
 
 _PACKAGES = pathlib.Path(__file__).resolve().parents[2] / "packages"
 _HOME = "packages/core/src/repowise/core/analysis/dead_code/file_reachability.py"
-_BARREL_MARKERS = {"__init__.py", "index.ts", "index.js", "mod.rs"}
+_BARREL_MARKERS = {
+    "index.ts",
+    "index.tsx",
+    "index.js",
+    "index.jsx",
+    "index.mts",
+    "index.cts",
+    "index.mjs",
+    "index.cjs",
+    "__init__.py",
+    "mod.rs",
+}
 
 
 def _check_assignment(node: ast.AST) -> list[str]:
-    if (isinstance(node, ast.Assign) and any(
-        isinstance(target, ast.Name) and target.id == "BARREL_FILENAMES" for target in node.targets
-    )) or (
+    if (
+        isinstance(node, ast.Assign)
+        and any(
+            isinstance(target, ast.Name) and target.id == "BARREL_FILENAMES" for target in node.targets
+        )
+    ) or (
         isinstance(node, ast.AnnAssign)
         and isinstance(node.target, ast.Name)
         and node.target.id == "BARREL_FILENAMES"


### PR DESCRIPTION
## Summary
Fixes #1491 by unifying barrel filename definitions across the codebase and enforcing `file_reachability.BARREL_FILENAMES` as the single source of truth for re-export barrel files.

## Changes Made
- **`file_reachability.py`**: Added `mod.rs` to `BARREL_FILENAMES` alongside Python and JS/TS variants (`index.ts`, `index.tsx`, `index.js`, `index.jsx`, `index.mts`, `index.cts`, `index.mjs`, `index.cjs`, `__init__.py`). `mod.rs` is Rust's module root / re-export barrel file and logically belongs in the unified set.
- **`split_file.py`**: Replaced the inline tuple in `_is_generated_path` with `BARREL_FILENAMES` imported directly from `file_reachability`. This fixes an issue where `.tsx`, `.jsx`, `.mts`, `.cts`, `.mjs`, `.cjs` barrels were previously offered as "split file" refactoring candidates.
- **`test_no_barrel_filename_copies.py`**: Added an AST architectural test covering all 10 barrel variants to prevent inline copies of barrel filename lists from appearing outside `file_reachability.py`.

## Behavior Changes
- **Unreachable File Rescue**: Adding `mod.rs` to `BARREL_FILENAMES` in `file_reachability.py` intentionally exempts Rust module root / re-export files (`mod.rs`) from being reported as unreachable files in `file_reachability.py:292` (matching the existing rescue mechanism for `__init__.py` and `index.ts`).

## Verification
- Ran new architectural and unit tests: `pytest tests/unit/test_no_barrel_filename_copies.py` (**13 passed**)
- Ran complete analysis test suite: `pytest tests/unit/analysis/ tests/unit/test_no_test_path_copies.py` (**574 passed**)
