### PR TITLE
Fix/docker standalone output path

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,15 +12,27 @@ FROM node:20-bookworm-slim AS frontend-builder
 
 WORKDIR /app
 
-# Copy root manifest/lockfile and all packages for monorepo resolution
-COPY package.json package-lock.json* pnpm-lock.yaml* ./
-COPY packages/ ./packages/
+# Copy root manifest/lockfile for workspace resolution
+COPY package.json package-lock.json* ./
+
+# Copy only workspace package.json manifests first so the npm install layer
+# is cached independently of source changes. Any edit to a .ts/.tsx/etc. file
+# will skip straight to `next build` without re-running the 2-min install.
+COPY packages/web/package.json       ./packages/web/package.json
+COPY packages/types/package.json     ./packages/types/package.json
+COPY packages/ui/package.json        ./packages/ui/package.json
+COPY packages/api-client/package.json ./packages/api-client/package.json
 
 # Change directory to web package and install dependencies
 WORKDIR /app/packages/web
 RUN npm install --production=false
 
+# Copy full package source (after install — source changes skip the install cache)
+WORKDIR /app
+COPY packages/ ./packages/
+
 # Build Next.js frontend
+WORKDIR /app/packages/web
 ENV NEXT_TELEMETRY_DISABLED=1
 ENV NEXT_PUBLIC_REPOWISE_API_URL=http://localhost:7337
 RUN npm run build

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,12 +12,15 @@ FROM node:20-bookworm-slim AS frontend-builder
 
 WORKDIR /app
 
-# Install dependencies first (cached layer)
-COPY packages/web/package.json packages/web/package-lock.json* ./
+# Copy root manifest/lockfile and all packages for monorepo resolution
+COPY package.json package-lock.json* pnpm-lock.yaml* ./
+COPY packages/ ./packages/
+
+# Change directory to web package and install dependencies
+WORKDIR /app/packages/web
 RUN npm install --production=false
 
-# Copy source and build
-COPY packages/web/ ./
+# Build Next.js frontend
 ENV NEXT_TELEMETRY_DISABLED=1
 ENV NEXT_PUBLIC_REPOWISE_API_URL=http://localhost:7337
 RUN npm run build
@@ -47,9 +50,9 @@ COPY packages/server/ packages/server/
 RUN pip install --no-cache-dir ".[all]"
 
 # Copy built Next.js standalone output
-COPY --from=frontend-builder /app/.next/standalone /app/web
-COPY --from=frontend-builder /app/.next/static /app/web/.next/static
-COPY --from=frontend-builder /app/public /app/web/public
+COPY --from=frontend-builder /app/packages/web/.next/standalone /app/web
+COPY --from=frontend-builder /app/packages/web/.next/static /app/web/packages/web/.next/static
+COPY --from=frontend-builder /app/packages/web/public /app/web/packages/web/public
 
 # Data volume for .repowise directory
 # mkdir is required: VOLUME only registers metadata and does not create the

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -16,7 +16,7 @@ uvicorn repowise.server.app:create_app \
   --port "${PORT_BACKEND}" &
 
 # Start the Next.js frontend
-# After PR #1236 moves the lockfile to workspace root, Next.js standalone output
+# outputFileTracingRoot points to the repo root, so Next.js standalone output
 # nests server.js under packages/web/ relative to the standalone root directory.
 echo "Starting repowise Web UI on port ${PORT_FRONTEND}..."
 cd /app/web/packages/web

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -16,8 +16,10 @@ uvicorn repowise.server.app:create_app \
   --port "${PORT_BACKEND}" &
 
 # Start the Next.js frontend
+# After PR #1236 moves the lockfile to workspace root, Next.js standalone output
+# nests server.js under packages/web/ relative to the standalone root directory.
 echo "Starting repowise Web UI on port ${PORT_FRONTEND}..."
-cd /app/web
+cd /app/web/packages/web
 REPOWISE_API_URL="http://localhost:${PORT_BACKEND}" \
 HOSTNAME="0.0.0.0" \
 PORT="${PORT_FRONTEND}" \

--- a/packages/web/next.config.ts
+++ b/packages/web/next.config.ts
@@ -1,7 +1,9 @@
+import path from "path";
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   output: "standalone",
+  outputFileTracingRoot: path.join(__dirname, "../../"),
   transpilePackages: ["@repowise-dev/ui", "@repowise-dev/types", "@repowise-dev/api-client"],
   experimental: {
     optimizePackageImports: ["lucide-react", "recharts"],


### PR DESCRIPTION
## Summary

- Added `outputFileTracingRoot: path.join(__dirname, "../../")` to `packages/web/next.config.ts`.
- Fixes monorepo package tracing for Next.js `standalone` mode so workspace packages (`@repowise-dev/*`) are properly included during Docker multi-stage builds.
- the orginal diagnosis of this pull request belongs to @Shivang9983

## Related Issues

combines #1236 and #1271


## Screenshots

<!-- Drag and drop your screenshots here -->
### 1. Next.js Web UI (`http://localhost:3000`)
<img width="955" height="481" alt="image" src="https://github.com/user-attachments/assets/7528a4ff-f984-4634-8359-6b81d77cac08" />

### 2. Backend Health Check (`http://localhost:7337/health`)
<img width="960" height="540" alt="image" src="https://github.com/user-attachments/assets/357a2364-eedc-4e7f-a858-729d48317a29" />

### 3. Docker Container Terminal Logs
<img width="867" height="464" alt="image" src="https://github.com/user-attachments/assets/8c6e653a-571c-4ae1-ba01-b41d2fc04b76" />

## Test Plan

- [x] Docker multi-stage build verified (`docker build -t repowise:test -f docker/Dockerfile .`)
- [x] Next.js standalone server verified starting successfully inside container on port 3000
- [x] FastAPI API server verified running in tandem on port 7337

## Checklist

- [x] My code follows the project's code style
- [x] All existing tests still pass
- [x] Web build passes (`npm run build`)
