### PR TITLE
Fix dead-code analysis for components rendered behind a prop guard

### DIFF
--- a/src/analyzer/deadCodeAnalyzer.ts
+++ b/src/analyzer/deadCodeAnalyzer.ts
@@ -1,0 +1,14 @@
+import { JSXElement } from 'typescript';
+
+// ... existing code ...
+
+function analyzeDeadCode(node: JSXElement, context: AnalysisContext): void {
+  // ... existing code ...
+
+  if (node.openingElement.attributes.some(attr => attr.name.text === 'if')) {
+    // Skip analysis for components rendered behind a prop guard
+    return;
+  }
+
+  // ... rest of the function ...
+}


### PR DESCRIPTION
Closes #1554. This change adds a check to skip dead-code analysis for components rendered behind a prop guard, which was causing false negatives in the analysis.