### PR TITLE
fix(ui): make Dismiss dismiss, and let the decisions page record one

### DIFF
--- a/packages/api-client/src/types/decisions.ts
+++ b/packages/api-client/src/types/decisions.ts
@@ -2,11 +2,16 @@
 // Decisions
 // ---------------------------------------------------------------------------
 
+// One vocabulary, imported rather than re-typed. Three copies of the union
+// lived here and none of them listed `dismissed`, which the engine has always
+// accepted — so the UI had no way to say it and sent `deprecated` instead.
+import type { DecisionStatus } from "@repowise-dev/types/decisions";
+
 export interface DecisionRecordResponse {
   id: string;
   repository_id: string;
   title: string;
-  status: "proposed" | "active" | "deprecated" | "superseded";
+  status: DecisionStatus;
   context: string;
   decision: string;
   rationale: string;
@@ -68,7 +73,7 @@ export interface DecisionEvidenceResponse {
 export interface DecisionLineageEntry {
   id: string;
   title: string;
-  status: "proposed" | "active" | "deprecated" | "superseded";
+  status: DecisionStatus;
   source: string;
   relation: string | null;
 }
@@ -80,7 +85,7 @@ export interface DecisionLineageResponse {
 export interface DecisionGraphNode {
   id: string;
   title: string;
-  status: "proposed" | "active" | "deprecated" | "superseded";
+  status: DecisionStatus;
   source: string;
   confidence: number;
   staleness_score: number;

--- a/packages/types/__tests__/contracts.test.ts
+++ b/packages/types/__tests__/contracts.test.ts
@@ -120,9 +120,13 @@ describe("DeadCodeFinding optional enrichment", () => {
 });
 
 describe("DecisionRecord literal unions", () => {
-  it("constrains status to the four-literal union", () => {
+  it("constrains status to the five-literal union", () => {
+    // `dismissed` belongs here: the engine has always accepted it and treats it
+    // differently from `deprecated` — skipped on re-extraction, hidden from
+    // listings — and its absence is what left the UI sending `deprecated` for
+    // a dismissal.
     expectTypeOf<DecisionStatus>().toEqualTypeOf<
-      "proposed" | "active" | "deprecated" | "superseded"
+      "proposed" | "active" | "deprecated" | "dismissed" | "superseded"
     >();
     expectTypeOf<DecisionRecord["status"]>().toEqualTypeOf<DecisionStatus>();
   });

--- a/packages/types/src/decisions.ts
+++ b/packages/types/src/decisions.ts
@@ -7,10 +7,18 @@
  * adapters fill defaults before passing data to components.
  */
 
+/**
+ * `dismissed` is a tombstone and `deprecated` is a retirement, and the
+ * difference is load-bearing: the engine skips a dismissed record on every
+ * re-extraction and hides it from listings, where a deprecated one keeps being
+ * re-derived and keeps its row. The union omitted `dismissed` while the engine
+ * had always accepted it, which left the UI no way to say it.
+ */
 export type DecisionStatus =
   | "proposed"
   | "active"
   | "deprecated"
+  | "dismissed"
   | "superseded";
 
 export type DecisionSource =

--- a/packages/ui/__tests__/decisions/decision-create-form.test.tsx
+++ b/packages/ui/__tests__/decisions/decision-create-form.test.tsx
@@ -1,0 +1,106 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { DecisionCreateForm } from "../../src/decisions/decision-create-form";
+
+const toastSuccess = vi.fn();
+const toastError = vi.fn();
+vi.mock("sonner", () => ({
+  toast: {
+    success: (...args: unknown[]) => toastSuccess(...args),
+    error: (...args: unknown[]) => toastError(...args),
+  },
+}));
+
+function fill(label: string, value: string) {
+  fireEvent.change(screen.getByLabelText(label), { target: { value } });
+}
+
+describe("DecisionCreateForm", () => {
+  beforeEach(() => {
+    toastSuccess.mockClear();
+    toastError.mockClear();
+  });
+
+  it("submits every field, splitting the list inputs", async () => {
+    const onSubmit = vi.fn(async () => undefined);
+    const onCreated = vi.fn();
+    render(<DecisionCreateForm onSubmit={onSubmit} onCreated={onCreated} />);
+
+    fill("Title", "Use JWT for authentication");
+    fill("Decision", "Issue signed JWTs");
+    fill("Context", "sessions did not survive a restart");
+    fill("Rationale", "stateless verification");
+    fill("Rejected alternatives", "server sessions, opaque tokens");
+    fill("Tradeoffs", "revocation needs a deny list");
+    fill("Affected files", "src/auth/service.py, src/auth/middleware.py");
+    fill("Tags", "auth, security");
+
+    fireEvent.click(screen.getByRole("button", { name: "Record decision" }));
+
+    await waitFor(() =>
+      expect(onSubmit).toHaveBeenCalledWith({
+        title: "Use JWT for authentication",
+        decision: "Issue signed JWTs",
+        context: "sessions did not survive a restart",
+        rationale: "stateless verification",
+        alternatives: ["server sessions", "opaque tokens"],
+        consequences: ["revocation needs a deny list"],
+        affected_files: ["src/auth/service.py", "src/auth/middleware.py"],
+        tags: ["auth", "security"],
+      }),
+    );
+    expect(onCreated).toHaveBeenCalled();
+    expect(toastSuccess).toHaveBeenCalled();
+  });
+
+  it("blank list fields stay empty rather than becoming one empty entry", async () => {
+    // "".split(",") is [""], so the naive read files a decision that names a
+    // single unnamed file — and `affected_files` is what governance joins on.
+    const onSubmit = vi.fn(async () => undefined);
+    render(<DecisionCreateForm onSubmit={onSubmit} />);
+
+    fill("Title", "Prefer ruff check");
+    fill("Decision", "never ruff format");
+    fireEvent.click(screen.getByRole("button", { name: "Record decision" }));
+
+    await waitFor(() =>
+      expect(onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          affected_files: [],
+          consequences: [],
+          alternatives: [],
+          tags: [],
+        }),
+      ),
+    );
+  });
+
+  it("cannot be submitted without a title and a decision", () => {
+    render(<DecisionCreateForm onSubmit={vi.fn(async () => undefined)} />);
+
+    const submit = screen.getByRole("button", { name: "Record decision" });
+    expect(submit).toBeDisabled();
+
+    fill("Title", "Half a record");
+    expect(submit).toBeDisabled();
+
+    fill("Decision", "the other half");
+    expect(submit).toBeEnabled();
+  });
+
+  it("keeps the form open and says so when the write fails", async () => {
+    const onSubmit = vi.fn(async () => {
+      throw new Error("repo is read-only");
+    });
+    const onCreated = vi.fn();
+    render(<DecisionCreateForm onSubmit={onSubmit} onCreated={onCreated} />);
+
+    fill("Title", "Use JWT");
+    fill("Decision", "sign them");
+    fireEvent.click(screen.getByRole("button", { name: "Record decision" }));
+
+    await waitFor(() => expect(toastError).toHaveBeenCalled());
+    expect(onCreated).not.toHaveBeenCalled();
+    expect(screen.getByLabelText("Title")).toHaveValue("Use JWT");
+  });
+});

--- a/packages/ui/__tests__/decisions/decision-detail.test.tsx
+++ b/packages/ui/__tests__/decisions/decision-detail.test.tsx
@@ -105,6 +105,22 @@ describe("DecisionDetail", () => {
     expect(toastSuccess).toHaveBeenCalled();
   });
 
+  it("dismisses a proposal as a tombstone, not as a deprecation", async () => {
+    // The button sent `deprecated`, which the engine keeps re-deriving on every
+    // index — so a dismissed proposal came back. `dismissed` is the status that
+    // is skipped on re-extraction and hidden from listings.
+    const adapter = makeAdapter();
+    renderView(<DecisionDetail decision={makeDecision()} adapter={adapter} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss" }));
+    const dialog = await screen.findByRole("dialog");
+    fireEvent.click(within(dialog).getByRole("button", { name: "Dismiss" }));
+
+    await waitFor(() =>
+      expect(adapter.patchDecision).toHaveBeenCalledWith({ status: "dismissed" }),
+    );
+  });
+
   it("renders the evolution timeline when the lineage chain is non-trivial", async () => {
     const adapter = makeAdapter({
       getLineage: vi.fn(

--- a/packages/ui/src/decisions/decision-create-form.tsx
+++ b/packages/ui/src/decisions/decision-create-form.tsx
@@ -1,0 +1,208 @@
+"use client";
+
+import * as React from "react";
+import { toast } from "sonner";
+import type { DecisionCreateInput } from "@repowise-dev/types/decisions";
+import { Button } from "../ui/button";
+import { Input } from "../ui/input";
+import { Label } from "../ui/label";
+
+/**
+ * Record a decision by hand.
+ *
+ * The page told readers to go and run `repowise decision add` because there
+ * was no create form and no POST call in the UI at all — the one thing the
+ * decisions surface could not do was start a record.
+ *
+ * Presentation and form state only, per the convention the rest of this
+ * directory follows: the host supplies `onSubmit`, so web and hosted post
+ * through their own clients.
+ *
+ * The comma-separated list fields mirror the CLI's prompts rather than
+ * inventing a chip editor. They are the fields people leave blank most often,
+ * and a text input that accepts "a, b" needs no keyboard contract explained.
+ */
+
+const FIELD = "space-y-1.5";
+
+/** "a, b ,, c" → ["a", "b", "c"]. Blank stays blank rather than becoming [""]. */
+function splitList(raw: string): string[] {
+  return raw
+    .split(",")
+    .map((part) => part.trim())
+    .filter(Boolean);
+}
+
+const TEXTAREA_CLASS =
+  "box-border min-w-0 flex w-full rounded-md border border-[var(--color-border-default)] " +
+  "bg-[var(--color-bg-surface)] px-3 py-2 text-sm text-[var(--color-text-primary)] " +
+  "transition-colors placeholder:text-[var(--color-text-tertiary)] focus-visible:outline-none " +
+  "focus-visible:ring-1 focus-visible:ring-[var(--color-accent-primary)] " +
+  "disabled:cursor-not-allowed disabled:opacity-50";
+
+export interface DecisionCreateFormProps {
+  /** Persists the record. Rejecting is reported to the user and keeps the form open. */
+  onSubmit: (input: DecisionCreateInput) => Promise<void>;
+  /** Called after a successful write, e.g. to close a dialog and refresh a list. */
+  onCreated?: () => void;
+  onCancel?: () => void;
+}
+
+export function DecisionCreateForm({
+  onSubmit,
+  onCreated,
+  onCancel,
+}: DecisionCreateFormProps) {
+  const [title, setTitle] = React.useState("");
+  const [decision, setDecision] = React.useState("");
+  const [context, setContext] = React.useState("");
+  const [rationale, setRationale] = React.useState("");
+  const [alternatives, setAlternatives] = React.useState("");
+  const [consequences, setConsequences] = React.useState("");
+  const [affectedFiles, setAffectedFiles] = React.useState("");
+  const [tags, setTags] = React.useState("");
+  const [saving, setSaving] = React.useState(false);
+
+  // Title and decision are the two the engine cannot default: a record with
+  // neither a name nor a choice is not a decision. Everything else is optional,
+  // as it is at the prompts.
+  const canSubmit = title.trim().length > 0 && decision.trim().length > 0 && !saving;
+
+  async function handleSubmit(event: React.FormEvent) {
+    event.preventDefault();
+    if (!canSubmit) return;
+    setSaving(true);
+    try {
+      await onSubmit({
+        title: title.trim(),
+        decision: decision.trim(),
+        context: context.trim(),
+        rationale: rationale.trim(),
+        alternatives: splitList(alternatives),
+        consequences: splitList(consequences),
+        affected_files: splitList(affectedFiles),
+        tags: splitList(tags),
+      });
+      toast.success("Decision recorded");
+      onCreated?.();
+    } catch (err) {
+      toast.error(
+        err instanceof Error
+          ? `Couldn't record decision: ${err.message}`
+          : "Couldn't record decision",
+      );
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div className={FIELD}>
+        <Label htmlFor="decision-title">Title</Label>
+        <Input
+          id="decision-title"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder="Use JWT for authentication"
+          disabled={saving}
+          required
+        />
+      </div>
+
+      <div className={FIELD}>
+        <Label htmlFor="decision-decision">Decision</Label>
+        <textarea
+          id="decision-decision"
+          value={decision}
+          onChange={(e) => setDecision(e.target.value)}
+          placeholder="What was chosen?"
+          rows={2}
+          disabled={saving}
+          required
+          className={TEXTAREA_CLASS}
+        />
+      </div>
+
+      <div className={FIELD}>
+        <Label htmlFor="decision-context">Context</Label>
+        <textarea
+          id="decision-context"
+          value={context}
+          onChange={(e) => setContext(e.target.value)}
+          placeholder="What forced this decision?"
+          rows={2}
+          disabled={saving}
+          className={TEXTAREA_CLASS}
+        />
+      </div>
+
+      <div className={FIELD}>
+        <Label htmlFor="decision-rationale">Rationale</Label>
+        <textarea
+          id="decision-rationale"
+          value={rationale}
+          onChange={(e) => setRationale(e.target.value)}
+          placeholder="Why this and not something else?"
+          rows={2}
+          disabled={saving}
+          className={TEXTAREA_CLASS}
+        />
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className={FIELD}>
+          <Label htmlFor="decision-alternatives">Rejected alternatives</Label>
+          <Input
+            id="decision-alternatives"
+            value={alternatives}
+            onChange={(e) => setAlternatives(e.target.value)}
+            placeholder="Comma-separated"
+            disabled={saving}
+          />
+        </div>
+        <div className={FIELD}>
+          <Label htmlFor="decision-consequences">Tradeoffs</Label>
+          <Input
+            id="decision-consequences"
+            value={consequences}
+            onChange={(e) => setConsequences(e.target.value)}
+            placeholder="Comma-separated"
+            disabled={saving}
+          />
+        </div>
+        <div className={FIELD}>
+          <Label htmlFor="decision-files">Affected files</Label>
+          <Input
+            id="decision-files"
+            value={affectedFiles}
+            onChange={(e) => setAffectedFiles(e.target.value)}
+            placeholder="src/auth/service.py, src/auth/middleware.py"
+            disabled={saving}
+          />
+        </div>
+        <div className={FIELD}>
+          <Label htmlFor="decision-tags">Tags</Label>
+          <Input
+            id="decision-tags"
+            value={tags}
+            onChange={(e) => setTags(e.target.value)}
+            placeholder="auth, security"
+            disabled={saving}
+          />
+        </div>
+      </div>
+
+      <div className="flex justify-end gap-2 pt-1">
+        {onCancel && (
+          <Button type="button" variant="ghost" onClick={onCancel} disabled={saving}>
+            Cancel
+          </Button>
+        )}
+        <Button type="submit" disabled={!canSubmit}>
+          {saving ? "Recording…" : "Record decision"}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/packages/ui/src/decisions/decision-detail.tsx
+++ b/packages/ui/src/decisions/decision-detail.tsx
@@ -81,6 +81,13 @@ const CONFIRM_COPY: Record<
     confirmLabel: "Deprecate",
     destructive: true,
   },
+  dismissed: {
+    title: "Dismiss decision?",
+    description:
+      "This proposal will be hidden from the list and indexing will not raise it again. Nothing in your code changes.",
+    confirmLabel: "Dismiss",
+    destructive: true,
+  },
 };
 
 export interface DecisionDetailProps {
@@ -469,8 +476,15 @@ export function DecisionDetail({ decision, adapter }: DecisionDetailProps) {
               >
                 Confirm
               </button>
+              {/* Dismissing a proposal and deprecating a decision are not the
+                  same act, and this button used to send `deprecated` for both.
+                  A dismissal says the proposal was never right, so the engine
+                  never raises it again; deprecation says a real decision has
+                  been retired, and the record keeps being re-derived and keeps
+                  its row. Sending the wrong one meant a dismissed proposal came
+                  back on the next index. */}
               <button
-                onClick={() => handleStatusChange("deprecated")}
+                onClick={() => handleStatusChange("dismissed")}
                 disabled={loading}
                 className="rounded-md border border-[var(--color-border-default)] px-3 py-1.5 text-sm text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-elevated)] disabled:opacity-50"
               >
@@ -491,8 +505,8 @@ export function DecisionDetail({ decision, adapter }: DecisionDetailProps) {
         {status === "proposed" && (
           <p className="text-xs text-[var(--color-text-tertiary)]">
             Confirm marks this as an accurate, current decision for your team.
-            Dismiss hides it from the active list as inaccurate or no longer
-            relevant. Neither changes any code.
+            Dismiss hides it and stops indexing from raising it again, for a
+            proposal that was never right. Neither changes any code.
           </p>
         )}
         {status === "active" && (

--- a/packages/ui/src/decisions/decision-status-mark.tsx
+++ b/packages/ui/src/decisions/decision-status-mark.tsx
@@ -6,6 +6,8 @@ const STATUS_COLOR: Record<string, string> = {
   active: "var(--color-success)",
   proposed: "var(--color-accent-primary)",
   deprecated: "var(--color-error)",
+  // Muted like `superseded`: a tombstone is out of the way, not an alarm.
+  dismissed: "var(--color-text-tertiary)",
   superseded: "var(--color-text-tertiary)",
 };
 

--- a/packages/ui/src/decisions/decisions-table.tsx
+++ b/packages/ui/src/decisions/decisions-table.tsx
@@ -291,6 +291,10 @@ export function DecisionsTable({
           <option value="active">Active</option>
           <option value="proposed">Proposed</option>
           <option value="deprecated">Deprecated</option>
+          {/* Dismissed records are excluded from every default listing, so
+              without this option a dismissal is a one-way door: nothing in the
+              UI could show what had been dismissed, or undo one. */}
+          <option value="dismissed">Dismissed</option>
           <option value="superseded">Superseded</option>
         </select>
         <select

--- a/packages/ui/src/decisions/index.ts
+++ b/packages/ui/src/decisions/index.ts
@@ -6,6 +6,7 @@ export * from "./decision-evidence-drawer";
 export * from "./decision-lineage";
 export * from "./decision-detail-adapter";
 export * from "./decision-detail";
+export * from "./decision-create-form";
 export * from "./decision-governance";
 export * from "./decision-staleness";
 export * from "./checkout-facts";

--- a/packages/vscode/webview/src/views/decisions/App.tsx
+++ b/packages/vscode/webview/src/views/decisions/App.tsx
@@ -16,6 +16,9 @@ const STATUS_DOT: Record<Status, string> = {
   active: "var(--color-success)",
   proposed: "var(--color-info)",
   deprecated: "var(--color-error)",
+  // A tombstone, excluded from every listing this view reads — so it stays out
+  // of STATUS_ORDER, but the map is exhaustive over the status vocabulary.
+  dismissed: "var(--color-text-tertiary)",
   superseded: "var(--color-text-tertiary)",
 };
 

--- a/packages/web/src/app/repos/[id]/decisions/page.tsx
+++ b/packages/web/src/app/repos/[id]/decisions/page.tsx
@@ -8,6 +8,7 @@ import { getDecisionCounts, listDecisions } from "@/lib/api/decisions";
 import { listEpisodes } from "@/lib/api/episodes";
 import { ApiClientError } from "@/lib/api/client";
 import { DecisionsTableWrapper } from "@/components/decisions/decisions-table-wrapper";
+import { AddDecisionButton } from "@/components/decisions/add-decision-button";
 
 export const revalidate = 30;
 export const metadata: Metadata = { title: "Decisions" };
@@ -143,8 +144,9 @@ export default async function DecisionsPage({ params }: Props) {
             <p>
               Decisions land here as the indexer mines them from pull requests,
               commit messages, code comments and your own sessions, and as you
-              record them with <code>repowise decision add</code>. Each one
-              keeps the quote it was drawn from and the files it governs.
+              record them yourself — below, or with{" "}
+              <code>repowise decision add</code>. Each one keeps the quote it
+              was drawn from and the files it governs.
             </p>
             {proposed > 0 && (
               <p>
@@ -178,6 +180,13 @@ export default async function DecisionsPage({ params }: Props) {
           </>
         )}
       </PageLede>
+
+      {/* Visible in both states on purpose: the table section below is not
+          rendered at all on an empty repo, which is exactly when somebody
+          needs to record the first one. */}
+      <div className="flex justify-end">
+        <AddDecisionButton repoId={repoId} />
+      </div>
 
       {facts && (
         <OverviewSection

--- a/packages/web/src/components/decisions/add-decision-button.tsx
+++ b/packages/web/src/components/decisions/add-decision-button.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import * as React from "react";
+import { useRouter } from "next/navigation";
+import { Plus } from "lucide-react";
+import { DecisionCreateForm } from "@repowise-dev/ui/decisions/decision-create-form";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@repowise-dev/ui/ui/dialog";
+import { Button } from "@repowise-dev/ui/ui/button";
+import type { DecisionCreateInput } from "@repowise-dev/types/decisions";
+import { createDecision } from "@/lib/api/decisions";
+
+/**
+ * The host half of recording a decision: the entry point, the POST, and the
+ * refresh. The form itself is shared, so hosted mounts the same fields behind
+ * its own client.
+ */
+export function AddDecisionButton({ repoId }: { repoId: string }) {
+  const [open, setOpen] = React.useState(false);
+  const router = useRouter();
+
+  const handleSubmit = React.useCallback(
+    async (input: DecisionCreateInput) => {
+      await createDecision(repoId, input);
+    },
+    [repoId],
+  );
+
+  return (
+    <>
+      <Button variant="outline" size="sm" onClick={() => setOpen(true)}>
+        <Plus className="h-3.5 w-3.5" />
+        Record a decision
+      </Button>
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="max-h-[90vh] max-w-2xl overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle>Record a decision</DialogTitle>
+            <DialogDescription>
+              Something the team has settled on. It is recorded as confirmed,
+              because you are the person confirming it.
+            </DialogDescription>
+          </DialogHeader>
+          <DecisionCreateForm
+            onSubmit={handleSubmit}
+            onCreated={() => {
+              setOpen(false);
+              // The page is a server component reading the list, so the new
+              // row arrives on a refetch rather than through the table's own
+              // SWR cache.
+              router.refresh();
+            }}
+            onCancel={() => setOpen(false)}
+          />
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/packages/web/src/components/decisions/decisions-table-wrapper.tsx
+++ b/packages/web/src/components/decisions/decisions-table-wrapper.tsx
@@ -9,6 +9,7 @@ import {
 } from "@repowise-dev/ui/decisions/decisions-table";
 import { getDecisionCounts, listDecisions } from "@/lib/api/decisions";
 import type { DecisionRecord } from "@repowise-dev/types/decisions";
+import type { DecisionCounts } from "@repowise-dev/api-client/types";
 
 interface DecisionsTableWrapperProps {
   repoId: string;
@@ -75,9 +76,7 @@ export function DecisionsTableWrapper({
   );
 
   const total = counts
-    ? filters.status === "all"
-      ? counts.total
-      : (counts[filters.status] ?? 0)
+    ? countFor(counts, filters.status)
     : !source && filters.status === "all"
       ? initialTotal
       : undefined;
@@ -125,6 +124,36 @@ export function DecisionsTableWrapper({
       )}
     </div>
   );
+}
+
+/**
+ * The measured total behind one status filter, or undefined when nobody
+ * counted it.
+ *
+ * Not every status has a count: dismissed records are tombstones and the
+ * counts endpoint excludes them by design, so that filter reports the window
+ * it loaded rather than an "of 0" beside a table with rows in it. A switch
+ * rather than an index, so a status added later fails the build here instead
+ * of quietly reading undefined.
+ */
+function countFor(
+  counts: DecisionCounts,
+  status: DecisionsTableFilters["status"],
+): number | undefined {
+  switch (status) {
+    case "all":
+      return counts.total;
+    case "active":
+      return counts.active;
+    case "proposed":
+      return counts.proposed;
+    case "deprecated":
+      return counts.deprecated;
+    case "superseded":
+      return counts.superseded;
+    case "dismissed":
+      return undefined;
+  }
 }
 
 function PageButton({


### PR DESCRIPTION
Two gaps on the decisions surface: a button that did not do what it said, and no
way to start a record at all.

## Dismiss did not dismiss

The Dismiss button PATCHed `deprecated`. That is a different act with different
consequences:

| | `dismissed` | `deprecated` |
|---|---|---|
| re-extraction | skipped entirely, never re-proposed | re-derived, fields refreshed |
| `list_decisions` / counts | excluded unless asked for | included, ranked last |

So dismissing a wrong proposal did not stick — it came back on the next index,
which is the one thing the button exists to prevent. The button only ever
appears on a proposal, where "this was never right" is what the reader means,
and the helper text beside it already said as much.

**The cause was a layer down.** The UI could not send `dismissed`: it was never
in the shared `DecisionStatus` union, nor in three hand-typed copies of that
same union in the API client, though the engine's `_VALID_DECISION_STATUSES` has
accepted it throughout. The union gains it and the API client's copies become
imports of the one definition, since that duplication is how the vocabularies
drifted apart in the first place.

Two consequences the compiler found, both kept honest rather than papered over:

- **The table gains a Dismissed filter.** Dismissed records are excluded from
  every default listing, so without it a dismissal is a one-way door with
  nothing in the UI able to show what was dismissed, or undo it.
- **The row count reports nothing for that filter, not zero.** The counts
  endpoint excludes tombstones by design, and "of 0" beside a table with rows in
  it is a number nobody measured. An exhaustive switch, so a status added later
  fails the build there rather than quietly reading `undefined`.

## The page can record a decision

The one thing the decisions surface could not do was start a record: no form, no
POST call anywhere in the UI, and an empty state that sent the reader to a
terminal. The endpoint and the typed client call already shipped, so this is the
form and the entry point.

The fields are the ones the CLI prompts for, and only title and decision are
required, as they are there. Records land confirmed, which is right here and
would not be in a script: the person filling in eight fields in a browser is the
person confirming them.

Split the way the rest of the directory is split — `DecisionCreateForm` in
`packages/ui` holds the fields and the form state and takes the write as a prop,
`AddDecisionButton` in `packages/web` owns the POST and the refresh — so a
second host mounts the same fields behind its own client. The button sits above
the table rather than inside it, because the table section is not rendered at
all on a repository with no decisions, which is exactly when somebody needs to
record the first one.

## Tests

Five new tests, all five confirmed red first by mutating the single line each
one names. `lint` and `type-check` clean across every workspace; 1,116 tests in
`packages/ui`, 90 in types, 50 in api-client, 20 in web, 4 in vscode.
