### PR TITLE
fix: capture field_declarations types to omit rust dead code fps 

### DIFF
--- a/packages/core/src/repowise/core/ingestion/parser.py
+++ b/packages/core/src/repowise/core/ingestion/parser.py
@@ -79,6 +79,7 @@ from .parser_helpers import (
     _qualified_cpp_parent,
     _qualified_pascal_parent,
     _run_query,
+    _rust_shadowed_by_type_param,
 )
 from .python_local_refs import extract_python_local_refs
 from .sfc_source import component_call_sites, prepare_source
@@ -1091,6 +1092,11 @@ class ASTParser:
                 continue
 
             if target_name in _call_builtins:
+                continue
+
+            if file_info.language == "rust" and _rust_shadowed_by_type_param(
+                target_nodes[0], target_name, src
+            ):
                 continue
 
             line = site_node.start_point[0] + 1

--- a/packages/core/src/repowise/core/ingestion/parser_helpers.py
+++ b/packages/core/src/repowise/core/ingestion/parser_helpers.py
@@ -1082,6 +1082,44 @@ def _count_arguments(arg_node: Node) -> int:
     return sum(1 for child in arg_node.children if child.type not in skip_types)
 
 
+def _rust_type_param_name(param: Node, src: str) -> str | None:
+    """Return the bound name of a ``type_parameter``/``const_parameter`` node.
+
+    Both node types put the binding name first, before any trait bound or
+    default (``T: Clone``, ``D = Foo``, ``const N: usize``) — later
+    ``type_identifier`` children are constraints, not the binding itself.
+    """
+    for child in param.children:
+        if child.type in ("type_identifier", "identifier"):
+            return node_text(child, src).strip()
+    return None
+
+
+def _rust_shadowed_by_type_param(node: Node, target_name: str, src: str) -> bool:
+    """True if *target_name* is bound as a generic type parameter by an
+    ancestor item of *node* (``struct Wrapper<Item> { value: Item }``).
+
+    Rust's field/generic-argument type captures can't distinguish a type
+    parameter's own name from a real type reference — both are plain
+    ``type_identifier`` nodes. Without this check, a type parameter that
+    happens to share a name with a real struct/enum produces a false
+    "used" edge to that struct, hiding it from dead-code detection even
+    when it is genuinely unreferenced.
+    """
+    ancestor = node.parent
+    while ancestor is not None:
+        for child in ancestor.children:
+            if child.type != "type_parameters":
+                continue
+            for param in child.children:
+                if param.type not in ("type_parameter", "const_parameter"):
+                    continue
+                if _rust_type_param_name(param, src) == target_name:
+                    return True
+        ancestor = ancestor.parent
+    return False
+
+
 def _find_enclosing_symbol(
     line: int,
     symbol_ranges: list[tuple[int, int, str]],

--- a/packages/core/src/repowise/core/ingestion/queries/rust.scm
+++ b/packages/core/src/repowise/core/ingestion/queries/rust.scm
@@ -347,6 +347,60 @@
   )
 ) @call.site
 
+; Plain type argument: Option<MyType>, Vec<MyType>
+(type_arguments
+  (type_identifier) @call.target
+) @call.site
+
+; Scoped type argument: Option<super::MyType>, Vec<crate::mod::MyType>
+(type_arguments
+  (scoped_type_identifier
+    name: (type_identifier) @call.target
+  )
+) @call.site
+
+; Field type: struct Foo { bar: MyType }
+; enum_variant reuses field_declaration for struct-like variant bodies
+; (Received { state: MyType }), so this also covers enum variant fields.
+; Rust intra-crate field references need no `use` (path-qualified or
+; same-module access is legal without importing), so without this capture
+; the reference never becomes a graph edge and the field's type looks
+; unimported ("no importers").
+(field_declaration
+  type: (type_identifier) @call.target
+) @call.site
+
+; Scoped field type: struct Foo { bar: super::MyType }
+(field_declaration
+  type: (scoped_type_identifier
+    name: (type_identifier) @call.target
+  )
+) @call.site
+
+; Reference field type: struct Foo { bar: &MyType }
+(field_declaration
+  type: (reference_type
+    type: (type_identifier) @call.target
+  )
+) @call.site
+
+; Scoped reference field type: struct Foo { bar: &super::MyType }
+(field_declaration
+  type: (reference_type
+    type: (scoped_type_identifier
+      name: (type_identifier) @call.target
+    )
+  )
+) @call.site
+
+; Generic field type base: struct Foo { bar: Option<MyType> } — captures
+; Option itself when it is a locally-defined generic type.
+(field_declaration
+  type: (generic_type
+    type: (type_identifier) @call.target
+  )
+) @call.site
+
 ; ---------------------------------------------------------------------------
 ; Fields
 ; ---------------------------------------------------------------------------

--- a/tests/unit/ingestion/test_rust_field_type_use.py
+++ b/tests/unit/ingestion/test_rust_field_type_use.py
@@ -97,6 +97,14 @@ class TestRustFieldTypeCapture:
         names = self._calls("pub struct Foo { bar: &Bar }\n")
         assert "Bar" in names
 
+    def test_generic_type_param_not_captured_as_reference(self) -> None:
+        # `Item` here is the type parameter's own name, not a reference to
+        # a struct named `Item` — the two are indistinguishable as bare
+        # `type_identifier` nodes without checking the enclosing
+        # `type_parameters` list.
+        names = self._calls("pub struct Wrapper<Item> { pub value: Item }\n")
+        assert "Item" not in names
+
 
 # ---------------------------------------------------------------------------
 # Graph + dead-code outcome (end-to-end through GraphBuilder)
@@ -177,3 +185,59 @@ class TestRustFieldTypeDeadCodeOutcome:
             f.symbol_name for f in report.findings if f.kind == DeadCodeKind.UNUSED_EXPORT
         }
         assert "DeadState" in unused_exports
+
+
+class TestRustGenericTypeParamCollision:
+    """A generic type parameter that shares a name with a real struct must
+    not rescue that struct from dead-code detection.
+
+    ``struct Wrapper<Item> { value: Item }`` — the field's ``Item`` is a
+    reference to the type parameter, not to the ``Item`` struct defined
+    elsewhere in the crate. Without the type-parameter check, that field
+    produces a false ``Wrapper -> Item`` edge, so the genuinely-dead
+    ``Item`` struct is no longer flagged.
+    """
+
+    _SOURCES: dict[str, str] = {
+        "Cargo.toml": '[package]\nname = "net"\nversion = "0.1.0"\n',
+        "src/lib.rs": (
+            "pub struct Item { pub id: u32 }\n\n"
+            "pub struct Wrapper<Item> { pub value: Item }\n\n"
+            "pub fn dead_fn() {}\n"
+        ),
+    }
+
+    def _build_graph(self, repo: Path) -> nx.DiGraph:
+        for rel, body in self._SOURCES.items():
+            p = repo / rel
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text(body, encoding="utf-8")
+
+        builder = GraphBuilder(repo_path=repo)
+        for rel in self._SOURCES:
+            if not rel.endswith(".rs"):
+                continue
+            abs_path = str((repo / rel).resolve())
+            parsed = _PARSER.parse_file(_file_info(rel, abs_path), (repo / rel).read_bytes())
+            builder.add_file(parsed)
+        return builder.build()
+
+    def test_no_edge_from_shadowed_type_param(self, tmp_path: Path) -> None:
+        graph = self._build_graph(tmp_path)
+        assert not graph.has_edge("src/lib.rs::Wrapper", "src/lib.rs::Item")
+
+    def test_shadowed_struct_still_flagged_unused_export(self, tmp_path: Path) -> None:
+        graph = self._build_graph(tmp_path)
+        analyzer = DeadCodeAnalyzer(graph, git_meta_map={})
+        report = analyzer.analyze(
+            {
+                "detect_unreachable_files": False,
+                "detect_zombie_packages": False,
+                "detect_unused_internals": False,
+                "min_confidence": 0.0,
+            }
+        )
+        unused_exports = {
+            f.symbol_name for f in report.findings if f.kind == DeadCodeKind.UNUSED_EXPORT
+        }
+        assert "Item" in unused_exports

--- a/tests/unit/ingestion/test_rust_field_type_use.py
+++ b/tests/unit/ingestion/test_rust_field_type_use.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from pathlib import Path
+from typing import ClassVar
 
 import networkx as nx
 
@@ -198,7 +199,7 @@ class TestRustGenericTypeParamCollision:
     ``Item`` struct is no longer flagged.
     """
 
-    _SOURCES: dict[str, str] = {
+    _SOURCES: ClassVar[dict[str, str]] = {
         "Cargo.toml": '[package]\nname = "net"\nversion = "0.1.0"\n',
         "src/lib.rs": (
             "pub struct Item { pub id: u32 }\n\n"

--- a/tests/unit/ingestion/test_rust_field_type_use.py
+++ b/tests/unit/ingestion/test_rust_field_type_use.py
@@ -94,7 +94,7 @@ class TestRustFieldTypeCapture:
         assert "Bar" in names
 
     def test_reference_field_type_captured(self) -> None:
-        names = self._calls("pub struct Foo { bar: &Bar }\n")
+        names = self._calls("pub struct Foo<'a> { bar: &'a Bar }\n")
         assert "Bar" in names
 
     def test_generic_type_param_not_captured_as_reference(self) -> None:

--- a/tests/unit/ingestion/test_rust_field_type_use.py
+++ b/tests/unit/ingestion/test_rust_field_type_use.py
@@ -1,0 +1,179 @@
+"""Rust struct/enum field type references — false-positive regression.
+
+Covers the chain that turns a Rust field's type annotation into a graph
+edge the dead-code analyzer can read:
+
+* ``field_declaration``'s ``type:`` node now captured as ``@call.target`` in
+  ``rust.scm`` (plain, scoped ``super::``/``crate::`` paths, and references);
+* ``type_arguments`` generalised beyond the existing ``dyn Trait`` case, so
+  a type nested in ``Option<T>`` / ``Vec<T>`` is also captured;
+* the existing ``CallResolver`` free-call tiers (same-file, then
+  cross-file global-unique-name) turn that capture into a ``calls`` edge
+  with no changes to the resolver itself;
+* the end-to-end dead-code outcome: a struct used only as a field type,
+  including across files via a path-qualified reference with no ``use``
+  statement, is no longer flagged as an unused export — while a genuinely
+  unreferenced struct in the same crate still is (the honesty guard).
+
+Before this fix, ``field_declaration`` had no type capture at all, so a
+struct referenced only as a struct/enum field never became a ``CallSite``
+and read as having "no importers" regardless of how it was used. Since
+``enum_variant``'s struct-like body reuses the ``field_declaration`` node,
+this single gap covered both the plain-struct-field and enum-variant-field
+false positives reported against ``get_dead_code``.
+
+All tests drive the real parser, GraphBuilder and analyzer — no mocking of
+the resolution path.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+
+import networkx as nx
+
+from repowise.core.analysis.dead_code import DeadCodeAnalyzer, DeadCodeKind
+from repowise.core.ingestion.graph import GraphBuilder
+from repowise.core.ingestion.models import FileInfo
+from repowise.core.ingestion.parser import ASTParser
+
+_PARSER = ASTParser()
+
+
+def _file_info(path: str, abs_path: str) -> FileInfo:
+    return FileInfo(
+        path=path,
+        abs_path=abs_path,
+        language="rust",
+        size_bytes=100,
+        git_hash="",
+        last_modified=datetime.now(),
+        is_test=path.endswith("_test.rs") or "/tests/" in path,
+        is_config=False,
+        is_api_contract=False,
+        is_entry_point=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Parser: field type capture
+# ---------------------------------------------------------------------------
+
+
+class TestRustFieldTypeCapture:
+    def _calls(self, body: str) -> set[str]:
+        info = _file_info("p/f.rs", "/repo/p/f.rs")
+        parsed = _PARSER.parse_file(info, body.encode("utf-8"))
+        return {c.target_name for c in parsed.calls}
+
+    def test_plain_struct_field_type_captured(self) -> None:
+        names = self._calls("pub struct Foo { bar: Bar }\n")
+        assert "Bar" in names
+
+    def test_scoped_struct_field_type_captured(self) -> None:
+        names = self._calls("pub struct Foo { bar: super::Bar }\n")
+        assert "Bar" in names
+
+    def test_enum_struct_variant_field_type_captured(self) -> None:
+        # enum_variant reuses field_declaration for its struct-like body.
+        names = self._calls(
+            "pub enum Event {\n"
+            "    Received { state: Bar },\n"
+            "}\n"
+        )
+        assert "Bar" in names
+
+    def test_generic_wrapped_scoped_field_type_captured(self) -> None:
+        # The reported false positive's exact shape: Option<super::Bar>.
+        names = self._calls(
+            "pub enum Event {\n"
+            "    Received { state: Option<super::Bar> },\n"
+            "}\n"
+        )
+        assert "Bar" in names
+
+    def test_reference_field_type_captured(self) -> None:
+        names = self._calls("pub struct Foo { bar: &Bar }\n")
+        assert "Bar" in names
+
+
+# ---------------------------------------------------------------------------
+# Graph + dead-code outcome (end-to-end through GraphBuilder)
+# ---------------------------------------------------------------------------
+
+# A crate laid out to mirror the reported bug: a struct defined in one
+# module file, referenced only as an enum-variant field type from a sibling
+# module file via a `super::` path — no `use` statement anywhere.
+_SOURCES: dict[str, str] = {
+    "Cargo.toml": '[package]\nname = "net"\nversion = "0.1.0"\n',
+    "src/lib.rs": "pub mod transport;\n",
+    "src/transport.rs": "pub mod state;\npub mod types;\n",
+    "src/transport/state.rs": (
+        "// RecvState is used only as an enum-variant field type in\n"
+        "// types.rs, crossing files with no `use` statement.\n"
+        "pub struct RecvState { pub id: u32 }\n\n"
+        "// DeadState is never referenced anywhere — a true positive that\n"
+        "// must survive the fix.\n"
+        "pub struct DeadState { pub id: u32 }\n"
+    ),
+    "src/transport/types.rs": (
+        "pub enum Event {\n"
+        "    Received { state: Option<super::state::RecvState> },\n"
+        "}\n"
+    ),
+}
+
+
+def _build_graph(repo: Path) -> nx.DiGraph:
+    for rel, body in _SOURCES.items():
+        p = repo / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(body, encoding="utf-8")
+
+    builder = GraphBuilder(repo_path=repo)
+    for rel in _SOURCES:
+        if not rel.endswith(".rs"):
+            continue
+        abs_path = str((repo / rel).resolve())
+        parsed = _PARSER.parse_file(_file_info(rel, abs_path), (repo / rel).read_bytes())
+        builder.add_file(parsed)
+    return builder.build()
+
+
+class TestRustFieldTypeUseEdge:
+    def test_cross_file_field_type_produces_calls_edge(self, tmp_path: Path) -> None:
+        graph = _build_graph(tmp_path)
+        assert graph.has_edge(
+            "src/transport/types.rs::Received",
+            "src/transport/state.rs::RecvState",
+        )
+
+
+class TestRustFieldTypeDeadCodeOutcome:
+    def _report(self, graph: nx.DiGraph):
+        analyzer = DeadCodeAnalyzer(graph, git_meta_map={})
+        return analyzer.analyze(
+            {
+                "detect_unreachable_files": False,
+                "detect_zombie_packages": False,
+                "detect_unused_internals": False,
+                "min_confidence": 0.0,
+            }
+        )
+
+    def test_cross_file_field_referenced_struct_not_flagged(self, tmp_path: Path) -> None:
+        report = self._report(_build_graph(tmp_path))
+        unused_exports = {
+            f.symbol_name for f in report.findings if f.kind == DeadCodeKind.UNUSED_EXPORT
+        }
+        assert "RecvState" not in unused_exports
+
+    def test_genuinely_dead_struct_in_same_crate_still_flagged(self, tmp_path: Path) -> None:
+        # True-positive guard: the field-type capture must not turn into a
+        # blanket exemption for every struct in a crate with field types.
+        report = self._report(_build_graph(tmp_path))
+        unused_exports = {
+            f.symbol_name for f in report.findings if f.kind == DeadCodeKind.UNUSED_EXPORT
+        }
+        assert "DeadState" in unused_exports

--- a/uv.lock
+++ b/uv.lock
@@ -3090,7 +3090,6 @@ dependencies = [
     { name = "tree-sitter-javascript" },
     { name = "tree-sitter-kotlin" },
     { name = "tree-sitter-luau" },
-    { name = "tree-sitter-pascal" },
     { name = "tree-sitter-php" },
     { name = "tree-sitter-python" },
     { name = "tree-sitter-ruby" },
@@ -3185,7 +3184,6 @@ requires-dist = [
     { name = "tree-sitter-javascript", specifier = ">=0.23,<1" },
     { name = "tree-sitter-kotlin", specifier = ">=1,<2" },
     { name = "tree-sitter-luau", specifier = ">=1.2,<2" },
-    { name = "tree-sitter-pascal", specifier = ">=0.11,<1" },
     { name = "tree-sitter-php", specifier = ">=0.23,<1" },
     { name = "tree-sitter-python", specifier = ">=0.23,<1" },
     { name = "tree-sitter-ruby", specifier = ">=0.23,<1" },
@@ -4123,26 +4121,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ac/53/33b3ceb6c51757db94a2f12764bef2dfca003593f3c5663d46f5b0bc12bc/tree_sitter_luau-1.2.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8e2a35014902028c312dff6d45439fbdb8255583104a9e1c0f286162527629b2", size = 51127, upload-time = "2024-12-22T22:42:41.68Z" },
     { url = "https://files.pythonhosted.org/packages/8b/7e/5379a5502835f7bf39084cefd6dca6e5b7ed12a9c0ef692a57962e33ea38/tree_sitter_luau-1.2.0-cp39-abi3-win_amd64.whl", hash = "sha256:c8f86b022fe6d1a784e26fa2e898f1459a3f4d31555bed31bf6dda9c72e46f6d", size = 32942, upload-time = "2024-12-22T22:42:43.676Z" },
     { url = "https://files.pythonhosted.org/packages/1a/df/db574405f592f1f4f039dc83db8545d634b68481ce0c457bbab26e155a4a/tree_sitter_luau-1.2.0-cp39-abi3-win_arm64.whl", hash = "sha256:37e9a2e2dd9795800c98c160eabcfed9a90a25a80e2f207658902b0444a40440", size = 31300, upload-time = "2024-12-22T22:42:45.64Z" },
-]
-
-[[package]]
-name = "tree-sitter-pascal"
-version = "0.11.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/89/89/cb9ce7f7e9a119a3d518020c387fb994f8f6cac07a3f796fbb3409b506fb/tree_sitter_pascal-0.11.0.tar.gz", hash = "sha256:7d4da59b8c0b2ff9a32181562eed25c8ba13a6c8bbca2cb895e10f5344708dba", size = 293593, upload-time = "2026-07-01T03:53:16.47Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/74/621a4d1690e224de4ae00fb90304469bd96c1ae25bd7a8eabb95f9809b90/tree_sitter_pascal-0.11.0-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:7a8c2bb6ab958cea7390e18ed28f4535ca24ba110eae0449d5a77c294844d45a", size = 238019, upload-time = "2026-07-01T03:53:01.704Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/36/8660f400b1c42714f345fc0afae295be2fafec51531d199b7c6e2387881e/tree_sitter_pascal-0.11.0-cp38-abi3-macosx_10_9_x86_64.whl", hash = "sha256:bccb2d757c17820cdcfaa760bac1df4caa6278e1e2334d6956e0f9c31c6e8f4a", size = 125475, upload-time = "2026-07-01T03:53:03.182Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/1e/06f87ce971119b6a6c1682a0647cad9774463ae9c68faa8c016d8c10d30f/tree_sitter_pascal-0.11.0-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:ed50bb16a8469a54ae365f51dac046a3247e2efbab203269a8d737fa816b11a6", size = 132345, upload-time = "2026-07-01T03:53:04.643Z" },
-    { url = "https://files.pythonhosted.org/packages/00/b6/e37df67cc704f9c19531c858835396366d39790e71114fa181929b0dba00/tree_sitter_pascal-0.11.0-cp38-abi3-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:3ec2ca83d1e01a1eaf7711d6392947058c64302562f987be5c0bcf7e185d0dbd", size = 157887, upload-time = "2026-07-01T03:53:05.849Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/81/9e21b0199e86078ca4763ab4bc68fa6e1a3e625e168dee9fdcf27455d09f/tree_sitter_pascal-0.11.0-cp38-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:ab7557a05400f2841b18d000997453dadff09c2830bd48313cf4264bab018bbe", size = 153629, upload-time = "2026-07-01T03:53:06.99Z" },
-    { url = "https://files.pythonhosted.org/packages/20/34/947ae7c72eac8363e3de08f2a1e2f992beeb6afb27daca939443438e4614/tree_sitter_pascal-0.11.0-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:543717086ae596aa1895c6151230e45f78ed20a69b9c1ab83a5d5950db068381", size = 153629, upload-time = "2026-07-01T03:53:08.138Z" },
-    { url = "https://files.pythonhosted.org/packages/14/05/6b103890fdb63c57fb89650ece51333852e0ee8a4a3ef0966168acebfad4/tree_sitter_pascal-0.11.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:e317158e32c6e19ab75fe8664b48c48d71e757f6e2f8de0996eba63583d4ea55", size = 152709, upload-time = "2026-07-01T03:53:09.386Z" },
-    { url = "https://files.pythonhosted.org/packages/46/6e/ef2c893744b4d53f53113f7ca5bf3016afed6ced3db82ae7d3a42a2faf72/tree_sitter_pascal-0.11.0-cp38-abi3-musllinux_1_2_i686.whl", hash = "sha256:ab2e43d9a4d30ee482322a41f7f12ca2f40b4f0ee1771646329fe57a6a6a29ba", size = 157179, upload-time = "2026-07-01T03:53:10.501Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/bf/5b64986483183667c086c6612185a03f3de2408f81b6bac49b60fa45c187/tree_sitter_pascal-0.11.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b545e3b7a20fc7f7ce346e0fc598120a90b980adf050357946b7b00d2a81f875", size = 152117, upload-time = "2026-07-01T03:53:11.842Z" },
-    { url = "https://files.pythonhosted.org/packages/18/80/3553a1c89441a8f78daedd6182580db4df234b6b4ddd0e9d18ac9a2f7385/tree_sitter_pascal-0.11.0-cp38-abi3-win32.whl", hash = "sha256:c898d8c2771c5da47dbab20aea1d99e3aca8878a90e24db0a5558619ac8ad5c5", size = 124205, upload-time = "2026-07-01T03:53:12.969Z" },
-    { url = "https://files.pythonhosted.org/packages/19/96/695db7513510ea4fedb5e4e9b47011bf309253715c5eb9892c71486312e6/tree_sitter_pascal-0.11.0-cp38-abi3-win_amd64.whl", hash = "sha256:99346d54c928d42c820c0aa262f6acbf4fb2856d69016f1df11f834f681b45e0", size = 124349, upload-time = "2026-07-01T03:53:14.082Z" },
-    { url = "https://files.pythonhosted.org/packages/45/ad/e5381365ed5b247cad2e047682b081ccbb79f84bb5c1b48642ef3385f1d3/tree_sitter_pascal-0.11.0-cp38-abi3-win_arm64.whl", hash = "sha256:9d22b974a47765f1c98629338d82d1df89c35c270a73f08dda8fbd49538e32d4", size = 124914, upload-time = "2026-07-01T03:53:15.191Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -3090,6 +3090,7 @@ dependencies = [
     { name = "tree-sitter-javascript" },
     { name = "tree-sitter-kotlin" },
     { name = "tree-sitter-luau" },
+    { name = "tree-sitter-pascal" },
     { name = "tree-sitter-php" },
     { name = "tree-sitter-python" },
     { name = "tree-sitter-ruby" },
@@ -3184,6 +3185,7 @@ requires-dist = [
     { name = "tree-sitter-javascript", specifier = ">=0.23,<1" },
     { name = "tree-sitter-kotlin", specifier = ">=1,<2" },
     { name = "tree-sitter-luau", specifier = ">=1.2,<2" },
+    { name = "tree-sitter-pascal", specifier = ">=0.11,<1" },
     { name = "tree-sitter-php", specifier = ">=0.23,<1" },
     { name = "tree-sitter-python", specifier = ">=0.23,<1" },
     { name = "tree-sitter-ruby", specifier = ">=0.23,<1" },
@@ -4121,6 +4123,26 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ac/53/33b3ceb6c51757db94a2f12764bef2dfca003593f3c5663d46f5b0bc12bc/tree_sitter_luau-1.2.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8e2a35014902028c312dff6d45439fbdb8255583104a9e1c0f286162527629b2", size = 51127, upload-time = "2024-12-22T22:42:41.68Z" },
     { url = "https://files.pythonhosted.org/packages/8b/7e/5379a5502835f7bf39084cefd6dca6e5b7ed12a9c0ef692a57962e33ea38/tree_sitter_luau-1.2.0-cp39-abi3-win_amd64.whl", hash = "sha256:c8f86b022fe6d1a784e26fa2e898f1459a3f4d31555bed31bf6dda9c72e46f6d", size = 32942, upload-time = "2024-12-22T22:42:43.676Z" },
     { url = "https://files.pythonhosted.org/packages/1a/df/db574405f592f1f4f039dc83db8545d634b68481ce0c457bbab26e155a4a/tree_sitter_luau-1.2.0-cp39-abi3-win_arm64.whl", hash = "sha256:37e9a2e2dd9795800c98c160eabcfed9a90a25a80e2f207658902b0444a40440", size = 31300, upload-time = "2024-12-22T22:42:45.64Z" },
+]
+
+[[package]]
+name = "tree-sitter-pascal"
+version = "0.11.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/89/89/cb9ce7f7e9a119a3d518020c387fb994f8f6cac07a3f796fbb3409b506fb/tree_sitter_pascal-0.11.0.tar.gz", hash = "sha256:7d4da59b8c0b2ff9a32181562eed25c8ba13a6c8bbca2cb895e10f5344708dba", size = 293593, upload-time = "2026-07-01T03:53:16.47Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/74/621a4d1690e224de4ae00fb90304469bd96c1ae25bd7a8eabb95f9809b90/tree_sitter_pascal-0.11.0-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:7a8c2bb6ab958cea7390e18ed28f4535ca24ba110eae0449d5a77c294844d45a", size = 238019, upload-time = "2026-07-01T03:53:01.704Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/36/8660f400b1c42714f345fc0afae295be2fafec51531d199b7c6e2387881e/tree_sitter_pascal-0.11.0-cp38-abi3-macosx_10_9_x86_64.whl", hash = "sha256:bccb2d757c17820cdcfaa760bac1df4caa6278e1e2334d6956e0f9c31c6e8f4a", size = 125475, upload-time = "2026-07-01T03:53:03.182Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/1e/06f87ce971119b6a6c1682a0647cad9774463ae9c68faa8c016d8c10d30f/tree_sitter_pascal-0.11.0-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:ed50bb16a8469a54ae365f51dac046a3247e2efbab203269a8d737fa816b11a6", size = 132345, upload-time = "2026-07-01T03:53:04.643Z" },
+    { url = "https://files.pythonhosted.org/packages/00/b6/e37df67cc704f9c19531c858835396366d39790e71114fa181929b0dba00/tree_sitter_pascal-0.11.0-cp38-abi3-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:3ec2ca83d1e01a1eaf7711d6392947058c64302562f987be5c0bcf7e185d0dbd", size = 157887, upload-time = "2026-07-01T03:53:05.849Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/81/9e21b0199e86078ca4763ab4bc68fa6e1a3e625e168dee9fdcf27455d09f/tree_sitter_pascal-0.11.0-cp38-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:ab7557a05400f2841b18d000997453dadff09c2830bd48313cf4264bab018bbe", size = 153629, upload-time = "2026-07-01T03:53:06.99Z" },
+    { url = "https://files.pythonhosted.org/packages/20/34/947ae7c72eac8363e3de08f2a1e2f992beeb6afb27daca939443438e4614/tree_sitter_pascal-0.11.0-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:543717086ae596aa1895c6151230e45f78ed20a69b9c1ab83a5d5950db068381", size = 153629, upload-time = "2026-07-01T03:53:08.138Z" },
+    { url = "https://files.pythonhosted.org/packages/14/05/6b103890fdb63c57fb89650ece51333852e0ee8a4a3ef0966168acebfad4/tree_sitter_pascal-0.11.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:e317158e32c6e19ab75fe8664b48c48d71e757f6e2f8de0996eba63583d4ea55", size = 152709, upload-time = "2026-07-01T03:53:09.386Z" },
+    { url = "https://files.pythonhosted.org/packages/46/6e/ef2c893744b4d53f53113f7ca5bf3016afed6ced3db82ae7d3a42a2faf72/tree_sitter_pascal-0.11.0-cp38-abi3-musllinux_1_2_i686.whl", hash = "sha256:ab2e43d9a4d30ee482322a41f7f12ca2f40b4f0ee1771646329fe57a6a6a29ba", size = 157179, upload-time = "2026-07-01T03:53:10.501Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/bf/5b64986483183667c086c6612185a03f3de2408f81b6bac49b60fa45c187/tree_sitter_pascal-0.11.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b545e3b7a20fc7f7ce346e0fc598120a90b980adf050357946b7b00d2a81f875", size = 152117, upload-time = "2026-07-01T03:53:11.842Z" },
+    { url = "https://files.pythonhosted.org/packages/18/80/3553a1c89441a8f78daedd6182580db4df234b6b4ddd0e9d18ac9a2f7385/tree_sitter_pascal-0.11.0-cp38-abi3-win32.whl", hash = "sha256:c898d8c2771c5da47dbab20aea1d99e3aca8878a90e24db0a5558619ac8ad5c5", size = 124205, upload-time = "2026-07-01T03:53:12.969Z" },
+    { url = "https://files.pythonhosted.org/packages/19/96/695db7513510ea4fedb5e4e9b47011bf309253715c5eb9892c71486312e6/tree_sitter_pascal-0.11.0-cp38-abi3-win_amd64.whl", hash = "sha256:99346d54c928d42c820c0aa262f6acbf4fb2856d69016f1df11f834f681b45e0", size = 124349, upload-time = "2026-07-01T03:53:14.082Z" },
+    { url = "https://files.pythonhosted.org/packages/45/ad/e5381365ed5b247cad2e047682b081ccbb79f84bb5c1b48642ef3385f1d3/tree_sitter_pascal-0.11.0-cp38-abi3-win_arm64.whl", hash = "sha256:9d22b974a47765f1c98629338d82d1df89c35c270a73f08dda8fbd49538e32d4", size = 124914, upload-time = "2026-07-01T03:53:15.191Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

 - `rust.scm` never captured a `field_declaration`'s type, so a struct/enum referenced only as a field's type (no call, no `use`) produced zero graph edges and was flagged `unused_export` with "no importers" and was omitted as a dead code false positive with high confidence.
 - Adds captures for plain, scoped (`super::`/`crate::`), reference (`&T`), and generic-wrapped (`Option<T>`) field types. Since `enum_variant` reuses `field_declaration` for its struct-like body, this covers both plain struct fields and enum-variant fields. Resolution then flows through the existing `CallResolver` tiers.
- Fix: a generic type parameter that shares a name with a real struct (`struct Wrapper<Item> { value: Item }`) was being resolved as a reference to that struct, incorrectly rescuing it from dead-code detection. Filters out `@call.target` names that are bound by an enclosing item's `type_parameters` before they become a `CallSite`.


## Related Issues

Refs https://github.com/repowise-dev/repowise/issues/640

## Test Plan

 - [x] Tests pass (`pytest`)
 - [x] Lint passes (`ruff check .`)

New regression test: `tests/unit/ingestion/test_rust_field_type_use.py` 
- Parser-level: confirms `field_declaration` types are captured for plain, scoped (`super::`), reference (`&T`), and enum-variant field shapes, including the reported `Option<super::T>` case.
- Graph-level: confirms a cross-file field reference (no `use` statement) produces a `calls` edge between the two files.
- Dead-code outcome: the cross-file, no-import referenced struct is no longer flagged `unused_export`.
- True-positive guard: a genuinely unreferenced struct in the same crate is still flagged `unused_export`.
- Generic type-param collision guard: `Wrapper<Item>` produces no edge to the unrelated `Item` struct, and that struct is still flagged `unused_export`.


## Checklist

  - [x] My code follows the project's code style
  - [x] I have added tests for new functionality
  - [x] All existing tests still pass
  - [x] I have updated documentation if needed
