### PR TITLE
test: confirm no FPs on exports only consumed from tests/*.rs in rust

### DIFF
--- a/tests/unit/ingestion/test_rust_test_consumer.py
+++ b/tests/unit/ingestion/test_rust_test_consumer.py
@@ -2,8 +2,14 @@
 (which compiles as a separate, external crate — exactly why the symbol
 must stay `pub`) must not be flagged `unused_export`. Drives the real
 parser, GraphBuilder and analyzer end-to-end against a crate where a
-struct and the function returning it are only referenced via
-`use net::build_report` from an integration test.
+function and a struct are only referenced from an integration test.
+
+`Report` is constructed inside `lib.rs` by `build_report`, so it is
+already reachable via an intra-file edge regardless of any test consumer —
+asserting `Report` isn't flagged doesn't exercise the test-consumer path.
+`Ticket` is declared in `lib.rs` but never constructed there; the
+integration test is its only consumer, so it is the type that actually
+pins the behavior under test.
 """
 
 from __future__ import annotations
@@ -20,28 +26,44 @@ from repowise.core.ingestion.parser import ASTParser
 
 _PARSER = ASTParser()
 
-# A crate whose only consumer of `Report` / `build_report` is an integration
+_LIB_RS = (
+    "// Report's fields are only ever asserted from the integration\n"
+    "// test below.\n"
+    "pub struct Report { pub id: u32, pub ok: bool }\n\n"
+    "pub fn build_report() -> Report { Report { id: 1, ok: true } }\n\n"
+    "// Ticket is never constructed in this file — the integration test\n"
+    "// is its only consumer.\n"
+    "pub struct Ticket { pub number: u32 }\n\n"
+    "// dead_fn is never referenced anywhere.\n"
+    "pub fn dead_fn() {}\n"
+)
+
+_TEST_RS = (
+    "use net::{build_report, Ticket};\n\n"
+    "#[test]\n"
+    "fn test_report_fields() {\n"
+    "    let r = build_report();\n"
+    "    assert_eq!(r.id, 1);\n"
+    "    assert!(r.ok);\n"
+    "    let t = Ticket { number: 7 };\n"
+    "    assert_eq!(t.number, 7);\n"
+    "}\n"
+)
+
+# A crate whose only consumer of `build_report` / `Ticket` is an integration
 # test under `tests/`, which compiles as an external crate and therefore
-# reaches them only through `use net::build_report` — no intra-crate edge.
+# reaches them only through `use net::{build_report, Ticket}` — no
+# intra-crate edge.
 _SOURCES: dict[str, str] = {
     "Cargo.toml": '[package]\nname = "net"\nversion = "0.1.0"\n',
-    "src/lib.rs": (
-        "// Report's fields are only ever asserted from the integration\n"
-        "// test below.\n"
-        "pub struct Report { pub id: u32, pub ok: bool }\n\n"
-        "pub fn build_report() -> Report { Report { id: 1, ok: true } }\n\n"
-        "// dead_fn is never referenced anywhere.\n"
-        "pub fn dead_fn() {}\n"
-    ),
-    "tests/report_test.rs": (
-        "use net::build_report;\n\n"
-        "#[test]\n"
-        "fn test_report_fields() {\n"
-        "    let r = build_report();\n"
-        "    assert_eq!(r.id, 1);\n"
-        "    assert!(r.ok);\n"
-        "}\n"
-    ),
+    "src/lib.rs": _LIB_RS,
+    "tests/report_test.rs": _TEST_RS,
+}
+
+# Same crate with the integration test removed — the consumer-deleted case.
+_SOURCES_NO_TEST: dict[str, str] = {
+    "Cargo.toml": '[package]\nname = "net"\nversion = "0.1.0"\n',
+    "src/lib.rs": _LIB_RS,
 }
 
 
@@ -60,14 +82,14 @@ def _file_info(path: str, abs_path: str) -> FileInfo:
     )
 
 
-def _build_graph(repo: Path) -> nx.DiGraph:
-    for rel, body in _SOURCES.items():
+def _build_graph(repo: Path, sources: dict[str, str]) -> nx.DiGraph:
+    for rel, body in sources.items():
         p = repo / rel
         p.parent.mkdir(parents=True, exist_ok=True)
         p.write_text(body, encoding="utf-8")
 
     builder = GraphBuilder(repo_path=repo)
-    for rel in _SOURCES:
+    for rel in sources:
         if not rel.endswith(".rs"):
             continue
         abs_path = str((repo / rel).resolve())
@@ -76,39 +98,49 @@ def _build_graph(repo: Path) -> nx.DiGraph:
     return builder.build()
 
 
-class TestRustIntegrationTestConsumer:
-    def _report(self, graph: nx.DiGraph):
-        analyzer = DeadCodeAnalyzer(graph, git_meta_map={})
-        return analyzer.analyze(
-            {
-                "detect_unreachable_files": False,
-                "detect_zombie_packages": False,
-                "detect_unused_internals": False,
-                "min_confidence": 0.0,
-            }
-        )
+def _unused_exports(graph: nx.DiGraph) -> set[str]:
+    analyzer = DeadCodeAnalyzer(graph, git_meta_map={})
+    report = analyzer.analyze(
+        {
+            "detect_unreachable_files": False,
+            "detect_zombie_packages": False,
+            "detect_unused_internals": False,
+            "min_confidence": 0.0,
+        }
+    )
+    return {f.symbol_name for f in report.findings if f.kind == DeadCodeKind.UNUSED_EXPORT}
 
+
+class TestRustIntegrationTestConsumer:
     def test_function_only_called_from_integration_test_not_flagged(
         self, tmp_path: Path
     ) -> None:
-        report = self._report(_build_graph(tmp_path))
-        unused_exports = {
-            f.symbol_name for f in report.findings if f.kind == DeadCodeKind.UNUSED_EXPORT
-        }
+        unused_exports = _unused_exports(_build_graph(tmp_path, _SOURCES))
         assert "build_report" not in unused_exports
 
     def test_struct_only_used_via_integration_test_not_flagged(self, tmp_path: Path) -> None:
-        report = self._report(_build_graph(tmp_path))
-        unused_exports = {
-            f.symbol_name for f in report.findings if f.kind == DeadCodeKind.UNUSED_EXPORT
-        }
-        assert "Report" not in unused_exports
+        # Ticket, not Report — Report is already rescued by the intra-file
+        # edge from build_report constructing it, so it can't exercise the
+        # test-consumer path on its own.
+        unused_exports = _unused_exports(_build_graph(tmp_path, _SOURCES))
+        assert "Ticket" not in unused_exports
 
     def test_genuinely_dead_export_still_flagged(self, tmp_path: Path) -> None:
         # True-positive guard: the test-consumer edge must not turn into a
         # blanket exemption for every export in a crate with a tests/ dir.
-        report = self._report(_build_graph(tmp_path))
-        unused_exports = {
-            f.symbol_name for f in report.findings if f.kind == DeadCodeKind.UNUSED_EXPORT
-        }
+        unused_exports = _unused_exports(_build_graph(tmp_path, _SOURCES))
         assert "dead_fn" in unused_exports
+
+
+class TestRustIntegrationTestConsumerRemoved:
+    """Deleting the only consumer must flip the finding back to flagged —
+    the property the "not flagged" tests above are actually pinning.
+    """
+
+    def test_function_flagged_once_its_only_consumer_is_gone(self, tmp_path: Path) -> None:
+        unused_exports = _unused_exports(_build_graph(tmp_path, _SOURCES_NO_TEST))
+        assert "build_report" in unused_exports
+
+    def test_struct_flagged_once_its_only_consumer_is_gone(self, tmp_path: Path) -> None:
+        unused_exports = _unused_exports(_build_graph(tmp_path, _SOURCES_NO_TEST))
+        assert "Ticket" in unused_exports

--- a/tests/unit/ingestion/test_rust_test_consumer.py
+++ b/tests/unit/ingestion/test_rust_test_consumer.py
@@ -1,0 +1,114 @@
+"""A `pub` symbol whose only consumer is a `tests/*.rs` integration test
+(which compiles as a separate, external crate — exactly why the symbol
+must stay `pub`) must not be flagged `unused_export`. Drives the real
+parser, GraphBuilder and analyzer end-to-end against a crate where a
+struct and the function returning it are only referenced via
+`use net::build_report` from an integration test.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+
+import networkx as nx
+
+from repowise.core.analysis.dead_code import DeadCodeAnalyzer, DeadCodeKind
+from repowise.core.ingestion.graph import GraphBuilder
+from repowise.core.ingestion.models import FileInfo
+from repowise.core.ingestion.parser import ASTParser
+
+_PARSER = ASTParser()
+
+# A crate whose only consumer of `Report` / `build_report` is an integration
+# test under `tests/`, which compiles as an external crate and therefore
+# reaches them only through `use net::build_report` — no intra-crate edge.
+_SOURCES: dict[str, str] = {
+    "Cargo.toml": '[package]\nname = "net"\nversion = "0.1.0"\n',
+    "src/lib.rs": (
+        "// Report's fields are only ever asserted from the integration\n"
+        "// test below.\n"
+        "pub struct Report { pub id: u32, pub ok: bool }\n\n"
+        "pub fn build_report() -> Report { Report { id: 1, ok: true } }\n\n"
+        "// dead_fn is never referenced anywhere.\n"
+        "pub fn dead_fn() {}\n"
+    ),
+    "tests/report_test.rs": (
+        "use net::build_report;\n\n"
+        "#[test]\n"
+        "fn test_report_fields() {\n"
+        "    let r = build_report();\n"
+        "    assert_eq!(r.id, 1);\n"
+        "    assert!(r.ok);\n"
+        "}\n"
+    ),
+}
+
+
+def _file_info(path: str, abs_path: str) -> FileInfo:
+    return FileInfo(
+        path=path,
+        abs_path=abs_path,
+        language="rust",
+        size_bytes=100,
+        git_hash="",
+        last_modified=datetime.now(),
+        is_test=path.startswith("tests/"),
+        is_config=False,
+        is_api_contract=False,
+        is_entry_point=False,
+    )
+
+
+def _build_graph(repo: Path) -> nx.DiGraph:
+    for rel, body in _SOURCES.items():
+        p = repo / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(body, encoding="utf-8")
+
+    builder = GraphBuilder(repo_path=repo)
+    for rel in _SOURCES:
+        if not rel.endswith(".rs"):
+            continue
+        abs_path = str((repo / rel).resolve())
+        parsed = _PARSER.parse_file(_file_info(rel, abs_path), (repo / rel).read_bytes())
+        builder.add_file(parsed)
+    return builder.build()
+
+
+class TestRustIntegrationTestConsumer:
+    def _report(self, graph: nx.DiGraph):
+        analyzer = DeadCodeAnalyzer(graph, git_meta_map={})
+        return analyzer.analyze(
+            {
+                "detect_unreachable_files": False,
+                "detect_zombie_packages": False,
+                "detect_unused_internals": False,
+                "min_confidence": 0.0,
+            }
+        )
+
+    def test_function_only_called_from_integration_test_not_flagged(
+        self, tmp_path: Path
+    ) -> None:
+        report = self._report(_build_graph(tmp_path))
+        unused_exports = {
+            f.symbol_name for f in report.findings if f.kind == DeadCodeKind.UNUSED_EXPORT
+        }
+        assert "build_report" not in unused_exports
+
+    def test_struct_only_used_via_integration_test_not_flagged(self, tmp_path: Path) -> None:
+        report = self._report(_build_graph(tmp_path))
+        unused_exports = {
+            f.symbol_name for f in report.findings if f.kind == DeadCodeKind.UNUSED_EXPORT
+        }
+        assert "Report" not in unused_exports
+
+    def test_genuinely_dead_export_still_flagged(self, tmp_path: Path) -> None:
+        # True-positive guard: the test-consumer edge must not turn into a
+        # blanket exemption for every export in a crate with a tests/ dir.
+        report = self._report(_build_graph(tmp_path))
+        unused_exports = {
+            f.symbol_name for f in report.findings if f.kind == DeadCodeKind.UNUSED_EXPORT
+        }
+        assert "dead_fn" in unused_exports


### PR DESCRIPTION
## Summary

  - One of the reported dead-code false-positive classes: a `pub` symbol whose only consumer is a `tests/*.rs` integration test (which compiles as a separate, external crate, exactly why the symbol has to stay `pub`) was flagged `unused_export` because the graph appeared to treat `tests/` as producing no consumer edges.
  
 - No code change, `tests/*.rs` integration tests already reach production symbols through ordinary `use my_crate::Thing` statements, which flow through the normal import-resolution path with no special-casing needed. This PR adds a guard test that reproduces the original bug's shape and confirms it no longer reproduces.

## Related Issues
Refs https://github.com/repowise-dev/repowise/issues/640

 ## Test Plan

  - [x] Tests pass (`pytest`)

 New regression test: `tests/unit/ingestion/test_rust_test_consumer.py`

  - Drives the real parser, GraphBuilder and analyzer against a crate where a function and a struct are referenced only from an integration test under `tests/`.
  - Confirms the function (`build_report`) is not flagged `unused_export`.
  - Confirms a struct only ever constructed in the integration test (`Ticket`) is not flagged `unused_export`. (A second struct, `Report`, is constructed inside `lib.rs` itself, so it's already reachable via an intra-file edge regardless of any test consumer, it doesn't exercise the test-consumer path on its own.)
  - True-positive guard: confirms a genuinely unreferenced export (`dead_fn`) in the same crate is still flagged.


## Checklist

  - [x] My code follows the project's code style
  - [x] I have added tests for new functionality
  - [x] All existing tests still pass
  - [x] I have updated documentation if needed
