### PR TITLE
feat(vscode): bring the extension onto the current design language

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -34,6 +34,7 @@
     "./dead-code/*": "./src/dead-code/*.tsx",
     "./health": "./src/health/index.ts",
     "./health/ai-prompt-builder": "./src/health/ai-prompt-builder.ts",
+    "./health/tokens": "./src/health/tokens.ts",
     "./health/*": "./src/health/*.tsx",
     "./coupling": "./src/coupling/index.ts",
     "./coupling/*": "./src/coupling/*.tsx",

--- a/packages/ui/src/decisions/decision-status-mark.tsx
+++ b/packages/ui/src/decisions/decision-status-mark.tsx
@@ -11,6 +11,19 @@ const STATUS_COLOR: Record<string, string> = {
   superseded: "var(--color-text-tertiary)",
 };
 
+/**
+ * The status colour, for a bare dot in a list too narrow to carry the word.
+ *
+ * Exported for the same reason `healthBandInk` is: a second surface that keeps
+ * its own copy of this table is a surface that can drift from it, and this one
+ * already had — a local map in the VS Code decisions panel painted `proposed`
+ * `--color-info` while this one painted it accent, so one status word had two
+ * colours depending on where you were looking.
+ */
+export function decisionStatusColor(status: DecisionStatus | string): string {
+  return STATUS_COLOR[status] ?? "var(--color-text-tertiary)";
+}
+
 export interface DecisionStatusMarkProps {
   status: DecisionStatus | string;
   className?: string;
@@ -28,7 +41,7 @@ export interface DecisionStatusMarkProps {
  * to use this page at all, and colour alone does not separate them for everyone.
  */
 export function DecisionStatusMark({ status, className }: DecisionStatusMarkProps) {
-  const color = STATUS_COLOR[status] ?? "var(--color-text-tertiary)";
+  const color = decisionStatusColor(status);
   return (
     <span
       className={cn(

--- a/packages/vscode/webview/src/runtime/chrome.tsx
+++ b/packages/vscode/webview/src/runtime/chrome.tsx
@@ -47,7 +47,7 @@ export function PanelChrome({ view, host }: { view: PanelViewId; host: WebviewHo
         className="flex shrink-0 items-center gap-1.5 rounded-md px-1.5 py-1 text-[var(--color-text-secondary)] transition-colors hover:bg-[var(--color-bg-surface)] hover:text-[var(--color-text-primary)]"
       >
         <Home className="h-4 w-4" />
-        <span className="hidden text-[11px] font-semibold tracking-wide sm:inline">Repowise</span>
+        <span className="hidden text-xs font-semibold tracking-wide sm:inline">Repowise</span>
       </button>
       <span aria-hidden className="mx-1 h-4 w-px shrink-0 bg-[var(--color-border-default)]" />
       <nav aria-label="Dashboards" className="flex min-w-0 items-center gap-0.5 overflow-x-auto">
@@ -95,7 +95,7 @@ function Tab({
       aria-current={active ? "page" : undefined}
       title={item.title}
       className={
-        "flex shrink-0 items-center gap-1.5 rounded-md px-2 py-1 text-[11px] font-medium transition-colors " +
+        "flex shrink-0 items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium transition-colors " +
         (active
           ? "bg-[var(--color-accent-muted)] text-[var(--color-accent-primary)]"
           : "text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-surface)] hover:text-[var(--color-text-primary)]")

--- a/packages/vscode/webview/src/runtime/mount.tsx
+++ b/packages/vscode/webview/src/runtime/mount.tsx
@@ -120,7 +120,7 @@ class ErrorBoundary extends Component<{ children: ReactNode }, ErrorBoundaryStat
   render(): ReactNode {
     if (this.state.error) {
       return (
-        <div className="m-6 rounded-lg border border-[var(--color-error)] p-4 text-sm">
+        <div className="m-6 rounded-lg border border-[var(--color-error)] p-4 text-[15px]">
           <p className="font-medium text-[var(--color-error)]">This view hit an error.</p>
           <p className="mt-2 text-[var(--color-text-secondary)]">{this.state.error.message}</p>
         </div>

--- a/packages/vscode/webview/src/runtime/theme.ts
+++ b/packages/vscode/webview/src/runtime/theme.ts
@@ -5,6 +5,11 @@
  * palette from a `.dark` class on the root element. This module keeps the two
  * in sync and exposes a subscription for code that needs the resolved kind
  * (the next-themes shim, canvas renderers).
+ *
+ * The two high-contrast kinds additionally stamp an `hc` class, which
+ * `theme-bridge.css` uses to widen borders and lift tertiary text. Contrast is
+ * read from the editor even when the light/dark preference is pinned: a user on
+ * a high-contrast theme needs the contrast whichever ramp they chose.
  */
 
 import type { ThemePreference } from "../../../src/shared/webviewMessages";
@@ -27,8 +32,17 @@ function compute(): ThemeKind {
   return "light";
 }
 
+/** True under either high-contrast kind. VS Code stamps the light one with
+ *  both `vscode-high-contrast-light` and, on some builds, the base class. */
+function computeHighContrast(): boolean {
+  const cls = document.body.classList;
+  return cls.contains("vscode-high-contrast") || cls.contains("vscode-high-contrast-light");
+}
+
 function apply(kind: ThemeKind): void {
-  document.documentElement.classList.toggle("dark", kind === "dark");
+  const root = document.documentElement;
+  root.classList.toggle("dark", kind === "dark");
+  root.classList.toggle("hc", computeHighContrast());
   if (kind === current) return;
   current = kind;
   for (const cb of subscribers) cb(kind);

--- a/packages/vscode/webview/src/styles/theme-bridge.css
+++ b/packages/vscode/webview/src/styles/theme-bridge.css
@@ -22,6 +22,38 @@
   --kg-card-texture: none;
 }
 
+/*
+ * High contrast, both kinds. The theme runtime stamps `hc` on the root under
+ * `vscode-high-contrast` and `vscode-high-contrast-light`, which previously
+ * fell through to the ordinary dark and light ramps: someone who explicitly
+ * asked for high contrast got the standard rgba(255,255,255,.07) hairlines and
+ * the standard tertiary text.
+ *
+ * The brand palette is kept rather than remapped onto --vscode-*, for the same
+ * reason the bridge above refuses the full remap and one more. Editor greys
+ * have no vocabulary for a health band, and green/amber/red on this surface
+ * carry one — a remap would trade contrast for making the map, the legend and
+ * every score unreadable as data. What is bridged is the part VS Code does
+ * define for this purpose: contrastBorder, contrastActiveBorder and
+ * focusBorder are set only by high-contrast themes, so the fallbacks below
+ * never fire outside one.
+ *
+ * Tertiary text is lifted to secondary rather than to a literal, so it follows
+ * the ramp instead of pinning a copy of it.
+ */
+.hc {
+  --color-border-default: var(--vscode-contrastBorder, currentColor);
+  --color-border-hover: var(--vscode-contrastActiveBorder, var(--color-text-primary));
+  --color-text-tertiary: var(--color-text-secondary);
+}
+
+/* HC themes outline the focused element rather than tinting it, and an
+   unfocusable-looking control is the accessibility end of this. */
+.hc :focus-visible {
+  outline: 1px solid var(--vscode-focusBorder, currentColor);
+  outline-offset: 2px;
+}
+
 html,
 body {
   margin: 0;

--- a/packages/vscode/webview/src/views/architecture/App.tsx
+++ b/packages/vscode/webview/src/views/architecture/App.tsx
@@ -181,10 +181,10 @@ function ArchitectureMap({ host, repo, params, refreshToken }: ViewProps<"archit
         <div className="flex items-center justify-between gap-3">
           <div className="min-w-0">
             <div className="flex items-center gap-2">
-              <h1 className="truncate text-sm font-semibold text-[var(--color-text-primary)]">
+              <h1 className="truncate text-[15px] font-semibold text-[var(--color-text-primary)]">
                 {repo.name}
               </h1>
-              <span className="rounded-full border border-[var(--color-border-default)] px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-[var(--color-text-secondary)]">
+              <span className="rounded-full border border-[var(--color-border-default)] px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.12em] text-[var(--color-text-secondary)]">
                 {levelLabel}
               </span>
             </div>

--- a/packages/vscode/webview/src/views/decisions/App.tsx
+++ b/packages/vscode/webview/src/views/decisions/App.tsx
@@ -1,7 +1,11 @@
 import { useEffect, useMemo, useState } from "react";
 import { FileText, Landmark, Lightbulb } from "lucide-react";
-import { Badge, Card, CardContent } from "@repowise-dev/ui/ui";
+import { Badge } from "@repowise-dev/ui/ui";
 import { EmptyState } from "@repowise-dev/ui/shared";
+import {
+  DecisionStatusMark,
+  decisionStatusColor,
+} from "@repowise-dev/ui/decisions/decision-status-mark";
 import { WikiMarkdown } from "@repowise-dev/ui/wiki/wiki-markdown";
 import { formatRelativeTime, stripMarkdown } from "@repowise-dev/ui/lib/format";
 import type { DecisionRecordResponse } from "@repowise-dev/api-client/types";
@@ -11,32 +15,14 @@ type Status = DecisionRecordResponse["status"];
 
 const STATUS_ORDER: readonly Status[] = ["active", "proposed", "deprecated", "superseded"];
 
-/** Left dot / accent per status, matching the shared decisions widget. */
-const STATUS_DOT: Record<Status, string> = {
-  active: "var(--color-success)",
-  proposed: "var(--color-info)",
-  deprecated: "var(--color-error)",
-  // A tombstone, excluded from every listing this view reads — so it stays out
-  // of STATUS_ORDER, but the map is exhaustive over the status vocabulary.
-  dismissed: "var(--color-text-tertiary)",
-  superseded: "var(--color-text-tertiary)",
-};
-
 function statusLabel(status: Status): string {
   return status.charAt(0).toUpperCase() + status.slice(1);
 }
 
-function StatusBadge({ status }: { status: Status }) {
-  const color = STATUS_DOT[status];
-  return (
-    <span
-      className="inline-flex items-center rounded border px-2 py-0.5 text-[11px] font-medium"
-      style={{ color, borderColor: `color-mix(in srgb, ${color} 35%, transparent)` }}
-    >
-      {statusLabel(status)}
-    </span>
-  );
-}
+/** Record section labels. Uppercase micro-labels are mono: it separates a
+ *  machine-shaped label from the prose under it without spending a colour. */
+const SECTION_LABEL =
+  "font-mono text-[10px] uppercase tracking-[0.12em] text-[var(--color-text-tertiary)]";
 
 function recencyKey(d: DecisionRecordResponse): number {
   const raw = d.updated_at || d.created_at;
@@ -62,14 +48,17 @@ function DecisionsSkeleton() {
         </div>
       </header>
       <div className="flex min-h-0 flex-1">
-        <div className="w-80 shrink-0 space-y-2 border-r border-[var(--color-border-default)] p-3">
+        {/* Borderless rows, matching the loaded list: a skeleton drawing seven
+            boxes for content that lands as seven plain rows reflows the panel
+            at exactly the moment it is meant to steady it. */}
+        <div className="w-80 shrink-0 space-y-1 border-r border-[var(--color-border-default)] p-3">
           {Array.from({ length: 7 }).map((_, i) => (
-            <div
-              key={i}
-              className="space-y-2 rounded-lg border border-[var(--color-border-default)] p-3"
-            >
-              <div className="h-4 w-3/4 animate-pulse rounded bg-[var(--color-bg-inset)]" />
-              <div className="h-3 w-1/2 animate-pulse rounded bg-[var(--color-bg-inset)]" />
+            <div key={i} className="flex items-start gap-3 px-3 py-2.5">
+              <div className="mt-1 h-2.5 w-2.5 shrink-0 animate-pulse rounded-full bg-[var(--color-bg-inset)]" />
+              <div className="min-w-0 flex-1 space-y-1.5">
+                <div className="h-4 w-3/4 animate-pulse rounded bg-[var(--color-bg-inset)]" />
+                <div className="h-3 w-1/2 animate-pulse rounded bg-[var(--color-bg-inset)]" />
+              </div>
             </div>
           ))}
         </div>
@@ -175,7 +164,7 @@ export function App({ host, refreshToken }: ViewProps<"decisions">) {
   return (
     <div className="flex h-full flex-col">
       <header className="border-b border-[var(--color-border-default)] px-6 py-4">
-        <h1 className="flex items-center gap-2 text-lg font-semibold text-[var(--color-text-primary)]">
+        <h1 className="flex items-center gap-2 text-[22px] font-semibold text-[var(--color-text-primary)]">
           <Landmark className="h-5 w-5 text-[var(--color-text-secondary)]" />
           Decisions
         </h1>
@@ -220,13 +209,13 @@ export function App({ host, refreshToken }: ViewProps<"decisions">) {
                 >
                   <span
                     className="mt-1.5 h-2.5 w-2.5 shrink-0 rounded-full"
-                    style={{ backgroundColor: STATUS_DOT[d.status] }}
+                    style={{ backgroundColor: decisionStatusColor(d.status) }}
                   />
                   <span className="min-w-0 flex-1">
-                    <span className="block truncate text-sm font-medium text-[var(--color-text-primary)]">
+                    <span className="block text-[15px] font-medium leading-snug text-[var(--color-text-primary)]">
                       {stripMarkdown(d.title)}
                     </span>
-                    <span className="mt-0.5 block text-[11px] text-[var(--color-text-tertiary)]">
+                    <span className="mt-0.5 block text-xs text-[var(--color-text-tertiary)]">
                       {formatRelativeTime(d.updated_at || d.created_at)}
                       {d.source ? ` · ${d.source.replace(/_/g, " ")}` : ""}
                     </span>
@@ -261,8 +250,8 @@ function Detail({
   return (
     <article className="mx-auto max-w-2xl space-y-5">
       <div className="space-y-3">
-        <StatusBadge status={decision.status} />
-        <h2 className="text-xl font-semibold leading-snug text-[var(--color-text-primary)]">
+        <DecisionStatusMark status={decision.status} className="capitalize" />
+        <h2 className="text-[22px] font-semibold leading-snug text-[var(--color-text-primary)]">
           {stripMarkdown(decision.title)}
         </h2>
         {decision.tags.length > 0 && (
@@ -278,10 +267,13 @@ function Detail({
 
       {sections.map((s) => (
         <section key={s.heading} className="space-y-1.5">
-          <h3 className="text-xs font-semibold uppercase tracking-wide text-[var(--color-text-tertiary)]">
+          <h3 className={SECTION_LABEL}>
             {s.heading}
           </h3>
-          <div className="prose-sm max-w-none text-sm text-[var(--color-text-secondary)]">
+          {/* No `prose` wrapper: WikiMarkdown themes every element it emits
+              through our tokens, so the plugin only imposes a second font
+              scale and set of margins over one that is already set. */}
+          <div className="max-w-none text-[var(--color-text-secondary)]">
             <WikiMarkdown content={s.body} />
           </div>
         </section>
@@ -296,7 +288,7 @@ function Detail({
 
       {decision.affected_files.length > 0 && (
         <section className="space-y-1.5">
-          <h3 className="text-xs font-semibold uppercase tracking-wide text-[var(--color-text-tertiary)]">
+          <h3 className={SECTION_LABEL}>
             Affected files
           </h3>
           <ul className="space-y-1">
@@ -310,18 +302,14 @@ function Detail({
       )}
 
       {decision.evidence_file && (
-        <Card>
-          <CardContent className="py-3">
-            <h3 className="mb-1.5 text-xs font-semibold uppercase tracking-wide text-[var(--color-text-tertiary)]">
-              Evidence
-            </h3>
-            <FileRef
-              host={host}
-              path={decision.evidence_file}
-              line={decision.evidence_line ?? undefined}
-            />
-          </CardContent>
-        </Card>
+        <section className="space-y-1.5 border-t border-[var(--color-border-default)] pt-4">
+          <h3 className={SECTION_LABEL}>Evidence</h3>
+          <FileRef
+            host={host}
+            path={decision.evidence_file}
+            line={decision.evidence_line ?? undefined}
+          />
+        </section>
       )}
     </article>
   );
@@ -330,10 +318,10 @@ function Detail({
 function ListSection({ heading, items }: { heading: string; items: string[] }) {
   return (
     <section className="space-y-1.5">
-      <h3 className="text-xs font-semibold uppercase tracking-wide text-[var(--color-text-tertiary)]">
+      <h3 className={SECTION_LABEL}>
         {heading}
       </h3>
-      <ul className="list-disc space-y-1 pl-5 text-sm text-[var(--color-text-secondary)]">
+      <ul className="list-disc space-y-1 pl-5 text-[15px] text-[var(--color-text-secondary)]">
         {items.map((item, i) => (
           <li key={i}>{item}</li>
         ))}
@@ -355,7 +343,7 @@ function FileRef({
     <button
       type="button"
       onClick={() => host.openFile(path, line)}
-      className="inline-flex items-center gap-1.5 text-sm text-[var(--color-accent-primary)] hover:underline"
+      className="inline-flex items-center gap-1.5 text-[15px] text-[var(--color-accent-primary)] hover:underline"
     >
       <FileText className="h-3.5 w-3.5 shrink-0" />
       <span className="break-all text-left">

--- a/packages/vscode/webview/src/views/docs/App.tsx
+++ b/packages/vscode/webview/src/views/docs/App.tsx
@@ -252,7 +252,7 @@ function CenteredState({
   return (
     <div className="flex h-full flex-col items-center justify-center gap-3 px-8 text-center">
       {icon}
-      <p className="text-sm font-semibold text-[var(--color-text-primary)]">{title}</p>
+      <p className="text-[15px] font-semibold text-[var(--color-text-primary)]">{title}</p>
       {detail && (
         <p className="max-w-sm text-xs text-[var(--color-text-secondary)]">{detail}</p>
       )}

--- a/packages/vscode/webview/src/views/graph/App.tsx
+++ b/packages/vscode/webview/src/views/graph/App.tsx
@@ -57,7 +57,7 @@ export function App({ host, params, repo, refreshToken }: ViewProps<"graph">) {
       <div className="relative min-h-0 flex-1">
         {data.error ? (
           <div className="flex h-full items-center justify-center p-6">
-            <div className="max-w-md rounded-lg border border-[var(--color-error)] bg-[var(--color-bg-elevated)] p-4 text-sm">
+            <div className="max-w-md rounded-lg border border-[var(--color-error)] bg-[var(--color-bg-elevated)] p-4 text-[15px]">
               <p className="font-medium text-[var(--color-error)]">
                 Could not load the knowledge graph.
               </p>

--- a/packages/vscode/webview/src/views/graph/graph-header.tsx
+++ b/packages/vscode/webview/src/views/graph/graph-header.tsx
@@ -9,7 +9,7 @@ export function GraphHeader({ repoName, stats }: GraphHeaderProps) {
   return (
     <header className="flex shrink-0 items-center justify-between gap-3 border-b border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-4 py-2">
       <div className="flex min-w-0 items-center gap-2">
-        <span className="text-sm font-medium text-[var(--color-text-primary)]">
+        <span className="text-[15px] font-medium text-[var(--color-text-primary)]">
           Knowledge Graph
         </span>
         <span className="truncate text-xs text-[var(--color-text-tertiary)]">

--- a/packages/vscode/webview/src/views/health/App.test.tsx
+++ b/packages/vscode/webview/src/views/health/App.test.tsx
@@ -6,6 +6,7 @@ import type {
   HealthOverviewResponse,
   HealthTrendResponse,
 } from "@repowise-dev/types/health";
+import { OVERLAY_SPECS } from "@repowise-dev/ui/health/code-health-map";
 import type { WebviewHost } from "../../runtime/rpc";
 import { App } from "./App";
 
@@ -57,6 +58,18 @@ const files: HealthFilesResponse = {
       nloc: 320,
       has_test_file: false,
       line_coverage_pct: 12,
+      module: "core",
+    },
+    // 7.6 is the score the old local threshold got wrong: it called anything
+    // at or above 7.5 healthy-green while the map beside it painted amber.
+    {
+      file_path: "src/mid.py",
+      score: 7.6,
+      max_ccn: 9,
+      max_nesting: 2,
+      nloc: 140,
+      has_test_file: true,
+      line_coverage_pct: 71,
       module: "core",
     },
   ],
@@ -123,7 +136,7 @@ function makeHost(): { host: WebviewHost; openFile: ReturnType<typeof vi.fn> } {
 afterEach(cleanup);
 
 describe("Health dashboard", () => {
-  it("renders the KPI header and the map section from host data", async () => {
+  it("renders the lede, the map section and the trend from host data", async () => {
     const { host } = makeHost();
     render(
       <App
@@ -134,16 +147,41 @@ describe("Health dashboard", () => {
       />,
     );
 
-    // KPI header: the three co-equal signal tiles.
+    // The lede leads with the defect score, as the web code-health page does.
     expect(await screen.findByText("Defect risk")).toBeTruthy();
-    expect(screen.getByText("Maintainability")).toBeTruthy();
-    expect(screen.getByText("Performance")).toBeTruthy();
+    // The figure, and again inside the sentence that makes it mean something.
+    expect(screen.getAllByText("7.4").length).toBeGreaterThan(0);
 
-    // The map is the hero section.
+    // The map is the page spine; trend sits under it.
     expect(screen.getByText("Code health map")).toBeTruthy();
+    expect(screen.getByText("Trend")).toBeTruthy();
 
     // Repo identity is surfaced in the header.
     expect(screen.getByText("demo-repo")).toBeTruthy();
+  });
+
+  it("paints a focused file's score the colour the map paints the same file", async () => {
+    const { host } = makeHost();
+    render(
+      <App
+        host={host}
+        repo={{ id: "r1", name: "demo-repo", headCommit: null, defaultBranch: "main" }}
+        params={{ selectPath: "src/mid.py" }}
+        refreshToken={0}
+      />,
+    );
+
+    const figure = await screen.findByText("7.6");
+    const mapFill = OVERLAY_SPECS.health.fill(
+      files.files.find((f) => f.file_path === "src/mid.py")!,
+    );
+
+    // The contradiction this replaced: the panel called 7.6 green while the
+    // canvas beside it coloured the same node amber. A passing render test
+    // would not have caught that, so assert against the map's own fill table
+    // rather than against a colour written out here a third time.
+    expect(mapFill).toBe("var(--color-caution)");
+    expect(figure.className).toContain(mapFill);
   });
 
   it("shows an error panel when the host fails", async () => {

--- a/packages/vscode/webview/src/views/health/App.tsx
+++ b/packages/vscode/webview/src/views/health/App.tsx
@@ -1,35 +1,43 @@
 /**
- * Health dashboard: a KPI header over the three health signals, the circle-pack
- * code map as the hero, and the churn-versus-complexity quadrant on a tab. Every
- * file click opens the file in an editor column via the host.
+ * Health dashboard: the shared code-health lede, the circle-pack map as the
+ * page spine with its lens switcher and key around it, and the trend section
+ * under it. Every file click opens the file in an editor column via the host.
+ *
+ * The composition mirrors `/repos/[id]/code-health` rather than reimplementing
+ * it. That page dropped its KPI grid for `CodeHealthLede` and folded the
+ * churn-versus-complexity quadrant into a *lens* on the map; this panel was the
+ * last consumer of both retired components in the monorepo, which is how it was
+ * going to diverge permanently. It composes the same pieces rather than
+ * mounting `TriageView` wholesale, because the drill-downs that view carries
+ * (findings tables, coverage, a file drawer, href-based navigation) are
+ * surfaces this panel does not have and an editor cannot address by URL.
  */
 
 import { useMemo, useState } from "react";
 import { ExternalLink } from "lucide-react";
-import { HealthKpiCards } from "@repowise-dev/ui/health/kpi-cards";
-import { CodeHealthMap, type CodeHealthOverlay } from "@repowise-dev/ui/health/code-health-map";
-import { ChurnComplexityQuadrant } from "@repowise-dev/ui/health/churn-complexity-quadrant";
-import type { HealthDimension, HealthFileMetric } from "@repowise-dev/types/health";
+import {
+  CodeHealthMap,
+  MapLegend,
+  MapLensSwitcher,
+  type CodeHealthOverlay,
+} from "@repowise-dev/ui/health/code-health-map";
+import { CodeHealthLede } from "@repowise-dev/ui/health/code-health-lede";
+import { TrendView } from "@repowise-dev/ui/health/trend-view";
+import { scoreTextColor } from "@repowise-dev/ui/health/tokens";
+import { OverviewSection } from "@repowise-dev/ui/overview";
+import type { HealthFileMetric } from "@repowise-dev/types/health";
 import type { ViewProps } from "../../runtime/mount";
-import { useDashboardData, type DashboardData } from "./useDashboardData";
-import { DashboardError, DashboardSkeleton, SectionHeading } from "./chrome";
+import { useChurnLens, useDashboardData, type DashboardData } from "./useDashboardData";
+import { DashboardError, DashboardSkeleton } from "./chrome";
 
-type HeroTab = "map" | "quadrant";
+/**
+ * Lenses offered. The three co-equal health signals ride on the map payload
+ * itself; churn arrives on its own request and is joined in below, which is why
+ * it is listed here rather than left to the map component's default.
+ */
+const LENSES: CodeHealthOverlay[] = ["health", "maintainability", "performance", "churn"];
 
-/** 0-10 health score to its band color; matches the sidebar Home hero. */
-function scoreColor(score: number | null): string {
-  if (score == null) return "var(--color-text-tertiary)";
-  if (score >= 7.5) return "var(--color-success)";
-  if (score >= 5) return "var(--color-warning)";
-  return "var(--color-error)";
-}
-
-/** The KPI pillar tiles map onto the code map's lenses (defect is "health"). */
-const PILLAR_TO_OVERLAY: Record<HealthDimension, CodeHealthOverlay> = {
-  defect: "health",
-  maintainability: "maintainability",
-  performance: "performance",
-};
+const MAP_HEIGHT = 640;
 
 export function App({ host, repo, params, refreshToken }: ViewProps<"health">) {
   const { data, error, loading } = useDashboardData(host, refreshToken);
@@ -55,49 +63,36 @@ function Dashboard({
   data: DashboardData;
   selectPath: string | null;
 }) {
-  const { overview, files, trend, churn } = data;
+  const { overview, files, trend } = data;
+  const [overlay, setOverlay] = useState<CodeHealthOverlay>("health");
 
-  // When the dashboard is opened from the status-bar score, lead with a card
+  // Churn is a second request and only the churn lens colors from it, so it is
+  // fetched on selection rather than on mount.
+  const {
+    files: mapFiles,
+    loading: churnLoading,
+    failed: churnFailed,
+  } = useChurnLens(host, files, overlay === "churn");
+
+  // When the dashboard is opened from the status-bar score, lead with a row
   // for that file so the two surfaces read as one. The map file set is large
-  // (nloc desc), so the active file is almost always present; if not, the card
+  // (nloc desc), so the active file is almost always present; if not, the row
   // still offers a way to open it.
   const focused = useMemo(() => {
     if (!selectPath) return null;
     const entry = files.files.find((f) => f.file_path === selectPath) ?? null;
     return { path: selectPath, entry };
   }, [selectPath, files.files]);
-  const [overlay, setOverlay] = useState<CodeHealthOverlay>("health");
-  const [tab, setTab] = useState<HeroTab>("map");
-
-  // KPI sparklines want oldest-first series; the trend history is newest-first.
-  const kpiTrend = useMemo(() => {
-    const history = trend.history ?? [];
-    const asc = history.slice().reverse();
-    const out: {
-      averageHistory?: number[];
-      hotspotHistory?: number[];
-      worstHistory?: number[];
-      averageDelta?: number;
-      hotspotDelta?: number;
-    } = {
-      averageHistory: asc.map((p) => p.average_health),
-      hotspotHistory: asc.map((p) => p.hotspot_health),
-      worstHistory: asc.map((p) => p.worst_performer_score ?? 0),
-    };
-    if (trend.summary?.average_delta != null) out.averageDelta = trend.summary.average_delta;
-    if (trend.summary?.hotspot_delta != null) out.hotspotDelta = trend.summary.hotspot_delta;
-    return out;
-  }, [trend]);
 
   const headCommit = repo.headCommit ? repo.headCommit.slice(0, 7) : null;
 
   return (
-    <div className="mx-auto max-w-[1400px] space-y-8 px-6 py-6">
-      <header className="space-y-1">
-        <h1 className="text-xl font-semibold tracking-tight text-[var(--color-text-primary)]">
+    <div className="mx-auto flex max-w-[1400px] flex-col gap-6 px-6 py-6 sm:gap-8">
+      <header className="flex flex-col gap-1">
+        <h1 className="text-[22px] font-semibold tracking-tight text-[var(--color-text-primary)]">
           Code health
         </h1>
-        <p className="text-sm text-[var(--color-text-secondary)]">
+        <p className="text-[15px] text-[var(--color-text-secondary)]">
           {repo.name}
           {headCommit ? (
             <span className="ml-2 font-mono text-xs text-[var(--color-text-tertiary)]">
@@ -115,53 +110,60 @@ function Dashboard({
         />
       ) : null}
 
-      <section aria-label="Health signals">
-        <HealthKpiCards
-          summary={overview.summary}
-          distribution={overview.distribution ?? null}
-          {...kpiTrend}
-          onSelectPillar={(pillar) => {
-            setOverlay(PILLAR_TO_OVERLAY[pillar]);
-            setTab("map");
-          }}
-        />
-      </section>
+      <CodeHealthLede
+        summary={overview.summary}
+        accuracy={overview.defect_accuracy ?? null}
+        distribution={overview.distribution ?? null}
+      />
 
-      <section aria-label="Health explorer" className="space-y-4">
-        <div className="flex items-center justify-between gap-3">
-          <SectionHeading
-            title={tab === "map" ? "Code health map" : "Churn versus complexity"}
-            subtitle={
-              tab === "map"
-                ? `${files.total.toLocaleString()} files · click a galaxy to zoom, a file to open`
-                : `${churn.total.toLocaleString()} changed files · the top-right corner is the refactor zone`
-            }
-          />
-          <TabSwitch tab={tab} onChange={setTab} />
-        </div>
-
-        {tab === "map" ? (
+      <OverviewSection
+        title="Code health map"
+        description="Every file as a node, clustered into module galaxies and sized by lines of code. The lens recolors the same field rather than redrawing it. Click a galaxy to zoom, a file to open it."
+        action={
+          <MapLensSwitcher overlay={overlay} onOverlayChange={setOverlay} lenses={LENSES} />
+        }
+      >
+        <div className="flex flex-col gap-2.5">
           <CodeHealthMap
-            files={files.files}
+            files={mapFiles.files}
             overlay={overlay}
-            onOverlayChange={setOverlay}
             onSelectFile={(path) => host.openFile(path)}
-            minHeight={640}
+            minHeight={MAP_HEIGHT}
+            chrome="none"
           />
-        ) : (
-          <ChurnComplexityQuadrant
-            points={churn.points}
-            height={520}
-            onSelect={(point) => host.openFile(point.file_path)}
-          />
-        )}
-      </section>
+          <div className="flex flex-wrap items-center justify-between gap-x-6 gap-y-2">
+            {/* A key describing bands the field cannot be showing is worse
+                than no key: every node is the "no data" swatch when the churn
+                request failed, so say that instead. */}
+            {churnFailed ? (
+              <span className="text-[11px] text-[var(--color-text-tertiary)]">
+                Could not load churn for this lens. The other lenses are
+                unaffected.
+              </span>
+            ) : (
+              <MapLegend overlay={overlay} loading={churnLoading} />
+            )}
+            <span className="font-mono text-[10px] uppercase tracking-[0.12em] tabular-nums text-[var(--color-text-tertiary)]">
+              {mapFiles.total.toLocaleString()} files
+            </span>
+          </div>
+        </div>
+      </OverviewSection>
+
+      <OverviewSection
+        title="Trend"
+        description="How the repo's scores have moved across indexed snapshots."
+      >
+        <TrendView data={trend} isLoading={false} error={null} />
+      </OverviewSection>
     </div>
   );
 }
 
 /** The file the dashboard was opened for (from the status-bar score), pinned
- *  above the repo-wide views with its three scores and a jump-to-file action. */
+ *  above the repo-wide views with its three scores and a jump-to-file action.
+ *  A hairline row rather than a card: the file name is the only thing here you
+ *  can act on, and the three scores beside it are statistics. */
 function FocusedFile({
   path,
   entry,
@@ -175,16 +177,16 @@ function FocusedFile({
   return (
     <section
       aria-label="Current file"
-      className="flex items-center justify-between gap-4 rounded-xl border border-[var(--color-accent-muted)] bg-[var(--color-bg-surface)] px-4 py-3"
+      className="flex items-center justify-between gap-4 border-t border-[var(--color-border-default)] pt-4"
     >
       <div className="min-w-0">
-        <p className="text-[10px] font-semibold uppercase tracking-wide text-[var(--color-text-tertiary)]">
+        <p className="font-mono text-[10px] uppercase tracking-[0.12em] text-[var(--color-text-tertiary)]">
           Current file
         </p>
         <button
           type="button"
           onClick={onOpen}
-          className="flex max-w-full items-center gap-1.5 truncate font-mono text-sm text-[var(--color-text-primary)] transition-colors hover:text-[var(--color-accent-primary)]"
+          className="mt-0.5 flex max-w-full items-center gap-1.5 font-mono text-[15px] text-[var(--color-text-primary)] transition-colors hover:text-[var(--color-accent-primary)]"
           title={path}
         >
           <span className="truncate">{name}</span>
@@ -192,13 +194,13 @@ function FocusedFile({
         </button>
       </div>
       {entry ? (
-        <div className="flex shrink-0 items-center gap-4 text-right">
+        <div className="flex shrink-0 items-center gap-5 text-right">
           <FocusedScore label="Defect" value={entry.defect_score ?? entry.score} />
           <FocusedScore label="Maint" value={entry.maintainability_score ?? null} />
           <FocusedScore label="Perf" value={entry.performance_score ?? null} />
         </div>
       ) : (
-        <span className="shrink-0 text-[11px] text-[var(--color-text-tertiary)]">
+        <span className="shrink-0 text-xs text-[var(--color-text-tertiary)]">
           Not among the mapped files
         </span>
       )}
@@ -207,39 +209,18 @@ function FocusedFile({
 }
 
 function FocusedScore({ label, value }: { label: string; value: number | null }) {
+  // The shared ramp, so this figure agrees with the map beside it and with the
+  // web app's file table. There is no local threshold here on purpose: the one
+  // this file used to carry called 7.6 healthy while the map coloured it amber.
+  const tone = value == null ? "text-[var(--color-text-tertiary)]" : scoreTextColor(value);
   return (
     <div>
-      <p className="text-[10px] uppercase tracking-wide text-[var(--color-text-tertiary)]">{label}</p>
-      <p className="font-mono text-sm tabular-nums" style={{ color: scoreColor(value) }}>
+      <p className="font-mono text-[10px] uppercase tracking-[0.12em] text-[var(--color-text-tertiary)]">
+        {label}
+      </p>
+      <p className={`font-mono text-[15px] tabular-nums ${tone}`}>
         {value == null ? "-" : value.toFixed(1)}
       </p>
-    </div>
-  );
-}
-
-/** A two-button segmented control switching the hero between map and quadrant. */
-function TabSwitch({ tab, onChange }: { tab: HeroTab; onChange: (tab: HeroTab) => void }) {
-  const tabs: { id: HeroTab; label: string }[] = [
-    { id: "map", label: "Map" },
-    { id: "quadrant", label: "Quadrant" },
-  ];
-  return (
-    <div className="inline-flex shrink-0 rounded-lg border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-0.5 text-xs">
-      {tabs.map((t) => (
-        <button
-          key={t.id}
-          type="button"
-          onClick={() => onChange(t.id)}
-          aria-pressed={tab === t.id}
-          className={
-            tab === t.id
-              ? "rounded-md bg-[var(--color-accent-primary)] px-3 py-1 font-medium text-[var(--color-text-inverse)]"
-              : "rounded-md px-3 py-1 text-[var(--color-text-secondary)] transition-colors hover:text-[var(--color-text-primary)]"
-          }
-        >
-          {t.label}
-        </button>
-      ))}
     </div>
   );
 }

--- a/packages/vscode/webview/src/views/health/chrome.tsx
+++ b/packages/vscode/webview/src/views/health/chrome.tsx
@@ -1,47 +1,61 @@
 /**
- * Presentational chrome for the Health dashboard: section heading, the loading
- * skeleton that mirrors the real layout, and the error panel. All token-driven
- * so both editor themes render correctly via the `.dark` class on the root.
+ * Presentational chrome for the Health dashboard: the loading skeleton that
+ * mirrors the real layout, and the error panel. Token-driven so both editor
+ * themes render correctly via the `.dark` class on the root.
  */
-
-/** A section title with a muted supporting line. */
-export function SectionHeading({ title, subtitle }: { title: string; subtitle?: string }) {
-  return (
-    <div className="min-w-0">
-      <h2 className="text-sm font-semibold uppercase tracking-wider text-[var(--color-text-tertiary)]">
-        {title}
-      </h2>
-      {subtitle ? (
-        <p className="mt-0.5 truncate text-xs text-[var(--color-text-tertiary)]">{subtitle}</p>
-      ) : null}
-    </div>
-  );
-}
 
 /** A pulsing placeholder block. */
 function Block({ className }: { className: string }) {
-  return (
-    <div
-      className={`animate-pulse rounded-xl border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] ${className}`}
-    />
-  );
+  return <div className={`animate-pulse rounded-lg bg-[var(--color-bg-inset)] ${className}`} />;
 }
 
-/** Skeleton laid out like the loaded dashboard so the transition is calm. */
+/** Skeleton laid out like the loaded dashboard so content landing does not
+ *  reflow the panel: header, lede (figure beside prose, then the stat ribbon),
+ *  the map section, and the trend section. */
 export function DashboardSkeleton() {
   return (
-    <div className="mx-auto max-w-[1400px] space-y-8 px-6 py-6" aria-busy="true" aria-label="Loading health">
-      <div className="space-y-2">
-        <Block className="h-6 w-40 border-0" />
-        <Block className="h-4 w-64 border-0" />
+    <div
+      className="mx-auto flex max-w-[1400px] flex-col gap-6 px-6 py-6 sm:gap-8"
+      aria-busy="true"
+      aria-label="Loading health"
+    >
+      <div className="flex flex-col gap-2">
+        <Block className="h-7 w-40" />
+        <Block className="h-5 w-64" />
       </div>
-      <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
-        <Block className="h-32" />
-        <Block className="h-32" />
-        <Block className="h-32" />
+
+      <div className="flex flex-col gap-6">
+        <div className="grid grid-cols-1 gap-6 xl:grid-cols-[240px_minmax(0,1fr)]">
+          <div className="flex flex-col gap-3">
+            <Block className="h-14 w-32" />
+            <Block className="h-2 w-full" />
+          </div>
+          <div className="flex flex-col gap-2">
+            <Block className="h-4 w-full" />
+            <Block className="h-4 w-11/12" />
+            <Block className="h-4 w-4/5" />
+          </div>
+        </div>
+        <div className="grid grid-cols-2 gap-4 sm:grid-cols-5">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <Block key={i} className="h-12" />
+          ))}
+        </div>
       </div>
-      <Block className="h-10" />
-      <Block className="h-[640px]" />
+
+      <div className="flex flex-col gap-3 border-t border-[var(--color-border-default)] pt-6 sm:pt-8">
+        <div className="flex items-baseline justify-between gap-4">
+          <Block className="h-5 w-40" />
+          <Block className="h-7 w-64" />
+        </div>
+        <Block className="h-[640px] w-full" />
+        <Block className="h-4 w-72" />
+      </div>
+
+      <div className="flex flex-col gap-3 border-t border-[var(--color-border-default)] pt-6 sm:pt-8">
+        <Block className="h-5 w-24" />
+        <Block className="h-64 w-full" />
+      </div>
     </div>
   );
 }
@@ -51,10 +65,10 @@ export function DashboardError({ message }: { message: string }) {
   return (
     <div className="mx-auto max-w-[1400px] px-6 py-6">
       <div className="rounded-xl border border-[var(--color-error)] bg-[var(--color-bg-surface)] p-6">
-        <h2 className="text-sm font-semibold text-[var(--color-error)]">
+        <h2 className="text-[15px] font-semibold text-[var(--color-error)]">
           Health data is unavailable
         </h2>
-        <p className="mt-2 text-sm text-[var(--color-text-secondary)]">{message}</p>
+        <p className="mt-2 text-[15px] text-[var(--color-text-secondary)]">{message}</p>
         <p className="mt-3 text-xs text-[var(--color-text-tertiary)]">
           Make sure the local Repowise server is running and this repository is indexed.
         </p>

--- a/packages/vscode/webview/src/views/health/useDashboardData.ts
+++ b/packages/vscode/webview/src/views/health/useDashboardData.ts
@@ -4,7 +4,7 @@
  * each call is an RPC the host serves from its shared cache and api-client.
  */
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import type {
   ChurnComplexityResponse,
   HealthOverviewResponse,
@@ -15,17 +15,23 @@ import type { WebviewHost } from "../../runtime/rpc";
 
 /** Files pulled for the map: biggest first, capped so the galaxy stays legible. */
 const MAP_FILE_LIMIT = 2000;
-/** Overview + trend history windows the KPI header reads. */
+/** Overview + trend history windows the lede and trend section read. */
 const OVERVIEW_LIMIT = 25;
 const TREND_LIMIT = 20;
-/** Points for the churn-versus-complexity scatter. */
-const QUADRANT_LIMIT = 400;
+/**
+ * Churn points pulled for the churn lens. Deliberately larger than
+ * `MAP_FILE_LIMIT`: the map ranks by NLOC and churn-complexity ranks by
+ * `commit_count × max_ccn`, so the two windows do not hold the same files, and
+ * a short window leaves mapped files painted as the key's "no data" swatch for
+ * data that exists. A repo past this ceiling degrades to that partial join
+ * rather than breaking.
+ */
+const CHURN_POINT_LIMIT = 5000;
 
 export interface DashboardData {
   overview: HealthOverviewResponse;
   files: HealthFilesResponse;
   trend: HealthTrendResponse;
-  churn: ChurnComplexityResponse;
 }
 
 export interface DashboardState {
@@ -35,7 +41,7 @@ export interface DashboardState {
 }
 
 /**
- * Fetch the four health payloads together. `refreshToken` is the only
+ * Fetch the three health payloads together. `refreshToken` is the only
  * dependency: it changes on first mount (0) and whenever the host reports the
  * index moved, so the effect re-runs and re-pulls the set.
  */
@@ -54,11 +60,10 @@ export function useDashboardData(host: WebviewHost, refreshToken: number): Dashb
       host.api.healthOverview(OVERVIEW_LIMIT),
       host.api.healthFiles({ limit: MAP_FILE_LIMIT, sort: "nloc", order: "desc" }),
       host.api.healthTrend(TREND_LIMIT),
-      host.api.churnComplexity(QUADRANT_LIMIT),
     ])
-      .then(([overview, files, trend, churn]) => {
+      .then(([overview, files, trend]) => {
         if (cancelled) return;
-        setState({ data: { overview, files, trend, churn }, error: null, loading: false });
+        setState({ data: { overview, files, trend }, error: null, loading: false });
       })
       .catch((err: unknown) => {
         if (cancelled) return;
@@ -72,4 +77,66 @@ export function useDashboardData(host: WebviewHost, refreshToken: number): Dashb
   }, [host, refreshToken]);
 
   return state;
+}
+
+/**
+ * Churn percentiles joined onto the map rows, for the churn lens only.
+ *
+ * A second request the other three lenses do not need, so it fires the first
+ * time the lens is selected and is then held.
+ *
+ * Until it lands every node paints the key's "no data" swatch, because the map
+ * payload carries no `churn_percentile` at all. That is the whole reason the
+ * legend has to be told it is loading: an all-grey field under a full churn key
+ * asserts "no churn anywhere", which is a claim rather than a wait. So the
+ * pending flag is derived from the data rather than from an effect — a
+ * `useState` set inside `useEffect` is written after paint, which would render
+ * one frame of the complete key over a field that has nothing in it yet.
+ */
+export function useChurnLens(
+  host: WebviewHost,
+  files: HealthFilesResponse,
+  wanted: boolean,
+): { files: HealthFilesResponse; loading: boolean; failed: boolean } {
+  const [churn, setChurn] = useState<ChurnComplexityResponse | null>(null);
+  const [failed, setFailed] = useState(false);
+  // Unmount, not lens-change. Cancelling when the reader switches away would
+  // throw away a 5,000-point response mid-flight and refetch the whole thing
+  // on the next click back, which is the one payload here worth not paying for
+  // twice. Nothing reads the result while another lens is selected.
+  const alive = useRef(true);
+  useEffect(() => {
+    alive.current = true;
+    return () => {
+      alive.current = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!wanted || churn || failed) return;
+    host.api
+      .churnComplexity(CHURN_POINT_LIMIT)
+      .then((r) => {
+        if (alive.current) setChurn(r);
+      })
+      // The lens degrades to "could not load" rather than to a silent
+      // all-clear; the other lenses and the rest of the panel are unaffected.
+      .catch(() => {
+        if (alive.current) setFailed(true);
+      });
+  }, [host, wanted, churn, failed]);
+
+  const joined = useMemo(() => {
+    if (!churn) return files;
+    const byPath = new Map(churn.points.map((p) => [p.file_path, p.churn_percentile]));
+    return {
+      ...files,
+      files: files.files.map((file) => ({
+        ...file,
+        churn_percentile: byPath.get(file.file_path) ?? null,
+      })),
+    };
+  }, [files, churn]);
+
+  return { files: joined, loading: wanted && !churn && !failed, failed: wanted && failed };
 }

--- a/packages/vscode/webview/src/views/home/App.tsx
+++ b/packages/vscode/webview/src/views/home/App.tsx
@@ -1,10 +1,16 @@
 /**
- * Sidebar Home: the face of the extension. A hero card with the repo's
- * hotspot-health score and trend, an index-freshness row with a one-click
- * update, and a launcher card per dashboard panel so everything the extension
- * can show is discoverable from the first click on the activity-bar icon.
- * Designed for the sidebar's ~300px width; the dashboards themselves open as
- * editor tabs via `host.openView`.
+ * Sidebar Home: the face of the extension. The repo's health score and trend,
+ * an index-freshness row with a one-click update, and a launcher card per
+ * dashboard panel so everything the extension can show is discoverable from the
+ * first click on the activity-bar icon. Designed for the sidebar's ~300px
+ * width; the dashboards themselves open as editor tabs via `host.openView`.
+ *
+ * The two statistics group with hairlines and the launchers keep their cards.
+ * That split is the rule rather than an inconsistency: a card means "a discrete
+ * object you can act on", which every launcher is and neither statistic was.
+ * Sizes stay at 11 and 13px here — a ~300px rail is the width argument the
+ * compact density exists for, and the full-tab panels do not get the same
+ * excuse.
  */
 
 import { useCallback, useEffect, useState, type ComponentType } from "react";
@@ -23,6 +29,7 @@ import {
   Sun,
   Wrench,
 } from "lucide-react";
+import { scoreTextColor } from "@repowise-dev/ui/health/tokens";
 import type {
   HomeSummary,
   PanelViewId,
@@ -40,12 +47,13 @@ import {
 import owlDarkTheme from "../../assets/owl-dark-theme.png";
 import owlLightTheme from "../../assets/owl-light-theme.png";
 
-/** 0-10 score to its signal color; the same bands the risk view uses, inverted. */
-function scoreColor(score: number | null): string {
-  if (score == null) return "var(--color-text-tertiary)";
-  if (score >= 7.5) return "var(--color-success)";
-  if (score >= 5) return "var(--color-warning)";
-  return "var(--color-error)";
+/**
+ * The shared score ramp, as a text class. This file used to carry its own
+ * thresholds — healthy at 7.5 — which disagreed with every other surface in the
+ * product and, more visibly, with the health dashboard this hero launches.
+ */
+function scoreTone(score: number | null): string {
+  return score == null ? "text-[var(--color-text-tertiary)]" : scoreTextColor(score);
 }
 
 /** Compact relative time for the freshness row ("3h ago"). */
@@ -81,7 +89,7 @@ const CARDS: CardSpec[] = [
     subtitle: (s) =>
       s?.health
         ? `${s.health.openFindings.toLocaleString()} open findings · ${s.health.fileCount.toLocaleString()} files`
-        : "Score map, trends, and the churn quadrant",
+        : "The score map, its lenses, and the trend",
   },
   {
     view: "architecture",
@@ -182,8 +190,11 @@ export function App({ host, repo, refreshToken }: ViewProps<"home">) {
         updating={updating}
         onUpdate={runUpdate}
       />
-      <nav aria-label="Dashboards" className="space-y-1.5">
-        <p className="px-1 pt-1 text-[10px] font-semibold uppercase tracking-[0.12em] text-[var(--color-text-tertiary)]">
+      <nav
+        aria-label="Dashboards"
+        className="space-y-1.5 border-t border-[var(--color-border-default)] pt-3"
+      >
+        <p className="px-1 pb-1 font-mono text-[10px] uppercase tracking-[0.12em] text-[var(--color-text-tertiary)]">
           Explore
         </p>
         {CARDS.map((card) => (
@@ -204,10 +215,10 @@ export function App({ host, repo, refreshToken }: ViewProps<"home">) {
           <Settings2 className="h-4 w-4" />
         </span>
         <span className="min-w-0 flex-1">
-          <span className="block truncate text-[13px] font-medium text-[var(--color-text-primary)]">
+          <span className="block text-[13px] font-medium text-[var(--color-text-primary)]">
             Settings
           </span>
-          <span className="block truncate text-[11px] text-[var(--color-text-tertiary)]">
+          <span className="block text-[11px] leading-snug text-[var(--color-text-tertiary)]">
             Toggle editor signals, server, and more
           </span>
         </span>
@@ -293,14 +304,13 @@ function Hero({
   // which case only the average shows.
   const hasHotspot = health?.hotspot != null;
   const headline = health?.average ?? health?.hotspot ?? null;
-  const color = scoreColor(headline);
+  // A statistic, not an object you can act on, so it groups with rhythm rather
+  // than with a border and a raised ground. The launchers below keep theirs:
+  // those are navigation buttons.
   return (
-    <section
-      aria-label="Repository health"
-      className="rounded-xl border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-4"
-    >
+    <section aria-label="Repository health" className="px-1 pt-1">
       <div className="flex items-center justify-between gap-2">
-        <p className="truncate text-sm font-semibold text-[var(--color-text-primary)]">
+        <p className="truncate text-[13px] font-semibold text-[var(--color-text-primary)]">
           {repoName}
         </p>
         {branch ? (
@@ -319,10 +329,12 @@ function Hero({
       ) : headline != null ? (
         <>
           <div className="mt-3 flex items-end gap-2">
-            <span className="text-4xl font-bold leading-none tracking-tight" style={{ color }}>
+            <span
+              className={`text-4xl font-bold leading-none tracking-tight tabular-nums ${scoreTone(headline)}`}
+            >
               {headline.toFixed(1)}
             </span>
-            <span className="pb-0.5 text-sm text-[var(--color-text-tertiary)]">/ 10</span>
+            <span className="pb-0.5 text-xs text-[var(--color-text-tertiary)]">/ 10</span>
           </div>
           <p className="mt-1.5 flex flex-wrap items-center gap-x-1.5 text-[11px] text-[var(--color-text-secondary)]">
             <span>Average health</span>
@@ -337,7 +349,7 @@ function Hero({
             <span>{(health?.fileCount ?? 0).toLocaleString()} files</span>
           </p>
           {hasHotspot && (health?.history.length ?? 0) >= 2 ? (
-            <Sparkline values={health?.history ?? []} color={scoreColor(health?.hotspot ?? null)} />
+            <Sparkline values={health?.history ?? []} tone={scoreTone(health?.hotspot ?? null)} />
           ) : null}
         </>
       ) : (
@@ -349,25 +361,30 @@ function Hero({
   );
 }
 
+/**
+ * Hotspot movement since the last snapshot.
+ *
+ * Not a filled pill and not coloured. Green forty pixels under a green health
+ * numeral is the two-marks-one-colour trap: on the numeral green means "band:
+ * healthy", here it would mean "direction: improved", and a reader who
+ * correctly infers one has been taught a rule that makes them wrong about the
+ * other. Health owns green/amber/red on this surface because those carry a
+ * band; direction is carried by the arrow, which needs no hue.
+ */
 function DeltaChip({ delta }: { delta: number | null }) {
   if (delta == null || delta === 0) return null;
-  const up = delta > 0;
   return (
     <span
-      className="mb-0.5 rounded-full px-1.5 py-0.5 text-[10px] font-semibold"
-      style={{
-        color: up ? "var(--color-success)" : "var(--color-error)",
-        backgroundColor: "var(--color-bg-inset)",
-      }}
+      className="text-[10px] font-medium tabular-nums text-[var(--color-text-tertiary)]"
       title="Hotspot health change since the previous snapshot"
     >
-      {up ? "▲" : "▼"} {Math.abs(delta).toFixed(1)}
+      {delta > 0 ? "▲" : "▼"} {Math.abs(delta).toFixed(1)}
     </span>
   );
 }
 
 /** Tiny inline trend line; the hero already labels it, so it is decorative. */
-function Sparkline({ values, color }: { values: number[]; color: string }) {
+function Sparkline({ values, tone }: { values: number[]; tone: string }) {
   const width = 100;
   const height = 24;
   const min = Math.min(...values);
@@ -381,10 +398,16 @@ function Sparkline({ values, color }: { values: number[]; color: string }) {
     <svg
       viewBox={`0 0 ${width} ${height}`}
       preserveAspectRatio="none"
-      className="mt-2 h-6 w-full"
+      className={`mt-2 h-6 w-full ${tone}`}
       aria-hidden
     >
-      <polyline points={points} fill="none" stroke={color} strokeWidth="1.5" opacity="0.9" />
+      <polyline
+        points={points}
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        opacity="0.9"
+      />
     </svg>
   );
 }
@@ -401,7 +424,6 @@ function Freshness({
   const stale = freshness?.stale ?? false;
   const indexed = short(freshness?.indexedCommit ?? null);
   const live = short(freshness?.liveCommit ?? null);
-  const dotColor = stale ? "var(--color-warning)" : "var(--color-success)";
 
   let detail = "";
   if (stale && indexed && live) detail = `${indexed} → ${live}`;
@@ -411,15 +433,19 @@ function Freshness({
   }
 
   return (
+    // A statistic plus its one action, so it groups with a hairline rather than
+    // a card. The dot renders only when the index is behind: a marker every
+    // state carries says nothing, and a quiet row is a fresh index.
     <section
       aria-label="Index freshness"
-      className="flex items-center gap-2.5 rounded-xl border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-3 py-2.5"
+      className="flex items-center gap-2.5 border-t border-[var(--color-border-default)] px-1 pt-3"
     >
-      <span
-        className="h-2 w-2 shrink-0 rounded-full"
-        style={{ backgroundColor: dotColor }}
-        aria-hidden
-      />
+      {stale ? (
+        <span
+          className="h-2 w-2 shrink-0 rounded-full bg-[var(--color-warning)]"
+          aria-hidden
+        />
+      ) : null}
       <div className="min-w-0 flex-1">
         <p className="text-xs font-medium text-[var(--color-text-primary)]">
           {updating ? "Updating index…" : stale ? "Index behind checkout" : "Index up to date"}
@@ -468,10 +494,10 @@ function LauncherCard({
         <Icon className="h-4 w-4" />
       </span>
       <span className="min-w-0 flex-1">
-        <span className="block truncate text-[13px] font-medium text-[var(--color-text-primary)]">
+        <span className="block text-[13px] font-medium text-[var(--color-text-primary)]">
           {spec.title}
         </span>
-        <span className="block truncate text-[11px] text-[var(--color-text-tertiary)]">
+        <span className="block text-[11px] leading-snug text-[var(--color-text-tertiary)]">
           {subtitle}
         </span>
       </span>

--- a/packages/vscode/webview/src/views/refactoring/App.tsx
+++ b/packages/vscode/webview/src/views/refactoring/App.tsx
@@ -202,10 +202,10 @@ function PlanDetailView({ host, planId, refreshToken, onBack }: PlanDetailViewPr
                 key={row.label}
                 className="rounded-lg border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-3 py-2"
               >
-                <dt className="text-[10px] uppercase tracking-wide text-[var(--color-text-tertiary)]">
+                <dt className="font-mono text-[10px] uppercase tracking-[0.12em] text-[var(--color-text-tertiary)]">
                   {row.label}
                 </dt>
-                <dd className="mt-0.5 font-mono text-sm tabular-nums text-[var(--color-text-primary)]">
+                <dd className="mt-0.5 font-mono text-[15px] tabular-nums text-[var(--color-text-primary)]">
                   {row.value}
                 </dd>
               </div>
@@ -237,7 +237,7 @@ function PlanDetailView({ host, planId, refreshToken, onBack }: PlanDetailViewPr
               </li>
             ))}
             {affected.length > 25 ? (
-              <li className="px-3.5 py-2 text-[11px] text-[var(--color-text-tertiary)]">
+              <li className="px-3.5 py-2 text-xs text-[var(--color-text-tertiary)]">
                 +{affected.length - 25} more
               </li>
             ) : null}
@@ -261,7 +261,7 @@ function PlanHeader({ plan, onOpenFile }: { plan: RefactoringPlan; onOpenFile: (
     <header>
       <div className="flex flex-wrap items-center gap-3">
         <span
-          className="inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1 text-sm font-semibold"
+          className="inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1 text-[15px] font-semibold"
           style={{ backgroundColor: `color-mix(in srgb, ${accent} 14%, transparent)`, color: accent }}
         >
           <Icon className="h-4 w-4" />
@@ -319,7 +319,7 @@ function CopyForAgentRow({ host, planId }: { host: WebviewHost; planId: string }
 
   return (
     <div className="sticky bottom-0 mt-8 -mx-6 border-t border-[var(--color-border-default)] bg-[var(--color-bg-root)]/95 px-6 py-3 backdrop-blur">
-      <div className="mb-2 flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-wide text-[var(--color-text-tertiary)]">
+      <div className="mb-2 flex items-center gap-1.5 font-mono text-[10px] uppercase tracking-[0.12em] text-[var(--color-text-tertiary)]">
         <Sparkles className="h-3.5 w-3.5" />
         Copy for agent
       </div>
@@ -397,7 +397,7 @@ function SummaryStrip({
         <span className="text-2xl font-semibold tabular-nums text-[var(--color-text-primary)]">
           {summary.total}
         </span>
-        <span className="text-sm text-[var(--color-text-secondary)]">
+        <span className="text-[15px] text-[var(--color-text-secondary)]">
           refactoring plan{summary.total === 1 ? "" : "s"}
           {filePath ? (
             <>
@@ -431,7 +431,7 @@ function SummaryStrip({
 function Section({ title, children }: { title: string; children: ReactNode }) {
   return (
     <section className="mt-6">
-      <h2 className="mb-2 text-xs font-semibold uppercase tracking-wide text-[var(--color-text-tertiary)]">
+      <h2 className="mb-2 font-mono text-[10px] uppercase tracking-[0.12em] text-[var(--color-text-tertiary)]">
         {title}
       </h2>
       {children}
@@ -464,7 +464,7 @@ function Badge({
 
 function CenteredNote({ children }: { children: ReactNode }) {
   return (
-    <div className="flex h-full items-center justify-center px-6 text-center text-sm text-[var(--color-text-tertiary)]">
+    <div className="flex h-full items-center justify-center px-6 text-center text-[15px] text-[var(--color-text-tertiary)]">
       {children}
     </div>
   );
@@ -472,7 +472,7 @@ function CenteredNote({ children }: { children: ReactNode }) {
 
 function ErrorNote({ title, children }: { title: string; children: ReactNode }) {
   return (
-    <div className="m-6 rounded-lg border border-[var(--color-error)] p-4 text-sm">
+    <div className="m-6 rounded-lg border border-[var(--color-error)] p-4 text-[15px]">
       <p className="font-medium text-[var(--color-error)]">{title}</p>
       <p className="mt-2 text-[var(--color-text-secondary)]">{children}</p>
     </div>

--- a/packages/vscode/webview/src/views/risk/App.tsx
+++ b/packages/vscode/webview/src/views/risk/App.tsx
@@ -1,3 +1,15 @@
+/**
+ * Change risk: the diff-shape score for the committed range as the lede, a
+ * verdict strip, what the working change touches, and the statistical
+ * breakdown.
+ *
+ * Grouping is hairlines and vertical rhythm, not boxes. This file carried
+ * thirty `Card` wrappers and not one of them was clickable — a card means "a
+ * discrete object you can act on", and a driver bar, a feature count and a
+ * reviewer ranking are none of those. Everything that does act (the verdict
+ * chips, the file rows, Copy, Run again) keeps its affordance.
+ */
+
 import { useCallback, useEffect, useState } from "react";
 import {
   Copy,
@@ -10,8 +22,10 @@ import {
   TestTube,
   Users,
 } from "lucide-react";
-import { Badge, Button, Card, CardContent, CardHeader, CardTitle } from "@repowise-dev/ui/ui";
+import { Badge, Button } from "@repowise-dev/ui/ui";
 import { EmptyState } from "@repowise-dev/ui/shared";
+import { PageLede } from "@repowise-dev/ui/shared/page-lede";
+import { OverviewSection } from "@repowise-dev/ui/overview";
 import type { ViewProps } from "../../runtime/mount";
 import type { WebviewHost } from "../../runtime/rpc";
 import type {
@@ -72,6 +86,14 @@ function formatFeatureValue(value: number): string {
   return Number.isInteger(value) ? String(value) : value.toFixed(2);
 }
 
+/** "87th", "91st", "22nd". The percentile reads in a sentence now, where a
+ *  hardcoded "th" produces "91th". */
+function ordinal(n: number): string {
+  const v = Math.round(n);
+  if (v % 100 >= 11 && v % 100 <= 13) return `${v}th`;
+  return `${v}${["th", "st", "nd", "rd"][v % 10] ?? "th"}`;
+}
+
 export function App({ host, repo, refreshToken }: ViewProps<"risk">) {
   const [report, setReport] = useState<RiskRangeReport | null>(null);
   const [impact, setImpact] = useState<ChangeImpactReport | null>(null);
@@ -117,11 +139,13 @@ export function App({ host, repo, refreshToken }: ViewProps<"risk">) {
   const base = report?.base ?? "";
 
   return (
-    <div className="mx-auto max-w-3xl space-y-5 p-6">
+    <div className="mx-auto flex max-w-3xl flex-col gap-6 p-6 sm:gap-8">
       <header className="flex items-start justify-between gap-4">
         <div className="min-w-0">
-          <h1 className="text-lg font-semibold text-[var(--color-text-primary)]">Change risk</h1>
-          <p className="mt-1 flex items-center gap-2 text-sm text-[var(--color-text-secondary)]">
+          <h1 className="text-[22px] font-semibold tracking-tight text-[var(--color-text-primary)]">
+            Change risk
+          </h1>
+          <p className="mt-1 flex items-center gap-2 text-[15px] text-[var(--color-text-secondary)]">
             <GitCompare className="h-4 w-4 shrink-0" />
             <span className="truncate">
               <code className="text-[var(--color-text-primary)]">{branch}</code>
@@ -166,34 +190,27 @@ export function App({ host, repo, refreshToken }: ViewProps<"risk">) {
  *  holds its shape while the working tree is scored. */
 function RiskSkeleton({ base }: { base: string }) {
   return (
-    <div className="space-y-5">
-      <Card>
-        <CardContent className="flex flex-wrap items-center gap-6 py-6" aria-hidden>
-          <div className="h-24 w-24 shrink-0 animate-pulse rounded-2xl bg-[var(--color-bg-inset)]" />
-          <div className="min-w-0 flex-1 space-y-3">
-            <div className="h-5 w-24 animate-pulse rounded bg-[var(--color-bg-inset)]" />
-            <div className="h-4 w-48 animate-pulse rounded bg-[var(--color-bg-inset)]" />
-            <div className="flex gap-2 pt-1">
-              <div className="h-5 w-20 animate-pulse rounded bg-[var(--color-bg-inset)]" />
-              <div className="h-5 w-28 animate-pulse rounded bg-[var(--color-bg-inset)]" />
-            </div>
+    <div className="flex flex-col gap-6 sm:gap-8" aria-hidden>
+      <div className="flex flex-col gap-4 sm:flex-row sm:gap-8">
+        <div className="flex shrink-0 flex-col gap-2.5">
+          <div className="h-3 w-20 animate-pulse rounded bg-[var(--color-bg-inset)]" />
+          <div className="h-12 w-32 animate-pulse rounded bg-[var(--color-bg-inset)]" />
+        </div>
+        <div className="min-w-0 flex-1 space-y-2 pt-1">
+          <div className="h-4 w-full animate-pulse rounded bg-[var(--color-bg-inset)]" />
+          <div className="h-4 w-4/5 animate-pulse rounded bg-[var(--color-bg-inset)]" />
+        </div>
+      </div>
+      <div className="flex flex-col gap-3 border-t border-[var(--color-border-default)] pt-6 sm:pt-8">
+        <div className="h-5 w-44 animate-pulse rounded bg-[var(--color-bg-inset)]" />
+        {Array.from({ length: 5 }).map((_, i) => (
+          <div key={i} className="flex items-center gap-3">
+            <div className="h-3 w-40 shrink-0 animate-pulse rounded bg-[var(--color-bg-inset)]" />
+            <div className="h-2 flex-1 animate-pulse rounded-full bg-[var(--color-bg-inset)]" />
+            <div className="h-3 w-14 shrink-0 animate-pulse rounded bg-[var(--color-bg-inset)]" />
           </div>
-        </CardContent>
-      </Card>
-      <Card>
-        <CardHeader className="pb-3">
-          <CardTitle className="text-sm">What moves the score</CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-3" aria-hidden>
-          {Array.from({ length: 5 }).map((_, i) => (
-            <div key={i} className="flex items-center gap-3">
-              <div className="h-3 w-40 shrink-0 animate-pulse rounded bg-[var(--color-bg-inset)]" />
-              <div className="h-2 flex-1 animate-pulse rounded-full bg-[var(--color-bg-inset)]" />
-              <div className="h-3 w-14 shrink-0 animate-pulse rounded bg-[var(--color-bg-inset)]" />
-            </div>
-          ))}
-        </CardContent>
-      </Card>
+        ))}
+      </div>
       <p className="flex items-center justify-center gap-2 text-xs text-[var(--color-text-tertiary)]">
         <RotateCw className="h-3.5 w-3.5 animate-spin" />
         Scoring the working tree{base ? ` against ${base}` : ""}
@@ -202,59 +219,68 @@ function RiskSkeleton({ base }: { base: string }) {
   );
 }
 
-/** The Kamei diff-shape risk score for the committed range (base..HEAD). */
+/**
+ * The Kamei diff-shape risk score for the committed range (base..HEAD).
+ *
+ * The figure carries a sentence rather than three badges: "6.8" and a
+ * "high review priority" pill say the same thing twice and neither says what
+ * the number was computed from.
+ */
 function ScoreHero({ report }: { report: RiskRangeReport }) {
   const r = report.result;
-  const tone = scoreTone(r.score);
-  const color = TONE_VAR[tone];
+  const color = TONE_VAR[scoreTone(r.score)];
   return (
-    <Card>
-      <CardContent className="flex flex-wrap items-center gap-6 py-6">
-        <div
-          className="flex h-24 w-24 shrink-0 flex-col items-center justify-center rounded-2xl border"
-          style={{
-            borderColor: `color-mix(in srgb, ${color} 45%, transparent)`,
-            backgroundColor: `color-mix(in srgb, ${color} 12%, transparent)`,
-          }}
-        >
-          <span className="text-3xl font-bold leading-none" style={{ color }}>
-            {r.score.toFixed(1)}
-          </span>
-          <span className="mt-1 text-[11px] text-[var(--color-text-tertiary)]">out of 10</span>
-        </div>
-        <div className="min-w-0 flex-1 space-y-2">
-          <div className="flex flex-wrap items-center gap-2">
-            <span
-              className="inline-flex items-center rounded border px-2 py-0.5 text-xs font-medium capitalize"
-              style={{ color, borderColor: `color-mix(in srgb, ${color} 40%, transparent)` }}
-            >
-              {r.level} risk
-            </span>
-            {r.is_fix && (
-              <Badge variant="outline" title="Classified as a fix change">
-                fix
-              </Badge>
-            )}
-          </div>
-          <p className="text-sm text-[var(--color-text-secondary)]">
-            Estimated defect probability{" "}
-            <span className="font-semibold text-[var(--color-text-primary)]">
-              {(r.probability * 100).toFixed(1)}%
-            </span>
-          </p>
-          <div className="flex flex-wrap gap-2 pt-1">
-            {r.risk_percentile != null && (
-              <Badge variant="default">{r.risk_percentile.toFixed(0)}th percentile</Badge>
-            )}
-            {r.review_priority && (
-              <Badge variant="accent" className="capitalize">
-                {r.review_priority} review priority
-              </Badge>
-            )}
-          </div>
-        </div>
-      </CardContent>
-    </Card>
+    <PageLede
+      // Not "Change risk" again: the page's h1 two lines above already says
+      // that, and a micro-label repeating the heading verbatim labels nothing.
+      label="Diff shape"
+      value={r.score.toFixed(1)}
+      valueColor={color}
+      unit="out of 10"
+      band={{ label: `${r.level} risk`, color }}
+      layout="beside"
+      badge={
+        r.is_fix ? (
+          <Badge variant="outline" title="Classified as a fix change">
+            fix
+          </Badge>
+        ) : undefined
+      }
+    >
+      <p>
+        Scored from the shape of this range's diff — how much it adds and
+        deletes, how many files, directories and subsystems it spreads across,
+        and how experienced its author is in them. We put the chance it carries
+        a defect at{" "}
+        <strong className="font-semibold text-[var(--color-text-primary)] tabular-nums">
+          {(r.probability * 100).toFixed(1)}%
+        </strong>
+        .
+      </p>
+      {(r.risk_percentile != null || r.review_priority) && (
+        <p className="mt-2.5">
+          {r.risk_percentile != null && (
+            <>
+              That ranks it at the{" "}
+              <strong className="font-semibold text-[var(--color-text-primary)] tabular-nums">
+                {ordinal(r.risk_percentile)} percentile
+              </strong>{" "}
+              against recent commits here
+              {r.review_priority ? ", so " : "."}
+            </>
+          )}
+          {r.review_priority && (
+            <>
+              {r.risk_percentile == null && "Worth "}
+              <strong className="font-semibold text-[var(--color-text-primary)]">
+                {r.review_priority}
+              </strong>{" "}
+              review priority.
+            </>
+          )}
+        </p>
+      )}
+    </PageLede>
   );
 }
 
@@ -268,7 +294,10 @@ function VerdictStrip({
   cochangeFloor: number;
 }) {
   const blast = impact?.blast;
-  if (!impact || !blast || impact.gitUnavailable) return null;
+  // `changed.length === 0` matters as well as `blast`: the impact block below
+  // renders an empty state in that case, so a chip would scroll to an anchor
+  // that is not on the page. The two must bail on the same condition.
+  if (!impact || !blast || impact.gitUnavailable || impact.changed.length === 0) return null;
 
   const downstream = blast.transitive_affected.length;
   const cochanges = selectMissingCochanges(impact, cochangeFloor).length;
@@ -328,17 +357,17 @@ function RiskBreakdown({ report }: { report: RiskRangeReport }) {
   return (
     <>
       {drivers.length > 0 && (
-        <Card>
-          <CardHeader className="pb-3">
-            <CardTitle className="text-sm">What moves the score</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-3">
+        <OverviewSection
+          title="What moves the score"
+          description="Each feature's signed contribution. Positive raises the estimate, negative lowers it; the bar is relative to the strongest driver."
+        >
+          <div className="flex flex-col gap-3">
             {drivers.map((d) => {
               const raises = d.contribution >= 0;
               const barColor = raises ? "var(--color-error)" : "var(--color-success)";
               const pct = maxDriver > 0 ? (Math.abs(d.contribution) / maxDriver) * 100 : 0;
               return (
-                <div key={d.feature} className="flex items-center gap-3 text-sm">
+                <div key={d.feature} className="flex items-center gap-3 text-[15px]">
                   <span className="w-40 shrink-0 truncate text-[var(--color-text-secondary)]">
                     {d.label}
                   </span>
@@ -357,31 +386,29 @@ function RiskBreakdown({ report }: { report: RiskRangeReport }) {
                 </div>
               );
             })}
-          </CardContent>
-        </Card>
+          </div>
+        </OverviewSection>
       )}
 
       {featureRows.length > 0 && (
-        <Card>
-          <CardHeader className="pb-3">
-            <CardTitle className="text-sm">Change shape</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <dl className="grid grid-cols-1 gap-x-8 gap-y-2 sm:grid-cols-2">
-              {featureRows.map(([key, label]) => (
-                <div
-                  key={key}
-                  className="flex items-baseline justify-between gap-3 border-b border-[var(--color-border-default)] py-1.5 last:border-b-0"
-                >
-                  <dt className="text-sm text-[var(--color-text-secondary)]">{label}</dt>
-                  <dd className="text-sm font-medium tabular-nums text-[var(--color-text-primary)]">
-                    {formatFeatureValue(r.features[key] as number)}
-                  </dd>
-                </div>
-              ))}
-            </dl>
-          </CardContent>
-        </Card>
+        <OverviewSection
+          title="Change shape"
+          description="The raw diff measurements the score is computed from."
+        >
+          <dl className="grid grid-cols-1 gap-x-8 sm:grid-cols-2">
+            {featureRows.map(([key, label]) => (
+              <div
+                key={key}
+                className="flex items-baseline justify-between gap-3 border-b border-[var(--color-border-default)] py-2 last:border-b-0"
+              >
+                <dt className="text-[15px] text-[var(--color-text-secondary)]">{label}</dt>
+                <dd className="text-[15px] font-medium tabular-nums text-[var(--color-text-primary)]">
+                  {formatFeatureValue(r.features[key] as number)}
+                </dd>
+              </div>
+            ))}
+          </dl>
+        </OverviewSection>
       )}
     </>
   );
@@ -404,38 +431,28 @@ function ChangeImpact({
 }) {
   if (loading && !impact) {
     return (
-      <>
-        <Card>
-          <CardContent className="space-y-3 py-5" aria-hidden>
-            <div className="h-4 w-40 animate-pulse rounded bg-[var(--color-bg-inset)]" />
-            {Array.from({ length: 3 }).map((_, i) => (
-              <div key={i} className="flex items-center gap-2">
-                <div className="h-3 flex-1 animate-pulse rounded bg-[var(--color-bg-inset)]" />
-                <div className="h-1.5 w-16 shrink-0 animate-pulse rounded-full bg-[var(--color-bg-inset)]" />
-              </div>
-            ))}
-          </CardContent>
-        </Card>
-        <Card>
-          <CardContent className="space-y-3 py-5" aria-hidden>
-            <div className="h-4 w-40 animate-pulse rounded bg-[var(--color-bg-inset)]" />
-            <div className="h-3 w-full animate-pulse rounded bg-[var(--color-bg-inset)]" />
-            <div className="h-3 w-2/3 animate-pulse rounded bg-[var(--color-bg-inset)]" />
-          </CardContent>
-        </Card>
-      </>
+      <div
+        className="flex flex-col gap-3 border-t border-[var(--color-border-default)] pt-6 sm:pt-8"
+        aria-hidden
+      >
+        <div className="h-5 w-48 animate-pulse rounded bg-[var(--color-bg-inset)]" />
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="flex items-center gap-2">
+            <div className="h-3 flex-1 animate-pulse rounded bg-[var(--color-bg-inset)]" />
+            <div className="h-1.5 w-16 shrink-0 animate-pulse rounded-full bg-[var(--color-bg-inset)]" />
+          </div>
+        ))}
+      </div>
     );
   }
   if (!impact) return null;
 
   if (impact.gitUnavailable) {
     return (
-      <Card>
-        <CardContent className="py-4 text-sm text-[var(--color-text-tertiary)]">
-          Enable Git for this workspace to see what your change touches, who
-          usually changes it with you, and who could review it.
-        </CardContent>
-      </Card>
+      <p className="border-t border-[var(--color-border-default)] pt-6 text-[15px] text-[var(--color-text-tertiary)] sm:pt-8">
+        Enable Git for this workspace to see what your change touches, who
+        usually changes it with you, and who could review it.
+      </p>
     );
   }
 
@@ -461,12 +478,10 @@ function ChangeImpact({
     impact.scope === "branch" ? "uncommitted and unpushed" : "uncommitted";
 
   return (
-    <div className="space-y-4">
-      <div className="flex flex-wrap items-center justify-between gap-2">
-        <h2 className="text-sm font-semibold text-[var(--color-text-primary)]">
-          What this change touches
-        </h2>
-        <span className="text-xs text-[var(--color-text-tertiary)]">
+    <OverviewSection
+      title="What this change touches"
+      action={
+        <span className="text-xs tabular-nums text-[var(--color-text-tertiary)]">
           {impact.changed.length} {scopeLabel} file{impact.changed.length === 1 ? "" : "s"}
           {overall != null && (
             <>
@@ -477,10 +492,11 @@ function ChangeImpact({
             </>
           )}
         </span>
-      </div>
-
+      }
+      className="gap-6"
+    >
       {directRisks.length > 0 && (
-        <ImpactCard
+        <ImpactBlock
           id={SECTION_IDS.directRisks}
           icon={<Gauge className="h-4 w-4" />}
           title="Riskiest files in this change"
@@ -490,11 +506,11 @@ function ChangeImpact({
             <DirectRiskRow key={f.path} risk={f} onOpen={() => host.openFile(f.path)} />
           ))}
           <MoreRow count={directRisks.length - 10} />
-        </ImpactCard>
+        </ImpactBlock>
       )}
 
       {downstream.length > 0 && (
-        <ImpactCard
+        <ImpactBlock
           id={SECTION_IDS.downstream}
           icon={<Network className="h-4 w-4" />}
           title="Downstream of your changes"
@@ -509,11 +525,11 @@ function ChangeImpact({
             />
           ))}
           <MoreRow count={downstream.length - 10} />
-        </ImpactCard>
+        </ImpactBlock>
       )}
 
       {cochanges.length > 0 && (
-        <ImpactCard
+        <ImpactBlock
           id={SECTION_IDS.cochanges}
           icon={<GitPullRequest className="h-4 w-4" />}
           title="Usually changes together"
@@ -528,11 +544,11 @@ function ChangeImpact({
             />
           ))}
           <MoreRow count={cochanges.length - 8} />
-        </ImpactCard>
+        </ImpactBlock>
       )}
 
       {testGaps.length > 0 && (
-        <ImpactCard
+        <ImpactBlock
           id={SECTION_IDS.testGaps}
           icon={<TestTube className="h-4 w-4" />}
           title="Changed without a test"
@@ -542,22 +558,25 @@ function ChangeImpact({
             <PathRow key={p} path={p} onOpen={() => host.openFile(p)} />
           ))}
           <MoreRow count={testGaps.length - 8} />
-        </ImpactCard>
+        </ImpactBlock>
       )}
 
       {reviewers.length > 0 && <Reviewers reviewers={reviewers} host={host} />}
-    </div>
+    </OverviewSection>
   );
 }
 
-function ImpactCard({
+/** One block of the impact read. A hairline and a heading, not a card: the
+ *  rows inside are the things you can act on, and each carrying its own box
+ *  put four bordered containers around four lists of file names. */
+function ImpactBlock({
   id,
   icon,
   title,
   hint,
   children,
 }: {
-  /** Anchor for the verdict chips; omitted for cards without a chip. */
+  /** Anchor for the verdict chips; omitted for blocks without a chip. */
   id?: string;
   icon: React.ReactNode;
   title: string;
@@ -565,16 +584,17 @@ function ImpactCard({
   children: React.ReactNode;
 }) {
   return (
-    <Card id={id}>
-      <CardHeader className="pb-2">
-        <CardTitle className="flex items-center gap-2 text-sm">
-          <span className="text-[var(--color-text-tertiary)]">{icon}</span>
-          {title}
-        </CardTitle>
-        <p className="text-xs text-[var(--color-text-tertiary)]">{hint}</p>
-      </CardHeader>
-      <CardContent className="space-y-0.5">{children}</CardContent>
-    </Card>
+    <section
+      {...(id ? { id } : {})}
+      className="flex scroll-mt-6 flex-col gap-1.5 border-t border-[var(--color-border-default)] pt-4"
+    >
+      <h3 className="flex items-center gap-2 text-[15px] font-semibold text-[var(--color-text-primary)]">
+        <span className="text-[var(--color-text-tertiary)]">{icon}</span>
+        {title}
+      </h3>
+      <p className="text-xs text-[var(--color-text-tertiary)]">{hint}</p>
+      <div className="mt-1 flex flex-col gap-0.5">{children}</div>
+    </section>
   );
 }
 
@@ -594,7 +614,7 @@ function PathRow({
       type="button"
       onClick={onOpen}
       title={`Open ${path}`}
-      className="flex w-full items-center gap-2 rounded px-1.5 py-1 text-left text-sm transition-colors hover:bg-[var(--color-bg-surface)]"
+      className="flex w-full items-center gap-2 rounded px-1.5 py-1 text-left text-[15px] transition-colors hover:bg-[var(--color-bg-surface)]"
     >
       <span className="min-w-0 flex-1 truncate">
         {dir && <span className="text-[var(--color-text-tertiary)]">{dir}</span>}
@@ -619,7 +639,7 @@ function DirectRiskRow({ risk, onOpen }: { risk: RankedDirectRisk; onOpen: () =>
       type="button"
       onClick={onOpen}
       title={`Open ${risk.path}`}
-      className="flex w-full items-center gap-2 rounded px-1.5 py-1 text-left text-sm transition-colors hover:bg-[var(--color-bg-surface)]"
+      className="flex w-full items-center gap-2 rounded px-1.5 py-1 text-left text-[15px] transition-colors hover:bg-[var(--color-bg-surface)]"
     >
       <span className="min-w-0 flex-1 truncate">
         {dir && <span className="text-[var(--color-text-tertiary)]">{dir}</span>}
@@ -674,30 +694,30 @@ function Reviewers({
   const maxScore = top.reduce((m, r) => Math.max(m, r.score), 0);
 
   return (
-    <Card>
-      <CardHeader className="flex flex-row items-center justify-between gap-2 pb-2">
-        <div>
-          <CardTitle className="flex items-center gap-2 text-sm">
+    <section className="flex flex-col gap-1.5 border-t border-[var(--color-border-default)] pt-4">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <h3 className="flex items-center gap-2 text-[15px] font-semibold text-[var(--color-text-primary)]">
             <span className="text-[var(--color-text-tertiary)]">
               <Users className="h-4 w-4" />
             </span>
             Suggested reviewers
-          </CardTitle>
+          </h3>
           <p className="text-xs text-[var(--color-text-tertiary)]">
             Ranked by ownership and co-change history of the changed files.
           </p>
         </div>
-        <Button variant="outline" size="sm" onClick={copy}>
+        <Button variant="outline" size="sm" onClick={copy} className="shrink-0">
           <Copy className="h-3.5 w-3.5" />
           Copy
         </Button>
-      </CardHeader>
-      <CardContent className="space-y-2.5">
+      </div>
+      <div className="mt-1 flex flex-col gap-2.5">
         {top.map((r) => {
           const pct = maxScore > 0 ? (r.score / maxScore) * 100 : 0;
           return (
             <div key={r.email ?? r.name} className="space-y-1">
-              <div className="flex items-center justify-between gap-3 text-sm">
+              <div className="flex items-center justify-between gap-3 text-[15px]">
                 <span className="min-w-0 truncate font-medium text-[var(--color-text-primary)]">
                   {r.name}
                 </span>
@@ -719,7 +739,7 @@ function Reviewers({
             </div>
           );
         })}
-      </CardContent>
-    </Card>
+      </div>
+    </section>
   );
 }

--- a/packages/vscode/webview/src/views/settings/App.tsx
+++ b/packages/vscode/webview/src/views/settings/App.tsx
@@ -7,8 +7,17 @@
  * one place to quiet the squiggles, gutter, and explorer badges.
  */
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { ExternalLink, RotateCcw, Settings2 } from "lucide-react";
+import {
+  SaveIndicator,
+  SettingsRow,
+  SettingsRows,
+  type SaveState,
+} from "@repowise-dev/ui/settings/settings-primitives";
+import { OverviewSection } from "@repowise-dev/ui/overview";
+import { Input } from "@repowise-dev/ui/ui/input";
+import { Switch } from "@repowise-dev/ui/ui/switch";
 import type {
   SettingKey,
   SettingsValues,
@@ -217,6 +226,21 @@ const GROUPS: Group[] = [
 export function App({ host, refreshToken }: ViewProps<"settings">) {
   const [values, setValues] = useState<SettingsValues | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [saveState, setSaveState] = useState<SaveState>("idle");
+
+  /** Monotonic stamp per write. A response that is no longer the newest is
+   *  dropped: this panel is exactly where someone flips four switches in two
+   *  seconds, and the host echoes the whole canonical map back, so an older
+   *  reply landing last silently un-does the newer one. */
+  const seq = useRef(0);
+  const savedTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(
+    () => () => {
+      if (savedTimer.current) clearTimeout(savedTimer.current);
+    },
+    [],
+  );
 
   const load = useCallback(() => {
     host.api
@@ -225,7 +249,12 @@ export function App({ host, refreshToken }: ViewProps<"settings">) {
         setValues(v);
         setError(null);
       })
-      .catch(() => setError("Could not load settings."));
+      .catch(() => {
+        setError("Could not load settings.");
+        // The indicator is the only thing that speaks on this surface, so a
+        // failed read has to reach it too, not just a failed write.
+        setSaveState("error");
+      });
   }, [host]);
 
   useEffect(() => load(), [load, refreshToken]);
@@ -235,18 +264,33 @@ export function App({ host, refreshToken }: ViewProps<"settings">) {
       // Optimistic: the control reflects the new value immediately; the host
       // echoes the canonical map back, and a rejected write reverts.
       setValues((prev) => (prev ? { ...prev, [key]: value } : prev));
+      const stamp = ++seq.current;
+      if (savedTimer.current) clearTimeout(savedTimer.current);
+      setSaveState("saving");
       host.api
         .updateSetting(key, value)
         .then((fresh) => {
+          if (stamp !== seq.current) return;
           setValues(fresh);
           setError(null);
+          setSaveState("saved");
+          savedTimer.current = setTimeout(() => setSaveState("idle"), 2000);
         })
         .catch((e: unknown) => {
+          if (stamp !== seq.current) return;
           setError(e instanceof Error ? e.message : "Could not save that setting.");
-          load();
+          setSaveState("error");
+          // Roll the control back to what the server actually has. Re-reads
+          // values only: `load()` would clear the error it was called to
+          // explain, leaving the indicator on the generic fallback and losing
+          // the host's real reason ("port 7777 already in use").
+          host.api
+            .getSettings()
+            .then(setValues)
+            .catch(() => undefined);
         });
     },
-    [host, load],
+    [host],
   );
 
   if (!values) {
@@ -258,51 +302,42 @@ export function App({ host, refreshToken }: ViewProps<"settings">) {
   }
 
   return (
-    <div className="mx-auto min-h-full max-w-3xl space-y-6 bg-[var(--color-bg-root)] px-6 py-6">
+    <div className="mx-auto flex min-h-full max-w-3xl flex-col gap-6 bg-[var(--color-bg-root)] px-6 py-6 sm:gap-8">
       <header className="flex items-center gap-2.5">
         <span className="grid h-8 w-8 shrink-0 place-items-center rounded-lg bg-[var(--color-accent-muted)] text-[var(--color-accent-primary)]">
           <Settings2 className="h-4 w-4" />
         </span>
         <div className="min-w-0 flex-1">
-          <h1 className="text-base font-semibold text-[var(--color-text-primary)]">
+          <h1 className="text-[22px] font-semibold tracking-tight text-[var(--color-text-primary)]">
             Repowise Settings
           </h1>
           <p className="text-xs text-[var(--color-text-tertiary)]">
             Saved to this workspace. Changes apply immediately.
           </p>
         </div>
+        {/* The one save affordance: nothing at rest, a spinner in flight,
+            "Saved" for two seconds, the error until it is fixed. It is
+            `aria-live="polite"`, which is right for "Saved" and wrong for a
+            rejected write, so the failure keeps the assertive announcement the
+            banner this replaced had. */}
+        <SaveIndicator state={saveState} error={error} className="shrink-0" />
+        <span role="alert" className="sr-only">
+          {saveState === "error" ? (error ?? "Could not save") : ""}
+        </span>
         <button
           type="button"
           onClick={() => host.openNativeSettings()}
           title="Open these settings in the VS Code Settings editor (search, sync, per-scope overrides)"
-          className="flex shrink-0 items-center gap-1.5 rounded-lg border border-[var(--color-border-default)] px-2.5 py-1.5 text-[11px] font-medium text-[var(--color-text-secondary)] transition-colors hover:border-[var(--color-border-hover)] hover:text-[var(--color-text-primary)]"
+          className="flex shrink-0 items-center gap-1.5 rounded-lg border border-[var(--color-border-default)] px-2.5 py-1.5 text-xs font-medium text-[var(--color-text-secondary)] transition-colors hover:border-[var(--color-border-hover)] hover:text-[var(--color-text-primary)]"
         >
           <ExternalLink className="h-3.5 w-3.5" />
           Open in Settings editor
         </button>
       </header>
 
-      {error ? (
-        <p
-          role="alert"
-          className="rounded-lg border border-[var(--color-error)] bg-[var(--color-bg-surface)] px-3 py-2 text-xs text-[var(--color-error)]"
-        >
-          {error}
-        </p>
-      ) : null}
-
       {GROUPS.map((group) => (
-        <section
-          key={group.title}
-          className="rounded-xl border border-[var(--color-border-default)] bg-[var(--color-bg-surface)]"
-        >
-          <div className="border-b border-[var(--color-border-default)] px-4 py-3">
-            <h2 className="text-sm font-semibold text-[var(--color-text-primary)]">
-              {group.title}
-            </h2>
-            <p className="mt-0.5 text-[11px] text-[var(--color-text-tertiary)]">{group.blurb}</p>
-          </div>
-          <div className="divide-y divide-[var(--color-border-default)]">
+        <OverviewSection key={group.title} title={group.title} description={group.blurb}>
+          <SettingsRows>
             {group.rows.map((row) => (
               <SettingRow
                 key={row.key}
@@ -312,8 +347,8 @@ export function App({ host, refreshToken }: ViewProps<"settings">) {
                 onCommit={commit}
               />
             ))}
-          </div>
-        </section>
+          </SettingsRows>
+        </OverviewSection>
       ))}
     </div>
   );
@@ -332,32 +367,23 @@ function SettingRow({
 }) {
   const value = values[row.key];
   const controlId = `set-${row.key.replace(/\./g, "-")}`;
-  // Rows gated by a parent toggle are indented under it with an elbow connector,
-  // so a dimmed child reads as "controlled by the switch above", not broken.
+  // Rows gated by a parent toggle are indented under it behind a left
+  // hairline, so a dimmed child reads as "controlled by the switch above"
+  // rather than as broken. It holds at every width: in a narrow editor column
+  // an indent that only starts at `sm` leaves the gated row looking broken at
+  // exactly the size where that reading matters most.
   const indented = row.needs != null;
   return (
-    <div
+    <SettingsRow
+      label={row.label}
+      htmlFor={controlId}
+      hint={row.description}
       className={
         (disabled ? "opacity-50 " : "") +
-        "flex items-start gap-3 py-3 pr-4 " +
-        (indented ? "pl-8" : "pl-4")
+        (indented ? "border-l border-[var(--color-border-default)] pl-4" : "")
       }
     >
-      {indented ? (
-        <span
-          aria-hidden
-          className="mt-1 h-3 w-3 shrink-0 rounded-bl border-b border-l border-[var(--color-border-default)]"
-        />
-      ) : null}
-      <div className="min-w-0 flex-1">
-        <label htmlFor={controlId} className="block text-[13px] font-medium text-[var(--color-text-primary)]">
-          {row.label}
-        </label>
-        <p className="mt-0.5 text-[11px] leading-relaxed text-[var(--color-text-tertiary)]">
-          {row.description}
-        </p>
-      </div>
-      <div className="shrink-0 pt-0.5">
+      <div className="flex sm:justify-end">
         <Control
           id={controlId}
           row={row}
@@ -366,7 +392,7 @@ function SettingRow({
           onCommit={(v) => onCommit(row.key, v)}
         />
       </div>
-    </div>
+    </SettingsRow>
   );
 }
 
@@ -385,7 +411,20 @@ function Control({
 }) {
   switch (row.kind) {
     case "toggle":
-      return <Toggle id={id} checked={value === true} disabled={disabled} onChange={onCommit} />;
+      return (
+        // The shared switch draws its off state as a white thumb on
+        // `bg-elevated` with a transparent border, which on the light ramp is
+        // cream on cream. Give the off state a real border so the control is
+        // visible at rest — and so `.hc` can reach it, since a transparent
+        // border cannot pick up `--vscode-contrastBorder`.
+        <Switch
+          id={id}
+          checked={value === true}
+          disabled={disabled}
+          onCheckedChange={onCommit}
+          className="border data-[state=unchecked]:border-[var(--color-border-hover)] data-[state=unchecked]:bg-[var(--color-bg-inset)]"
+        />
+      );
     case "select":
       return (
         <Select
@@ -439,46 +478,16 @@ function Control({
   }
 }
 
-function Toggle({
-  id,
-  checked,
-  disabled,
-  onChange,
-}: {
-  id: string;
-  checked: boolean;
-  disabled: boolean;
-  onChange: (value: boolean) => void;
-}) {
-  return (
-    <button
-      id={id}
-      type="button"
-      role="switch"
-      aria-checked={checked}
-      disabled={disabled}
-      onClick={() => onChange(!checked)}
-      className={
-        // The off state carries a border and a filled knob so the switch stays
-        // visible on a light card, where bg-inset alone is nearly the surface color.
-        "relative inline-flex h-5 w-9 shrink-0 items-center rounded-full border transition-colors disabled:cursor-not-allowed " +
-        (checked
-          ? "border-[var(--color-accent-primary)] bg-[var(--color-accent-primary)]"
-          : "border-[var(--color-border-default)] bg-[var(--color-bg-inset)]")
-      }
-    >
-      <span
-        className={
-          "inline-block h-4 w-4 transform rounded-full shadow-sm transition-transform " +
-          (checked ? "translate-x-4 bg-white" : "translate-x-0.5 bg-[var(--color-text-tertiary)]")
-        }
-      />
-    </button>
-  );
-}
-
+/**
+ * The native `<select>` is kept where the shared Radix `Select` is not.
+ *
+ * Everything else here is now the shared control. This one stays because it
+ * buys nothing: it themes through the same tokens either way, and the Radix
+ * version renders through a portal, which is a real behaviour to take on inside
+ * a webview in exchange for no visual difference at these three call sites.
+ */
 const CONTROL_CLASS =
-  "rounded-md border border-[var(--color-border-default)] bg-[var(--color-bg-inset)] px-2 py-1 text-[12px] text-[var(--color-text-primary)] focus:border-[var(--color-accent-primary)] focus:outline-none disabled:cursor-not-allowed";
+  "h-9 rounded-md border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-3 text-xs text-[var(--color-text-primary)] transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--color-accent-primary)] disabled:cursor-not-allowed disabled:opacity-50";
 
 function Select({
   id,
@@ -537,7 +546,7 @@ function MultiSelect({
             aria-pressed={on}
             onClick={() => toggle(o.value)}
             className={
-              "rounded-full border px-2 py-0.5 text-[11px] transition-colors disabled:cursor-not-allowed " +
+              "rounded-full border px-2 py-0.5 text-xs transition-colors disabled:cursor-not-allowed " +
               (on
                 ? "border-[var(--color-accent-primary)] bg-[var(--color-accent-muted)] text-[var(--color-accent-primary)]"
                 : "border-[var(--color-border-default)] text-[var(--color-text-tertiary)] hover:text-[var(--color-text-primary)]")
@@ -578,7 +587,7 @@ function NumberInput({
     setDraft(String(clamped));
   };
   return (
-    <input
+    <Input
       id={id}
       type="number"
       inputMode="decimal"
@@ -590,7 +599,7 @@ function NumberInput({
       onChange={(e) => setDraft(e.target.value)}
       onBlur={commit}
       onKeyDown={(e) => e.key === "Enter" && e.currentTarget.blur()}
-      className={CONTROL_CLASS + " w-20 text-right"}
+      className="w-24 text-right"
     />
   );
 }
@@ -622,7 +631,7 @@ function PortInput({
     if (n !== value) onCommit(n);
   };
   return (
-    <input
+    <Input
       id={id}
       type="text"
       inputMode="numeric"
@@ -632,7 +641,7 @@ function PortInput({
       onChange={(e) => setDraft(e.target.value)}
       onBlur={commit}
       onKeyDown={(e) => e.key === "Enter" && e.currentTarget.blur()}
-      className={CONTROL_CLASS + " w-20 text-right"}
+      className="w-24 text-right"
     />
   );
 }
@@ -657,7 +666,7 @@ function TextInput({
   };
   return (
     <span className="flex items-center gap-1.5">
-      <input
+      <Input
         id={id}
         type="text"
         value={draft}
@@ -666,7 +675,7 @@ function TextInput({
         onChange={(e) => setDraft(e.target.value)}
         onBlur={commit}
         onKeyDown={(e) => e.key === "Enter" && e.currentTarget.blur()}
-        className={CONTROL_CLASS + " w-44"}
+        className="w-44"
       />
       {value !== "" ? (
         <button


### PR DESCRIPTION
The extension's view code predates most of the current UI conventions, so it
had quietly become a second design system: its own health thresholds, its own
status colours, its own settings primitives, and card chrome around things you
cannot click. This brings it back onto the shared vocabulary, mostly by
deleting local code in favour of an import.

## Two defects first

**The health bands were wrong, and contradicted a map on the same screen.**
Two local `scoreColor` copies treated anything at or above 7.5 as healthy-green.
The canonical bands in `@repowise-dev/types` start Healthy at 8, and the shared
score ramp every other surface paints from puts 7.5-7.99 in amber. So the health
panel printed a file's score in green directly beside a map colouring the same
file amber, and the second copy's comment cheerfully noted it "matches the
sidebar Home hero" — two copies agreeing with each other and with nothing else.

Both are gone. The figure takes the shared ramp, so it agrees with the map
beside it and with the web app's file table. Checked against the live index:
`packages/ui/src/health/code-health-map.tsx` scores 7.83 and now reads amber on
all three surfaces, where it used to read green in the extension alone. The
test asserts the rendered class against the map's own fill table rather than
against a colour spelled out a third time, since that is the contradiction that
matters and a plain render test would not catch it.

**High-contrast themes got no handling at all.** `vscode-high-contrast` fell
through to the ordinary dark ramp and `vscode-high-contrast-light` to ordinary
light, so someone who explicitly opted into high contrast received the standard
`rgba(255,255,255,.07)` hairlines and the standard tertiary text. Both kinds now
stamp an `hc` root class that widens borders and lifts tertiary text to
secondary.

The brand palette stays rather than remapping onto `--vscode-*`. Green, amber
and red on these surfaces carry a health band; editor greys have no vocabulary
for one, so a full remap would trade contrast for making the map, its key and
every score unreadable as data — the wrong direction for the person who asked
for high contrast. What is bridged is the part VS Code defines for exactly this
purpose: `contrastBorder`, `contrastActiveBorder` and `focusBorder`, none of
which are set outside a high-contrast theme, so the fallbacks never fire
elsewhere. Tertiary text points at the secondary token rather than a literal, so
it follows the ramp instead of pinning a stale copy of it.

## Then the drift

- **Health** drops `HealthKpiCards` and `ChurnComplexityQuadrant`. Grepping both
  across the monorepo returned this panel and nothing else: it was the last
  consumer of two components the product had already retired, which is the
  mechanism by which it would have diverged permanently. It now composes the
  same pieces the web code-health page leads with — `CodeHealthLede`, the map
  with its chrome placed around the canvas instead of floating on it, the lens
  switcher, the key, and `TrendView`. Churn becomes a lens rather than a
  quadrant, fetched on selection and joined onto the map rows by path. That also
  retires the hand-rolled segmented control, since there is no second dataset
  left for it to switch between.
- **Settings** takes the shared `SettingsRow`, `SaveIndicator`, `Switch` and
  `Input`. A write in flight had no spinner and a successful one no
  acknowledgement; only the error banner ever spoke. Writes are now stamped, so
  two toggles flipped within a second cannot end with the older payload silently
  undoing the newer. The optimistic update and its rollback are unchanged — they
  were already right.
- **Decisions** takes `DecisionStatusMark`. Its local map painted `proposed` as
  `--color-info` where the shared one paints accent: one status word, two
  colours, depending on which surface you were looking at.
- **The risk view** carried thirty `Card` wrappers and not one of them was
  clickable. Those become hairlines and vertical rhythm, with the score hero on
  the shared `PageLede`. Everything that actually acts keeps its affordance.
- **The home sidebar's** two statistics stop wearing card chrome; the seven
  launchers keep theirs, because those are real navigation buttons. The delta
  chip gives up green so it cannot collide with the health numeral forty pixels
  above it, where green means a band rather than a direction, and the freshness
  dot renders only when the index is actually behind.
- Every uppercase micro-label is mono, and the full-tab panels move onto the
  documented size steps. The ~300px sidebar keeps its 11 and 13px, which is the
  width argument compact density exists for.

## Shared package

Two small additions so the shared tables have one owner each: a
`./health/tokens` subpath export, and `decisionStatusColor` beside
`DecisionStatusMark` for lists too narrow to carry the status word.

## Verification

- Type-check, extension bundle, webview bundle, 44/44 webview tests and the
  extension-host smoke test all pass.
- The undefined-custom-property sweep scoped to `packages/vscode` still returns
  empty.
- `grep -rn "score >= 7.5\|score >= 5" packages/vscode` returns nothing.
- Every screen touched was rendered and inspected in light, dark and both
  high-contrast kinds.

Net product code shrinks by 15 lines; the swap files account for -101 between
them.

## Known and deliberately left

- `CodeHealthLede` reads the repo average on the five-step ladder, so 7.4 shows
  as "Good" in green above a map painting 7.4-scoring files amber. That lives in
  the shared component and the web page has the identical adjacency, so
  diverging here would recreate the drift this removes. Worth settling in
  `packages/ui`.
- `refactoring/App.tsx` still has bordered stat tiles and a boxed file list. Its
  type scale and labels are fixed here; the container rework is not.
