### PR TITLE
feat(web): put the repositories back at the centre of the dashboard

### DIFF
--- a/packages/ui/__tests__/overview/repo-rows.test.tsx
+++ b/packages/ui/__tests__/overview/repo-rows.test.tsx
@@ -1,0 +1,115 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { RepoRows, type RepoRow } from "../../src/overview/repo-rows.js";
+
+function row(overrides: Partial<RepoRow> = {}): RepoRow {
+  return {
+    id: "r1",
+    name: "repowise",
+    localPath: "/home/me/code/repowise",
+    href: "/repos/r1/overview",
+    status: "indexed",
+    health: 7.4,
+    fileCount: 3600,
+    hotspotCount: 364,
+    docPageCount: 4059,
+    docFreshPageCount: 3797,
+    deadExportCount: 19,
+    updatedAt: null,
+    indexBehind: false,
+    ...overrides,
+  };
+}
+
+describe("RepoRows", () => {
+  it("gives every figure the noun it counts", () => {
+    render(<RepoRows repos={[row()]} />);
+
+    // "3,600" alone reads as nothing in particular. The unit is what makes it
+    // a fact rather than a decoration.
+    expect(screen.getByText(/3,600 files/)).toBeTruthy();
+    expect(screen.getByText(/364 hotspots/)).toBeTruthy();
+    expect(screen.getByText(/19 unused exports/)).toBeTruthy();
+    expect(screen.getByText(/94% of 4,059 doc pages fresh/)).toBeTruthy();
+  });
+
+  it("renders no marker when a repo is current", () => {
+    // A badge every row carries says nothing. A quiet list is a healthy list.
+    render(<RepoRows repos={[row()]} />);
+
+    expect(screen.queryByText("Index behind HEAD")).toBeNull();
+    expect(screen.queryByText("Not indexed yet")).toBeNull();
+  });
+
+  it("marks a repo whose index is behind the checkout", () => {
+    render(<RepoRows repos={[row({ indexBehind: true })]} />);
+
+    expect(screen.getByText("Index behind HEAD")).toBeTruthy();
+  });
+
+  it("treats an unknown freshness comparison as unremarkable", () => {
+    // `null` means the check could not run, which is not the same as behind.
+    render(<RepoRows repos={[row({ indexBehind: null })]} />);
+
+    expect(screen.queryByText("Index behind HEAD")).toBeNull();
+  });
+
+  it("shows a dash rather than a zero for a repo with no health snapshot", () => {
+    // A 0.0 in red would report "analysed, and terrible" about a repository
+    // nobody has analysed.
+    render(<RepoRows repos={[row({ health: null })]} />);
+
+    expect(screen.queryByText("0.0")).toBeNull();
+    expect(screen.getByText("—")).toBeTruthy();
+  });
+
+  it("bands the score on the canonical three-band ladder", () => {
+    render(
+      <RepoRows
+        repos={[
+          row({ id: "a", name: "alpha", health: 9.1 }),
+          row({ id: "b", name: "beta", health: 5.0 }),
+          row({ id: "c", name: "gamma", health: 3.0 }),
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("Healthy")).toBeTruthy();
+    expect(screen.getByText("Warning")).toBeTruthy();
+    expect(screen.getByText("Alert")).toBeTruthy();
+  });
+
+  it("does not quote figures for a repo that was never indexed", () => {
+    render(
+      <RepoRows repos={[row({ status: "needs_index", health: null, fileCount: 0 })]} />,
+    );
+
+    expect(screen.getByText("Not indexed yet")).toBeTruthy();
+    expect(screen.getByText(/Run an index to see/)).toBeTruthy();
+    expect(screen.queryByText(/0 files/)).toBeNull();
+  });
+
+  it("renders row actions outside the row link", () => {
+    // A button nested in an anchor is invalid and swallows its own clicks, so
+    // the two are siblings. This is the assertion that catches a regression
+    // back to the nested form.
+    const { container } = render(
+      <RepoRows repos={[row()]} actionsFor={() => <button type="button">Delete</button>} />,
+    );
+
+    const anchor = container.querySelector("a");
+    expect(anchor).toBeTruthy();
+    expect(anchor?.querySelector("button")).toBeNull();
+    expect(screen.getByRole("button", { name: "Delete" })).toBeTruthy();
+  });
+
+  it("does not truncate the repository name", () => {
+    // A title needing an ellipsis means the layout is wrong, and a directory
+    // name is exactly the string somebody is scanning for.
+    const long = "a-very-long-monorepo-name-that-would-be-cut-by-a-fixed-width-column";
+    const { container } = render(<RepoRows repos={[row({ name: long })]} />);
+
+    expect(screen.getByText(long)).toBeTruthy();
+    expect(container.querySelector(".truncate")).toBeNull();
+  });
+});

--- a/packages/ui/src/overview/index.ts
+++ b/packages/ui/src/overview/index.ts
@@ -19,6 +19,9 @@ export type { RepoIdentityHeaderProps, RepoIdentityMeta } from "./repo-identity-
 export { RepoAvatar, githubOwnerFromRemote } from "./repo-avatar";
 export type { RepoAvatarProps } from "./repo-avatar";
 
+export { RepoRows } from "./repo-rows";
+export type { RepoRow, RepoRowsProps } from "./repo-rows";
+
 export { HealthLede, healthBand } from "./health-lede";
 export type { HealthLedeProps } from "./health-lede";
 

--- a/packages/ui/src/overview/repo-rows.tsx
+++ b/packages/ui/src/overview/repo-rows.tsx
@@ -1,0 +1,201 @@
+import * as React from "react";
+import { bandForScore, HEALTH_BAND_LABEL } from "@repowise-dev/types/health";
+import type { RepoIndexStatus } from "@repowise-dev/types/repos";
+import { healthInk } from "../health/tokens";
+import { formatNumber, formatRelativeTime } from "../lib/format";
+import { RepoAvatar } from "./repo-avatar";
+
+export interface RepoRow {
+  id: string;
+  name: string;
+  localPath: string;
+  href: string;
+  status: RepoIndexStatus;
+  /** Latest health score, 0-10. `null` means never analysed, which must not
+   *  render as a 0 — that reads as "analysed, and terrible". */
+  health: number | null;
+  fileCount: number;
+  hotspotCount: number;
+  docPageCount: number;
+  docFreshPageCount: number;
+  deadExportCount: number;
+  updatedAt: string | null;
+  /** Index is behind the working tree. `null` when the comparison could not
+   *  run, which is not the same as up to date, so neither gets a marker. */
+  indexBehind: boolean | null;
+}
+
+export interface RepoRowsProps {
+  repos: RepoRow[];
+  LinkComponent?: React.ElementType | undefined;
+  /**
+   * Per-row secondary actions, rendered outside the row's link.
+   *
+   * The row's one verb is "open this repository" and it belongs to the whole
+   * row; anything else the host wants goes here, where it can be an overflow
+   * rather than a second competing target. Kept as a slot because deleting a
+   * repo needs a confirm dialog and therefore a client boundary, which this
+   * component does not have and should not grow.
+   */
+  actionsFor?: ((repo: RepoRow) => React.ReactNode) | undefined;
+}
+
+/** A marker that renders only when there is something to do. */
+function StatusMark({ repo }: { repo: RepoRow }) {
+  if (repo.status === "missing_dir") {
+    return <Mark color="var(--color-error)" label="Directory missing" />;
+  }
+  if (repo.status !== "indexed") {
+    return <Mark color="var(--color-warning)" label="Not indexed yet" />;
+  }
+  if (repo.indexBehind === true) {
+    return <Mark color="var(--color-caution)" label="Index behind HEAD" />;
+  }
+  return null;
+}
+
+/**
+ * Dot plus word, never a filled pill.
+ *
+ * A tinted ground, a border and coloured text on a token that repeats once per
+ * row tiles into stripes down a list and outweighs the repo names it belongs
+ * to. The word stays because these states are amber and amber-adjacent, which
+ * is exactly the pair colour alone cannot separate.
+ */
+function Mark({ color, label }: { color: string; label: string }) {
+  return (
+    <span className="inline-flex items-center gap-1.5 text-[11px] font-medium" style={{ color }}>
+      <span
+        aria-hidden
+        className="h-1.5 w-1.5 shrink-0 rounded-full"
+        style={{ background: color }}
+      />
+      {label}
+    </span>
+  );
+}
+
+/** The figures line: every number carries the noun it counts. */
+function figuresFor(repo: RepoRow): string[] {
+  if (repo.status !== "indexed") return [];
+  const parts = [`${formatNumber(repo.fileCount)} files`];
+  if (repo.docPageCount > 0) {
+    const pct = Math.round((repo.docFreshPageCount / repo.docPageCount) * 100);
+    parts.push(`${pct}% of ${formatNumber(repo.docPageCount)} doc pages fresh`);
+  }
+  if (repo.hotspotCount > 0) parts.push(`${formatNumber(repo.hotspotCount)} hotspots`);
+  if (repo.deadExportCount > 0) {
+    parts.push(`${formatNumber(repo.deadExportCount)} unused exports`);
+  }
+  return parts;
+}
+
+/**
+ * The repositories on this machine, as hairline rows.
+ *
+ * The multi-repo dashboard used to open with four cross-repo totals and put
+ * the repos themselves in a card underneath. Summing findings across unrelated
+ * repositories produces a number with no action attached to it — there is no
+ * thing you do about "the total dead code across your side project and your
+ * monorepo" — so the list is the subject here and the aggregates moved into
+ * the ribbon above it.
+ *
+ * Health leads the right-hand column because it is the figure that decides
+ * which repo you open. It is painted on `bandForScore`, the canonical three
+ * bands, rather than the five-step `healthBand` reading: that one belongs to a
+ * lede, where nothing adjacent contradicts it, and a column of rows is the
+ * case where two ladders visibly disagree.
+ */
+export function RepoRows({ repos, LinkComponent, actionsFor }: RepoRowsProps) {
+  const A = LinkComponent ?? "a";
+  if (repos.length === 0) return null;
+
+  return (
+    <ul className="m-0 list-none divide-y divide-[var(--color-border-default)] border-t border-[var(--color-border-default)] p-0">
+      {repos.map((repo) => {
+        const figures = figuresFor(repo);
+        const actions = actionsFor?.(repo);
+        const band = repo.health === null ? null : bandForScore(repo.health);
+
+        return (
+          <li key={repo.id} className="group">
+            {/* The link and the actions are siblings, not nested: a button
+                inside an anchor is invalid and swallows its own clicks. */}
+            <div className="flex items-start gap-3 py-3.5 transition-colors hover:bg-[var(--color-bg-wash-hover)] sm:gap-4">
+              <A
+                href={repo.href}
+                className="flex min-w-0 flex-1 items-start gap-3 no-underline sm:gap-4"
+              >
+                <RepoAvatar name={repo.name} size={32} className="mt-0.5" />
+
+                <div className="min-w-0 flex-1">
+                  <div className="flex flex-wrap items-center gap-x-2.5 gap-y-1">
+                    {/* No truncation. If a repo name needs an ellipsis the
+                        layout is wrong, and a directory name is exactly the
+                        string somebody is scanning for. */}
+                    <span className="text-[15px] font-medium text-[var(--color-text-primary)] transition-colors group-hover:text-[var(--color-accent-primary)]">
+                      {repo.name}
+                    </span>
+                    <StatusMark repo={repo} />
+                  </div>
+
+                  <p className="mt-0.5 font-mono text-[11px] text-[var(--color-text-tertiary)] [overflow-wrap:anywhere]">
+                    {repo.localPath}
+                  </p>
+
+                  <p className="mt-1.5 text-xs tabular-nums text-[var(--color-text-secondary)]">
+                    {figures.length > 0 ? (
+                      figures.join(" · ")
+                    ) : (
+                      <span className="text-[var(--color-text-tertiary)]">
+                        Run an index to see this repository&rsquo;s figures.
+                      </span>
+                    )}
+                    {repo.updatedAt && (
+                      <span className="text-[var(--color-text-tertiary)]">
+                        {figures.length > 0 ? " · " : " "}
+                        Synced {formatRelativeTime(repo.updatedAt)}
+                      </span>
+                    )}
+                  </p>
+                </div>
+              </A>
+
+              <div className="flex shrink-0 items-start gap-2 sm:gap-4">
+                <div className="w-[74px] text-right sm:w-[92px]">
+                  <p className="font-mono text-[10px] uppercase tracking-[0.12em] text-[var(--color-text-tertiary)]">
+                    Health
+                  </p>
+                  {repo.health === null || band === null ? (
+                    <p
+                      className="mt-1 text-[15px] leading-none text-[var(--color-text-tertiary)]"
+                      title="No health snapshot yet — this repository has not been analysed."
+                    >
+                      &mdash;
+                    </p>
+                  ) : (
+                    <>
+                      <p
+                        className="mt-1 text-[22px] font-semibold leading-none tabular-nums"
+                        style={{ color: healthInk(repo.health) }}
+                      >
+                        {repo.health.toFixed(1)}
+                      </p>
+                      <p
+                        className="mt-1 text-[11px]"
+                        style={{ color: healthInk(repo.health) }}
+                      >
+                        {HEALTH_BAND_LABEL[band]}
+                      </p>
+                    </>
+                  )}
+                </div>
+                {actions}
+              </div>
+            </div>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/packages/web/src/app/page.tsx
+++ b/packages/web/src/app/page.tsx
@@ -1,280 +1,193 @@
 import type { Metadata } from "next";
 import { redirect } from "next/navigation";
 import Link from "next/link";
-import {
-  FileText,
-  CheckCircle2,
-  AlertCircle,
-  Ban,
-  Skull,
-  Activity,
-  RefreshCw,
-  Clock,
-} from "lucide-react";
-import { listRepos, getRepoStats } from "@/lib/api/repos";
+import { LayoutGrid } from "lucide-react";
+import type { RepoSummaryRow } from "@repowise-dev/types/repos";
+import { PageShell } from "@repowise-dev/ui/shared";
+import { PageLede } from "@repowise-dev/ui/shared/page-lede";
+import { OverviewSection, RepoRows, type RepoRow } from "@repowise-dev/ui/overview";
+// Direct path, not the `ui/stats` barrel: that barrel re-exports two
+// "use client" modules, which would drag a hydration boundary into this
+// server page for a component that has no state.
+import { StatRibbon, type RibbonStat } from "@repowise-dev/ui/stats/stat-ribbon";
+import { formatNumber } from "@repowise-dev/ui/lib/format";
+import { getReposSummary } from "@/lib/api/repos";
 import { listJobs } from "@/lib/api/jobs";
-import { getGitSummary } from "@/lib/api/git";
 import { getWorkspace } from "@/lib/api/workspace";
-import type { RepoStatsResponse, GitSummaryResponse } from "@/lib/api/types";
-import { MetricCard } from "@repowise-dev/ui/shared/metric-card";
-import { Card, CardContent, CardHeader, CardTitle } from "@repowise-dev/ui/ui/card";
-import { Badge } from "@repowise-dev/ui/ui/badge";
-import { EmptyState } from "@repowise-dev/ui/shared/empty-state";
-import { formatRelativeTime, formatNumber } from "@repowise-dev/ui/lib/format";
+import { attentionSentence, byAttention } from "@/lib/repo-attention";
 import { DeleteRepoButton } from "@/components/repos/delete-repo-button";
 import { EmptyReposState } from "@/components/repos/empty-repos-state";
-import { LiveJobProgress } from "@/components/jobs/live-job-progress";
+import { JobRows } from "@/components/jobs/job-rows";
 
 export const metadata: Metadata = { title: "Dashboard" };
 
 export const revalidate = 30;
 
+/** Jobs the activity section holds. One screen's worth; the figure is not
+ *  reported anywhere, so this cap cannot be mistaken for a total. */
+const JOB_WINDOW = 10;
+
+/**
+ * The multi-repo dashboard.
+ *
+ * Only ever rendered with two or more repositories: one redirects to its
+ * overview and workspace mode redirects to `/workspace`, both below.
+ *
+ * It used to open with four cross-repo totals in `MetricCard`s — total pages,
+ * fresh, stale, dead code — and put the repositories themselves in a card
+ * underneath. Two things were wrong with that beyond the styling. Summing
+ * findings across unrelated repositories produces a number with no action
+ * attached to it, and the headline figure was `file_count` from `/stats`,
+ * which counted symbol nodes as files and so over-reported by roughly 10x
+ * under a label that said "Total Pages". Both are fixed at the source; see
+ * `GET /api/repos/summary`.
+ *
+ * So the list is the subject now, ordered by what needs attention rather than
+ * by last write, and the aggregates that do legitimately add sit in the ribbon
+ * above it.
+ */
 export default async function DashboardPage() {
-  const [repos, jobs, ws] = await Promise.allSettled([
-    listRepos(),
-    listJobs({ limit: 10 }),
+  // One wave. The shape this replaces fetched the repo list, then a stats call
+  // per repo, then a git-summary call per repo, in two sequential rounds.
+  const [summary, jobs, ws] = await Promise.allSettled([
+    getReposSummary(),
+    listJobs({ limit: JOB_WINDOW }),
     getWorkspace({ cache: "no-store" }),
   ]);
 
-  const repoList = repos.status === "fulfilled" ? repos.value : [];
+  const repos = summary.status === "fulfilled" ? summary.value.repos : [];
   const jobList = jobs.status === "fulfilled" ? jobs.value : [];
   const workspace = ws.status === "fulfilled" ? ws.value : null;
 
-  // Workspace mode → workspace dashboard
-  if (workspace?.is_workspace) {
-    redirect("/workspace");
+  if (workspace?.is_workspace) redirect("/workspace");
+  if (repos.length === 1) redirect(`/repos/${repos[0].id}/overview`);
+
+  if (repos.length === 0) {
+    return (
+      <PageShell
+        title="Repositories"
+        icon={<LayoutGrid className="h-5 w-5 text-[var(--color-text-tertiary)]" />}
+        description="Everything repowise has indexed from this machine."
+      >
+        <EmptyReposState />
+      </PageShell>
+    );
   }
 
-  // Single repo → go straight to its overview
-  if (repoList.length === 1) {
-    redirect(`/repos/${repoList[0].id}/overview`);
-  }
-
-  // Aggregate stats across all repos
-
-  const statsResults = await Promise.allSettled(
-    repoList.map((r) => getRepoStats(r.id)),
+  const totals = repos.reduce(
+    (acc, r) => ({
+      files: acc.files + r.file_count,
+      symbols: acc.symbols + r.symbol_count,
+      pages: acc.pages + r.doc_page_count,
+      freshPages: acc.freshPages + r.doc_fresh_page_count,
+      hotspots: acc.hotspots + r.hotspot_count,
+      deadExports: acc.deadExports + r.dead_export_count,
+    }),
+    { files: 0, symbols: 0, pages: 0, freshPages: 0, hotspots: 0, deadExports: 0 },
   );
-  const gitResults = await Promise.allSettled(
-    repoList.map((r) => getGitSummary(r.id)),
-  );
 
-  const statsMap = new Map<string, RepoStatsResponse>();
-  const gitMap = new Map<string, GitSummaryResponse>();
-  repoList.forEach((r, i) => {
-    if (statsResults[i]?.status === "fulfilled")
-      statsMap.set(r.id, (statsResults[i] as PromiseFulfilledResult<RepoStatsResponse>).value);
-    if (gitResults[i]?.status === "fulfilled")
-      gitMap.set(r.id, (gitResults[i] as PromiseFulfilledResult<GitSummaryResponse>).value);
-  });
+  const ribbon: RibbonStat[] = [
+    {
+      label: "Files",
+      value: formatNumber(totals.files),
+      sub: `across ${repos.length} repositories`,
+    },
+    {
+      label: "Symbols",
+      value: formatNumber(totals.symbols),
+      sub: "functions, classes and methods",
+    },
+    {
+      label: "Doc freshness",
+      value: totals.pages > 0 ? `${Math.round((totals.freshPages / totals.pages) * 100)}%` : "—",
+      sub:
+        totals.pages > 0
+          ? `${formatNumber(totals.freshPages)} of ${formatNumber(totals.pages)} pages`
+          : "no documentation generated yet",
+    },
+    {
+      label: "Hotspots",
+      value: formatNumber(totals.hotspots),
+      sub: "files by churn and prior fixes",
+    },
+    {
+      label: "Unused exports",
+      value: formatNumber(totals.deadExports),
+      sub: "open dead-code findings",
+    },
+  ];
 
-  // Aggregate stats across all repos
-  let totalPages = 0;
-  let freshPages = 0;
-  let deadCode = 0;
-  for (const s of statsMap.values()) {
-    totalPages += s.file_count;
-    freshPages += Math.round(s.file_count * s.doc_coverage_pct / 100);
-    deadCode += s.dead_export_count;
-  }
-  const stalePages = totalPages - freshPages;
+  const activeJobs = jobList.filter((j) => j.status === "running" || j.status === "pending");
+  const nameFor = (id: string) => repos.find((r) => r.id === id)?.name ?? null;
 
   return (
-    <div className="p-5 sm:p-8 space-y-8 max-w-[1200px]">
-      {/* Header */}
-      <div>
-        <h1 className="text-2xl font-semibold text-[var(--color-text-primary)]">Dashboard</h1>
-        <p className="text-sm text-[var(--color-text-secondary)] mt-1">
-          {repoList.length} {repoList.length === 1 ? "repository" : "repositories"} registered
+    <PageShell
+      title="Repositories"
+      icon={<LayoutGrid className="h-5 w-5 text-[var(--color-text-tertiary)]" />}
+      description="Everything repowise has indexed from this machine."
+    >
+      <PageLede
+        label="Repositories"
+        value={String(repos.length)}
+        unit="indexed on this machine"
+        layout="beside"
+      >
+        <p>
+          {formatNumber(totals.files)} files and {formatNumber(totals.symbols)} symbols are under
+          intelligence here, with {formatNumber(totals.pages)} documentation pages written from
+          them. Every figure below is measured from the index rather than estimated.
         </p>
-      </div>
+        <p>{attentionSentence(repos)}</p>
+      </PageLede>
 
-      {/* Stat Cards */}
-      <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
-        <MetricCard
-          label="Total Pages"
-          value={formatNumber(totalPages)}
-          icon={<FileText className="h-4 w-4" />}
-        />
-        <MetricCard
-          label="Fresh Pages"
-          value={formatNumber(freshPages)}
-          description="Confidence ≥ 80%"
-          icon={<CheckCircle2 className="h-4 w-4 text-[var(--color-success)]" />}
-        />
-        <MetricCard
-          label="Stale Pages"
-          value={formatNumber(stalePages)}
-          description="Need regeneration"
-          icon={<AlertCircle className="h-4 w-4 text-[var(--color-warning)]" />}
-        />
-        <MetricCard
-          label="Dead Code"
-          value={deadCode > 0 ? formatNumber(deadCode) : "—"}
-          description={deadCode > 0 ? "Unused exports" : "Analyze to detect"}
-          icon={<Skull className="h-4 w-4 text-[var(--color-text-tertiary)]" />}
-        />
-      </div>
+      <StatRibbon stats={ribbon} />
 
-      <div className="grid gap-4 lg:grid-cols-2">
-        {/* Repositories */}
-        <Card>
-          <CardHeader className="pb-3">
-            <CardTitle className="text-sm font-medium">Repositories</CardTitle>
-          </CardHeader>
-          <CardContent className="p-0">
-            {repoList.length === 0 ? (
-              <div className="px-6 pb-6">
-                <EmptyReposState />
-              </div>
-            ) : (
-              <ul className="divide-y divide-[var(--color-border-default)]">
-                {repoList.map((repo) => {
-                  const activeJob = jobList.find(
-                    (j) =>
-                      j.repository_id === repo.id &&
-                      (j.status === "running" || j.status === "pending"),
-                  );
-                  const g = gitMap.get(repo.id);
-                  return (
-                    <li key={repo.id} className="group">
-                      <div className="flex items-start gap-3 px-6 py-3.5 transition-colors hover:bg-[var(--color-bg-elevated)]">
-                        <Link
-                          href={`/repos/${repo.id}`}
-                          className="flex items-start gap-3 flex-1 min-w-0"
-                        >
-                          <div className="mt-0.5 h-2 w-2 rounded-full bg-[var(--color-accent-primary)] shrink-0" />
-                          <div className="flex-1 min-w-0">
-                            <div className="flex items-center gap-2 flex-wrap">
-                              <p
-                                className="text-sm font-medium text-[var(--color-text-primary)] truncate group-hover:text-[var(--color-accent-primary)] transition-colors"
-                                title={repo.head_commit ? `at ${repo.head_commit.slice(0, 7)}` : undefined}
-                              >
-                                {repo.name}
-                              </p>
-                              {/* Health signals lead; raw SHA demoted to the title tooltip. */}
-                              {g && g.hotspot_count > 0 && (
-                                <Badge variant="outdated">
-                                  {g.hotspot_count} hotspot{g.hotspot_count !== 1 ? "s" : ""}
-                                </Badge>
-                              )}
-                              {g && g.stable_count > 0 && (
-                                <Badge variant="fresh">{g.stable_count} stable</Badge>
-                              )}
-                              {activeJob && (
-                                <span className="text-xs">
-                                  <LiveJobProgress
-                                    jobId={activeJob.id}
-                                    initialCompleted={activeJob.completed_pages}
-                                    initialTotal={activeJob.total_pages}
-                                  />
-                                </span>
-                              )}
-                            </div>
-                            <div className="flex items-center gap-2 mt-0.5">
-                              <p className="text-xs text-[var(--color-text-tertiary)] font-mono truncate" title={repo.local_path}>
-                                {repo.local_path}
-                              </p>
-                            </div>
-                            <div className="flex items-center gap-2 mt-1 flex-wrap">
-                              <span className="text-xs text-[var(--color-text-tertiary)]">
-                                Updated {formatRelativeTime(repo.updated_at)}
-                              </span>
-                            </div>
-                          </div>
-                        </Link>
-                        <DeleteRepoButton repoId={repo.id} repoName={repo.name} />
-                      </div>
-                    </li>
-                  );
-                })}
-              </ul>
-            )}
-          </CardContent>
-        </Card>
+      {activeJobs.length > 0 && (
+        <OverviewSection
+          title={activeJobs.length === 1 ? "Indexing now" : `Indexing now (${activeJobs.length})`}
+          description="Progress streams live; this page does not need a refresh to catch up."
+        >
+          <JobRows jobs={activeJobs} nameFor={nameFor} />
+        </OverviewSection>
+      )}
 
-        {/* Recent Jobs */}
-        <Card>
-          <CardHeader className="pb-3">
-            <CardTitle className="text-sm font-medium">Recent Jobs</CardTitle>
-          </CardHeader>
-          <CardContent className="p-0">
-            {jobList.length === 0 ? (
-              <div className="px-6 pb-6">
-                <EmptyState
-                  title="No jobs yet"
-                  description="Indexing and sync runs show up here, with live progress."
-                  icon={<Activity className="h-8 w-8" />}
-                />
-              </div>
-            ) : (
-              <ul className="divide-y divide-[var(--color-border-default)]">
-                {jobList.map((job) => (
-                  <li key={job.id}>
-                    <Link
-                      href={`/repos/${job.repository_id}/overview`}
-                      className="flex items-center gap-3 px-6 py-3 hover:bg-[var(--color-bg-elevated)] transition-colors"
-                    >
-                    <JobStatusIcon status={job.status} />
-                    <div className="flex-1 min-w-0">
-                      <div className="flex items-center gap-2">
-                        <span className="text-xs font-mono text-[var(--color-text-secondary)]">
-                          {job.status === "running" || job.status === "pending" ? (
-                            <LiveJobProgress
-                              jobId={job.id}
-                              initialCompleted={job.completed_pages}
-                              initialTotal={job.total_pages}
-                            />
-                          ) : (
-                            `${job.total_pages} pages`
-                          )}
-                        </span>
-                        <Badge
-                          variant={
-                            job.status === "completed"
-                              ? "fresh"
-                              : job.status === "failed"
-                              ? "outdated"
-                              : job.status === "running"
-                              ? "accent"
-                              : job.status === "cancelled"
-                              ? "stale"
-                              : "default"
-                          }
-                        >
-                          {job.status}
-                        </Badge>
-                      </div>
-                      <p className="text-xs text-[var(--color-text-tertiary)] mt-0.5">
-                        {job.model_name} · {formatRelativeTime(job.updated_at)}
-                      </p>
-                    </div>
-                    </Link>
-                  </li>
-                ))}
-              </ul>
-            )}
-          </CardContent>
-        </Card>
-      </div>
-    </div>
+      <OverviewSection
+        title="Repositories"
+        description="Ordered by what needs attention first — never indexed, then behind their working tree, then by health score — rather than by when they last changed."
+      >
+        <RepoRows
+          repos={repos.slice().sort(byAttention).map(toRow)}
+          LinkComponent={Link}
+          actionsFor={(repo) => <DeleteRepoButton repoId={repo.id} repoName={repo.name} />}
+        />
+      </OverviewSection>
+
+      {jobList.length > 0 && (
+        <OverviewSection
+          title="Recent activity"
+          description="The last indexing and sync runs across every repository."
+        >
+          <JobRows jobs={jobList} nameFor={nameFor} />
+        </OverviewSection>
+      )}
+    </PageShell>
   );
 }
 
-function JobStatusIcon({ status }: { status: string }) {
-  if (status === "running") {
-    return (
-      <RefreshCw className="h-4 w-4 shrink-0 animate-spin text-[var(--color-accent-primary)]" />
-    );
-  }
-  if (status === "completed") {
-    return <CheckCircle2 className="h-4 w-4 shrink-0 text-[var(--color-success)]" />;
-  }
-  if (status === "failed") {
-    return <AlertCircle className="h-4 w-4 shrink-0 text-[var(--color-error)]" />;
-  }
-  if (status === "cancelled") {
-    return <Ban className="h-4 w-4 shrink-0 text-[var(--color-text-tertiary)]" />;
-  }
-  return <Clock className="h-4 w-4 shrink-0 text-[var(--color-text-tertiary)]" />;
+function toRow(repo: RepoSummaryRow): RepoRow {
+  return {
+    id: repo.id,
+    name: repo.name,
+    localPath: repo.local_path,
+    href: `/repos/${repo.id}/overview`,
+    status: repo.status,
+    health: repo.average_health,
+    fileCount: repo.file_count,
+    hotspotCount: repo.hotspot_count,
+    docPageCount: repo.doc_page_count,
+    docFreshPageCount: repo.doc_fresh_page_count,
+    deadExportCount: repo.dead_export_count,
+    updatedAt: repo.updated_at,
+    indexBehind: repo.index_behind,
+  };
 }

--- a/packages/web/src/components/jobs/job-rows.tsx
+++ b/packages/web/src/components/jobs/job-rows.tsx
@@ -1,0 +1,80 @@
+import Link from "next/link";
+import { formatRelativeTime } from "@repowise-dev/ui/lib/format";
+import type { JobResponse } from "@/lib/api/types";
+import { LiveJobProgress } from "@/components/jobs/live-job-progress";
+
+/** Status as a dot plus the word, on the success/error/neutral set only.
+ *  A filled pill per row tiles into stripes down a list and outweighs the
+ *  thing it labels. */
+const STATUS_INK: Record<string, string> = {
+  completed: "var(--color-success)",
+  failed: "var(--color-error)",
+  running: "var(--color-accent-primary)",
+  pending: "var(--color-text-tertiary)",
+  cancelled: "var(--color-text-tertiary)",
+  paused: "var(--color-text-tertiary)",
+};
+
+export function JobRows({
+  jobs,
+  nameFor,
+}: {
+  jobs: JobResponse[];
+  /** Repo name for a job's repository id, so a row says which repo it ran on
+   *  — the old list showed a model name and a page count with no subject. */
+  nameFor: (repositoryId: string) => string | null;
+}) {
+  if (jobs.length === 0) return null;
+
+  return (
+    <ul className="m-0 list-none divide-y divide-[var(--color-border-default)] border-t border-[var(--color-border-default)] p-0">
+      {jobs.map((job) => {
+        const live = job.status === "running" || job.status === "pending";
+        const ink = STATUS_INK[job.status] ?? "var(--color-text-tertiary)";
+        const repoName = nameFor(job.repository_id);
+
+        return (
+          <li key={job.id}>
+            <Link
+              href={`/repos/${job.repository_id}/overview`}
+              className="flex flex-col gap-1 py-2.5 no-underline transition-colors hover:bg-[var(--color-bg-wash-hover)] sm:flex-row sm:items-baseline sm:gap-4"
+            >
+              <span className="flex min-w-0 shrink-0 items-center gap-2 sm:w-56">
+                <span
+                  aria-hidden
+                  className="h-1.5 w-1.5 shrink-0 rounded-full"
+                  style={{ background: ink }}
+                />
+                <span className="text-[13px] font-medium text-[var(--color-text-primary)]">
+                  {repoName ?? "Unknown repository"}
+                </span>
+                <span className="text-[11px]" style={{ color: ink }}>
+                  {job.status}
+                </span>
+              </span>
+
+              <span className="min-w-0 flex-1 text-xs tabular-nums text-[var(--color-text-secondary)]">
+                {live ? (
+                  <LiveJobProgress
+                    jobId={job.id}
+                    initialCompleted={job.completed_pages}
+                    initialTotal={job.total_pages}
+                  />
+                ) : (
+                  `${job.total_pages.toLocaleString()} pages`
+                )}
+                {job.model_name && (
+                  <span className="text-[var(--color-text-tertiary)]"> · {job.model_name}</span>
+                )}
+              </span>
+
+              <span className="shrink-0 text-xs text-[var(--color-text-tertiary)]">
+                {formatRelativeTime(job.updated_at)}
+              </span>
+            </Link>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/packages/web/src/lib/repo-attention.test.ts
+++ b/packages/web/src/lib/repo-attention.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "vitest";
+import type { RepoSummaryRow } from "@repowise-dev/types/repos";
+import { attentionSentence, byAttention } from "./repo-attention";
+
+function repo(overrides: Partial<RepoSummaryRow> = {}): RepoSummaryRow {
+  return {
+    id: overrides.name ?? "id",
+    name: "repo",
+    local_path: "/tmp/repo",
+    updated_at: null,
+    status: "indexed",
+    file_count: 100,
+    symbol_count: 500,
+    entry_point_count: 2,
+    doc_page_count: 50,
+    doc_fresh_page_count: 50,
+    dead_export_count: 0,
+    tracked_file_count: 100,
+    hotspot_count: 0,
+    average_health: 8,
+    hotspot_health: 8,
+    health_taken_at: null,
+    indexed_commit: null,
+    live_head: null,
+    index_behind: false,
+    ...overrides,
+  };
+}
+
+describe("byAttention", () => {
+  it("puts never-indexed repos first, then ones behind their checkout", () => {
+    const rows = [
+      repo({ name: "healthy" }),
+      repo({ name: "behind", index_behind: true }),
+      repo({ name: "unindexed", status: "needs_index", average_health: null }),
+    ];
+
+    expect(rows.sort(byAttention).map((r) => r.name)).toEqual([
+      "unindexed",
+      "behind",
+      "healthy",
+    ]);
+  });
+
+  it("orders the rest by health, worst first", () => {
+    const rows = [
+      repo({ name: "good", average_health: 9.1 }),
+      repo({ name: "bad", average_health: 3.2 }),
+      repo({ name: "middling", average_health: 6.4 }),
+    ];
+
+    expect(rows.sort(byAttention).map((r) => r.name)).toEqual(["bad", "middling", "good"]);
+  });
+
+  it("does not sort an unanalysed repo as if it scored zero", () => {
+    // Absent is not zero. Ranking null at 0 would park every unanalysed repo
+    // above the genuinely unhealthy one, which is the row that needs the
+    // reader.
+    const rows = [
+      repo({ name: "unanalysed", average_health: null }),
+      repo({ name: "unhealthy", average_health: 2.1 }),
+    ];
+
+    expect(rows.sort(byAttention).map((r) => r.name)).toEqual(["unhealthy", "unanalysed"]);
+  });
+
+  it("is stable on ties", () => {
+    const rows = [
+      repo({ name: "zebra", average_health: 7 }),
+      repo({ name: "alpha", average_health: 7 }),
+    ];
+
+    expect(rows.sort(byAttention).map((r) => r.name)).toEqual(["alpha", "zebra"]);
+  });
+});
+
+describe("attentionSentence", () => {
+  it("names a single unindexed repo", () => {
+    const text = attentionSentence([
+      repo({ name: "fresh-clone", status: "needs_index", average_health: null }),
+      repo({ name: "ok" }),
+    ]);
+
+    expect(text).toContain("fresh-clone has not been indexed yet.");
+  });
+
+  it("counts rather than names when several are behind", () => {
+    const text = attentionSentence([
+      repo({ name: "a", index_behind: true }),
+      repo({ name: "b", index_behind: true }),
+    ]);
+
+    expect(text).toContain("2 are behind their working trees");
+    expect(text).toContain("repowise update");
+  });
+
+  it("says so when nothing needs attention", () => {
+    const text = attentionSentence([repo({ name: "a" }), repo({ name: "b" })]);
+
+    expect(text).toContain("Every index is current with its checkout.");
+  });
+
+  it("reports the lowest score and which repo holds it", () => {
+    const text = attentionSentence([
+      repo({ name: "good", average_health: 9 }),
+      repo({ name: "worst", average_health: 4.62 }),
+    ]);
+
+    expect(text).toContain("Lowest health score is 4.6 out of 10, in worst.");
+  });
+
+  it("never names an unanalysed repo as the lowest-scoring one", () => {
+    const text = attentionSentence([
+      repo({ name: "unanalysed", average_health: null }),
+      repo({ name: "scored", average_health: 5.5 }),
+    ]);
+
+    expect(text).toContain("in scored.");
+    expect(text).not.toContain("unanalysed.");
+  });
+
+  it("does not claim a comparison it cannot make", () => {
+    const text = attentionSentence([
+      repo({ name: "a", average_health: null }),
+      repo({ name: "b", average_health: null }),
+    ]);
+
+    expect(text).toBe(
+      "None of them has been analysed yet, so there are no health scores to compare.",
+    );
+  });
+
+  it("treats an unknown freshness comparison as not behind", () => {
+    // `index_behind: null` means the check could not run — no git checkout, an
+    // unreadable HEAD. Reporting that as "behind" would send the reader to run
+    // an update that nothing asked for.
+    const text = attentionSentence([repo({ name: "a", index_behind: null })]);
+
+    expect(text).toContain("Every index is current with its checkout.");
+  });
+});

--- a/packages/web/src/lib/repo-attention.ts
+++ b/packages/web/src/lib/repo-attention.ts
@@ -1,0 +1,80 @@
+import type { RepoSummaryRow } from "@repowise-dev/types/repos";
+
+/**
+ * Ordering and prose for the multi-repo dashboard.
+ *
+ * Kept out of the page so both are testable: a page file can only export the
+ * handful of names the App Router recognises, and these two carry the
+ * decisions worth pinning — which repo the reader is steered to first, and
+ * what the page claims when nothing is wrong.
+ */
+
+/** Score to sort a never-analysed repo by. Mid-band on purpose: absent is not
+ *  zero, and sorting it as zero would park every unanalysed repo above the
+ *  genuinely unhealthy one. */
+const UNSCORED_RANK = 6;
+
+/** Never indexed first, then behind the checkout, then worst health, then by
+ *  name so the order is stable between renders. */
+export function byAttention(a: RepoSummaryRow, b: RepoSummaryRow): number {
+  const rank = (r: RepoSummaryRow) => (r.status !== "indexed" ? 0 : r.index_behind === true ? 1 : 2);
+  const byRank = rank(a) - rank(b);
+  if (byRank !== 0) return byRank;
+
+  const score = (r: RepoSummaryRow) => r.average_health ?? UNSCORED_RANK;
+  const byScore = score(a) - score(b);
+  if (byScore !== 0) return byScore;
+
+  return a.name.localeCompare(b.name);
+}
+
+/**
+ * The sentence under the lede figure, which is the part that makes the count
+ * mean something.
+ *
+ * Reports the worst thing that is true, and says so plainly when nothing is —
+ * an empty state that says "nothing is wrong" is worth more than one that says
+ * nothing at all.
+ */
+export function attentionSentence(repos: RepoSummaryRow[]): string {
+  const unindexed = repos.filter((r) => r.status !== "indexed");
+  const behind = repos.filter((r) => r.index_behind === true);
+  const parts: string[] = [];
+
+  if (unindexed.length > 0) {
+    parts.push(
+      unindexed.length === 1
+        ? `${unindexed[0].name} has not been indexed yet.`
+        : `${unindexed.length} repositories have not been indexed yet.`,
+    );
+  }
+
+  if (behind.length > 0) {
+    parts.push(
+      behind.length === 1
+        ? `${behind[0].name} is behind its working tree — run repowise update in it to catch up.`
+        : `${behind.length} are behind their working trees — run repowise update in them to catch up.`,
+    );
+  }
+
+  // Only repos that have actually been analysed can hold the "lowest score".
+  // Treating a null as a 0 here would name an unanalysed repo as the worst one
+  // on the machine.
+  const scored = repos.filter((r) => r.average_health !== null);
+  if (scored.length > 0) {
+    const worst = scored.reduce((a, b) =>
+      (a.average_health as number) <= (b.average_health as number) ? a : b,
+    );
+    parts.push(
+      `Lowest health score is ${(worst.average_health as number).toFixed(1)} out of 10, in ${worst.name}.`,
+    );
+  }
+
+  if (parts.length === 0) {
+    return "None of them has been analysed yet, so there are no health scores to compare.";
+  }
+  if (unindexed.length === 0 && behind.length === 0) {
+    return `Every index is current with its checkout. ${parts.join(" ")}`;
+  }
+  return parts.join(" ");
+}


### PR DESCRIPTION
The multi-repo dashboard opened with four `MetricCard`s — Total Pages, Fresh Pages, Stale Pages, Dead Code — and put the repositories themselves in a card underneath. Six bordered containers at near-identical weight, so nothing led.

The figures were the deeper problem. Summing dead exports across a side project and a monorepo produces a number with no action attached to it, so there was no honest sentence to put beside it. "Total Pages" was reading `file_count`, which counted symbol nodes as files — the wrong noun over a number about 10x too large. "Fresh Pages" was derived from average page confidence while a real freshness field sat unused on the same payload. Both are fixed at the source in #1577.

## What is on the page now

- **The repository list is the subject**, as hairline rows. Each carries its health score in its band, the figures that decide whether to open it, and a marker only when something needs doing — never indexed, or behind the working tree. A quiet list is a healthy list.
- **Ordered by attention** — never indexed, then behind the checkout, then worst health — rather than by last write, so the page is triage instead of a log. The section header says so; an unexplained order reads as no order.
- **The lede's sentence names the worst thing that is true**, and says plainly when nothing is.
- **The aggregates that legitimately add** — files, symbols, doc freshness, hotspots, unused exports — moved into a `StatRibbon`, each with a visible second line rather than a tooltip.
- **Job status is a dot plus a word**, not a filled pill on every row, and a row now says which repository it ran on. It previously showed a model name and a page count with no subject.
- **One verb per row**: the row opens the repo, and delete sits outside its link.

## Notes for review

- `RepoRows` is new in `packages/ui`, so a hosted port is a package bump plus wiring.
- Health uses `bandForScore` (the canonical three bands), not the five-step `healthBand`. The five-step reading is for a lede where nothing adjacent contradicts it; a column of rows is exactly where two ladders visibly disagree. A repo with no snapshot renders a dash, never a `0.0` in red.
- An unanalysed repo sorts as mid-band rather than at zero. Ranking `null` at 0 would park every unanalysed repo above the genuinely unhealthy one, which is the row that needs the reader.
- `DeleteRepoButton` is a sibling of the row link, not a child. A button nested in an anchor is invalid and swallows its own clicks; `renders row actions outside the row link` is the test that catches a regression to the nested form.
- Fetching is one wave of three calls. The page stays a server component and `LiveJobProgress` remains the only client island. `StatRibbon` is imported by direct path rather than through the `ui/stats` barrel, which re-exports two `"use client"` modules.

## Verification

`packages/ui` and `packages/web` suites green (19 new tests), typecheck clean on all four packages, `next lint` clean, `next build` clean, and no undefined `--color-*` tokens in the new files.

Rendered end to end against a copy of a real index with two repositories — one indexed and behind its checkout, one registered but never indexed — so both markers and the null-health path are confirmed on real data rather than fixtures. Every figure on the page matched the API.

Not covered: no browser here, so the rendered DOM and data are verified, not the pixels. The responsive rules are in place but the narrow-viewport eyeball check has not been done.

