### PR TITLE
fix(tests): record the two /repos/summary surfaces as hotspot_health plumbing

### DIFF
--- a/tests/unit/test_no_hotspot_health_copies.py
+++ b/tests/unit/test_no_hotspot_health_copies.py
@@ -44,6 +44,7 @@ _PLUMBING: dict[str, str] = {
     "repowise/core/persistence/crud/git.py": "supplies the hotspot path set, not the score",
     "repowise/core/persistence/stores/_sql_analysis.py": "passthrough to the crud writer",
     "repowise/core/persistence/_interfaces/_analysis.py": "the store ABC's parameter name",
+    "repowise/server/schemas/repository.py": "the response field",
     "alembic/versions/0019_code_health.py": "the migration that adds the column",
     # --- writers: hand ``compute_kpis`` output to the snapshot ---------------
     "repowise/core/pipeline/persist.py": "persists the KPI dict from the health report",
@@ -56,6 +57,7 @@ _PLUMBING: dict[str, str] = {
     # --- pure renderers: read a value someone else computed ------------------
     "repowise/cli/commands/health_cmd/command.py": "prints the KPI dict it was handed",
     "repowise/core/generation/editor_files/data.py": "the CodeHealthBlock field",
+    "repowise/server/routers/repos.py": "serves the latest snapshot column on /repos/summary",
 }
 
 


### PR DESCRIPTION
Main is red on `tests/unit/test_no_hotspot_health_copies.py::test_every_surface_gets_hotspot_health_from_the_one_owner`, on all three Python versions.

The one-call `/api/repos/summary` work added two new mentions of `hotspot_health`:

- `server/routers/repos.py` selects the persisted `HealthSnapshot.hotspot_health` column and rounds it
- `server/schemas/repository.py` declares the response field

Neither computes the KPI, so neither imports the owner in `core.analysis.health.scoring` — which is exactly the shape the guard cannot distinguish from a new implementation. Both get an allowlist entry stating why.

The `_PLUMBING` dead-entry test covers both new keys, so they cannot rot silently if either surface stops carrying the number.

Verified: `pytest tests/unit/test_no_hotspot_health_copies.py` -> 19 passed. Test-only change.