### PR TITLE
fix(chat): never leave the chat window streaming with nothing to show

### DIFF
--- a/docs/architecture/chat.md
+++ b/docs/architecture/chat.md
@@ -244,6 +244,12 @@ data: {"type": "...", ...}
 
 **Retry:** `retry: 3000` sent at stream start.
 
+**Terminal event:** every stream ends with `done` or `error` on the `data`
+channel. `useChat` switches on `type` and nothing else, so an event sent on a
+different channel, or without a `type`, is dropped: the client then sees a
+stream that simply stopped mid-answer. The client settles its own state when
+the reader ends without a terminal event, but the server still owes it one.
+
 ---
 
 ## 7. Agentic Loop

--- a/packages/api-client/src/chat.test.ts
+++ b/packages/api-client/src/chat.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("./client", () => ({
+  apiGet: vi.fn(),
+  apiDelete: vi.fn(),
+  BASE_URL: "http://localhost:7337",
+  buildHeaders: () => new Headers(),
+}));
+
+import { postChatMessage } from "./chat";
+
+function okStream(): Response {
+  return new Response("retry: 3000\n\n", {
+    status: 200,
+    headers: { "Content-Type": "text/event-stream" },
+  });
+}
+
+describe("postChatMessage", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    fetchMock.mockReset().mockResolvedValue(okStream());
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  it("passes the caller's abort signal to fetch", async () => {
+    const controller = new AbortController();
+    await postChatMessage("r1", { message: "hi", signal: controller.signal });
+
+    // Without this the request outlives a cancelled send: the server keeps
+    // running the agentic loop against a body nobody reads.
+    const init = fetchMock.mock.calls[0]![1] as RequestInit;
+    expect(init.signal).toBe(controller.signal);
+  });
+
+  it("omits signal entirely when the caller gives none", async () => {
+    await postChatMessage("r1", { message: "hi" });
+
+    const init = fetchMock.mock.calls[0]![1] as RequestInit;
+    expect("signal" in init).toBe(false);
+  });
+});

--- a/packages/api-client/src/chat.ts
+++ b/packages/api-client/src/chat.ts
@@ -41,6 +41,13 @@ export async function postChatMessage(
     conversationId?: string;
     provider?: string;
     model?: string;
+    /**
+     * Aborts the request itself, not just the caller's read loop. Without it,
+     * a cancelled or superseded send leaves the POST running on the server and
+     * the response body abandoned, so the agentic loop keeps going and its
+     * open DB session is only torn down when the socket eventually collapses.
+     */
+    signal?: AbortSignal;
   },
 ): Promise<Response> {
   const url = `${BASE_URL}/api/repos/${repoId}/chat/messages`;
@@ -56,6 +63,7 @@ export async function postChatMessage(
       provider: opts.provider ?? null,
       model: opts.model ?? null,
     }),
+    ...(opts.signal ? { signal: opts.signal } : {}),
   });
 
   if (!res.ok) {

--- a/packages/server/src/repowise/server/routers/chat.py
+++ b/packages/server/src/repowise/server/routers/chat.py
@@ -156,7 +156,16 @@ async def chat_messages(repo_id: str, body: ChatRequest, request: Request):
                 if conv_id:
                     conv = await crud.get_conversation(session, conv_id)
                     if not conv or conv.repository_id != repo_id:
-                        yield _sse_event("error", {"message": "Conversation not found"})
+                        # Every other failure here goes out on the ``data``
+                        # channel carrying a ``type``, which is the only shape
+                        # the client switches on. This one used to be an
+                        # ``error``-channel event with no ``type``, so the UI
+                        # dropped it and then sat on the stream's close with
+                        # nothing to show.
+                        yield _sse_event(
+                            "data",
+                            {"type": "error", "message": "Conversation not found"},
+                        )
                         return
                 else:
                     title = " ".join(body.message.split()[:6])

--- a/packages/web/src/lib/hooks/use-chat.ts
+++ b/packages/web/src/lib/hooks/use-chat.ts
@@ -64,12 +64,20 @@ export function useChat(repoId: string) {
         ],
       }));
 
+      // The server closes the stream with a `done` or an `error` event, and
+      // those are the only things that clear `isStreaming`. A stream that ends
+      // without either one (an early return in the SSE generator, a dropped
+      // connection, a provider that stops mid-answer) used to leave the
+      // composer spinning forever with nothing on screen to explain it.
+      let settled = false;
+
       try {
         const res = await postChatMessage(repoId, {
           message: text,
           conversationId: state.conversationId ?? undefined,
           provider: opts?.provider,
           model: opts?.model,
+          signal: abort.signal,
         });
 
         if (!res.body) throw new Error("No response body");
@@ -102,6 +110,7 @@ export function useChat(repoId: string) {
         }
       } catch (err: unknown) {
         if (!abort.signal.aborted) {
+          settled = true;
           setState((prev) => ({
             ...prev,
             isStreaming: false,
@@ -113,7 +122,21 @@ export function useChat(repoId: string) {
         }
       }
 
+      if (!settled && !abort.signal.aborted) {
+        setState((prev) => ({
+          ...prev,
+          isStreaming: false,
+          error:
+            prev.error ??
+            "The response ended before it finished. The server log should say why.",
+          messages: prev.messages.map((m) =>
+            m.id === asstMsgId ? { ...m, isStreaming: false } : m,
+          ),
+        }));
+      }
+
       function handleEvent(ev: ChatSSEEvent, asstId: string) {
+        if (ev.type === "done" || ev.type === "error") settled = true;
         setState((prev) => {
           const messages = prev.messages.map((m) => {
             if (m.id !== asstId) return m;

--- a/tests/unit/server/test_chat_stream_terminal_event.py
+++ b/tests/unit/server/test_chat_stream_terminal_event.py
@@ -1,0 +1,140 @@
+"""The chat SSE stream must always end with an event the client can read.
+
+The web client parses ``data:`` lines only and switches on the payload's
+``type`` field (``packages/web/src/lib/hooks/use-chat.ts``). ``done`` and
+``error`` are the two values that stop the "assistant is typing" state.
+
+Bug (pre-fix): the unknown-conversation branch emitted its failure on the
+``error`` channel with a payload carrying only ``message`` and no ``type``.
+The client dropped it, the generator returned, and the chat window sat on a
+spinner with nothing on screen to explain why. Every other failure in the
+handler already used ``data`` + ``type``; this one branch did not.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from datetime import UTC, datetime
+from unittest.mock import patch
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from repowise.core.persistence.database import init_db
+from repowise.core.persistence.models import Repository
+from repowise.server.routers import chat
+
+_NOW = datetime(2026, 8, 15, 10, 0, 0, tzinfo=UTC)
+_REPO_ID = "repo-1"
+
+
+class _SilentProvider:
+    """A ChatProvider that ends its turn without emitting anything.
+
+    ``ChatProvider`` is a runtime-checkable Protocol, so implementing
+    ``stream_chat`` is all the handler's isinstance check asks for. Yielding
+    nothing drives the agentic loop straight to its "no pending tool calls"
+    exit, which is the shortest path to the end of the stream.
+    """
+
+    provider_name = "test"
+    model_name = "test-model"
+
+    async def stream_chat(self, **_kwargs) -> AsyncIterator[object]:
+        return
+        yield  # pragma: no cover - makes this an async generator
+
+
+async def _make_app() -> FastAPI:
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    await init_db(engine)
+    factory = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+    async with factory() as session:
+        session.add(
+            Repository(
+                id=_REPO_ID,
+                name="repo",
+                url="https://example.com/repo",
+                local_path="/tmp/repo",
+                default_branch="main",
+                settings_json="{}",
+                created_at=_NOW,
+                updated_at=_NOW,
+            )
+        )
+        await session.commit()
+
+    @asynccontextmanager
+    async def noop_lifespan(app: FastAPI):
+        yield
+
+    app = FastAPI(title="chat-stream-test", lifespan=noop_lifespan)
+    app.state.session_factory = factory
+    app.state.workspace_sessions = {}
+    app.include_router(chat.router)
+    return app
+
+
+def _data_events(body: str) -> list[dict]:
+    """Parse the stream the way the web client does: ``data:`` lines only."""
+    events = []
+    for line in body.splitlines():
+        if line.startswith("data: "):
+            try:
+                events.append(json.loads(line[6:]))
+            except json.JSONDecodeError:
+                continue
+    return events
+
+
+async def _post(app: FastAPI, payload: dict) -> str:
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+        response = await client.post(
+            f"/api/repos/{_REPO_ID}/chat/messages", json=payload
+        )
+    assert response.status_code == 200, response.text
+    return response.text
+
+
+@pytest.mark.asyncio
+async def test_unknown_conversation_ends_the_stream_with_a_typed_error():
+    app = await _make_app()
+
+    with patch(
+        "repowise.server.routers.chat.get_chat_provider_instance",
+        return_value=_SilentProvider(),
+    ):
+        body = await _post(
+            app, {"message": "hi", "conversation_id": "no-such-conversation"}
+        )
+
+    events = _data_events(body)
+    assert events, f"stream carried no readable data events: {body!r}"
+    assert events[-1]["type"] == "error"
+    assert "not found" in events[-1]["message"].lower()
+
+
+@pytest.mark.asyncio
+async def test_a_completed_turn_ends_the_stream_with_done():
+    app = await _make_app()
+
+    with patch(
+        "repowise.server.routers.chat.get_chat_provider_instance",
+        return_value=_SilentProvider(),
+    ):
+        body = await _post(app, {"message": "hi"})
+
+    events = _data_events(body)
+    assert events, f"stream carried no readable data events: {body!r}"
+    assert events[-1]["type"] == "done"
+    assert events[-1]["conversation_id"]


### PR DESCRIPTION
## The report

Two pieces of OSS dashboard feedback against v0.42.0, a day apart, both from `http://localhost:3000/repos/{id}/chat`: "I couldn't use chat feature. The chat window just froze", with this in the server log:

```
ERROR Exception terminating connection <AdaptedConnection
      <aiosqlite.core.Connection object at 0x...>>          base.py:377
```

The log line is a symptom, not the cause. `pool/base.py:377` is `_close_connection(terminate=True)`, and for aiosqlite `terminate()` only takes its force-close branch outside a greenlet, which is the GC path. Something abandoned a DB session rather than closing it.

## What was actually wrong

Three defects, all still on `main` before this change. None of them is the first thing to go wrong in a chat turn, but together they guarantee that when anything does, the user sees a spinner and no explanation.

**1. The client never left the streaming state.** `useChat` cleared `isStreaming` only from inside `handleEvent`, on `done` or `error`. A stream that closed without either one left the assistant message pinned at `isStreaming: true` forever. That is the reported symptom exactly.

**2. One server branch sent an event the client cannot read.** The unknown-conversation path emitted `event: error` with a payload carrying only `message`. The client parses `data:` lines and switches on `type`, so the event was dropped and the stream's close read as a hang. Every other failure in the handler already used `data` + `type`, which is also what `docs/architecture/chat.md` documents.

**3. The AbortController was never wired to `fetch`.** `postChatMessage` took no signal, so `abort()` broke only the local read loop. The POST kept running with its response body abandoned, the agentic loop kept going, and the open `get_session` was left for the GC. That is where the aiosqlite line in the log comes from.

## The change

- `useChat` settles its own state when the reader ends without a terminal event, and puts a reason on screen.
- The unknown-conversation branch now sends `data` + `type: "error"`.
- `postChatMessage` accepts an `AbortSignal` and passes it to `fetch`.
- `docs/architecture/chat.md` gains the terminal-event invariant the client depends on.

## Verification

- New `tests/unit/server/test_chat_stream_terminal_event.py` parses the stream the way the client does. Confirmed it fails with `KeyError: 'type'` against the pre-fix code and passes after.
- New `packages/api-client/src/chat.test.ts` pins the signal passthrough.
- `tests/unit/server` 2173 passed, api-client 52 passed, web 31 passed, ui chat 47 passed.
- `ruff check .` clean, workspace `type-check` clean, web lint clean.

## Known gaps

The `useChat` change has no automated test. CI runs tests for `api-client`, `types` and `ui` only; `packages/web` is type-checked and linted but its suite is never invoked, and it has no jsdom or React testing setup. Adding that harness is worth doing but is a bigger change than this fix.

The original trigger is still unknown, since the feedback is anonymous. A stalled provider is the likeliest candidate, as `stream_chat` has no timeout. What this change buys is that the next occurrence surfaces an error the reporter can quote instead of a silent freeze.