### PR TITLE
feat(providers): move the default OpenAI model to gpt-5.6-luna

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [Unreleased]
+
+### Changed
+
+- **Default OpenAI model is now `gpt-5.6-luna`** (was `gpt-5.4-nano`). Same input
+  price ($0.20/MTok), cheaper output ($1.20 vs $1.25), so it gets its own pricing
+  rows rather than an alias, and nano stays selectable on its own rate. The
+  5.6 family also changed its reasoning ladder: `minimal` is gone and `xhigh` is
+  new, so `--reasoning minimal` is now rejected up front for these models instead
+  of failing as a 400 on the first live call. Despite what the model docs say,
+  the API also rejects `max` for 5.6 (verified live against both `gpt-5.6-luna`
+  and `gpt-5.6-sol`), so it is not offered.
+
+---
+
 ## [0.42.0] — 2026-08-13
 
 repowise shipped real integrations for exactly three agents — Claude Code, Codex and VS Code — with no cheap way to add a fourth. The wiring lived in four unrelated places, each carrying its own copy of what a given agent needs, and the two plugins had already forked from one another with nothing detecting the skew. This cycle puts every agent behind one descriptor seam and then proves it by adding three: **Cursor, OpenCode and Hermes**. A new `repowise agents` command group lists what is wired, adds and removes targets, and prints a config snippet for hosts we write nothing for. A support tier is derived from what a target actually wires rather than declared, so the docs cannot claim more than the code delivers.

--- a/docs/reference/CONFIG.md
+++ b/docs/reference/CONFIG.md
@@ -518,7 +518,7 @@ repowise init --provider anthropic --model claude-haiku-4-5-20251001
 
 ```bash
 export OPENAI_API_KEY="sk-..."
-repowise init --provider openai --model gpt-4.1
+repowise init --provider openai --model gpt-5.6-luna
 ```
 
 For an OpenAI-compatible Qwen3 endpoint served by vLLM or SGLang:

--- a/docs/start/USER_GUIDE.md
+++ b/docs/start/USER_GUIDE.md
@@ -414,7 +414,7 @@ repowise export --format markdown --output ./docs/wiki/   # static hosting
 ### Changing provider or model
 
 ```bash
-repowise init --provider openai --model gpt-5.4-nano --force   # regenerate
+repowise init --provider openai --model gpt-5.6-luna --force   # regenerate
 repowise update --provider gemini                              # just future updates
 ```
 

--- a/packages/cli/src/repowise/cli/ui/provider_selection.py
+++ b/packages/cli/src/repowise/cli/ui/provider_selection.py
@@ -26,7 +26,7 @@ from repowise.core.reasoning import ReasoningMode, normalize_reasoning
 
 _PROVIDER_DEFAULTS: dict[str, str] = {
     "gemini": "gemini-3.5-flash-lite",
-    "openai": "gpt-5.4-nano",
+    "openai": "gpt-5.6-luna",
     "anthropic": "claude-haiku-4-5",
     "deepseek": "deepseek-v4-flash",
     "kimi": "kimi-for-coding",
@@ -642,6 +642,11 @@ def interactive_provider_select(
 # family name is a flagship one, so `gpt-5.4-nano` is not mistaken for `gpt-5`.
 _BUDGET_MODEL_TOKENS = (
     "nano",
+    # OpenAI's 5.6 budget tier carries no cheap-tier word in its name, and
+    # `gpt-5` matches it as flagship. Without this, accepting the default
+    # printed a note advising the user to switch to a cheaper model than the
+    # one they were already on.
+    "luna",
     "mini",
     "lite",
     "haiku",

--- a/packages/core/src/repowise/core/cost_estimator/pricing.py
+++ b/packages/core/src/repowise/core/cost_estimator/pricing.py
@@ -2,6 +2,20 @@
 
 Rates are USD per 1K tokens (input, output). Exact model names win
 first; longest-prefix fallback catches unknown variants.
+
+Ceiling: input is priced at one rate, so cached input is billed as if it
+were fresh. Providers now discount it heavily (gpt-5.6-luna reads cached
+input at $0.02/MTok, a 10x cut), which makes every figure here an
+over-estimate on a re-run: safe direction, wrong number.
+
+The token count is not the missing piece: ``cached_tokens`` already flows
+provider -> ``GeneratedPage`` -> the ``pages`` table, and the run report
+prints it. What is missing is a third rate (here, in
+``generation/cost_tracker.py``, and in the TS mirror at
+``packages/ui/src/dashboard/quick-actions.tsx``), plus splitting the
+cached count out of ``input_tokens`` in the cost arithmetic. Worth doing
+when we report cost per re-index, where the discount is the whole story;
+not worth it to move a one-off init estimate by ~10%.
 """
 
 from __future__ import annotations
@@ -12,6 +26,9 @@ _COST_TABLE_EXACT: dict[str, tuple[float, float]] = {
     "gpt-5.4": (0.0025, 0.015),  # $2.50 / $15 per MTok
     "gpt-5.4-mini": (0.00075, 0.0045),  # $0.75 / $4.50 per MTok
     "gpt-5.4-nano": (0.0002, 0.00125),  # $0.20 / $1.25 per MTok
+    # OpenAI GPT-5.6 family. Same input rate as nano, cheaper output: near
+    # enough to alias by eye, which is exactly why it gets a real row.
+    "gpt-5.6-luna": (0.0002, 0.0012),  # $0.20 / $1.20 per MTok
     # Gemini family
     "gemini-3.1-pro-preview": (0.002, 0.012),  # $2 / $12 per MTok
     "gemini-3-flash-preview": (0.0005, 0.003),  # $0.50 / $3 per MTok
@@ -23,8 +40,12 @@ _COST_TABLE_EXACT: dict[str, tuple[float, float]] = {
     "claude-haiku-4-5": (0.001, 0.005),  # $1 / $5 per MTok
 }
 
-# Prefix fallbacks for unknown variants.
+# Prefix fallbacks for unknown variants. No `gpt-5.6` catch-all: the 5.6
+# variants are not one price tier, and an unpriced model reads as free here
+# (``_lookup_cost`` falls through to (0.0, 0.0)), so a guess would be worse
+# than the miss it hides.
 _COST_TABLE_PREFIX: dict[str, tuple[float, float]] = {
+    "gpt-5.6-luna": (0.0002, 0.0012),
     "gpt-5.4-nano": (0.0002, 0.00125),
     "gpt-5.4-mini": (0.00075, 0.0045),
     "gpt-5.4": (0.0025, 0.015),

--- a/packages/core/src/repowise/core/generation/cost_tracker.py
+++ b/packages/core/src/repowise/core/generation/cost_tracker.py
@@ -43,6 +43,11 @@ _PRICING: dict[str, dict[str, float]] = {
     # indexing run ~40x.
     "gpt-5-nano": {"input": 0.05, "output": 0.40},
     "gpt-5.4-nano": {"input": 0.20, "output": 1.25},
+    # The default. Mandatory rather than cosmetic: `gpt-5.6-luna` contains
+    # neither "nano" nor "mini", so without this row ``_family_pricing``'s
+    # gpt-5 branch prices it at the flagship $2.50/$15 tier, 12.5x over on
+    # output, with no unknown-model warning to notice it by.
+    "gpt-5.6-luna": {"input": 0.20, "output": 1.20},
     "gpt-4o": {"input": 2.5, "output": 10.0},
     "gpt-4o-mini": {"input": 0.15, "output": 0.6},
     # Google Gemini

--- a/packages/core/src/repowise/core/providers/__init__.py
+++ b/packages/core/src/repowise/core/providers/__init__.py
@@ -9,7 +9,7 @@ Preferred entry points:
     from repowise.core.providers.llm import get_provider
     from repowise.core.providers.embedding import get_embedder
 
-    provider = get_provider("openai", api_key="sk-...", model="gpt-5.4-nano")
+    provider = get_provider("openai", api_key="sk-...", model="gpt-5.6-luna")
     response = await provider.generate(system_prompt="...", user_prompt="...")
 
     embedder = get_embedder("openai", api_key="sk-...")

--- a/packages/core/src/repowise/core/providers/llm/__init__.py
+++ b/packages/core/src/repowise/core/providers/llm/__init__.py
@@ -10,7 +10,7 @@ to instantiate a provider by name — this is the preferred entry point.
 
 Built-in providers:
     anthropic  — claude-opus-4-6, claude-sonnet-4-6, claude-haiku-4-5
-    openai     — gpt-5.4-nano, gpt-5.4-mini, gpt-5.4
+    openai     — gpt-5.6-luna, gpt-5.4-mini, gpt-5.4
     gemini     — gemini-3.1-flash-lite-preview, gemini-3-flash-preview, gemini-3.1-pro-preview
     openrouter — 200+ models via OpenRouter (anthropic/claude-sonnet-4.6, etc.)
     deepseek   — deepseek-v4-flash, deepseek-v4-pro via api.deepseek.com

--- a/packages/core/src/repowise/core/providers/llm/openai.py
+++ b/packages/core/src/repowise/core/providers/llm/openai.py
@@ -5,7 +5,7 @@ Also works as a base for any OpenAI-compatible API endpoint via the
 `base_url` parameter.
 
 Recommended models (as of 2026):
-    - gpt-5.4-nano   — fastest, cheapest ($0.20/$1.25 per MTok) [default]
+    - gpt-5.6-luna   — fastest, cheapest ($0.20/$1.20 per MTok) [default]
     - gpt-5.4-mini   — balanced speed and quality ($0.75/$4.50 per MTok)
     - gpt-5.4        — highest quality ($2.50/$15 per MTok)
 """
@@ -93,6 +93,17 @@ def _openai_supported_reasoning_modes(model: str) -> tuple[ReasoningMode, ...]:
         return ("none", "low", "medium", "high")
     if leaf.startswith("gpt-5-pro"):
         return ("high",)
+    if leaf.startswith("gpt-5.6"):
+        # 5.6 dropped `minimal` and added `xhigh`. Must stay above the generic
+        # `gpt-5` branch, which is a prefix of this one and would otherwise win
+        # and offer `minimal`, which 5.6 rejects, and only on a live call.
+        #
+        # `max` is deliberately absent even though the model docs list it: the
+        # API rejects it with `unsupported_value`, naming exactly the five
+        # below. Verified live on both gpt-5.6-luna and gpt-5.6-sol
+        # (2026-08-15). Family-level rather than per-model on the same
+        # evidence: the two variants answered identically.
+        return ("none", "low", "medium", "high", "xhigh")
     if leaf.startswith("gpt-5"):
         return ("minimal", "low", "medium", "high")
     return ("low", "medium", "high")
@@ -128,7 +139,13 @@ def _openai_reasoning_kwargs(reasoning: ReasoningMode, *, model: str) -> dict[st
         }
     if mode == "off":
         return {}
-    if mode in ("none", "minimal", "low", "medium", "high", "xhigh"):
+    # `max` is listed for completeness over ReasoningMode, not because any
+    # OpenAI model accepts it today. None does, so the validation gate above
+    # rejects it first. It is here so that whenever one does, adding it to that
+    # model's tuple is the only edit needed: the previous shape passed
+    # validation and then dropped the effort silently, which reads as "max
+    # worked" while the request carried no reasoning_effort at all.
+    if mode in ("none", "minimal", "low", "medium", "high", "xhigh", "max"):
         return {"reasoning_effort": mode}
     return {}
 
@@ -219,7 +236,7 @@ class OpenAIProvider(BaseProvider):
 
     Args:
         api_key:   OpenAI API key. Falls back to OPENAI_API_KEY env var.
-        model:     Model identifier. Defaults to gpt-5.4-nano.
+        model:     Model identifier. Defaults to gpt-5.6-luna.
         base_url:  Optional custom base URL for OpenAI-compatible endpoints.
         rate_limiter: Optional RateLimiter instance.
     """
@@ -227,7 +244,7 @@ class OpenAIProvider(BaseProvider):
     def __init__(
         self,
         api_key: str | None = None,
-        model: str = "gpt-5.4-nano",
+        model: str = "gpt-5.6-luna",
         base_url: str | None = None,
         rate_limiter: RateLimiter | None = None,
         cost_tracker: CostTracker | None = None,

--- a/packages/core/src/repowise/core/providers/llm/openrouter.py
+++ b/packages/core/src/repowise/core/providers/llm/openrouter.py
@@ -7,7 +7,7 @@ No additional pip install required — uses the ``openai`` package.
 
 Popular models:
     - google/gemini-3.5-flash-lite  — fast + cheap (default)
-    - openai/gpt-5.4-nano           — OpenAI budget tier
+    - openai/gpt-5.6-luna           — OpenAI budget tier
     - anthropic/claude-haiku-4-5    — Anthropic budget tier
 """
 

--- a/packages/core/src/repowise/core/upgrade/_data/CHANGELOG.md
+++ b/packages/core/src/repowise/core/upgrade/_data/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [Unreleased]
+
+### Changed
+
+- **Default OpenAI model is now `gpt-5.6-luna`** (was `gpt-5.4-nano`). Same input
+  price ($0.20/MTok), cheaper output ($1.20 vs $1.25), so it gets its own pricing
+  rows rather than an alias, and nano stays selectable on its own rate. The
+  5.6 family also changed its reasoning ladder: `minimal` is gone and `xhigh` is
+  new, so `--reasoning minimal` is now rejected up front for these models instead
+  of failing as a 400 on the first live call. Despite what the model docs say,
+  the API also rejects `max` for 5.6 (verified live against both `gpt-5.6-luna`
+  and `gpt-5.6-sol`), so it is not offered.
+
+---
+
 ## [0.42.0] — 2026-08-13
 
 repowise shipped real integrations for exactly three agents — Claude Code, Codex and VS Code — with no cheap way to add a fourth. The wiring lived in four unrelated places, each carrying its own copy of what a given agent needs, and the two plugins had already forked from one another with nothing detecting the skew. This cycle puts every agent behind one descriptor seam and then proves it by adding three: **Cursor, OpenCode and Hermes**. A new `repowise agents` command group lists what is wired, adds and removes targets, and prints a config snippet for hosts we write nothing for. A support tier is derived from what a target actually wires rather than declared, so the docs cannot claim more than the code delivers.

--- a/packages/server/src/repowise/server/provider_config.py
+++ b/packages/server/src/repowise/server/provider_config.py
@@ -58,8 +58,8 @@ PROVIDER_CATALOG: list[dict[str, Any]] = [
     {
         "id": "openai",
         "name": "OpenAI",
-        "default_model": "gpt-5.4-nano",
-        "models": ["gpt-5.4-nano", "gpt-5.4-mini", "gpt-5.4"],
+        "default_model": "gpt-5.6-luna",
+        "models": ["gpt-5.6-luna", "gpt-5.4-nano", "gpt-5.4-mini", "gpt-5.4"],
         "env_keys": ["OPENAI_API_KEY"],
         "requires_key": True,
     },
@@ -69,7 +69,7 @@ PROVIDER_CATALOG: list[dict[str, Any]] = [
         "default_model": "google/gemini-3.5-flash-lite",
         "models": [
             "google/gemini-3.5-flash-lite",
-            "openai/gpt-5.4-nano",
+            "openai/gpt-5.6-luna",
             "anthropic/claude-haiku-4-5",
             "anthropic/claude-sonnet-5",
         ],

--- a/packages/ui/src/dashboard/quick-actions.tsx
+++ b/packages/ui/src/dashboard/quick-actions.tsx
@@ -22,6 +22,7 @@ const COST_TABLE_EXACT: Record<string, [number, number]> = {
   "gpt-5.4": [0.0025, 0.015],
   "gpt-5.4-mini": [0.00075, 0.0045],
   "gpt-5.4-nano": [0.0002, 0.00125],
+  "gpt-5.6-luna": [0.0002, 0.0012],
   "gemini-3.1-pro-preview": [0.002, 0.012],
   "gemini-3-flash-preview": [0.0005, 0.003],
   "gemini-3.1-flash-lite-preview": [0.00025, 0.0015],
@@ -33,6 +34,7 @@ const COST_TABLE_EXACT: Record<string, [number, number]> = {
 };
 
 const COST_TABLE_PREFIX: [string, [number, number]][] = [
+  ["gpt-5.6-luna", [0.0002, 0.0012]],
   ["gpt-5.4-nano", [0.0002, 0.00125]],
   ["gpt-5.4-mini", [0.00075, 0.0045]],
   ["gpt-5.4", [0.0025, 0.015]],

--- a/packages/web/src/components/settings/provider-section.tsx
+++ b/packages/web/src/components/settings/provider-section.tsx
@@ -24,7 +24,7 @@ const EMBEDDERS = ["mock", "gemini", "openai", "openrouter", "ollama"] as const;
 
 const MODEL_PLACEHOLDERS: Record<string, string> = {
   gemini: "gemini-3.5-flash-lite",
-  openai: "gpt-5.4-nano",
+  openai: "gpt-5.6-luna",
   anthropic: "claude-haiku-4-5",
   deepseek: "deepseek-v4-flash",
   kimi: "kimi-for-coding",

--- a/tests/integration/test_provider_live.py
+++ b/tests/integration/test_provider_live.py
@@ -25,7 +25,7 @@ OPENAI_KEY = os.environ.get("OPENAI_API_KEY", "")
 
 
 @pytest.mark.skipif(not OPENAI_KEY, reason="OPENAI_API_KEY not set")
-@pytest.mark.parametrize("model", ["gpt-5.4-nano", "gpt-5.4-mini", "gpt-5.4"])
+@pytest.mark.parametrize("model", ["gpt-5.6-luna", "gpt-5.4-nano", "gpt-5.4-mini", "gpt-5.4"])
 async def test_openai_live(model):
     from repowise.core.providers.llm.openai import OpenAIProvider
 
@@ -42,6 +42,28 @@ async def test_openai_live(model):
     print(
         f"\n[{model}] tokens: {result.input_tokens}in / {result.output_tokens}out | content: {result.content!r}"
     )
+
+
+@pytest.mark.skipif(not OPENAI_KEY, reason="OPENAI_API_KEY not set")
+@pytest.mark.parametrize("effort", ["none", "low", "medium", "high", "xhigh"])
+async def test_openai_luna_accepts_every_advertised_effort(effort):
+    """The half of the reasoning contract only a real call can settle.
+
+    Which efforts a model takes is a server-side fact, and getting it wrong is
+    a 400 on the first real generation, after the user has committed to a run.
+    The unit tests pin what we *offer*; this pins that the API agrees. `max` is
+    excluded deliberately: the model docs list it, the API rejects it.
+    """
+    from repowise.core.providers.llm.openai import OpenAIProvider
+
+    provider = OpenAIProvider(api_key=OPENAI_KEY, model="gpt-5.6-luna")
+    result = await provider.generate(
+        system_prompt="You are a concise assistant.",
+        user_prompt="Reply with exactly: OK",
+        max_tokens=16,
+        reasoning=effort,
+    )
+    assert result.content.strip()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/generation/test_cost_pricing.py
+++ b/tests/unit/generation/test_cost_pricing.py
@@ -25,6 +25,18 @@ def test_nano_models_priced_at_nano_rate_not_fallback() -> None:
         assert pricing != _FALLBACK_PRICING
 
 
+def test_luna_priced_from_its_own_row_not_the_gpt5_flagship_tier() -> None:
+    """The default model's failure mode is over-pricing, not the fallback.
+
+    ``gpt-5.6-luna`` carries no "nano"/"mini" qualifier, so with no exact row
+    ``_family_pricing``'s gpt-5 branch prices it at the flagship $2.50/$15,
+    12.5x over on output, and nowhere near ``_FALLBACK_PRICING``, so the usual
+    "not the fallback" assertion would pass while the number was wrong. Assert
+    the exact published rate instead.
+    """
+    assert get_model_pricing("gpt-5.6-luna") == {"input": 0.20, "output": 1.20}
+
+
 def test_unknown_model_still_falls_back() -> None:
     assert get_model_pricing("totally-made-up-model-9000") == _FALLBACK_PRICING
 

--- a/tests/unit/test_providers/test_cost_estimator.py
+++ b/tests/unit/test_providers/test_cost_estimator.py
@@ -19,6 +19,9 @@ from repowise.cli.cost_estimator.heuristics import heuristic_tokens
         ("gpt-5.4-nano", 0.0002, 0.00125),
         ("gpt-5.4-mini", 0.00075, 0.0045),
         ("gpt-5.4", 0.0025, 0.015),
+        # The default. An unpriced model reads as free here (_lookup_cost
+        # falls through to (0.0, 0.0)), so this row is the guard.
+        ("gpt-5.6-luna", 0.0002, 0.0012),
         # Gemini
         ("gemini-3.1-flash-lite-preview", 0.00025, 0.0015),
         ("gemini-3-flash-preview", 0.0005, 0.003),

--- a/tests/unit/test_providers/test_openai_provider.py
+++ b/tests/unit/test_providers/test_openai_provider.py
@@ -24,9 +24,9 @@ def test_provider_name():
     assert p.provider_name == "openai"
 
 
-def test_default_model_is_nano():
+def test_default_model_is_luna():
     p = OpenAIProvider(api_key="sk-test")
-    assert p.model_name == "gpt-5.4-nano"
+    assert p.model_name == "gpt-5.6-luna"
 
 
 def test_api_key_from_env(monkeypatch):
@@ -59,6 +59,27 @@ def test_supported_reasoning_modes_are_model_specific():
         api_key="sk-test",
         model="gpt-4o",
     ).supported_reasoning_modes() == ("auto",)
+
+
+def test_gpt56_family_ladder_drops_minimal_and_max():
+    """Pin the 5.6 ladder: it is neither the gpt-5 one nor what the docs say.
+
+    Verified against the live API on 2026-08-15 for both variants. The model
+    docs advertise `max`; the API rejects it with `unsupported_value` and names
+    exactly these five. `minimal` is gone from 5.6 entirely, and offering it
+    fails only on a real call, which is what this pins.
+    """
+    for model in ("gpt-5.6-luna", "gpt-5.6-sol"):
+        assert OpenAIProvider(
+            api_key="sk-test",
+            model=model,
+        ).supported_reasoning_modes() == ("auto", "none", "low", "medium", "high", "xhigh")
+
+    # The generic gpt-5 branch is a prefix of gpt-5.6 and must not win.
+    assert "minimal" in OpenAIProvider(
+        api_key="sk-test",
+        model="gpt-5.4-nano",
+    ).supported_reasoning_modes()
 
 
 def test_gpt54_model():
@@ -113,7 +134,7 @@ def test_available_model_options_falls_back_to_configured_model(monkeypatch):
 
     options = OpenAIProvider(api_key="sk-test").available_model_options()
 
-    assert options[0].model == "gpt-5.4-nano"
+    assert options[0].model == "gpt-5.6-luna"
     assert options[0].recommended is True
     assert options[0].source == "fallback"
 
@@ -247,6 +268,41 @@ async def test_generate_forwards_minimal_reasoning_effort():
     assert captured_kwargs[0]["reasoning_effort"] == "minimal"
 
 
+async def test_generate_forwards_xhigh_reasoning_effort_for_luna():
+    """The top effort 5.6 does accept must reach the API, not be dropped.
+
+    The mapping used to enumerate the efforts it forwarded, so an effort that
+    passed validation but was missing from that list produced a request with no
+    `reasoning_effort` at all, indistinguishable from success at the call site.
+    """
+    provider = OpenAIProvider(api_key="sk-test", model="gpt-5.6-luna")
+    mock_response = _make_mock_chat_response()
+    captured_kwargs: list[dict] = []
+
+    async def fake_create(**kwargs):
+        captured_kwargs.append(kwargs)
+        return mock_response
+
+    with patch("openai.AsyncOpenAI") as mock_client:
+        mock_client.return_value.chat.completions.create = fake_create
+        provider._client = mock_client.return_value
+        await provider.generate("system msg", "user msg", reasoning="xhigh")
+
+    assert captured_kwargs[0]["reasoning_effort"] == "xhigh"
+
+
+async def test_generate_rejects_max_for_luna():
+    """`max` is a valid repowise mode that no OpenAI model accepts."""
+    provider = OpenAIProvider(api_key="sk-test", model="gpt-5.6-luna")
+
+    with patch("openai.AsyncOpenAI") as mock_client:
+        provider._client = mock_client.return_value
+        with pytest.raises(ProviderError, match="reasoning='max' is not supported"):
+            await provider.generate("system msg", "user msg", reasoning="max")
+
+    mock_client.return_value.chat.completions.create.assert_not_called()
+
+
 async def test_generate_forwards_none_reasoning_effort_for_gpt51():
     provider = OpenAIProvider(api_key="sk-test", model="gpt-5.1")
     mock_response = _make_mock_chat_response()
@@ -311,7 +367,7 @@ async def test_generate_rejects_minimal_for_non_reasoning_model():
 
 @pytest.mark.parametrize(
     "model",
-    ["gpt-5.1", "gpt-5-pro"],
+    ["gpt-5.1", "gpt-5-pro", "gpt-5.6-luna", "gpt-5.6-sol"],
 )
 async def test_generate_rejects_minimal_for_known_unsupported_reasoning_models(model):
     provider = OpenAIProvider(api_key="sk-test", model=model)


### PR DESCRIPTION
## What

`gpt-5.6-luna` replaces `gpt-5.4-nano` as the default OpenAI model.

Input is the same $0.20/MTok. Output is $1.20 against nano's $1.25, so this is not an alias: luna gets its own row in both pricing tables, and nano stays selectable on its own rate.

## Why the pricing rows are mandatory

A missing row fails silently, in opposite directions in the two tables:

| table | units | behaviour with no row for luna |
|---|---|---|
| `cost_estimator/pricing.py` | per 1K tokens | `_lookup_cost` falls through to `(0.0, 0.0)`: luna reads as **free**, and the cost gate never fires |
| `generation/cost_tracker.py` | per 1M tokens | the name carries no `nano`/`mini` qualifier, so `_family_pricing` bills it at the flagship **$2.50/$15** tier, 12.5x over on output, with no unknown-model warning |

Both now carry an exact row. Both tests assert the published rate rather than "not the fallback", because for luna the wrong answer is not the fallback value in either table.

## Reasoning efforts

The 5.6 family changed its ladder: `minimal` is gone, `xhigh` is new. The generic `gpt-5` branch is a string prefix of `gpt-5.6`, so without a branch above it the picker offered `minimal`, and the request 400ed on the first real generation.

The API also rejects `max`, which the model documentation lists as supported:

```
400 unsupported_value: 'reasoning_effort' does not support 'max' with this
model. Supported values are: 'none', 'low', 'medium', 'high', and 'xhigh'.
```

Checked against the live endpoint for both `gpt-5.6-luna` and `gpt-5.6-sol`, which answered identically, which is why the branch is keyed on the family rather than on one model id. `tests/integration/test_provider_live.py` now calls each accepted effort for real: which efforts a model takes is a server-side fact, and no mock can settle it.

## Picker heuristic

`gpt-5` matches inside `gpt-5.6-luna`, and no cheap-tier word does, so the flagship heuristic labelled the new default flagship. Accepting the default printed a note advising the user to switch to a cheaper model than the one they were already on. `luna` joins `_BUDGET_MODEL_TOKENS`, which is checked first.

## Surfaces updated

CLI picker defaults, server provider catalog (luna default, nano still listed), openrouter model list, web settings placeholder, the cost table mirrored in `packages/ui`, both provider docstrings, user guide, config reference.

## Cached input

$0.02/MTok is left unmodelled, and the ceiling is written down in `pricing.py`. The token count is not what is missing: `cached_tokens` already flows provider to `GeneratedPage` to the `pages` table and the run report prints it. What is missing is a third rate in each table and splitting the cached count out of the cost arithmetic. That pays off when reporting cost per re-index, not to move a one-off init estimate by ~10%.

## Verification

- 350 unit tests pass across the provider, pricing, CLI and server suites.
- `ruff check .` clean, `npm run type-check` clean across api-client, web and vscode.
- Live calls against `gpt-5.6-luna` for `none`, `low`, `medium`, `high`, `xhigh`: all accepted. `minimal` and `max` are rejected by validation before any request is sent.
- Cold `repowise init --prose --provider openai --yes` on a 106-file repo: 1m29s, $0.02, reported as `openai / gpt-5.6-luna`.