### PR TITLE
fix(git): avoid partial-clone history fetches

### DIFF
--- a/packages/core/src/repowise/core/ingestion/git_indexer/indexer.py
+++ b/packages/core/src/repowise/core/ingestion/git_indexer/indexer.py
@@ -98,6 +98,7 @@ class GitIndexer:
         on_commit_done: Callable[[], None] | None = None,
         on_co_change_start: Callable[[int], None] | None = None,
         on_co_change_done: Callable[[], None] | None = None,
+        on_warning: Callable[[str], None] | None = None,
     ) -> tuple[GitIndexSummary, list[dict]]:
         """Full index of all tracked files. Returns summary + list of metadata
         dicts ready for bulk upsert.
@@ -113,11 +114,30 @@ class GitIndexer:
           on_co_change_done() — fired the moment co-change accumulation
                                 completes (BEFORE per-file git indexing
                                 finishes).
+          on_warning(text) — reports a degraded git phase to the caller.
         """
         start = time.monotonic()
         repo = self._get_repo()
         if repo is None:
             return GitIndexSummary(0, 0, 0, 0.0), []
+
+        partial_filter = self._partial_clone_filter(repo)
+        if partial_filter is not None:
+            warning = (
+                "Git history skipped for partial clone "
+                f"(filter: {partial_filter}) to avoid fetching missing objects; "
+                "use a full clone to enable history, churn, and ownership signals."
+            )
+            logger.warning(
+                "git_history_skipped_partial_clone",
+                partial_clone_filter=partial_filter,
+            )
+            if on_warning is not None:
+                with contextlib.suppress(Exception):
+                    on_warning(warning)
+            if on_start is not None:
+                on_start(0)
+            return GitIndexSummary(0, 0, 0, time.monotonic() - start), []
 
         tracked_files = self._get_tracked_files(repo)
         if not tracked_files:
@@ -926,6 +946,41 @@ class GitIndexer:
                 error=str(exc),
             )
             return None
+
+    @staticmethod
+    def _partial_clone_filter(repo: Any) -> str | None:
+        """Return the active partial-clone filter for a promisor remote.
+
+        History walks use ``--numstat``, which needs blob contents. Git silently
+        downloads missing blobs for a promisor remote, turning an otherwise local
+        index into an unbounded network operation. Detection reads local config
+        only and degrades safely when Git cannot answer.
+        """
+        try:
+            promisor_config = repo.git.config(
+                "--get-regexp",
+                r"^remote\..*\.promisor$",
+            )
+        except Exception:
+            return None
+
+        for line in promisor_config.splitlines():
+            key, separator, value = line.partition(" ")
+            if not separator or value.strip().lower() != "true":
+                continue
+            parts = key.split(".")
+            if len(parts) < 3:
+                continue
+            remote = ".".join(parts[1:-1])
+            try:
+                clone_filter = repo.git.config(
+                    "--get",
+                    f"remote.{remote}.partialclonefilter",
+                ).strip()
+            except Exception:
+                clone_filter = ""
+            return clone_filter or "promisor"
+        return None
 
     def _get_tracked_files(self, repo: Any) -> list[str]:
         try:

--- a/packages/core/src/repowise/core/ingestion/git_indexer/indexer.py
+++ b/packages/core/src/repowise/core/ingestion/git_indexer/indexer.py
@@ -121,22 +121,11 @@ class GitIndexer:
         if repo is None:
             return GitIndexSummary(0, 0, 0, 0.0), []
 
-        partial_filter = self._partial_clone_filter(repo)
-        if partial_filter is not None:
-            warning = (
-                "Git history skipped for partial clone "
-                f"(filter: {partial_filter}) to avoid fetching missing objects; "
-                "use a full clone to enable history, churn, and ownership signals."
-            )
-            logger.warning(
-                "git_history_skipped_partial_clone",
-                partial_clone_filter=partial_filter,
-            )
-            if on_warning is not None:
-                with contextlib.suppress(Exception):
-                    on_warning(warning)
+        if self._skip_partial_clone_history(repo, on_warning=on_warning):
             if on_start is not None:
                 on_start(0)
+            with contextlib.suppress(Exception):
+                repo.close()
             return GitIndexSummary(0, 0, 0, time.monotonic() - start), []
 
         tracked_files = self._get_tracked_files(repo)
@@ -391,6 +380,7 @@ class GitIndexer:
         all_files: set[str] | None = None,
         co_change_sink: dict[str, list[dict]] | None = None,
         idle_decay_sink: dict[str, dict] | None = None,
+        on_warning: Callable[[str], None] | None = None,
     ) -> list[dict]:
         """Incremental update: re-index only changed files.
 
@@ -426,6 +416,10 @@ class GitIndexer:
         """
         repo = self._get_repo()
         if repo is None:
+            return []
+        if self._skip_partial_clone_history(repo, on_warning=on_warning):
+            with contextlib.suppress(Exception):
+                repo.close()
             return []
 
         loop = asyncio.get_event_loop()
@@ -644,6 +638,9 @@ class GitIndexer:
         if repo is None:
             return []
         try:
+            if self._skip_partial_clone_history(repo):
+                return []
+
             from ..git_commit_index import load_commit_index
             from .commit_rows import build_commit_rows
 
@@ -966,7 +963,7 @@ class GitIndexer:
 
         for line in promisor_config.splitlines():
             key, separator, value = line.partition(" ")
-            if not separator or value.strip().lower() != "true":
+            if not separator or value.strip().lower() not in {"true", "1", "yes", "on"}:
                 continue
             parts = key.split(".")
             if len(parts) < 3:
@@ -981,6 +978,31 @@ class GitIndexer:
                 clone_filter = ""
             return clone_filter or "promisor"
         return None
+
+    def _skip_partial_clone_history(
+        self,
+        repo: Any,
+        *,
+        on_warning: Callable[[str], None] | None = None,
+    ) -> bool:
+        """Report and bound git enrichment when *repo* is a partial clone."""
+        partial_filter = self._partial_clone_filter(repo)
+        if partial_filter is None:
+            return False
+
+        warning = (
+            "Git history skipped for partial clone "
+            f"(filter: {partial_filter}) to avoid fetching missing objects; "
+            "use a full clone to enable history, churn, and ownership signals."
+        )
+        logger.warning(
+            "git_history_skipped_partial_clone",
+            partial_clone_filter=partial_filter,
+        )
+        if on_warning is not None:
+            with contextlib.suppress(Exception):
+                on_warning(warning)
+        return True
 
     def _get_tracked_files(self, repo: Any) -> list[str]:
         try:

--- a/packages/core/src/repowise/core/pipeline/incremental.py
+++ b/packages/core/src/repowise/core/pipeline/incremental.py
@@ -288,6 +288,7 @@ async def rebuild_graph_and_git(
             all_files=set(source_map.keys()),
             co_change_sink=co_change_full,
             idle_decay_sink=idle_decay_sink,
+            on_warning=log,
         )
         git_meta_map = {m["file_path"]: m for m in updated_meta}
         if co_change_full:

--- a/packages/core/src/repowise/core/pipeline/phases/git.py
+++ b/packages/core/src/repowise/core/pipeline/phases/git.py
@@ -12,7 +12,7 @@ from typing import Any
 import structlog
 
 from repowise.core.ingestion.git_indexer import GitIndexTier
-from repowise.core.pipeline.progress import ProgressCallback
+from repowise.core.pipeline.progress import ProgressCallback, emit_warning
 
 from ._common import _phase_done
 
@@ -85,6 +85,9 @@ async def _run_git_indexing(
             # per-file git walk that keeps running afterwards (audit #29).
             _phase_done(progress, "co_change")
 
+        def _on_warning(text: str) -> None:
+            emit_warning(progress, text)
+
         git_summary, git_metadata_list = await git_indexer.index_repo(
             "",
             on_start=_on_start,
@@ -92,6 +95,7 @@ async def _run_git_indexing(
             on_co_change_start=_on_co_change_start,
             on_commit_done=_on_commit_done,
             on_co_change_done=_on_co_change_done,
+            on_warning=_on_warning,
         )
         git_meta_map = {m["file_path"]: m for m in git_metadata_list}
         _phase_done(progress, "git")

--- a/tests/unit/pipeline/test_git_partial_clone_warning.py
+++ b/tests/unit/pipeline/test_git_partial_clone_warning.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from repowise.core.pipeline.incremental import rebuild_graph_and_git
 from repowise.core.pipeline.phases.git import _run_git_indexing
 
 
@@ -35,3 +36,33 @@ async def test_partial_clone_warning_reaches_progress_channel(tmp_path) -> None:
         "warning",
         "Git history skipped for partial clone (filter: blob:none).",
     )
+
+
+@pytest.mark.asyncio
+async def test_partial_clone_warning_reaches_incremental_log(tmp_path) -> None:
+    """The update path must surface the same visible degraded-state warning."""
+    graph_builder = MagicMock()
+    graph_builder.compute_metrics_parallel = AsyncMock()
+    messages: list[str] = []
+
+    async def index_changed_files(_paths, **callbacks):
+        callbacks["on_warning"]("Git history skipped for partial clone (filter: blob:none).")
+        return []
+
+    with (
+        patch(
+            "repowise.core.pipeline.incremental.build_repo_graph",
+            return_value=([], {}, graph_builder, MagicMock(), 0),
+        ),
+        patch("repowise.core.ingestion.git_indexer.GitIndexer") as indexer_type,
+    ):
+        indexer_type.return_value.index_changed_files.side_effect = index_changed_files
+        await rebuild_graph_and_git(
+            tmp_path,
+            [],
+            {},
+            [],
+            log=messages.append,
+        )
+
+    assert messages == ["Git history skipped for partial clone (filter: blob:none)."]

--- a/tests/unit/pipeline/test_git_partial_clone_warning.py
+++ b/tests/unit/pipeline/test_git_partial_clone_warning.py
@@ -1,0 +1,37 @@
+"""Regression coverage for degraded partial-clone git indexing."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from repowise.core.pipeline.phases.git import _run_git_indexing
+
+
+@pytest.mark.asyncio
+async def test_partial_clone_warning_reaches_progress_channel(tmp_path) -> None:
+    """A bounded git degradation must remain visible in normal CLI output."""
+    progress = MagicMock()
+    summary = MagicMock()
+
+    async def index_repo(_repo_id: str, **callbacks):
+        callbacks["on_warning"]("Git history skipped for partial clone (filter: blob:none).")
+        return summary, []
+
+    with patch("repowise.core.ingestion.git_indexer.GitIndexer") as indexer_type:
+        indexer_type.return_value.index_repo.side_effect = index_repo
+        result, metadata, metadata_map = await _run_git_indexing(
+            tmp_path,
+            commit_depth=500,
+            follow_renames=False,
+            progress=progress,
+        )
+
+    assert result is summary
+    assert metadata == []
+    assert metadata_map == {}
+    progress.on_message.assert_any_call(
+        "warning",
+        "Git history skipped for partial clone (filter: blob:none).",
+    )

--- a/tests/unit/test_git_indexer.py
+++ b/tests/unit/test_git_indexer.py
@@ -889,6 +889,57 @@ class TestGitUnavailableGraceful:
         assert "blob:none" in on_warning.call_args.args[0]
         get_tracked_files.assert_not_called()
         repo.git.log.assert_not_called()
+        repo.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_partial_clone_skips_incremental_file_history(self) -> None:
+        """Incremental updates must not re-enter the blob-dependent walk."""
+        indexer = GitIndexer("/tmp/repo")
+        repo = MagicMock()
+        repo.git.config.side_effect = [
+            "remote.origin.promisor true",
+            "blob:none",
+        ]
+        on_warning = MagicMock()
+
+        with patch.object(indexer, "_get_repo", return_value=repo):
+            metadata = await indexer.index_changed_files(
+                ["changed.py"],
+                on_warning=on_warning,
+            )
+
+        assert metadata == []
+        on_warning.assert_called_once()
+        assert "partial clone" in on_warning.call_args.args[0]
+        repo.git.log.assert_not_called()
+        repo.close.assert_called_once()
+
+    def test_partial_clone_skips_incremental_commit_capture(self) -> None:
+        """Standalone commit capture must obey the same no-fetch invariant."""
+        indexer = GitIndexer("/tmp/repo")
+        repo = MagicMock()
+        repo.git.config.side_effect = [
+            "remote.origin.promisor true",
+            "blob:none",
+        ]
+
+        with patch.object(indexer, "_get_repo", return_value=repo):
+            rows = indexer.capture_new_commit_rows()
+
+        assert rows == []
+        repo.git.log.assert_not_called()
+        repo.close.assert_called_once()
+
+    @pytest.mark.parametrize("promisor_value", ["true", "1", "yes", "on"])
+    def test_partial_clone_accepts_git_boolean_aliases(self, promisor_value: str) -> None:
+        indexer = GitIndexer("/tmp/repo")
+        repo = MagicMock()
+        repo.git.config.side_effect = [
+            f"remote.origin.promisor {promisor_value}",
+            "blob:none",
+        ]
+
+        assert indexer._partial_clone_filter(repo) == "blob:none"
 
     def test_non_promisor_clone_keeps_history_enabled(self) -> None:
         indexer = GitIndexer("/tmp/repo")

--- a/tests/unit/test_git_indexer.py
+++ b/tests/unit/test_git_indexer.py
@@ -859,6 +859,44 @@ class TestGitUnavailableGraceful:
         assert summary.stable_files == 0
         assert metadata == []
 
+    @pytest.mark.asyncio
+    async def test_partial_clone_skips_history_without_touching_objects(self) -> None:
+        """A promisor clone must not turn local indexing into a network fetch."""
+        indexer = GitIndexer("/tmp/repo")
+        repo = MagicMock()
+        repo.git.config.side_effect = [
+            "remote.origin.promisor true",
+            "blob:none",
+        ]
+        on_start = MagicMock()
+        on_warning = MagicMock()
+
+        with (
+            patch.object(indexer, "_get_repo", return_value=repo),
+            patch.object(indexer, "_get_tracked_files") as get_tracked_files,
+        ):
+            summary, metadata = await indexer.index_repo(
+                "test-repo-id",
+                on_start=on_start,
+                on_warning=on_warning,
+            )
+
+        assert summary.files_indexed == 0
+        assert metadata == []
+        on_start.assert_called_once_with(0)
+        on_warning.assert_called_once()
+        assert "partial clone" in on_warning.call_args.args[0]
+        assert "blob:none" in on_warning.call_args.args[0]
+        get_tracked_files.assert_not_called()
+        repo.git.log.assert_not_called()
+
+    def test_non_promisor_clone_keeps_history_enabled(self) -> None:
+        indexer = GitIndexer("/tmp/repo")
+        repo = MagicMock()
+        repo.git.config.side_effect = RuntimeError("no matching config")
+
+        assert indexer._partial_clone_filter(repo) is None
+
 
 # ---------------------------------------------------------------------------
 # 6. test_co_change_below_threshold_skipped


### PR DESCRIPTION
## Summary

- detect promisor/partial clones before the git-history phase starts
- skip history, churn, co-change, and ownership enrichment instead of allowing Git to lazy-fetch missing objects
- surface the degradation through the normal progress warning channel
- add regression coverage for both the no-history-call invariant and visible warning delivery

Fixes #1604.

## Why

The repo-wide `git log --numstat` walk needs blob contents. On a `blob:none` partial clone, Git silently downloads missing objects from the promisor remote before any per-file progress callback can advance. In the reported checkout this presented as `Indexing file history... 0/4774` while Git fetched 5,321 objects over a slow connection.

This patch chooses a conservative boundary: a configured promisor remote disables Git enrichment for that run. It does not synthesize zero churn or incomplete ownership as if those values were authoritative. The source/graph ingestion path remains available, and the user gets an actionable message to use a full clone when history signals are required.

The PR intentionally does not change workspace repository discovery or the existing `--dry-run` behavior tracked in #1504.

## Review note

This is opened as a draft because #1604 is not assigned yet. I am happy to adjust the product policy if maintainers prefer an explicit opt-in fetch or a names-only degraded history mode instead of skipping Git enrichment.

## Validation

- `uv run ruff format --check` on all changed files
- `uv run ruff check` on all changed files
- targeted Git/pipeline suite: **69 passed**
- real sparse partial-clone smoke: completed in **0.026s**, returned zero Git metadata, emitted the partial-clone warning, and did not call the history walk
- full `tests/unit/` run reached 78% before the 300s local timeout; it had one earlier failure in `tests/unit/cli/test_agent_target_baseline.py`, outside this change surface

## Risk and invariant

- **Risk:** a nominally local index triggers an unbounded network fetch and appears deadlocked.
- **Invariant:** a promisor clone must not enter blob-dependent history/co-change/blame paths without explicit user opt-in.
- **Test layer:** GitIndexer unit test for no Git history call; pipeline unit test for visible degraded-state reporting.