### PR TITLE
fix critical repository execution boundaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,46 @@ jobs:
         run: uv run ruff check .
 
   # ---------------------------------------------------------------------------
+  # Dependency advisories — audit the exact Python and JavaScript lockfiles.
+  # Keep this independent from the test matrix: advisory results do not vary
+  # by interpreter, and one authoritative run avoids three identical queries.
+  # ---------------------------------------------------------------------------
+  dependency-audit:
+    name: Dependency advisories
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          version: "latest"
+          enable-cache: true
+
+      - name: Export the complete Python lock
+        run: >-
+          uv export --frozen --all-packages --all-groups --all-extras
+          --no-emit-workspace --no-hashes
+          --output-file /tmp/repowise-requirements.txt
+
+      - name: Audit Python dependencies
+        run: >-
+          uvx --from pip-audit==2.10.1 pip-audit
+          --requirement /tmp/repowise-requirements.txt
+          --no-deps --disable-pip --strict
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: package-lock.json
+
+      - name: Audit JavaScript dependencies
+        run: npm audit --package-lock-only --audit-level=low
+
+  # ---------------------------------------------------------------------------
   # Integration tests (run on push to main only, slower)
   # ---------------------------------------------------------------------------
   test-integration:

--- a/packages/cli/src/repowise/cli/ui/env_persistence.py
+++ b/packages/cli/src/repowise/cli/ui/env_persistence.py
@@ -5,12 +5,26 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
+from repowise.core.providers.llm.registry import PROVIDER_API_KEY_ENVS
+
+# ``.repowise/.env`` is repository-controlled input.  Interactive setup writes
+# provider credentials there, so those are the only names it may project into
+# the ambient process environment.  In particular, process-loader, subprocess,
+# cache-sealing, database, and network-routing controls must remain owned by the
+# user who launched RepoWise.
+_REPO_ENV_ALLOWLIST = frozenset(
+    env_var for env_vars in PROVIDER_API_KEY_ENVS.values() for env_var in env_vars
+)
+
 
 def load_dotenv(repo_path: Path) -> None:
-    """Load ``<repo>/.repowise/.env`` into ``os.environ`` (without overwriting).
+    """Load saved provider keys into ``os.environ`` without overwriting.
 
-    Supports ``export KEY=value``, quoted values (``KEY="value"``, ``KEY='value'``),
-    and inline comments (``KEY=value  # comment``).
+    ``.repowise/.env`` is untrusted repository state, not a general-purpose
+    process dotenv.  Only the built-in providers' documented API-key names are
+    accepted.  Supports ``export KEY=value``, quoted values
+    (``KEY="value"``, ``KEY='value'``), and inline comments
+    (``KEY=value  # comment``).
     """
     env_file = repo_path / ".repowise" / ".env"
     if not env_file.exists():
@@ -38,7 +52,7 @@ def load_dotenv(repo_path: Path) -> None:
         # Strip matching surrounding quotes
         value = _strip_quotes(raw_value)
         # Don't overwrite existing env vars (explicit env takes priority)
-        if key and value and key not in os.environ:
+        if key in _REPO_ENV_ALLOWLIST and value and key not in os.environ:
             os.environ[key] = value
 
 

--- a/packages/core/src/repowise/core/precedent/structural.py
+++ b/packages/core/src/repowise/core/precedent/structural.py
@@ -486,13 +486,26 @@ def _head_commit(root: Path) -> str | None:
 
 
 def _ruff_executable(root: Path) -> str | None:
-    """Prefer the checkout's own environment, then PATH."""
-    for venv_name in _VENV_DIRNAMES:
-        for scripts_dir, filename in (
-            (root / venv_name / "Scripts", "ruff.exe"),
-            (root / venv_name / "bin", "ruff"),
-        ):
-            candidate = scripts_dir / filename
-            if candidate.is_file():
-                return str(candidate)
-    return shutil.which("ruff")
+    """Return a launcher selected by the caller's PATH, never by the repository.
+
+    The checkout is untrusted input.  A committed ``.venv/bin/ruff`` must not
+    turn an indexing check into arbitrary code execution, even when a relative
+    PATH entry or symlink makes :func:`shutil.which` discover it.  Resolve the
+    selected launcher once and execute that canonical path so a repository
+    symlink cannot be swapped between validation and use.
+    """
+    executable = shutil.which("ruff")
+    if executable is None:
+        return None
+    try:
+        root_lexical = Path(os.path.abspath(root))
+        root_resolved = root.resolve(strict=True)
+        candidate_lexical = Path(os.path.abspath(executable))
+        candidate_resolved = candidate_lexical.resolve(strict=True)
+    except (OSError, RuntimeError):
+        return None
+    if candidate_lexical.is_relative_to(root_lexical) or candidate_resolved.is_relative_to(
+        root_resolved
+    ):
+        return None
+    return str(candidate_resolved)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ dependencies = [
     # Vector search (LanceDB — pure Python wheel)
     "lancedb>=0.12,<1",
     # CLI
-    "click>=8.1,<9",
+    "click>=8.3.3,<9",
     "rich>=13,<14",
     "watchdog>=4,<5",
     # Server
@@ -110,8 +110,8 @@ graph-extra = [
     "graspologic>=3.4,<4",
 ]
 dev = [
-    "pytest>=8,<9",
-    "pytest-asyncio>=0.23,<1",
+    "pytest>=9.0.3,<10",
+    "pytest-asyncio>=1,<2",
     "pytest-snapshot>=0.9,<1",
     "respx>=0.21,<1",
     "time-machine>=2.14,<3",
@@ -172,8 +172,8 @@ members = [
 
 [dependency-groups]
 dev = [
-    "pytest>=8,<9",
-    "pytest-asyncio>=0.23,<1",
+    "pytest>=9.0.3,<10",
+    "pytest-asyncio>=1,<2",
     "pytest-snapshot>=0.9,<1",
     "respx>=0.21,<1",
     "time-machine>=2.14,<3",

--- a/tests/unit/cli/test_env_persistence.py
+++ b/tests/unit/cli/test_env_persistence.py
@@ -1,0 +1,92 @@
+"""Repository dotenv values may supply provider keys, never process controls."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import os
+import pickle
+
+import pytest
+
+from repowise.cli.ui.env_persistence import load_dotenv
+from repowise.core.cache_seal import load_sealed_pickle, reset_key_cache_for_tests
+
+
+def _write_repo_env(tmp_path, text: str):
+    env_dir = tmp_path / ".repowise"
+    env_dir.mkdir()
+    (env_dir / ".env").write_text(text, encoding="utf-8")
+
+
+def test_load_dotenv_imports_only_provider_api_keys(tmp_path, monkeypatch):
+    names = (
+        "OPENAI_API_KEY",
+        "GEMINI_API_KEY",
+        "OLLAMA_BASE_URL",
+        "REPOWISE_CACHE_HMAC_KEY",
+        "REPOWISE_DB_URL",
+        "LD_PRELOAD",
+        "NODE_OPTIONS",
+    )
+    for name in names:
+        monkeypatch.delenv(name, raising=False)
+
+    _write_repo_env(
+        tmp_path,
+        "\n".join(
+            (
+                "OPENAI_API_KEY=sk-openai",
+                'export GEMINI_API_KEY="sk-gemini"',
+                "OLLAMA_BASE_URL=https://attacker.invalid",
+                "REPOWISE_CACHE_HMAC_KEY=" + "cd" * 32,
+                "REPOWISE_DB_URL=postgresql://attacker.invalid/db",
+                "LD_PRELOAD=/tmp/evil.so",
+                "NODE_OPTIONS=--require=/tmp/evil.js",
+            )
+        ),
+    )
+
+    load_dotenv(tmp_path)
+
+    assert os.environ["OPENAI_API_KEY"] == "sk-openai"
+    assert os.environ["GEMINI_API_KEY"] == "sk-gemini"
+    for name in names[2:]:
+        assert name not in os.environ
+
+
+def test_load_dotenv_preserves_explicit_provider_key(tmp_path, monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "from-launcher")
+    _write_repo_env(tmp_path, "OPENAI_API_KEY=from-repository\n")
+
+    load_dotenv(tmp_path)
+
+    assert os.environ["OPENAI_API_KEY"] == "from-launcher"
+
+
+def test_repo_dotenv_cannot_authenticate_a_malicious_pickle(tmp_path, monkeypatch):
+    marker = tmp_path / "PWNED"
+
+    class Evil:
+        def __reduce__(self):
+            return (marker.write_text, ("pwned",))
+
+    attacker_key = bytes.fromhex("cd" * 32)
+    payload = pickle.dumps(Evil())
+    domain = "parse_cache.pkl"
+    mac = hmac.new(attacker_key, domain.encode() + b"\x00" + payload, hashlib.sha256).digest()
+    cache_path = tmp_path / domain
+    cache_path.write_bytes(b"RWCH1" + mac + payload)
+
+    monkeypatch.delenv("REPOWISE_CACHE_HMAC_KEY", raising=False)
+    monkeypatch.setenv("REPOWISE_CACHE_KEY_PATH", str(tmp_path / "trusted" / "cache-key"))
+    _write_repo_env(tmp_path, "REPOWISE_CACHE_HMAC_KEY=" + attacker_key.hex() + "\n")
+    reset_key_cache_for_tests()
+    try:
+        load_dotenv(tmp_path)
+        with pytest.raises(ValueError, match="HMAC"):
+            load_sealed_pickle(cache_path, domain=domain)
+    finally:
+        reset_key_cache_for_tests()
+
+    assert not marker.exists()

--- a/tests/unit/cli/test_search_collapse.py
+++ b/tests/unit/cli/test_search_collapse.py
@@ -18,6 +18,7 @@ The same three things have to hold as for the other adapters:
 
 from __future__ import annotations
 
+import inspect
 import json
 
 import pytest
@@ -238,10 +239,17 @@ def repo(tmp_path):
     return tmp_path
 
 
+def _split_runner() -> CliRunner:
+    """Keep stderr separate across the Click 8.1 and 8.2+ runner APIs."""
+    if "mix_stderr" in inspect.signature(CliRunner.__init__).parameters:
+        return CliRunner(mix_stderr=False)
+    return CliRunner()
+
+
 def _invoke(monkeypatch, command, args, repo, payload, calls=None, expect_exit=0):
     """``risk`` takes its repo as ``--path``; it has no ``--no-workspace``."""
     monkeypatch.setattr(_ta, "run", _spy_run(payload, calls if calls is not None else []))
-    result = CliRunner(mix_stderr=False).invoke(command, [*args, "--path", str(repo)])
+    result = _split_runner().invoke(command, [*args, "--path", str(repo)])
     assert result.exit_code == expect_exit, result.output + (result.stderr or "")
     return result
 
@@ -249,7 +257,7 @@ def _invoke(monkeypatch, command, args, repo, payload, calls=None, expect_exit=0
 def _search(monkeypatch, args, repo, payload, calls=None, expect_exit=0):
     """``search`` takes its repo as a trailing positional, not ``--path``."""
     monkeypatch.setattr(_ta, "run", _spy_run(payload, calls if calls is not None else []))
-    result = CliRunner(mix_stderr=False).invoke(
+    result = _split_runner().invoke(
         search_command, [*args, str(repo), "--no-workspace"]
     )
     assert result.exit_code == expect_exit, result.output + (result.stderr or "")
@@ -385,7 +393,7 @@ def test_search_reaches_the_tool_with_the_mapped_mode(monkeypatch, repo, request
         return CONCEPT_PAYLOAD
 
     monkeypatch.setattr(_ta, "run", _run)
-    result = CliRunner(mix_stderr=False).invoke(
+    result = _split_runner().invoke(
         search_command, ["width", "--mode", requested, str(repo), "--no-workspace"]
     )
     assert result.exit_code == 0, result.output
@@ -481,11 +489,11 @@ def test_no_results_still_emits_a_document_and_says_so(monkeypatch, repo):
 
 
 def test_an_unindexed_repo_emits_a_document(monkeypatch, tmp_path):
-    result = CliRunner(mix_stderr=False).invoke(
+    result = _split_runner().invoke(
         search_command, ["q", str(tmp_path), "--no-workspace", "--format", "json"]
     )
     assert result.exit_code == 0
-    assert json.loads(result.output) == {"query": "q", "mode": "concept", "results": []}
+    assert json.loads(result.stdout) == {"query": "q", "mode": "concept", "results": []}
 
 
 # --------------------------------------------------------------------------
@@ -671,7 +679,7 @@ def test_risk_without_a_target_still_scores_a_revspec(monkeypatch, repo):
         "repowise.cli.commands.risk_cmd.score_live_change",
         lambda *a, **k: called.append(a) or (_ for _ in ()).throw(RuntimeError("boom")),
     )
-    result = CliRunner(mix_stderr=False).invoke(risk_command, ["HEAD", "--path", str(repo)])
+    result = _split_runner().invoke(risk_command, ["HEAD", "--path", str(repo)])
     assert called, "a bare `repowise risk` must still reach the change scorer"
     assert result.exit_code != 0  # our own boom
 
@@ -797,7 +805,7 @@ def test_risk_full_on_a_revspec_is_json_not_a_table(monkeypatch, repo):
         "repowise.cli.commands.risk_cmd.score_live_change",
         lambda *a, **k: _FakeChangeResult(),
     )
-    result = CliRunner(mix_stderr=False).invoke(
+    result = _split_runner().invoke(
         risk_command, ["HEAD", "--path", str(repo), "--full", "--baseline", "0"]
     )
     assert result.exit_code == 0, result.output + (result.stderr or "")
@@ -829,7 +837,7 @@ class _FakeChangeResult:
 def test_changed_file_without_a_target_is_a_usage_error(monkeypatch, repo):
     """It is a modifier on ``--target``, and silently scoring HEAD instead
     would answer a question nobody asked."""
-    result = CliRunner(mix_stderr=False).invoke(
+    result = _split_runner().invoke(
         risk_command, ["--changed-file", "a.py", "--path", str(repo)]
     )
     assert result.exit_code == 2

--- a/tests/unit/cli/test_tool_adapter_commands.py
+++ b/tests/unit/cli/test_tool_adapter_commands.py
@@ -18,6 +18,7 @@ Three things have to hold and each has tests below.
 
 from __future__ import annotations
 
+import inspect
 import json
 
 import pytest
@@ -247,6 +248,13 @@ def repo(tmp_path):
     return tmp_path
 
 
+def _split_runner() -> CliRunner:
+    """Keep stderr separate across the Click 8.1 and 8.2+ runner APIs."""
+    if "mix_stderr" in inspect.signature(CliRunner.__init__).parameters:
+        return CliRunner(mix_stderr=False)
+    return CliRunner()
+
+
 def _spy_run(payload: dict, calls: list):
     """Stand in for ``_tool_adapters.run``, but call the factory for real.
 
@@ -266,7 +274,7 @@ def _spy_run(payload: dict, calls: list):
 
 def _invoke(monkeypatch, command, args, repo, payload, calls=None, expect_exit=0):
     monkeypatch.setattr(_ta, "run", _spy_run(payload, calls if calls is not None else []))
-    result = CliRunner(mix_stderr=False).invoke(
+    result = _split_runner().invoke(
         command, [*args, "--path", str(repo), "--no-workspace"]
     )
     assert result.exit_code == expect_exit, result.output + (result.stderr or "")
@@ -668,7 +676,7 @@ def test_the_command_builds_the_coroutine_of_the_tool_it_names(
 def test_an_unindexed_repo_is_refused_before_any_tool_runs(monkeypatch, tmp_path):
     calls: list = []
     monkeypatch.setattr(_ta, "run", _spy_run({}, calls))
-    result = CliRunner(mix_stderr=False).invoke(
+    result = _split_runner().invoke(
         ask_command, ["q?", "--path", str(tmp_path), "--no-workspace"]
     )
     assert result.exit_code != 0
@@ -692,7 +700,7 @@ def test_logs_are_silenced_at_every_format_not_only_the_machine_ones(
         lambda: silenced.append(True),
     )
     monkeypatch.setattr("repowise.cli.tool_bridge.call_tool", lambda p, f, t: {"_meta": {}})
-    result = CliRunner(mix_stderr=False).invoke(
+    result = _split_runner().invoke(
         ask_command, ["q?", *args, "--path", str(repo), "--no-workspace"]
     )
     assert result.exit_code == 0, result.output

--- a/tests/unit/precedent/test_structural_episodes.py
+++ b/tests/unit/precedent/test_structural_episodes.py
@@ -7,9 +7,12 @@ must produce nothing rather than a partial answer.
 
 from __future__ import annotations
 
+import shutil
 import subprocess
 from pathlib import Path
 from types import SimpleNamespace
+
+import pytest
 
 from repowise.core.ingestion.traverser import FileTraverser
 from repowise.core.precedent import EpisodeStore
@@ -271,6 +274,56 @@ class TestFormatterDrift:
         )
         episodes = derive_structural_episodes(repo, _traverser(repo), allow_formatter_check=True)
         assert KIND_FORMATTER_DRIFT not in _kinds(episodes)
+
+    def test_repo_local_ruff_is_never_executed(self, tmp_path: Path, monkeypatch) -> None:
+        repo = self._declaring_repo(tmp_path)
+        repo_ruff = repo / ".venv" / "bin" / "ruff"
+        repo_ruff.parent.mkdir(parents=True)
+        repo_ruff.write_text("#!/bin/sh\ntouch PWNED\n", encoding="utf-8")
+        monkeypatch.setattr(shutil, "which", lambda _name: str(repo_ruff))
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda *_a, **_k: (_ for _ in ()).throw(
+                AssertionError("repository-controlled ruff must not execute")
+            ),
+        )
+
+        episodes = derive_structural_episodes(repo, _traverser(repo), allow_formatter_check=True)
+
+        assert KIND_FORMATTER_DRIFT not in _kinds(episodes)
+        assert not (repo / "PWNED").exists()
+
+    def test_path_ruff_outside_repo_remains_available(self, tmp_path: Path, monkeypatch) -> None:
+        from repowise.core.precedent.structural import _ruff_executable
+
+        (tmp_path / "repo").mkdir()
+        repo = self._declaring_repo(tmp_path / "repo")
+        trusted_ruff = tmp_path / "trusted-tools" / "ruff"
+        trusted_ruff.parent.mkdir()
+        trusted_ruff.write_text("trusted", encoding="utf-8")
+        monkeypatch.setattr(shutil, "which", lambda _name: str(trusted_ruff))
+
+        assert _ruff_executable(repo) == str(trusted_ruff.resolve())
+
+    def test_repo_symlink_to_external_ruff_is_still_rejected(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        from repowise.core.precedent.structural import _ruff_executable
+
+        (tmp_path / "repo").mkdir()
+        repo = self._declaring_repo(tmp_path / "repo")
+        trusted_ruff = tmp_path / "trusted-ruff"
+        trusted_ruff.write_text("trusted", encoding="utf-8")
+        repo_ruff = repo / ".venv" / "bin" / "ruff"
+        repo_ruff.parent.mkdir(parents=True)
+        try:
+            repo_ruff.symlink_to(trusted_ruff)
+        except OSError:
+            pytest.skip("symlinks are unavailable on this platform")
+        monkeypatch.setattr(shutil, "which", lambda _name: str(repo_ruff))
+
+        assert _ruff_executable(repo) is None
 
     def test_drift_is_reported_with_the_true_count(self, tmp_path: Path, monkeypatch) -> None:
         repo = self._declaring_repo(tmp_path)

--- a/uv.lock
+++ b/uv.lock
@@ -514,14 +514,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.1.8"
+version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593, upload-time = "2024-12-21T18:38:44.339Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/d4/7ebdbd03970677812aac39c869717059dbb71a4cfc033ca6e5221787892c/click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2", size = 98188, upload-time = "2024-12-21T18:38:41.666Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
 ]
 
 [[package]]
@@ -2780,7 +2780,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -2789,21 +2789,22 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]
 name = "pytest-asyncio"
-version = "0.26.0"
+version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8e/c4/453c52c659521066969523e87d85d54139bbd17b78f09532fb8eb8cdb58e/pytest_asyncio-0.26.0.tar.gz", hash = "sha256:c4df2a697648241ff39e7f0e4a73050b03f123f760673956cf0d72a4990e312f", size = 54156, upload-time = "2025-03-25T06:22:28.883Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/7f/338843f449ace853647ace35870874f69a764d251872ed1b4de9f234822c/pytest_asyncio-0.26.0-py3-none-any.whl", hash = "sha256:7b51ed894f4fbea1340262bdae5135797ebbe21d8638978e35d31c6d19f72fb0", size = 19694, upload-time = "2025-03-25T06:22:27.807Z" },
+    { url = "https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
 ]
 
 [[package]]
@@ -3090,6 +3091,7 @@ dependencies = [
     { name = "tree-sitter-javascript" },
     { name = "tree-sitter-kotlin" },
     { name = "tree-sitter-luau" },
+    { name = "tree-sitter-pascal" },
     { name = "tree-sitter-php" },
     { name = "tree-sitter-python" },
     { name = "tree-sitter-ruby" },
@@ -3143,7 +3145,7 @@ requires-dist = [
     { name = "apscheduler", specifier = ">=3.10,<4" },
     { name = "asyncpg", marker = "extra == 'postgres'", specifier = ">=0.29,<1" },
     { name = "build", marker = "extra == 'dev'", specifier = ">=1.0" },
-    { name = "click", specifier = ">=8.1,<9" },
+    { name = "click", specifier = ">=8.3.3,<9" },
     { name = "cryptography", specifier = ">=50.0.0,<51" },
     { name = "fastapi", specifier = ">=0.115,<1" },
     { name = "gitpython", specifier = ">=3.1,<4" },
@@ -3160,8 +3162,8 @@ requires-dist = [
     { name = "pathspec", specifier = ">=0.12,<1" },
     { name = "pgvector", marker = "extra == 'postgres'", specifier = ">=0.3,<1" },
     { name = "pydantic", specifier = ">=2.8,<3" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8,<9" },
-    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23,<1" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3,<10" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1,<2" },
     { name = "pytest-snapshot", marker = "extra == 'dev'", specifier = ">=0.9,<1" },
     { name = "pyyaml", specifier = ">=6.0,<7" },
     { name = "respx", marker = "extra == 'dev'", specifier = ">=0.21,<1" },
@@ -3184,6 +3186,7 @@ requires-dist = [
     { name = "tree-sitter-javascript", specifier = ">=0.23,<1" },
     { name = "tree-sitter-kotlin", specifier = ">=1,<2" },
     { name = "tree-sitter-luau", specifier = ">=1.2,<2" },
+    { name = "tree-sitter-pascal", specifier = ">=0.11,<1" },
     { name = "tree-sitter-php", specifier = ">=0.23,<1" },
     { name = "tree-sitter-python", specifier = ">=0.23,<1" },
     { name = "tree-sitter-ruby", specifier = ">=0.23,<1" },
@@ -3202,8 +3205,8 @@ provides-extras = ["postgres", "graph-extra", "dev"]
 dev = [
     { name = "httpx", specifier = ">=0.27,<1" },
     { name = "mypy", specifier = ">=1.11,<2" },
-    { name = "pytest", specifier = ">=8,<9" },
-    { name = "pytest-asyncio", specifier = ">=0.23,<1" },
+    { name = "pytest", specifier = ">=9.0.3,<10" },
+    { name = "pytest-asyncio", specifier = ">=1,<2" },
     { name = "pytest-snapshot", specifier = ">=0.9,<1" },
     { name = "respx", specifier = ">=0.21,<1" },
     { name = "ruff", specifier = ">=0.6,<1" },
@@ -4121,6 +4124,26 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ac/53/33b3ceb6c51757db94a2f12764bef2dfca003593f3c5663d46f5b0bc12bc/tree_sitter_luau-1.2.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8e2a35014902028c312dff6d45439fbdb8255583104a9e1c0f286162527629b2", size = 51127, upload-time = "2024-12-22T22:42:41.68Z" },
     { url = "https://files.pythonhosted.org/packages/8b/7e/5379a5502835f7bf39084cefd6dca6e5b7ed12a9c0ef692a57962e33ea38/tree_sitter_luau-1.2.0-cp39-abi3-win_amd64.whl", hash = "sha256:c8f86b022fe6d1a784e26fa2e898f1459a3f4d31555bed31bf6dda9c72e46f6d", size = 32942, upload-time = "2024-12-22T22:42:43.676Z" },
     { url = "https://files.pythonhosted.org/packages/1a/df/db574405f592f1f4f039dc83db8545d634b68481ce0c457bbab26e155a4a/tree_sitter_luau-1.2.0-cp39-abi3-win_arm64.whl", hash = "sha256:37e9a2e2dd9795800c98c160eabcfed9a90a25a80e2f207658902b0444a40440", size = 31300, upload-time = "2024-12-22T22:42:45.64Z" },
+]
+
+[[package]]
+name = "tree-sitter-pascal"
+version = "0.11.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/89/89/cb9ce7f7e9a119a3d518020c387fb994f8f6cac07a3f796fbb3409b506fb/tree_sitter_pascal-0.11.0.tar.gz", hash = "sha256:7d4da59b8c0b2ff9a32181562eed25c8ba13a6c8bbca2cb895e10f5344708dba", size = 293593, upload-time = "2026-07-01T03:53:16.47Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/74/621a4d1690e224de4ae00fb90304469bd96c1ae25bd7a8eabb95f9809b90/tree_sitter_pascal-0.11.0-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:7a8c2bb6ab958cea7390e18ed28f4535ca24ba110eae0449d5a77c294844d45a", size = 238019, upload-time = "2026-07-01T03:53:01.704Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/36/8660f400b1c42714f345fc0afae295be2fafec51531d199b7c6e2387881e/tree_sitter_pascal-0.11.0-cp38-abi3-macosx_10_9_x86_64.whl", hash = "sha256:bccb2d757c17820cdcfaa760bac1df4caa6278e1e2334d6956e0f9c31c6e8f4a", size = 125475, upload-time = "2026-07-01T03:53:03.182Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/1e/06f87ce971119b6a6c1682a0647cad9774463ae9c68faa8c016d8c10d30f/tree_sitter_pascal-0.11.0-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:ed50bb16a8469a54ae365f51dac046a3247e2efbab203269a8d737fa816b11a6", size = 132345, upload-time = "2026-07-01T03:53:04.643Z" },
+    { url = "https://files.pythonhosted.org/packages/00/b6/e37df67cc704f9c19531c858835396366d39790e71114fa181929b0dba00/tree_sitter_pascal-0.11.0-cp38-abi3-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:3ec2ca83d1e01a1eaf7711d6392947058c64302562f987be5c0bcf7e185d0dbd", size = 157887, upload-time = "2026-07-01T03:53:05.849Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/81/9e21b0199e86078ca4763ab4bc68fa6e1a3e625e168dee9fdcf27455d09f/tree_sitter_pascal-0.11.0-cp38-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:ab7557a05400f2841b18d000997453dadff09c2830bd48313cf4264bab018bbe", size = 153629, upload-time = "2026-07-01T03:53:06.99Z" },
+    { url = "https://files.pythonhosted.org/packages/20/34/947ae7c72eac8363e3de08f2a1e2f992beeb6afb27daca939443438e4614/tree_sitter_pascal-0.11.0-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:543717086ae596aa1895c6151230e45f78ed20a69b9c1ab83a5d5950db068381", size = 153629, upload-time = "2026-07-01T03:53:08.138Z" },
+    { url = "https://files.pythonhosted.org/packages/14/05/6b103890fdb63c57fb89650ece51333852e0ee8a4a3ef0966168acebfad4/tree_sitter_pascal-0.11.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:e317158e32c6e19ab75fe8664b48c48d71e757f6e2f8de0996eba63583d4ea55", size = 152709, upload-time = "2026-07-01T03:53:09.386Z" },
+    { url = "https://files.pythonhosted.org/packages/46/6e/ef2c893744b4d53f53113f7ca5bf3016afed6ced3db82ae7d3a42a2faf72/tree_sitter_pascal-0.11.0-cp38-abi3-musllinux_1_2_i686.whl", hash = "sha256:ab2e43d9a4d30ee482322a41f7f12ca2f40b4f0ee1771646329fe57a6a6a29ba", size = 157179, upload-time = "2026-07-01T03:53:10.501Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/bf/5b64986483183667c086c6612185a03f3de2408f81b6bac49b60fa45c187/tree_sitter_pascal-0.11.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b545e3b7a20fc7f7ce346e0fc598120a90b980adf050357946b7b00d2a81f875", size = 152117, upload-time = "2026-07-01T03:53:11.842Z" },
+    { url = "https://files.pythonhosted.org/packages/18/80/3553a1c89441a8f78daedd6182580db4df234b6b4ddd0e9d18ac9a2f7385/tree_sitter_pascal-0.11.0-cp38-abi3-win32.whl", hash = "sha256:c898d8c2771c5da47dbab20aea1d99e3aca8878a90e24db0a5558619ac8ad5c5", size = 124205, upload-time = "2026-07-01T03:53:12.969Z" },
+    { url = "https://files.pythonhosted.org/packages/19/96/695db7513510ea4fedb5e4e9b47011bf309253715c5eb9892c71486312e6/tree_sitter_pascal-0.11.0-cp38-abi3-win_amd64.whl", hash = "sha256:99346d54c928d42c820c0aa262f6acbf4fb2856d69016f1df11f834f681b45e0", size = 124349, upload-time = "2026-07-01T03:53:14.082Z" },
+    { url = "https://files.pythonhosted.org/packages/45/ad/e5381365ed5b247cad2e047682b081ccbb79f84bb5c1b48642ef3385f1d3/tree_sitter_pascal-0.11.0-cp38-abi3-win_arm64.whl", hash = "sha256:9d22b974a47765f1c98629338d82d1df89c35c270a73f08dda8fbd49538e32d4", size = 124914, upload-time = "2026-07-01T03:53:15.191Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Restrict repository `.repowise/.env` loading to documented provider API-key variables.
- Reject repository-owned or repository-symlinked Ruff executables during formatter analysis.
- Upgrade vulnerable Click and pytest versions and keep the CLI tests compatible with the newer Click runner API.
- Add Python and JavaScript dependency-advisory checks to CI.

## Root cause

RepoWise treated two repository-controlled inputs as trusted process configuration:

1. `.repowise/.env` could set arbitrary environment variables, including the HMAC key used to authenticate executable pickle cache data.
2. Formatter discovery preferred `<repo>/.venv/bin/ruff`, allowing a repository to choose the executable launched during structural analysis.

The dependency lock also contained Click 8.1.8 and pytest 8.4.2, which were reported by the current advisory database.

## Impact

A repository can no longer use its dotenv file to choose cache-sealing, loader, database, subprocess, or network-routing controls. It can still provide the documented provider API keys, and explicit launcher environment values retain precedence.

Formatter analysis now accepts only a canonical Ruff path selected from the launcher's PATH and located outside the repository. Global developer tooling continues to work.

## Validation

- 172 focused security and Click compatibility tests passed.
- 9 provider/UI compatibility tests passed in an isolated clean process.
- Ruff checks passed on every changed Python file.
- `git diff --check`, workflow YAML parsing, and `uv lock --check` passed.
- `pip-audit`: no known vulnerabilities.
- `npm audit --package-lock-only`: zero vulnerabilities.
- Broad unit run: 12,846 passed, 12 skipped, and 7 unrelated platform, stale-fixture, or suite-order failures.

The exploit regressions verify that a repository dotenv key cannot authenticate a malicious pickle and that a repository-owned Ruff launcher is never executed.

## Residual risk

The cache format remains Python pickle. Independent compromise of the trusted launcher-owned HMAC key would still make deserialization dangerous; replacing pickle is the stronger long-term design.

