### PR TITLE
release(vscode): 0.8.0 release notes and a server floor for the risk panel

### DIFF
--- a/packages/vscode/CHANGELOG.md
+++ b/packages/vscode/CHANGELOG.md
@@ -9,8 +9,61 @@ release history.
 
 ## 0.8.0
 
-A small release. The webviews compile the shared Repowise UI at build time, so
-these arrived with a rebuild rather than with edits to the extension itself.
+The views are on the current design language, and the risk panel now leads with
+where a change lands rather than with how big it is. Much of the rest arrived
+with a rebuild: the webviews compile the shared Repowise UI at build time, so
+improvements to the shared components ship here when the extension is rebuilt.
+
+**Requires repowise 0.43.0 or newer.** The risk panel reads a payload field no
+earlier server sends, so the status bar flags an older one and asks you to
+upgrade with `pip install --upgrade repowise`.
+
+### Design language
+
+- Two local copies of the health score colour called anything at or above 7.5
+  healthy-green, while the canonical bands start Healthy at 8 and the shared
+  ramp paints 7.5 to 7.99 amber. The health panel therefore printed a file's
+  score in green beside a map colouring the same file amber. Both copies are
+  gone, so the figure, the map and the web app's file table now agree.
+- High-contrast themes get a high-contrast treatment. They used to fall through
+  to the ordinary ramps, so a user who explicitly asked for high contrast got
+  0.07-alpha hairlines and ordinary tertiary text. The brand palette stays:
+  editor greys have no vocabulary for a health band, and remapping would trade
+  contrast for making the map unreadable as data.
+- Health takes the same lede, map, lens switcher, legend and trend the web page
+  leads with. Churn is a lens over the map rather than its own quadrant chart,
+  fetched on selection and joined onto the map rows by path.
+- Settings takes the shared rows, switches, inputs and save indicator, and
+  stamps each write so a slow response cannot undo a newer one. The optimistic
+  update and its rollback are unchanged.
+- The risk view's thirty card wrappers, none of them clickable, become
+  hairlines and vertical rhythm, with the score on the shared page lede. The
+  home sidebar's two statistics lose their card chrome; the seven launchers
+  keep theirs, because those are navigation buttons.
+- Decisions takes the shared status mark, whose `proposed` colour differed from
+  the local copy's.
+
+### Change risk
+
+- The panel leads with the repo-relative ranking. The classification and
+  percentile are the headline, the raw 0-10 score drops to a secondary line
+  that names the corpus it is anchored to, and a new note says which of the
+  touched files have broken before and where that sits among the repo's own
+  fix-bearing files. That is the signal the score cannot see: the score
+  restates diff size, so a small edit to a file that keeps breaking used to
+  read safer than a large mechanical change to files that never have.
+- `probability` is gone from the payload. It was the score divided by ten with
+  extra decimal places, presented as a second, more precise-looking number for
+  the same quantity.
+- The language-model tool description says what the tool now returns, so an
+  agent asking for it is told to read the fix history before the score.
+
+### Decisions
+
+- Dismiss dismisses. The button sent "deprecated", which the engine keeps
+  re-deriving on every re-index, so dismissing a wrong proposal did not stick.
+  A Dismissed filter comes with it, without which a dismissal is a one-way door
+  with nothing able to show or undo it.
 
 ### Docs
 

--- a/packages/vscode/src/constants.ts
+++ b/packages/vscode/src/constants.ts
@@ -12,8 +12,12 @@ export const CONFIG_SECTION = "repowise";
 /**
  * Lowest server version this build understands. Older servers may serve a
  * store shape this extension cannot read, so the status bar flags them.
+ *
+ * 0.43.0: the risk panel leads with `fix_history`, which no earlier server
+ * sends. `RiskRangeResponse.fix_history` is a required field and the panel
+ * dereferences it, so an older server would throw rather than degrade.
  */
-export const MIN_SERVER_VERSION = "0.26.0";
+export const MIN_SERVER_VERSION = "0.43.0";
 
 /** Command ids contributed by the extension, mirrored from package.json. */
 export const Commands = {


### PR DESCRIPTION
Release prep for the VS Code extension. No version edit: `packages/vscode/package.json` was bumped to 0.8.0 at the v0.40.0 release and never tagged, so 0.8.0 is what ships and 0.7.0 is what users are on today.

## Why now

The webviews compile `@repowise-dev/ui` into the VSIX at build time, so shared-component work reaches extension users only on a rebuild. Since `vscode-v0.7.0` there are 22 `packages/ui/src` commits and 5 `packages/vscode/` commits, including the design-language pass (#1575), the risk panel rework (#1583, #1593) and the decisions fix (#1567). All of it is sitting undelivered.

## What this PR changes

- **`packages/vscode/CHANGELOG.md`**: the 0.8.0 section described only what had landed by v0.40.0, since that is when it was written. It now covers everything since 0.7.0: the design-language pass (the two local `scoreColor` copies that disagreed with the canonical bands, high-contrast theme support, health taking the shared lede/map/lens/legend/trend, settings taking the shared primitives with stamped writes, card chrome removed where nothing was clickable), the risk panel leading with the repo-relative ranking and fix history with `probability` gone, and Dismiss actually dismissing.
- **`MIN_SERVER_VERSION` 0.26.0 to 0.43.0.** The risk panel reads `fix_history`, a required field on `RiskRangeResponse` that no server before 0.43.0 sends, and `FixHistoryNote` dereferences it with no guard, so against an older server the panel throws rather than degrades. Bumping the constant is what the constant is for: `serverManager` flags the server in the status bar with an upgrade hint and the views never get data. The alternative, guarding one field, under-fixes it, since #1583 also dropped `probability` and added `score_unit` to the same payload.

## Test plan

Following `packages/vscode/RELEASING.md`, which builds rather than only type-checking.

- [x] `npm run type-check --workspace packages/vscode` (host + webview tsconfigs)
- [x] `npm run build --workspace packages/vscode`: `dist/extension.js` 120.8 KB against a 300 KB budget
- [x] `npm run build:webview --workspace packages/vscode`: built clean, ELK still the largest lazy chunk as expected
- [x] `npm run test:webview --workspace packages/vscode`: 44 tests, 12 files
- [x] `npm run test --workspace packages/vscode`: electron smoke, 4 passing
- [x] `npm run package --workspace packages/vscode`: `repowise-0.8.0.vsix`, 158 files, 2.22 MB
- [ ] Clean-profile VSIX install smoke test (walkthrough, diagnostics and gutter heat on a low-health file, a dashboard rendering, MCP tools listed in agent mode)
- [ ] Tag `vscode-v0.8.0` after merge and watch `publish-vscode.yml`
- [ ] Verify the Marketplace and Open VSX listings render

The clean-profile install is the one step that needs a person driving the UI.
