### PR TITLE
fix(decisions): stop ADR discovery mining paths git cannot see

### DIFF
--- a/packages/core/src/repowise/core/analysis/decisions/extractor.py
+++ b/packages/core/src/repowise/core/analysis/decisions/extractor.py
@@ -48,6 +48,8 @@ import structlog
 
 from repowise.core.analysis.decisions.gate import apply_substring_gate
 from repowise.core.analysis.decisions.scope import resolve_module_nodes
+from repowise.core.fs_walk import PRUNED_DIRS, walk_repo
+from repowise.core.ingestion.traverser import load_gitignore_spec
 
 from .prompts import (
     _SYSTEM_PROMPT,
@@ -248,23 +250,10 @@ MARKER_RE = re.compile(
     r"\s*:\s*(?P<text>.+)",
 )
 
-_SKIP_DIRS = frozenset(
-    {
-        ".git",
-        "node_modules",
-        "__pycache__",
-        ".repowise",
-        ".venv",
-        "venv",
-        ".tox",
-        ".mypy_cache",
-        ".pytest_cache",
-        "dist",
-        "build",
-        ".next",
-        ".nuxt",
-    }
-)
+# fs_walk's never-source set plus the two derived-output names the decision
+# walks have always skipped: a bundled ``dist``/``build`` copy of a source file
+# would double every marker it contains.
+_SKIP_DIRS = PRUNED_DIRS | {"dist", "build"}
 
 # Regex to detect fenced code blocks in markdown files (``` or ~~~).
 _CODE_FENCE_RE = re.compile(r"^\s*(`{3,}|~{3,})")
@@ -339,17 +328,20 @@ DECISION_SIGNAL_KEYWORDS = [
 # ADR / PR / comment source configuration
 # ---------------------------------------------------------------------------
 
-# Directories conventionally holding Architecture Decision Records, plus a
-# filename glob for ADRs that live loose. Globbed relative to the repo root.
-_ADR_DIR_GLOBS = (
-    "adr/*.md",
-    "adrs/*.md",
-    "docs/adr/*.md",
-    "docs/adrs/*.md",
-    "docs/decisions/*.md",
-    "decisions/*.md",
-    "architecture/*.md",
-    "doc/adr/*.md",
+# Conventional ADR homes, as repo-root-relative posix directories. Every ``.md``
+# directly inside one is a candidate regardless of filename; matching is on the
+# whole relative dir, so a stray ``vendor/x/adr/`` does not qualify.
+_ADR_DIRS = frozenset(
+    {
+        "adr",
+        "adrs",
+        "docs/adr",
+        "docs/adrs",
+        "docs/decisions",
+        "decisions",
+        "architecture",
+        "doc/adr",
+    }
 )
 _MAX_ADR_FILES = 60
 
@@ -788,49 +780,53 @@ class DecisionExtractor:
     def _find_adr_files(self) -> list[Path]:
         """Collect candidate ADR files from the conventional dirs + name match.
 
-        Performance: the conventional-dir globs are shallow (one directory
-        each). The loose ``*adr*.md`` scan uses a pruned ``os.walk`` rather than
-        a recursive ``**`` glob so it never descends into ``node_modules`` /
-        ``.git`` / ``.venv`` on a large repo, and bails as soon as the cap is
-        hit.
+        One :func:`walk_repo` pass answers both halves: files directly under a
+        conventional ADR directory (root-anchored, as the old shallow globs
+        were) rank ahead of loose ``*adr*.md`` name matches, and the cap is
+        applied to the two buckets in that order.
+
+        Ignored paths are excluded. :mod:`repowise.core.fs_walk` prunes junk
+        dirs and nested repos but deliberately reads no ignore files, so
+        gitignore/``info/exclude`` handling is this function's job: without it
+        a scratch dir that ``git status`` cannot see contributes ``active``
+        decision records citing files no clone of the repo contains.
         """
-        import os
+        ignore = load_gitignore_spec(self._repo_path)
+        conventional: list[Path] = []
+        loose: list[Path] = []
+        for dirpath, dirnames, filenames in walk_repo(self._repo_path, prune_dirs=_SKIP_DIRS):
+            rel_dir = dirpath.relative_to(self._repo_path).as_posix()
+            rel_dir = "" if rel_dir == "." else rel_dir
+            # Prune ignored and packaging-metadata subtrees in place. Ignored
+            # DIRECTORIES match with a trailing slash, as git matches them.
+            dirnames[:] = [
+                d
+                for d in dirnames
+                if not d.endswith((".egg-info", ".dist-info"))
+                and not ignore.match_file(f"{rel_dir}/{d}/" if rel_dir else f"{d}/")
+            ]
 
-        seen: set[Path] = set()
-        files: list[Path] = []
-        for pattern in _ADR_DIR_GLOBS:
-            for p in self._repo_path.glob(pattern):
-                if p.is_file() and p not in seen:
-                    seen.add(p)
-                    files.append(p)
+            in_adr_dir = rel_dir in _ADR_DIRS
+            for fname in filenames:
+                low = fname.lower()
+                if not low.endswith(".md"):
+                    continue
+                if in_adr_dir:
+                    bucket = conventional
+                elif "adr" in low and low != "readme.md" and "template" not in low:
+                    bucket = loose
+                else:
+                    continue
+                if ignore.match_file(f"{rel_dir}/{fname}" if rel_dir else fname):
+                    continue
+                bucket.append(dirpath / fname)
 
-        if len(files) < _MAX_ADR_FILES:
-            for dirpath, dirnames, filenames in os.walk(self._repo_path):
-                # Prune skip-listed + nested-git subtrees in place.
-                dirnames[:] = [
-                    d
-                    for d in dirnames
-                    if d not in _SKIP_DIRS
-                    and not d.endswith((".egg-info", ".dist-info"))
-                    and not (Path(dirpath) / d / ".git").exists()
-                ]
-                for fname in filenames:
-                    low = fname.lower()
-                    if not low.endswith(".md") or "adr" not in low:
-                        continue
-                    if low == "readme.md" or "template" in low:
-                        continue
-                    p = Path(dirpath) / fname
-                    if p in seen:
-                        continue
-                    seen.add(p)
-                    files.append(p)
-                    if len(files) >= _MAX_ADR_FILES:
-                        break
-                if len(files) >= _MAX_ADR_FILES:
-                    break
+            if len(conventional) + len(loose) >= _MAX_ADR_FILES:
+                break
 
-        return files[:_MAX_ADR_FILES]
+        # No dedup pass: walk_repo yields each directory once, and each file
+        # lands in exactly one bucket.
+        return [*conventional, *loose][:_MAX_ADR_FILES]
 
     def _parse_adr(self, content: str, rel_path: str) -> ExtractedDecision | None:
         """Deterministically parse a structured ADR. Returns None if unstructured.
@@ -1432,31 +1428,20 @@ class DecisionExtractor:
     def _iter_source_files(self):
         """Yield source files under repo_path, skipping irrelevant dirs.
 
-        Uses os.walk so we can prune entire subtrees (nested git repos,
-        node_modules, etc.) without descending into them. When the repo is a git
-        checkout, the walk is further restricted to git-tracked files so
-        untracked / excluded working directories never contribute decisions;
-        gitless indexes fall back to the full walk.
+        Walks via :func:`walk_repo`, which prunes junk subtrees and nested git
+        repos (separate codebases that must not contribute decisions to the
+        parent) without descending into them. When the repo is a git checkout,
+        the walk is further restricted to git-tracked files so untracked /
+        excluded working directories never contribute decisions; gitless
+        indexes fall back to the full walk.
         """
-        import os
-
         tracked = self._tracked_files()
 
-        for dirpath, dirnames, filenames in os.walk(self._repo_path):
-            # Prune skip-listed directories in-place so os.walk won't descend
-            dirnames[:] = [
-                d
-                for d in dirnames
-                if d not in _SKIP_DIRS
-                # Skip setuptools build metadata: PKG-INFO embeds the README
-                # verbatim, so example marker lines in docs become spurious
-                # decisions. Same risk for *.dist-info from wheels.
-                and not d.endswith(".egg-info")
-                and not d.endswith(".dist-info")
-                # Skip nested git repositories — they are separate codebases
-                # and should not contribute decisions to the parent repo.
-                and not (Path(dirpath) / d / ".git").exists()
-            ]
+        for dirpath, dirnames, filenames in walk_repo(self._repo_path, prune_dirs=_SKIP_DIRS):
+            # Skip setuptools build metadata: PKG-INFO embeds the README
+            # verbatim, so example marker lines in docs become spurious
+            # decisions. Same risk for *.dist-info from wheels.
+            dirnames[:] = [d for d in dirnames if not d.endswith((".egg-info", ".dist-info"))]
 
             for fname in filenames:
                 fpath = Path(dirpath) / fname

--- a/packages/core/src/repowise/core/ingestion/traverser.py
+++ b/packages/core/src/repowise/core/ingestion/traverser.py
@@ -360,7 +360,7 @@ class FileTraverser:
         self.repo_root = repo_root.resolve()
         self.max_file_size_bytes = max_file_size_kb * 1024
         self._extra_ignore_filename = extra_ignore_filename
-        self._gitignore = _load_gitignore_spec(self.repo_root)
+        self._gitignore = load_gitignore_spec(self.repo_root)
         self._extra_ignore = _load_extra_ignore_spec(self.repo_root, extra_ignore_filename)
         self._blocked_patterns = _BLOCKED_FILENAME_SPEC
         patterns = extra_exclude_patterns or []
@@ -1182,13 +1182,18 @@ def _compile_gitignore(lines: Iterable[str]) -> pathspec.PathSpec:
     return pathspec.PathSpec(patterns)
 
 
-def _load_gitignore_spec(repo_root: Path) -> pathspec.PathSpec:
+def load_gitignore_spec(repo_root: Path) -> pathspec.PathSpec:
     """Root ignore spec: ``.gitignore`` merged with ``.git/info/exclude``.
 
     ``info/exclude`` is git's local-only ignore file — paths excluded there
     (scratch dirs, private checkouts) are invisible to ``git status`` and
     must be equally invisible to the index, or local-only files leak into
     the graph, blast-radius lists, and generated docs.
+
+    Public because :mod:`repowise.core.fs_walk` deliberately does not read
+    ignore files — every repo-wide scan that must respect them (the index
+    traversal here, ADR discovery in the decision extractor) pairs a pruned
+    walk with this spec.
     """
     lines: list[str] = []
     for ignore_file in (

--- a/tests/unit/analysis/test_decision_sources.py
+++ b/tests/unit/analysis/test_decision_sources.py
@@ -98,6 +98,66 @@ async def test_discover_adrs_maps_superseded_status_from_frontmatter(tmp_path):
 
 
 
+class TestAdrDiscoveryHonorsIgnoreFiles:
+    """A path git cannot see must not become a decision record.
+
+    The loose ``*adr*.md`` scan read the whole tree with no ignore handling, so
+    a scratch dir excluded locally shipped ``active`` records whose evidence
+    file no clone of the repo contains. ``fs_walk`` alone does not fix this: it
+    prunes junk dirs and nested repos but reads no ignore files.
+    """
+
+    async def test_gitignored_dir_contributes_no_adr(self, tmp_path):
+        (tmp_path / ".gitignore").write_text("scratch/\n", encoding="utf-8")
+        scratch = tmp_path / "scratch" / "notes"
+        scratch.mkdir(parents=True)
+        (scratch / "adr-postgres.md").write_text(_NYGARD_ADR, encoding="utf-8")
+
+        decisions = await DecisionExtractor(repo_path=tmp_path).discover_adrs()
+
+        assert decisions == []
+
+    async def test_info_exclude_dir_contributes_no_adr(self, tmp_path):
+        """``.git/info/exclude`` is the local-only half, and the half that leaked.
+
+        It is what hides ``local-stash/`` in this project's own checkout, where
+        the miner stored four records citing a bench file nobody else has.
+        """
+        info = tmp_path / ".git" / "info"
+        info.mkdir(parents=True)
+        (info / "exclude").write_text("local-stash/\n", encoding="utf-8")
+        stash = tmp_path / "local-stash" / "bench"
+        stash.mkdir(parents=True)
+        (stash / "adr-postgres.md").write_text(_NYGARD_ADR, encoding="utf-8")
+
+        decisions = await DecisionExtractor(repo_path=tmp_path).discover_adrs()
+
+        assert decisions == []
+
+    async def test_ignored_file_inside_a_conventional_dir_is_skipped(self, tmp_path):
+        """The conventional dirs were globbed, not walked, so they leaked too."""
+        (tmp_path / ".gitignore").write_text("docs/adr/local-*.md\n", encoding="utf-8")
+        adr_dir = tmp_path / "docs" / "adr"
+        adr_dir.mkdir(parents=True)
+        (adr_dir / "local-postgres.md").write_text(_NYGARD_ADR, encoding="utf-8")
+
+        decisions = await DecisionExtractor(repo_path=tmp_path).discover_adrs()
+
+        assert decisions == []
+
+    async def test_tracked_adr_is_still_discovered(self, tmp_path):
+        """Ablation partner: the ignore layer must not swallow everything."""
+        (tmp_path / ".gitignore").write_text("scratch/\n", encoding="utf-8")
+        adr_dir = tmp_path / "docs" / "adr"
+        adr_dir.mkdir(parents=True)
+        (adr_dir / "0001-use-postgres.md").write_text(_NYGARD_ADR, encoding="utf-8")
+
+        decisions = await DecisionExtractor(repo_path=tmp_path).discover_adrs()
+
+        assert len(decisions) == 1
+        assert "Use PostgreSQL" in decisions[0].title
+
+
 async def test_extract_all_runs_deterministic_sources_and_gates(tmp_path):
     adr_dir = tmp_path / "docs" / "adr"
     adr_dir.mkdir(parents=True)

--- a/tests/unit/ingestion/test_fs_walk.py
+++ b/tests/unit/ingestion/test_fs_walk.py
@@ -543,11 +543,6 @@ _WALK_ALLOWLIST: dict[tuple[str, str], frozenset[str]] = {
     # Repo DISCOVERY: exists to find nested .git dirs, prunes in-place;
     # migration onto walk_repo(prune_nested_git=False) is a tracked follow-up.
     ("core", "workspace/scanner.py"): frozenset({"os.walk"}),
-    # Decision mining: pruned in-place walks. The ``rglob`` entry went with the
-    # readme_mining/changelog miners (#1290) — the ADR scan globs a fixed set
-    # of patterns and walks with in-place pruning. Migration onto walk_repo is
-    # a tracked follow-up (sequenced after the source_map reuse).
-    ("core", "analysis/decisions/extractor.py"): frozenset({"os.walk"}),
     # Sizes .repowise/ only — repowise-owned, cannot contain junk trees.
     ("cli", "commands/status_cmd.py"): frozenset({"rglob"}),
     # Scans repowise's own packaged web/ui source dirs, not the user repo.


### PR DESCRIPTION
The ADR scan read the whole tree with no ignore handling, so a directory hidden by `.gitignore` or `.git/info/exclude` still supplied decision records. On this repo's own checkout that meant four candidates out of `local-stash/`, a local-only scratch dir, stored with `verification: exact` and citing evidence files no clone contains.

Two independent defects, both fixed here.

### Ignore files were never consulted

This is the leak. Discovery now loads the root spec via `load_gitignore_spec`, prunes ignored directories in place during the walk (trailing slash, as git matches them), and drops ignored files.

`fs_walk` deliberately reads no ignore files, so adopting it alone would not have fixed this. The pruned walk and the spec have to be paired. `_load_gitignore_spec` is promoted to public API for the second caller, with a docstring note on why it exists alongside `fs_walk`.

### The walk bypassed fs_walk

Conventional ADR dirs were shallow-globbed and the loose `*adr*.md` scan used a raw `os.walk` with a hand-rolled prune list and its own nested-`.git` probe, both of which `walk_repo` already does, with junction-cycle and symlink guards it did not have. Both halves are now one `walk_repo` pass that buckets conventional matches ahead of loose ones, preserving the previous priority and cap, and the local skip list derives from `PRUNED_DIRS`.

The legacy marker walk in `_iter_source_files` moves onto `walk_repo` too. That lets the extractor's `os.walk` exemption come out of the `fs_walk` guard allowlist entirely rather than staying open over the fixed code. The guard already covered `os.walk`; the exemption is how this one hid.

### Verification

Real extraction against the checkout that reproduces it, not only unit tests:

| | ADR candidates |
|---|---|
| before | 4, all under `local-stash/` |
| after | 0 |

Tracked ADRs are still discovered. All four new tests were ablated against the parent: the three ignore tests fail there with the ADR discovered, and `test_tracked_adr_is_still_discovered` passes, which is what makes it a useful partner. The guard-test change fails on the parent with exactly `['core:analysis/decisions/extractor.py [os.walk]']`.

`ruff check .` clean. `tests/unit/analysis` + `tests/unit/ingestion`: 2552 passed, 1 skipped. Wider `-k "distill or decision or traverser or walk"` sweep: 1456 passed, 2 skipped.

### Out of scope

The `"adr" not in low` filter is a bare substring test, so it matches "headroom", "quadratic", "cadre" — all four leaked candidates were `*headroom*.md`. Left alone here.

### Known limitation, pre-existing

`load_gitignore_spec` reads `repo_root/.git/info/exclude` as a path, so in a git worktree, where `.git` is a file rather than a directory, `info/exclude` is silently not found. That is behavior the traverser has always had and is unchanged here; it is a separate fix with its own blast radius across the index traversal.
