### PR TITLE
perf(workspace): walk each repo once when scanning .csproj manifests

### DIFF
--- a/packages/core/src/repowise/core/workspace/breaking_change.py
+++ b/packages/core/src/repowise/core/workspace/breaking_change.py
@@ -35,6 +35,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+from repowise.core.fsutils import atomic_write_text
 from repowise.core.workspace.config import WORKSPACE_DATA_DIR, ensure_workspace_data_dir
 from repowise.core.workspace.contract_schema import ContractSchema, SchemaField
 from repowise.core.workspace.contracts import (
@@ -576,9 +577,10 @@ def save_breaking_change_report(report: BreakingChangeReport, workspace_root: Pa
     """Write the report to ``.repowise-workspace/breaking_changes.json``."""
     data_dir = ensure_workspace_data_dir(workspace_root)
     out_path = data_dir / BREAKING_CHANGES_FILENAME
-    out_path.write_text(
-        json.dumps(report.to_dict(), indent=2, ensure_ascii=False),
-        encoding="utf-8",
+    # Atomic: the MCP enricher reads these artifacts from a separate
+    # process and must never observe a half-written file.
+    atomic_write_text(
+        out_path, json.dumps(report.to_dict(), indent=2, ensure_ascii=False)
     )
     return out_path
 

--- a/packages/core/src/repowise/core/workspace/conformance.py
+++ b/packages/core/src/repowise/core/workspace/conformance.py
@@ -40,6 +40,7 @@ from fnmatch import fnmatchcase
 from pathlib import Path
 from typing import Any
 
+from repowise.core.fsutils import atomic_write_text
 from repowise.core.workspace.config import (
     WORKSPACE_DATA_DIR,
     ConformanceRule,
@@ -364,9 +365,10 @@ def save_conformance_report(report: ConformanceReport, workspace_root: Path) -> 
     """Write the report to ``.repowise-workspace/conformance.json``."""
     data_dir = ensure_workspace_data_dir(workspace_root)
     out_path = data_dir / CONFORMANCE_FILENAME
-    out_path.write_text(
-        json.dumps(report.to_dict(), indent=2, ensure_ascii=False),
-        encoding="utf-8",
+    # Atomic: the MCP enricher reads these artifacts from a separate
+    # process and must never observe a half-written file.
+    atomic_write_text(
+        out_path, json.dumps(report.to_dict(), indent=2, ensure_ascii=False)
     )
     return out_path
 

--- a/packages/core/src/repowise/core/workspace/contracts.py
+++ b/packages/core/src/repowise/core/workspace/contracts.py
@@ -20,6 +20,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from repowise.core.fsutils import atomic_write_text
 from repowise.core.workspace.config import (
     WORKSPACE_DATA_DIR,
     WorkspaceConfig,
@@ -683,9 +684,10 @@ def save_contract_store(store: ContractStore, workspace_root: Path) -> Path:
     """Write contract store to ``.repowise-workspace/contracts.json``."""
     data_dir = ensure_workspace_data_dir(workspace_root)
     out_path = data_dir / CONTRACTS_FILENAME
-    out_path.write_text(
-        json.dumps(store.to_dict(), indent=2, ensure_ascii=False),
-        encoding="utf-8",
+    # Atomic: the MCP enricher reads these artifacts from a separate
+    # process and must never observe a half-written file.
+    atomic_write_text(
+        out_path, json.dumps(store.to_dict(), indent=2, ensure_ascii=False)
     )
     return out_path
 

--- a/packages/core/src/repowise/core/workspace/cross_repo.py
+++ b/packages/core/src/repowise/core/workspace/cross_repo.py
@@ -20,6 +20,7 @@ from collections import defaultdict
 from dataclasses import asdict, dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path, PurePosixPath
+from typing import Any
 
 from .config import WorkspaceConfig, ensure_workspace_data_dir
 
@@ -798,10 +799,70 @@ def _scan_go_mod(
     return results
 
 
+_CSPROJ_SKIP_DIRS = frozenset(
+    {"bin", "obj", ".vs", "packages", "node_modules", ".git", "TestResults"}
+)
+
+
+@dataclass
+class _CsprojIndex:
+    """Every ``.csproj`` in the workspace, walked and parsed exactly once.
+
+    ``_scan_csproj`` needs two things: the assembly-name → repo-alias map
+    (built from *all* repos) and the current repo's own project files. Built
+    per repo, the map is rebuilt identically for every alias, so an R-repo
+    workspace walked R*R + R trees and re-parsed every project file R times.
+    The map depends only on ``repo_paths``, never on the alias being scanned,
+    so hoisting it here is a pure de-duplication: same inputs, same map, R
+    walks instead of R*R + R.
+    """
+
+    # Parsed once and shared; ElementTree instances are only ever read.
+    trees: dict[Path, Any] = field(default_factory=dict)
+    by_repo: dict[str, list[Path]] = field(default_factory=dict)
+    assembly_to_repo: dict[str, str] = field(default_factory=dict)
+
+
+def _index_csproj_files(repo_paths: dict[str, Path]) -> _CsprojIndex:
+    """Walk each repo once, parse each ``.csproj`` once, build the assembly map."""
+    from xml.etree import ElementTree as ET
+
+    from repowise.core.fs_walk import iter_glob
+
+    index = _CsprojIndex()
+    # Insertion order matches the previous per-alias rebuild, so a name
+    # defined in two repos still resolves to the last repo in repo_paths.
+    for alias, path in repo_paths.items():
+        found: list[Path] = []
+        # Each *selected* workspace repo is walked from its own root;
+        # iter_glob's nested-git pruning keeps any physically-nested
+        # unselected repo out of the scan.
+        for csproj in iter_glob(path, "*.csproj"):
+            if any(part in _CSPROJ_SKIP_DIRS for part in csproj.parts):
+                continue
+            try:
+                tree = ET.parse(csproj)
+            except (ET.ParseError, OSError):
+                continue
+            found.append(csproj)
+            index.trees[csproj] = tree
+            assembly_name = csproj.stem  # default: filename minus extension
+            for elem in tree.getroot().iter():
+                tag = elem.tag.split("}", 1)[1] if elem.tag.startswith("{") else elem.tag
+                if tag == "AssemblyName" and elem.text:
+                    assembly_name = elem.text.strip()
+                    break
+            index.assembly_to_repo[assembly_name] = alias
+        index.by_repo[alias] = found
+    return index
+
+
 def _scan_csproj(
     repo_path: Path,
     repo_paths: dict[str, Path],
     alias: str,
+    *,
+    csproj_index: _CsprojIndex | None = None,
 ) -> list[CrossRepoPackageDep]:
     """Scan every .csproj for cross-repo references.
 
@@ -818,42 +879,21 @@ def _scan_csproj(
        in a separate repo.
 
     Skips ``bin``/``obj``/``packages``/``.vs``/``TestResults`` build outputs.
-    """
-    from xml.etree import ElementTree as ET
 
-    from repowise.core.fs_walk import iter_glob
+    ``csproj_index`` lets a caller scanning several repos share one walk;
+    omitted, the scan builds its own and behaves exactly as a standalone call.
+    """
+    index = csproj_index if csproj_index is not None else _index_csproj_files(repo_paths)
+    if alias not in index.by_repo:
+        # Scanning a repo the index does not cover (an alias absent from
+        # repo_paths). Walk it on its own so the standalone contract holds.
+        index = _index_csproj_files({**repo_paths, alias: repo_path})
+    assembly_to_repo = index.assembly_to_repo
 
     results: list[CrossRepoPackageDep] = []
-    skip = {"bin", "obj", ".vs", "packages", "node_modules", ".git", "TestResults"}
 
-    # Pre-compute the assembly-name → repo-alias map so we can resolve
-    # internal-NuGet references in a second pass. Each *selected* workspace
-    # repo is walked from its own root; iter_glob's nested-git pruning keeps
-    # any physically-nested unselected repo out of the scan.
-    assembly_to_repo: dict[str, str] = {}
-    for sib_alias, sib_path in repo_paths.items():
-        for csproj in iter_glob(sib_path, "*.csproj"):
-            if any(part in skip for part in csproj.parts):
-                continue
-            try:
-                tree = ET.parse(csproj)
-            except (ET.ParseError, OSError):
-                continue
-            assembly_name = csproj.stem  # default: filename minus extension
-            for elem in tree.getroot().iter():
-                tag = elem.tag.split("}", 1)[1] if elem.tag.startswith("{") else elem.tag
-                if tag == "AssemblyName" and elem.text:
-                    assembly_name = elem.text.strip()
-                    break
-            assembly_to_repo[assembly_name] = sib_alias
-
-    for csproj in iter_glob(repo_path, "*.csproj"):
-        if any(part in skip for part in csproj.parts):
-            continue
-        try:
-            tree = ET.parse(csproj)
-        except (ET.ParseError, OSError):
-            continue
+    for csproj in index.by_repo.get(alias, ()):
+        tree = index.trees[csproj]
         try:
             rel_manifest = csproj.relative_to(repo_path).as_posix()
         except ValueError:
@@ -899,19 +939,29 @@ def detect_package_dependencies(
     results: list[CrossRepoPackageDep] = []
     seen: set[tuple[str, str, str]] = set()  # (source, target, kind)
 
+    # One walk per repo, shared across every alias. The .csproj scan is the
+    # only manifest scanner that walks the tree rather than reading a fixed
+    # root file, and it needs a workspace-wide view, so building its index
+    # per repo re-walked every tree once per repo.
+    csproj_index = _index_csproj_files(repo_paths)
+
     for alias, path in repo_paths.items():
         for scanner in (
             _scan_package_json,
             _scan_pyproject_toml,
             _scan_cargo_toml,
             _scan_go_mod,
-            _scan_csproj,
         ):
             for dep in scanner(path, repo_paths, alias):
                 key = (dep.source_repo, dep.target_repo, dep.kind)
                 if key not in seen:
                     seen.add(key)
                     results.append(dep)
+        for dep in _scan_csproj(path, repo_paths, alias, csproj_index=csproj_index):
+            key = (dep.source_repo, dep.target_repo, dep.kind)
+            if key not in seen:
+                seen.add(key)
+                results.append(dep)
 
     return results
 

--- a/packages/core/src/repowise/core/workspace/cross_repo.py
+++ b/packages/core/src/repowise/core/workspace/cross_repo.py
@@ -22,6 +22,7 @@ from datetime import UTC, datetime
 from pathlib import Path, PurePosixPath
 from typing import Any
 
+from ..fsutils import atomic_write_text
 from .config import WorkspaceConfig, ensure_workspace_data_dir
 
 _log = logging.getLogger("repowise.workspace.cross_repo")
@@ -1005,9 +1006,10 @@ def save_overlay(overlay: CrossRepoOverlay, workspace_root: Path) -> Path:
     """Save overlay to ``.repowise-workspace/cross_repo_edges.json``."""
     data_dir = ensure_workspace_data_dir(workspace_root)
     out_path = data_dir / CROSS_REPO_EDGES_FILENAME
-    out_path.write_text(
-        json.dumps(overlay.to_dict(), indent=2, ensure_ascii=False),
-        encoding="utf-8",
+    # Atomic: the MCP enricher reads these artifacts from a separate
+    # process and must never observe a half-written file.
+    atomic_write_text(
+        out_path, json.dumps(overlay.to_dict(), indent=2, ensure_ascii=False)
     )
     return out_path
 

--- a/packages/core/src/repowise/core/workspace/cross_repo.py
+++ b/packages/core/src/repowise/core/workspace/cross_repo.py
@@ -824,36 +824,44 @@ class _CsprojIndex:
     assembly_to_repo: dict[str, str] = field(default_factory=dict)
 
 
-def _index_csproj_files(repo_paths: dict[str, Path]) -> _CsprojIndex:
-    """Walk each repo once, parse each ``.csproj`` once, build the assembly map."""
+def _walk_csproj(repo_root: Path, index: _CsprojIndex) -> list[Path]:
+    """Walk one repo for ``.csproj`` files, parsing each into *index.trees*."""
     from xml.etree import ElementTree as ET
 
     from repowise.core.fs_walk import iter_glob
 
+    found: list[Path] = []
+    # Each *selected* workspace repo is walked from its own root; iter_glob's
+    # nested-git pruning keeps any physically-nested unselected repo out.
+    for csproj in iter_glob(repo_root, "*.csproj"):
+        if any(part in _CSPROJ_SKIP_DIRS for part in csproj.parts):
+            continue
+        try:
+            index.trees[csproj] = ET.parse(csproj)
+        except (ET.ParseError, OSError):
+            continue
+        found.append(csproj)
+    return found
+
+
+def _assembly_name(tree: Any, csproj: Path) -> str:
+    """The project's assembly name, defaulting to the filename minus extension."""
+    for elem in tree.getroot().iter():
+        tag = elem.tag.split("}", 1)[1] if elem.tag.startswith("{") else elem.tag
+        if tag == "AssemblyName" and elem.text:
+            return elem.text.strip()
+    return csproj.stem
+
+
+def _index_csproj_files(repo_paths: dict[str, Path]) -> _CsprojIndex:
+    """Walk each repo once, parse each ``.csproj`` once, build the assembly map."""
     index = _CsprojIndex()
     # Insertion order matches the previous per-alias rebuild, so a name
     # defined in two repos still resolves to the last repo in repo_paths.
     for alias, path in repo_paths.items():
-        found: list[Path] = []
-        # Each *selected* workspace repo is walked from its own root;
-        # iter_glob's nested-git pruning keeps any physically-nested
-        # unselected repo out of the scan.
-        for csproj in iter_glob(path, "*.csproj"):
-            if any(part in _CSPROJ_SKIP_DIRS for part in csproj.parts):
-                continue
-            try:
-                tree = ET.parse(csproj)
-            except (ET.ParseError, OSError):
-                continue
-            found.append(csproj)
-            index.trees[csproj] = tree
-            assembly_name = csproj.stem  # default: filename minus extension
-            for elem in tree.getroot().iter():
-                tag = elem.tag.split("}", 1)[1] if elem.tag.startswith("{") else elem.tag
-                if tag == "AssemblyName" and elem.text:
-                    assembly_name = elem.text.strip()
-                    break
-            index.assembly_to_repo[assembly_name] = alias
+        found = _walk_csproj(path, index)
+        for csproj in found:
+            index.assembly_to_repo[_assembly_name(index.trees[csproj], csproj)] = alias
         index.by_repo[alias] = found
     return index
 
@@ -885,15 +893,22 @@ def _scan_csproj(
     omitted, the scan builds its own and behaves exactly as a standalone call.
     """
     index = csproj_index if csproj_index is not None else _index_csproj_files(repo_paths)
-    if alias not in index.by_repo:
-        # Scanning a repo the index does not cover (an alias absent from
-        # repo_paths). Walk it on its own so the standalone contract holds.
-        index = _index_csproj_files({**repo_paths, alias: repo_path})
+
+    own = index.by_repo.get(alias)
+    if own is None or repo_paths.get(alias) != repo_path:
+        # The index does not describe this exact tree — *alias* is absent from
+        # repo_paths, or the caller passed a repo_path that disagrees with it.
+        # Walk the tree we were actually handed, and leave assembly_to_repo
+        # alone: it is defined by repo_paths, and folding this repo's own
+        # names into it would let them shadow a sibling that legitimately
+        # owns the same assembly name.
+        own = _walk_csproj(repo_path, index)
+
     assembly_to_repo = index.assembly_to_repo
 
     results: list[CrossRepoPackageDep] = []
 
-    for csproj in index.by_repo.get(alias, ()):
+    for csproj in own:
         tree = index.trees[csproj]
         try:
             rel_manifest = csproj.relative_to(repo_path).as_posix()

--- a/packages/core/src/repowise/core/workspace/system_graph.py
+++ b/packages/core/src/repowise/core/workspace/system_graph.py
@@ -37,6 +37,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+from repowise.core.fsutils import atomic_write_text
 from repowise.core.workspace.config import (
     WORKSPACE_DATA_DIR,
     WorkspaceConfig,
@@ -429,9 +430,10 @@ def save_system_graph(graph: SystemGraph, workspace_root: Path) -> Path:
     """Write the system graph to ``.repowise-workspace/system_graph.json``."""
     data_dir = ensure_workspace_data_dir(workspace_root)
     out_path = data_dir / SYSTEM_GRAPH_FILENAME
-    out_path.write_text(
-        json.dumps(graph.to_dict(), indent=2, ensure_ascii=False),
-        encoding="utf-8",
+    # Atomic: the MCP enricher reads these artifacts from a separate
+    # process and must never observe a half-written file.
+    atomic_write_text(
+        out_path, json.dumps(graph.to_dict(), indent=2, ensure_ascii=False)
     )
     return out_path
 

--- a/tests/unit/workspace/test_dotnet_workspace.py
+++ b/tests/unit/workspace/test_dotnet_workspace.py
@@ -283,3 +283,45 @@ class TestScanCsproj:
 
         assert standalone == shared
         assert standalone  # guard against both sides being vacuously empty
+
+    def test_assembly_name_collision_resolves_to_last_repo(self, tmp_path: Path) -> None:
+        """Two repos publishing one assembly name: the later repo wins.
+
+        The shared index builds this map once instead of per repo, so pin the
+        ordering it depends on — a map rebuilt in a different order would
+        silently retarget the edge at the other repo.
+        """
+        repos = self._two_repo_workspace(tmp_path)
+        rival = tmp_path / "rival-libs"
+        (rival / "src" / "Common").mkdir(parents=True)
+        (rival / "src" / "Common" / "Rival.csproj").write_text(
+            _csproj(assembly_name="Acme.Common")
+        )
+        (repos["api"] / "src" / "Api" / "Api.csproj").write_text(
+            _csproj(packages=["Acme.Common"])
+        )
+        # "shared" then "rival": last one to claim the name owns it.
+        ordered = {"api": repos["api"], "shared": repos["shared"], "rival": rival}
+
+        deps = detect_package_dependencies(ordered)
+        nuget = [d for d in deps if d.kind == "dotnet_nuget_internal"]
+        assert [d.target_repo for d in nuget] == ["rival"]
+
+    def test_scan_uses_the_repo_path_it_is_given(self, tmp_path: Path) -> None:
+        """A repo_path disagreeing with repo_paths[alias] must still be scanned.
+
+        The shared index is keyed by alias, so a caller passing a different
+        tree for that alias must not silently get the indexed tree's results.
+        """
+        repos = self._two_repo_workspace(tmp_path)
+        other = tmp_path / "other-api"
+        (other / "src" / "Api").mkdir(parents=True)
+        (other / "src" / "Api" / "Other.csproj").write_text(
+            _csproj(packages=["Acme.Common"])
+        )
+        # repo_paths["api"] holds no .csproj at all; the scanned tree does.
+        deps = _scan_csproj(
+            other, repos, alias="api", csproj_index=_index_csproj_files(repos)
+        )
+        assert [d.target_repo for d in deps] == ["shared"]
+        assert deps[0].source_manifest == "src/Api/Other.csproj"

--- a/tests/unit/workspace/test_dotnet_workspace.py
+++ b/tests/unit/workspace/test_dotnet_workspace.py
@@ -14,7 +14,11 @@ from __future__ import annotations
 from pathlib import Path
 from textwrap import dedent
 
+import pytest
+
+from repowise.core import fs_walk
 from repowise.core.workspace.cross_repo import (
+    _index_csproj_files,
     _scan_csproj,
     detect_package_dependencies,
 )
@@ -228,3 +232,54 @@ class TestScanCsproj:
         deps = detect_package_dependencies(repos)
         kinds = {d.kind for d in deps}
         assert "dotnet_project_ref" in kinds
+
+    def test_detect_package_dependencies_walks_each_repo_once(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The .csproj scan must not re-walk every tree once per repo.
+
+        The assembly-name map spans the whole workspace but does not depend on
+        the repo being scanned, so building it per repo cost R*R + R tree
+        walks. One walk per repo is the floor: each repo's project files have
+        to be found once.
+        """
+        repos = self._two_repo_workspace(tmp_path)
+        (repos["api"] / "src" / "Api" / "Api.csproj").write_text(
+            _csproj(packages=["Acme.Common"])
+        )
+
+        walked: list[Path] = []
+        real_iter_glob = fs_walk.iter_glob
+
+        def counting_iter_glob(root, patterns, **kwargs):
+            if patterns == "*.csproj":
+                walked.append(Path(root))
+            return real_iter_glob(root, patterns, **kwargs)
+
+        monkeypatch.setattr(fs_walk, "iter_glob", counting_iter_glob)
+
+        deps = detect_package_dependencies(repos)
+
+        assert len(walked) == len(repos), (
+            f"expected one *.csproj walk per repo ({len(repos)}), got {len(walked)}: {walked}"
+        )
+        # The saving must not have cost us the dependency itself.
+        assert any(d.kind == "dotnet_nuget_internal" for d in deps)
+
+    def test_shared_index_matches_standalone_scan(self, tmp_path: Path) -> None:
+        """A shared index must produce exactly what an isolated scan produces."""
+        repos = self._two_repo_workspace(tmp_path)
+        (repos["api"] / "src" / "Api" / "Api.csproj").write_text(
+            _csproj(
+                deps=[r"..\..\..\shared-libs\src\Common\Common.csproj"],
+                packages=["Acme.Common", "Newtonsoft.Json"],
+            )
+        )
+
+        standalone = _scan_csproj(repos["api"], repos, alias="api")
+        shared = _scan_csproj(
+            repos["api"], repos, alias="api", csproj_index=_index_csproj_files(repos)
+        )
+
+        assert standalone == shared
+        assert standalone  # guard against both sides being vacuously empty


### PR DESCRIPTION
## What

`detect_package_dependencies` spent most of a workspace update inside
`_scan_csproj`, the .NET manifest scanner, even in workspaces containing no
.NET code at all. On a three repository workspace (roughly 2,000, 700 and 400
files) it cost a median of 9.2s and returned zero dependencies.

The cause is that `_scan_csproj` built its `assembly_to_repo` map by walking
every repository in `repo_paths`, and it was called once per repository. That
map depends only on `repo_paths`, never on the alias being scanned, so it was
rebuilt identically every time: R*R tree walks for the map plus R for each
repository's own project files. Three repositories meant twelve full
filesystem walks where three are enough.

The other four manifest scanners read a single fixed file at the repository
root, which is why none of them showed up in the profile.

## How

Added `_CsprojIndex`, built once per `detect_package_dependencies` call: each
repository walked once, each `.csproj` parsed once, and the assembly map built
from that single pass.

`_scan_csproj` takes an optional `csproj_index=`, and builds its own when the
argument is omitted, so the existing three argument form behaves exactly as
before. When the `repo_path` it is handed disagrees with `repo_paths[alias]`,
or the alias is absent from `repo_paths`, it walks the tree it was actually
given and leaves the shared assembly map untouched, so one repository's own
assembly names cannot shadow a sibling that legitimately owns the same name.

Separately, the five `.repowise-workspace/` writers (`breaking_change`,
`conformance`, `contracts`, `cross_repo`, `system_graph`) moved from a bare
`write_text` to the `atomic_write_text` helper already used in this package
for `state.json`. All five had the same exposure: the MCP enricher reads these
files from another process and could observe a half written document. They
were the identical shape, so they are fixed together rather than one of five.

## Behavior

No change to results. Same dependencies, same co-change edges, same totals.
The scan is faster and the artifacts are written atomically.

Measured on the same three repository workspace, five runs each, nothing else
running on the machine:

| | before | after |
|---|---|---|
| `detect_package_dependencies` | median 9.165s / min 8.405s | median 2.359s / min 2.228s |
| `detect_cross_repo_co_changes` | median 1.085s / min 1.003s | median 1.065s / min 1.033s |

A 74.3% reduction on the median. Co-change mining is untouched and measures
the same, which is the control. Both sides produced identical output:
0 package dependencies, 150 co-change edges, 1207 mined.

## Verification

`tests/unit/workspace`, `tests/unit/server` and `tests/unit/cli` pass.
`ruff check .` is clean.

Four tests added in `tests/unit/workspace/test_dotnet_workspace.py`:

- `test_detect_package_dependencies_walks_each_repo_once` counts `iter_glob`
  calls and asserts one walk per repository. Checked against the previous
  behavior, where it sees 6 walks for 2 repositories instead of 2.
- `test_scan_uses_the_repo_path_it_is_given` covers the divergent path case.
  Checked by removing the guard, where it returns no dependencies.
- `test_assembly_name_collision_resolves_to_last_repo` pins the map ordering
  that the shared index now depends on, so a map rebuilt in a different order
  cannot silently retarget an edge.
- `test_shared_index_matches_standalone_scan` is an equivalence guard for the
  new argument rather than a regression test, since the API is new.
