### PR TITLE
fix(ingestion): record this.method() self-dispatch calls in 6 languages

### DIFF
--- a/packages/core/src/repowise/core/ingestion/queries/csharp.scm
+++ b/packages/core/src/repowise/core/ingestion/queries/csharp.scm
@@ -183,10 +183,13 @@
   arguments: (argument_list) @call.arguments
 ) @call.site
 
-; Member call: obj.Method(args)
+; Member call: obj.Method(args) — and self-dispatch: this.Method(args).
+; ``this`` is an ANONYMOUS node in tree-sitter-c-sharp, so it is matched as the
+; literal token "this"; `(this)` does not compile. See typescript.scm for why
+; this is an alternation rather than a second pattern.
 (invocation_expression
   function: (member_access_expression
-    expression: (identifier) @call.receiver
+    expression: [(identifier) "this"] @call.receiver
     name: (identifier) @call.target
   )
   arguments: (argument_list) @call.arguments

--- a/packages/core/src/repowise/core/ingestion/queries/javascript.scm
+++ b/packages/core/src/repowise/core/ingestion/queries/javascript.scm
@@ -179,10 +179,12 @@
   arguments: (arguments) @call.arguments
 ) @call.site
 
-; Method call: obj.method(args)
+; Method call: obj.method(args) — and self-dispatch: this.method(args).
+; See typescript.scm for why ``this`` rides an alternation in the receiver slot
+; instead of a second pattern.
 (call_expression
   function: (member_expression
-    object: (identifier) @call.receiver
+    object: [(identifier) (this)] @call.receiver
     property: (property_identifier) @call.target
   )
   arguments: (arguments) @call.arguments

--- a/packages/core/src/repowise/core/ingestion/queries/kotlin.scm
+++ b/packages/core/src/repowise/core/ingestion/queries/kotlin.scm
@@ -61,10 +61,12 @@
   (value_arguments) @call.arguments
 ) @call.site
 
-; Member call: obj.method(args)
+; Member call: obj.method(args) — and self-dispatch: this.method(args).
+; See typescript.scm for why ``this`` rides an alternation in the receiver slot
+; instead of a second pattern.
 (call_expression
   (navigation_expression
-    (identifier) @call.receiver
+    [(identifier) (this_expression)] @call.receiver
     (identifier) @call.target
   )
   (value_arguments) @call.arguments

--- a/packages/core/src/repowise/core/ingestion/queries/swift.scm
+++ b/packages/core/src/repowise/core/ingestion/queries/swift.scm
@@ -72,10 +72,12 @@
   )
 ) @call.site
 
-; Member call: obj.method(args)
+; Member call: obj.method(args) — and self-dispatch: self.method(args).
+; Swift spells it ``self``, which the resolver treats identically to ``this``.
+; See typescript.scm for why this is an alternation rather than a second pattern.
 (call_expression
   (navigation_expression
-    (simple_identifier) @call.receiver
+    [(simple_identifier) (self_expression)] @call.receiver
     (navigation_suffix
       (simple_identifier) @call.target
     )

--- a/packages/core/src/repowise/core/ingestion/queries/typescript.scm
+++ b/packages/core/src/repowise/core/ingestion/queries/typescript.scm
@@ -216,10 +216,16 @@
   arguments: (arguments) @call.arguments
 ) @call.site
 
-; Method call: obj.method(args)
+; Method call: obj.method(args) — and self-dispatch: this.method(args).
+; ``this`` is its own node type, not an identifier, so it is an alternation in
+; the receiver slot rather than a second pattern: one pattern means tree-sitter
+; does not run an extra match pass over every call_expression (measured +29-40%
+; parse time on angular for the two-pattern form, ~0% for this one), and there
+; is no duplicate rule to keep in sync. ``receiver_name`` then reads "this",
+; which call_resolver Strategy 3 already resolves against the caller's class.
 (call_expression
   function: (member_expression
-    object: (identifier) @call.receiver
+    object: [(identifier) (this)] @call.receiver
     property: (property_identifier) @call.target
   )
   arguments: (arguments) @call.arguments

--- a/tests/unit/ingestion/test_self_call_resolution.py
+++ b/tests/unit/ingestion/test_self_call_resolution.py
@@ -15,6 +15,8 @@ from __future__ import annotations
 from datetime import datetime
 from pathlib import Path
 
+import pytest
+
 from repowise.core.ingestion.call_resolver import CallResolver
 from repowise.core.ingestion.models import FileInfo, ParsedFile
 from repowise.core.ingestion.parser import parse_file
@@ -101,6 +103,145 @@ class TestSelfCallStrategy:
     def test_self_call_does_not_cross_classes(self, tmp_path: Path) -> None:
         """Other.lonely calls self.helper() but Other has no helper: no edge."""
         parsed = _parse_all(tmp_path, {"src/widget.py": ("python", WIDGET_PY)})
+        edges = _edges(parsed, tmp_path)
+        bad = [e for e in edges if e[0].endswith("::Other::lonely")]
+        assert bad == [], f"cross-class self-call must not resolve: {bad}"
+
+
+# ---------------------------------------------------------------------------
+# Self-dispatch across the languages whose self-reference keyword is NOT an
+# ordinary identifier node.
+#
+# Python reaches strategy 3 because ``self`` parses as ``(identifier)`` and the
+# stock member-call pattern captures it. In these six grammars the keyword is a
+# distinct node type (``this`` / ``this_expression`` / ``self_expression``, and
+# an anonymous ``"this"`` token in C#), so the member-call pattern used to match
+# nothing at all — not a lower-confidence edge, none — and the whole call site
+# was dropped before resolution. The receiver slot is now an alternation.
+#
+# Each case pins both directions: the in-class call resolves at strategy 3's
+# 0.95, and the same call from a class WITHOUT that method stays unresolved, so
+# widening the receiver did not turn into a name-only match.
+# ---------------------------------------------------------------------------
+
+TS_SRC = """
+class Widget {
+  helper(): number { return 1; }
+  run(): number { return this.helper(); }
+}
+
+class Other {
+  lonely(): number { return this.helper(); }
+}
+"""
+
+JS_SRC = """
+class Widget {
+  helper() { return 1; }
+  run() { return this.helper(); }
+}
+
+class Other {
+  lonely() { return this.helper(); }
+}
+"""
+
+CS_SRC = """
+class Widget {
+    int helper() { return 1; }
+    int run() { return this.helper(); }
+}
+
+class Other {
+    int lonely() { return this.helper(); }
+}
+"""
+
+KT_SRC = """
+class Widget {
+    fun helper(): Int { return 1 }
+    fun run(): Int { return this.helper() }
+}
+
+class Other {
+    fun lonely(): Int { return this.helper() }
+}
+"""
+
+SWIFT_SRC = """
+class Widget {
+    func helper() -> Int { return 1 }
+    func run() -> Int { return self.helper() }
+}
+
+class Other {
+    func lonely() -> Int { return self.helper() }
+}
+"""
+
+# Same shape, but with JSX in the method bodies: a .tsx file binds the
+# JSX-aware grammar, and plain TypeScript would exercise it only incidentally.
+# The render method is what makes the file actually need that grammar.
+TSX_SRC = """
+class Widget {
+  helper(): number { return 1; }
+  run(): number { return this.helper(); }
+  render() { return <div className="w">{this.run()}</div>; }
+}
+
+class Other {
+  lonely(): number { return this.helper(); }
+}
+"""
+
+# (id, relative path, language tag, source). ``.tsx`` is listed separately
+# because it binds the JSX-aware grammar while reusing typescript.scm — a
+# pattern valid against one grammar is not automatically valid against the other.
+SELF_DISPATCH_CASES = [
+    ("typescript", "src/widget.ts", "typescript", TS_SRC),
+    ("tsx", "src/widget.tsx", "typescript", TSX_SRC),
+    ("javascript", "src/widget.js", "javascript", JS_SRC),
+    ("csharp", "src/Widget.cs", "csharp", CS_SRC),
+    ("kotlin", "src/Widget.kt", "kotlin", KT_SRC),
+    ("swift", "src/Widget.swift", "swift", SWIFT_SRC),
+]
+
+
+@pytest.mark.parametrize(
+    ("rel", "lang", "source"),
+    [c[1:] for c in SELF_DISPATCH_CASES],
+    ids=[c[0] for c in SELF_DISPATCH_CASES],
+)
+class TestSelfDispatchAcrossLanguages:
+    def test_self_call_is_recorded_as_a_call_site(
+        self, tmp_path: Path, rel: str, lang: str, source: str
+    ) -> None:
+        """The parser must emit a CallSite at all — the original bug dropped it."""
+        parsed = _parse_all(tmp_path, {rel: (lang, source)})
+        receivers = {c.receiver_name for c in parsed[rel].calls if c.target_name == "helper"}
+        assert receivers, f"no call site recorded for the self-call in {rel}"
+        assert receivers <= {"this", "self"}, (
+            f"self-call receiver must be this/self so strategy 3 fires; got {receivers}"
+        )
+
+    def test_self_call_resolves_within_same_class(
+        self, tmp_path: Path, rel: str, lang: str, source: str
+    ) -> None:
+        parsed = _parse_all(tmp_path, {rel: (lang, source)})
+        edges = _edges(parsed, tmp_path)
+        hits = [
+            e
+            for e in edges
+            if e[0].endswith("::Widget::run") and e[1].endswith("::Widget::helper")
+        ]
+        assert hits, f"this.helper() inside Widget.run must resolve; edges: {edges}"
+        assert hits[0][2] == 0.95
+
+    def test_self_call_does_not_cross_classes(
+        self, tmp_path: Path, rel: str, lang: str, source: str
+    ) -> None:
+        """Other.lonely calls this.helper() but Other has no helper: no edge."""
+        parsed = _parse_all(tmp_path, {rel: (lang, source)})
         edges = _edges(parsed, tmp_path)
         bad = [e for e in edges if e[0].endswith("::Other::lonely")]
         assert bad == [], f"cross-class self-call must not resolve: {bad}"


### PR DESCRIPTION
## The bug

A call written `this.method()` produced **no `CallSite` at all** in typescript, tsx, javascript, csharp, kotlin and swift. Not a low-confidence edge, none. The member-call pattern in each `.scm` required `object: (identifier)`, but the self-reference keyword is a distinct node type in these grammars, so it matched nothing:

| grammar | node type |
|---|---|
| typescript / tsx / javascript | `this` (named) |
| csharp | `this` (**anonymous** token, so `(this)` will not compile) |
| kotlin | `this_expression` |
| swift | `self_expression` |

The resolver already knew what to do. `call_resolver.py` Strategy 3 resolves a `self`/`this` receiver against the caller's own class, and is exercised daily by Python, whose `self` happens to parse as an ordinary identifier. The branch was simply unreachable for these six languages. **No resolver change is needed and none is made.**

Java, PHP, Ruby, Dart, Go, Rust and Scala were already fine: their patterns do not constrain the receiver, so the call is recorded without one and resolves through the same-file name index.

## The fix

Widen the receiver slot of the **existing** member-call pattern into an alternation, rather than appending a second pattern:

```scheme
object: [(identifier) (this)] @call.receiver
```

Both forms produce byte-identical output. The alternation is the one to ship because a second pattern makes tree-sitter run an extra match pass over every `call_expression`:

| implementation | angular parse time |
|---|---|
| baseline | 20.4s / 24.0s |
| second pattern appended | 28.6s / 31.0s (**+29 to +40%**) |
| alternation (this PR) | 20.6s (**flat**) |

Measured twice per variant with the run order reversed, so the cost is not a warm-heap artifact. The alternation also leaves one rule to maintain instead of two.

`typescript.scm` covers `.tsx` as well, since the tsx grammar reuses it. `dart.scm` already had an explicit `(this)` receiver and is untouched.

## Measured effect

test-repos/angular, 7,020 files, verified against this branch's build rather than a patched copy:

| | before | after |
|---|---|---|
| call sites | 277,027 | 283,743 |
| **CALLS edges** | 22,422 | **26,488 (+18.1%)** |
| symbols with a caller | 8,270 | 10,352 (+25.2%) |
| parse time | 20.5s | 19.0s |

Smaller repos scale with house style: vue +2.9% edges, zod +4.0%, hono +0.7%. Repos that do not write `this.` are completely unaffected, and eShopOnWeb (zero such calls) reports identical numbers on every metric.

Edge count feeds centrality, blast radius and change risk, so this is a recall improvement across all three on class-heavy code.

## Tests

Extends `tests/unit/ingestion/test_self_call_resolution.py`, which already pinned this behaviour for Python, with a parametrized case per affected language. Each pins three things: the call site is recorded, the receiver is `this`/`self`, it resolves within the class at Strategy 3's 0.95, and a self-call from a class **without** that method stays unresolved.

Confirmed the tests are meaningful by running the new file against the pre-fix build: 12 of 22 fail (6 languages x 2 positive assertions), and the 6 cross-class negatives pass in both directions. The `.tsx` case carries real JSX in a `render` method so it genuinely exercises the JSX-aware grammar.

Green locally: `tests/unit/ingestion` (1,975 passed) and `tests/unit/analysis` + `tests/unit/dead_code` (891 passed).

## Notes for review

Two pre-existing limits of Strategy 3 become reachable in these languages for the first time. Neither is introduced here, and both already applied to Python:

- **`this` rebinding.** A plain `function () { this.helper() }` callback is attributed to the enclosing method, so it resolves even where `this` is bound elsewhere at runtime.
- **Inheritance.** Strategy 3 searches only the caller's own class in its own file, so `this.baseMethod()` on an inherited method does not resolve.

Not in this PR: `repowise update` only persists `graph_edges` for git-changed files, so existing stores keep stale edges for files that have not changed. That is a separate follow-up and is why this is not yet fully visible to existing users without a re-index.
