### PR TITLE
fix(risk): ignore shallow boundary in fix history

### DIFF
--- a/packages/core/src/repowise/core/analysis/change_risk/fix_history.py
+++ b/packages/core/src/repowise/core/analysis/change_risk/fix_history.py
@@ -65,11 +65,20 @@ def clear_fix_pressure_cache() -> None:
 
 def _walk(repo_path: str, upto_ref: str, depth: int) -> dict[str, list[float]]:
     """Commit timestamps of every bug-fix touching each file, up to *upto_ref*."""
+    is_shallow = (
+        _git(["rev-parse", "--is-shallow-repository"], repo_path, check=False).strip() == "true"
+    )
     try:
         proc = subprocess.run(
             [
-                "git", "log", f"-n{depth}", "--no-merges",
-                "--format=%x1e%ct%x1f%s", "--name-only", "--end-of-options", upto_ref,
+                "git",
+                "log",
+                f"-n{depth}",
+                "--no-merges",
+                "--format=%x1e%P%x1f%ct%x1f%s",
+                "--name-only",
+                "--end-of-options",
+                upto_ref,
             ],
             cwd=repo_path,
             capture_output=True,
@@ -93,14 +102,17 @@ def _walk(repo_path: str, upto_ref: str, depth: int) -> dict[str, list[float]]:
         if not block:
             continue
         lines = block.split("\n")
-        head = lines[0].split("\x1f")
-        if len(head) != 2:
+        head = lines[0].split("\x1f", 2)
+        if len(head) != 3:
+            continue
+        parents, timestamp_raw, subject = head
+        if is_shallow and not parents:
             continue
         try:
-            timestamp = float(head[0])
+            timestamp = float(timestamp_raw)
         except ValueError:
             continue
-        if not is_fix_commit(head[1]):
+        if not is_fix_commit(subject):
             continue
         for path in lines[1:]:
             path = path.strip()

--- a/tests/unit/analysis/test_change_risk_fix_history.py
+++ b/tests/unit/analysis/test_change_risk_fix_history.py
@@ -64,6 +64,60 @@ def repo_with_history(tmp_path: Path) -> Path:
     return repo
 
 
+def test_fix_pressure_skips_fix_shaped_shallow_boundary(tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    source.mkdir()
+    _git(["init", "-q"], source)
+    _git(["config", "user.name", "Dev"], source)
+    _git(["config", "user.email", "d@e.com"], source)
+
+    _commit(
+        source,
+        {"hot.py": "v = 0\n", "cold.py": "c = 0\n"},
+        "feat: seed",
+    )
+    _commit(source, {"hot.py": "v = 1\n"}, "feat: prepare")
+    _commit(source, {"hot.py": "v = 2\n"}, "fix: boundary bug")
+    _commit(source, {"hot.py": "v = 3\n"}, "fix: later bug")
+    _commit(source, {"cold.py": "c = 1\n"}, "feat: latest")
+
+    shallow = tmp_path / "shallow"
+    subprocess.run(
+        [
+            "git",
+            "clone",
+            "-q",
+            "--depth=3",
+            source.resolve().as_uri(),
+            str(shallow),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    shallow_pressure = fix_pressure(str(shallow), "HEAD")
+    full_pressure = fix_pressure(str(source), "HEAD")
+
+    assert "cold.py" not in shallow_pressure
+    assert set(shallow_pressure) <= set(full_pressure)
+    assert shallow_pressure["hot.py"] < full_pressure["hot.py"]
+
+
+def test_fix_pressure_keeps_parentless_root_in_full_repo(tmp_path: Path) -> None:
+    repo = tmp_path / "full"
+    repo.mkdir()
+    _git(["init", "-q"], repo)
+    _git(["config", "user.name", "Dev"], repo)
+    _git(["config", "user.email", "d@e.com"], repo)
+
+    _commit(repo, {"root.py": "value = 1\n"}, "fix: seed repository")
+
+    pressure = fix_pressure(str(repo), "HEAD")
+
+    assert pressure["root.py"] == pytest.approx(1.0, abs=0.05)
+
+
 def test_fix_pressure_counts_only_fix_commits(repo_with_history: Path) -> None:
     pressure = fix_pressure(str(repo_with_history), "HEAD")
     assert pressure["hot.py"] == pytest.approx(3.0, abs=0.05)


### PR DESCRIPTION
## Summary

- detect shallow repositories before walking fix history
- skip parentless boundary commits only when the repository is shallow
- preserve normal root-commit behavior for full clones
- add regression coverage using a real depth-limited clone

## Why

In a shallow clone, Git treats the oldest available commit as parentless. When that boundary commit has a fix-shaped subject, `git log --name-only` reports its tree as if the commit introduced all of those files.

`fix_pressure` then incorrectly credits those files with bug-fix history.

This change ignores that untrustworthy boundary commit while keeping the valid visible history after it.

Fixes #1623

## Test plan

- [x] `uv run pytest tests/unit/analysis/test_change_risk_fix_history.py -q`
- [x] `uv run pytest tests/unit/` — existing 12 unrelated failures
- [x] `npm run lint`
- [x] `npm run type-check`
- [x] `uv run repowise impacted-tests --staged`
- [x] `uv run repowise risk main..HEAD`
- [x] `uv run repowise health --file packages/core/src/repowise/core/analysis/change_risk/fix_history.py`