### PR TITLE
test(graph): fail when a second answer to a type's bare name appears

### DIFF
--- a/packages/core/src/repowise/core/ingestion/languages/specs/rust.py
+++ b/packages/core/src/repowise/core/ingestion/languages/specs/rust.py
@@ -94,5 +94,22 @@ SPEC = LanguageSpec(
             "FnOnce",
         }
     ),
+    # Primitives plus the prelude names a file may use without importing them,
+    # so a type reference to one can never point at a file this repo declares.
+    # Wider than ``builtin_parents``: that set only has to cover what may sit in
+    # an impl clause, this one every position a type may be written in.
+    builtin_types=frozenset(
+        {
+            "bool", "char", "str", "u8", "u16", "u32", "u64", "u128", "usize",
+            "i8", "i16", "i32", "i64", "i128", "isize", "f32", "f64",
+            "String", "Vec", "Option", "Result", "Box", "Arc", "Rc",
+            "HashMap", "HashSet", "BTreeMap", "BTreeSet", "Cow",
+            "Pin", "Future", "Send", "Sync", "Sized", "Copy", "Clone",
+            "Debug", "Display", "Default", "Iterator", "IntoIterator",
+            "From", "Into", "TryFrom", "TryInto", "AsRef", "AsMut",
+            "Fn", "FnMut", "FnOnce", "Drop", "Deref", "DerefMut",
+            "Self", "self",
+        }
+    ),
     color_hex="#DEA584",
 )

--- a/packages/core/src/repowise/core/ingestion/type_ref_resolution.py
+++ b/packages/core/src/repowise/core/ingestion/type_ref_resolution.py
@@ -158,19 +158,6 @@ def _resolve_csharp_type_refs(
 # Strategy: Rust
 # ---------------------------------------------------------------------------
 
-_RUST_BUILTIN_TYPES = frozenset({
-    "bool", "char", "str", "u8", "u16", "u32", "u64", "u128", "usize",
-    "i8", "i16", "i32", "i64", "i128", "isize", "f32", "f64",
-    "String", "Vec", "Option", "Result", "Box", "Arc", "Rc",
-    "HashMap", "HashSet", "BTreeMap", "BTreeSet", "Cow",
-    "Pin", "Future", "Send", "Sync", "Sized", "Copy", "Clone",
-    "Debug", "Display", "Default", "Iterator", "IntoIterator",
-    "From", "Into", "TryFrom", "TryInto", "AsRef", "AsMut",
-    "Fn", "FnMut", "FnOnce", "Drop", "Deref", "DerefMut",
-    "Self", "self",
-})
-
-
 def _resolve_rust_type_refs(
     parsed: ParsedFile,
     ctx: ResolverContext,
@@ -181,6 +168,10 @@ def _resolve_rust_type_refs(
     if not parsed.type_refs:
         return 0
 
+    from .language_data import get_builtin_types
+    from .type_names import bare_type_name
+
+    rust_builtin_types = get_builtin_types("rust")
     from_path = parsed.file_info.path
     emitted = 0
 
@@ -193,10 +184,12 @@ def _resolve_rust_type_refs(
 
     for ref in parsed.type_refs:
         type_name = ref.type_name
-        if not type_name or type_name in _RUST_BUILTIN_TYPES:
+        if not type_name:
             continue
-        bare = type_name.rsplit("::", 1)[-1]
-        if bare in _RUST_BUILTIN_TYPES:
+        # Tested after reduction, so a path ending in a prelude type is caught
+        # as well as one written bare.
+        bare = bare_type_name(type_name)
+        if bare in rust_builtin_types:
             continue
 
         target = _find_rust_type_file(

--- a/tests/unit/test_no_bare_type_name_copies.py
+++ b/tests/unit/test_no_bare_type_name_copies.py
@@ -1,0 +1,219 @@
+"""No second answer to "what is this type's bare name".
+
+An architecture check rather than a behaviour one: it fails when a new
+qualifier-splitting expression appears in the modules that resolve type names,
+anywhere outside :mod:`repowise.core.ingestion.type_names`. The
+characterisation tables catch a *wrong* answer from an extractor that already
+exists; only this catches a second implementation appearing.
+
+These are expressions rather than named functions, so the match is on shape: a
+call to ``split`` / ``rsplit`` / ``partition`` / ``rpartition`` whose first
+argument is a separator a qualifier is spelled with, or a bracket that opens a
+type-argument group. That shape is also how a file extension or a URL is taken
+apart, which is why the scan is confined to the modules that resolve types —
+over the whole tree it would match hundreds of legitimate uses and mean nothing.
+
+Ceiling: string shape only. A copy that reaches for ``re``, splits on a
+separator held in a variable, or navigates the syntax tree instead of the text
+stays invisible — the per-language head extractors in ``parser_helpers.py`` are
+node walks and are deliberately out of reach. It catches the shape that
+actually recurred here.
+
+``_KNOWN`` holds the sites that stay, each with the reason it is exempt. It
+records a count rather than a bare path so a new copy cannot hide in a file
+that is already exempt, and a second test holds the counts exact so a converted
+site cannot leave a stale exemption behind.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+
+import pytest
+
+import repowise.core.ingestion.type_names as type_names
+
+# Splitting on one of these is how a qualifier is taken off a type name.
+_SEPARATORS = frozenset({".", "::", "\\"})
+
+# ...and these open a type-argument group or a constructor call, so cutting at
+# one is how the other half of the question was answered.
+_OPENERS = frozenset({"<", "[", "("})
+
+_SPLIT_METHODS = frozenset({"split", "rsplit", "partition", "rpartition"})
+
+_PACKAGES = pathlib.Path(__file__).resolve().parents[2] / "packages"
+_INGESTION = _PACKAGES / "core" / "src" / "repowise" / "core" / "ingestion"
+
+# Where the question gets asked. Everything here reduces a type name written in
+# source; nothing else in the tree is scanned.
+_SCOPE = (
+    _INGESTION / "extractors" / "heritage",
+    _INGESTION / "dynamic_hints",
+    _INGESTION / "framework_edges",
+    _INGESTION / "languages",
+    _INGESTION / "parser_helpers.py",
+    _INGESTION / "type_ref_resolution.py",
+    _INGESTION / "call_resolver.py",
+    _INGESTION / "heritage_resolver.py",
+)
+
+_PREFIX = "packages/core/src/repowise/core/ingestion/"
+
+# Sites that split on a separator but are not answering this question, or that
+# are and cannot be converted yet, with the reason each is exempt and how many
+# matches it is allowed. Shrink, never grow.
+_KNOWN: dict[str, int] = {
+    # Splits our own `path::Class::method` symbol IDs, which we mint. The
+    # separator is ours rather than the language's, so the shared helper would
+    # be answering about a type where these ask about an ID.
+    _PREFIX + "call_resolver.py": 3,
+    _PREFIX + "heritage_resolver.py": 1,
+    # Normalises the method name out of `#selector(Type.method)`. The last
+    # segment here is a member, not a type.
+    _PREFIX + "dynamic_hints/swift.py": 1,
+    # Splits an import statement's package path, not a type reference.
+    _PREFIX + "languages/jvm_same_package.py": 1,
+    # Split a route handler's path to reach a function name, and keep the
+    # prefix to resolve the package it came from. Neither wants a type.
+    _PREFIX + "framework_edges/rust.py": 1,
+    _PREFIX + "framework_edges/go.py": 1,
+    # Real copies, each held by a consumer no gate here measures: converting
+    # them moves framework edges, C++ symbol parent names and Go
+    # `method_implements` edges respectively. Removable once those are covered.
+    _PREFIX + "framework_edges/jakarta.py": 2,
+    _PREFIX + "framework_edges/micronaut.py": 2,
+    _PREFIX + "framework_edges/spring.py": 4,
+    _PREFIX + "framework_edges/laravel.py": 1,
+    _PREFIX + "parser_helpers.py": 1,
+    _PREFIX + "languages/go_interface_satisfaction.py": 1,
+}
+
+# Builtin-type lists are language identity data and belong on the spec beside
+# `builtin_calls` and `builtin_parents`, where every language can be compared
+# against every other. Matches on the name, so a set spelled differently is out
+# of reach.
+_SPECS = _INGESTION / "languages" / "specs"
+
+
+def _splits_on_a_qualifier(node: ast.AST) -> str | None:
+    """Describe *node* if it is a call that cuts a name at a qualifier."""
+    if not isinstance(node, ast.Call):
+        return None
+    if not isinstance(node.func, ast.Attribute) or node.func.attr not in _SPLIT_METHODS:
+        return None
+    if not node.args:
+        return None
+    first = node.args[0]
+    if not isinstance(first, ast.Constant) or not isinstance(first.value, str):
+        return None
+    if first.value not in _SEPARATORS | _OPENERS:
+        return None
+    return f"{node.func.attr}({first.value!r})"
+
+
+def _python_files() -> list[pathlib.Path]:
+    files: list[pathlib.Path] = []
+    for entry in _SCOPE:
+        files.extend(sorted(entry.rglob("*.py")) if entry.is_dir() else [entry])
+    return files
+
+
+def _offenders() -> dict[str, list[str]]:
+    """Map of repo-relative path -> the splitting expressions it holds."""
+    found: dict[str, list[str]] = {}
+    for path in _python_files():
+        rel = path.relative_to(_PACKAGES.parent).as_posix()
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        hits = [
+            f"line {node.lineno}: {described}"
+            for node in ast.walk(tree)
+            if (described := _splits_on_a_qualifier(node))
+        ]
+        if hits:
+            found[rel] = hits
+    return found
+
+
+def test_no_new_bare_type_name_expressions() -> None:
+    offenders = {p: hits for p, hits in _offenders().items() if len(hits) > _KNOWN.get(p, 0)}
+    assert not offenders, (
+        "New qualifier-splitting expression(s) outside"
+        " repowise.core.ingestion.type_names:\n"
+        + "\n".join(f"  {p}\n    " + "\n    ".join(hits) for p, hits in sorted(offenders.items()))
+        + "\n\nCall bare_type_name / strip_type_arguments / strip_call_arguments from"
+        " repowise.core.ingestion.type_names instead. If a site genuinely asks a"
+        " different question, say why in the code and add it to _KNOWN in this file."
+    )
+
+
+def test_known_copies_still_exist() -> None:
+    """Every allowlist count must be exact, so the list cannot rot."""
+    found = _offenders()
+    stale = {
+        path: (expected, len(found.get(path, [])))
+        for path, expected in _KNOWN.items()
+        if len(found.get(path, [])) != expected
+    }
+    assert not stale, (
+        "These no longer hold the number of matches _KNOWN allows"
+        " (path: allowed -> actual):\n"
+        + "\n".join(f"  {p}: {exp} -> {act}" for p, (exp, act) in sorted(stale.items()))
+    )
+
+
+def test_the_shape_is_what_gets_caught() -> None:
+    """A copy is caught; taking a path or an extension apart is not."""
+
+    def found(source: str) -> list[str]:
+        return [
+            described
+            for node in ast.walk(ast.parse(source))
+            if (described := _splits_on_a_qualifier(node))
+        ]
+
+    assert found('bare = raw.rsplit("::", 1)[-1]') == ["rsplit('::')"]
+    assert found('head = raw.split("<")[0]') == ["split('<')"]
+    assert found('ext = name.rsplit("/", 1)[-1]') == []
+    assert found("part = raw.split(sep)[0]") == []
+
+
+def test_builtin_type_lists_live_on_the_language_specs() -> None:
+    strays: dict[str, list[str]] = {}
+    for path in sorted(_PACKAGES.rglob("*.py")):
+        if _SPECS in path.parents:
+            continue
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except (SyntaxError, UnicodeDecodeError):  # not ours to police
+            continue
+        names: list[str] = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Assign):
+                names.extend(
+                    t.id
+                    for t in node.targets
+                    if isinstance(t, ast.Name) and t.id.endswith("BUILTIN_TYPES")
+                )
+            elif (
+                isinstance(node, ast.AnnAssign)
+                and isinstance(node.target, ast.Name)
+                and node.target.id.endswith("BUILTIN_TYPES")
+            ):
+                names.append(node.target.id)
+        if names:
+            strays[path.relative_to(_PACKAGES.parent).as_posix()] = sorted(names)
+    assert not strays, (
+        "Builtin-type list(s) outside ingestion/languages/specs/:\n"
+        + "\n".join(f"  {p}: {', '.join(n)}" for p, n in sorted(strays.items()))
+        + "\n\nPut them on that language's LanguageSpec.builtin_types and read them"
+        " back with get_builtin_types()."
+    )
+
+
+@pytest.mark.parametrize(
+    "name", ["bare_type_name", "strip_type_arguments", "strip_call_arguments"]
+)
+def test_shared_module_exports_the_replacements(name: str) -> None:
+    assert callable(getattr(type_names, name))


### PR DESCRIPTION
#1634 collapsed twenty implementations of "what is this type's bare name" into
one module. The characterisation tables it shipped catch a *wrong* answer from
an extractor that already exists. Nothing catches a twenty-first implementation
appearing, which is how the count reached twenty in the first place.

## A guard, matched on shape

These were expressions rather than named functions, so the check matches on
shape: a `split` / `rsplit` / `partition` / `rpartition` whose first argument is
a qualifier separator (`.` `::` `\`) or a type-argument bracket (`<` `[` `(`).

Over the whole tree that shape is also how a file extension or a URL is taken
apart, so it is confined to the modules that reduce a type name: the heritage
extractors, the dynamic-hint extractors, the language modules, the framework-edge
passes, `parser_helpers.py`, `type_ref_resolution.py`, `call_resolver.py` and
`heritage_resolver.py`.

`_KNOWN` holds the sites that stay, each with the reason it is exempt written
where it is exempted. Two details make it hard to rot:

- It records a **count per file**, not a bare path. Six of the ten scanned files
  with matches are exempt, including `parser_helpers.py`, which houses every
  per-language head extractor and is the likeliest home of the next copy. Keyed
  on path alone, a new copy there would ship green.
- A second test holds those counts **exact**, so a converted site cannot leave a
  stale exemption behind.

Four entries are real copies rather than different questions, each held by a
consumer this PR does not measure — converting them would move framework edges,
C++ symbol parent names, or Go `method_implements` edges. `framework_edges/`
is the notable one: `jakarta.py` and `micronaut.py` hold
`type_name.split("<")[0].rsplit(".", 1)[-1].strip()` character-identically, one
pipeline stage after the heritage extractors that produce their input, and that
truncation is wrong in the way `strip_type_arguments` documents — `Outer<a.b.C>`
takes its qualifier from inside the type-argument group. They are recorded so
the next copy fails, and left for the change that can prove their edges.

Ceiling: string shape only. A copy that reaches for `re`, splits on a separator
held in a variable, or navigates the syntax tree instead of the text stays
invisible. The six per-language head extractors in `parser_helpers.py` are node
walks and are deliberately out of reach; the docstring says so rather than
implying coverage it does not have.

## The seventh builtin list

#1634 moved six frozensets of "type names that never resolve to a repo-declared
symbol" onto `LanguageSpec.builtin_types` and said the lists live in the
registry. `_RUST_BUILTIN_TYPES` stayed behind in `type_ref_resolution.py`, so
that was not yet true.

It moves verbatim — the set is identical to its previous contents in both
directions — and is read back through `get_builtin_types("rust")`. The qualifier
split beside it becomes `bare_type_name`. The raw-name test it sat behind was
redundant once the reduction is a no-op on a plain identifier, which every name
in the set is, so one test remains.

A sibling check keeps builtin-type lists on the language specs, since a set
living outside them is exactly what had to be gone and retrieved here.

## Gates

- **Zero edges moved.** Heritage relations over a 22-repo corpus spanning java,
  kotlin, cpp, go, python, typescript, csharp, ruby, swift, php, scala and dart:
  every repo byte-identical, 9783 relations before and after.
- **The guard fails on a copy.** Verified against a deliberately-added splitting
  expression, and against one added *inside a file that is already exempt* —
  the case the count-keyed allowlist exists for. Verified likewise for a builtin
  list re-added outside the specs.
- **Set equality.** The Rust builtin set proved identical across the move, 55
  names each way, symmetric difference empty.
- `ruff check` clean on the changed files; `tests/unit/ingestion` plus both
  architecture checks pass.

## Known, not addressed here

`queries/rust.scm` declares no `@param.type` capture, so `parsed.type_refs` is
always empty for Rust and `_resolve_rust_type_refs` returns at its first guard.
The strategy is unreachable today, which is why the corpus cannot witness this
half and set equality is the evidence instead. Whether to wire the capture or
drop the strategy is its own change.
