### PR TITLE
fix(graph): emit inheritance for JavaScript classes

### DIFF
--- a/packages/core/src/repowise/core/ingestion/extractors/heritage/ts_js.py
+++ b/packages/core/src/repowise/core/ingestion/extractors/heritage/ts_js.py
@@ -27,15 +27,35 @@ def _type_clause(
             out.append(HeritageRelation(child_name=name, parent_name=parent, kind=kind, line=line))
 
 
+_CLAUSE_KINDS = {"extends_clause": "extends", "implements_clause": "implements"}
+
+# What a base may be spelled as when it sits directly under the heritage node.
+# `extends` takes any expression there, but only these two can name a class;
+# anything else is the grammar reading something it does not understand, which
+# is what a type annotation in a .js file looks like to it.
+_UNWRAPPED_BASE_TYPES = frozenset({"identifier", "member_expression"})
+
+
 def _class_heritage(
     heritage: Node, name: str, line: int, src: str, out: list[HeritageRelation]
 ) -> None:
     """``class Foo extends Bar implements IFoo, IBar``."""
-    for clause in heritage.children:
-        if clause.type == "extends_clause":
-            _type_clause(clause, name, line, src, "extends", "extends", out)
-        elif clause.type == "implements_clause":
-            _type_clause(clause, name, line, src, "implements", "implements", out)
+    clauses = [child for child in heritage.children if child.type in _CLAUSE_KINDS]
+    for clause in clauses:
+        kind = _CLAUSE_KINDS[clause.type]
+        _type_clause(clause, name, line, src, kind, kind, out)
+    if clauses:
+        return
+    # TypeScript's grammar wraps the base in a clause node; JavaScript's puts
+    # the keyword and the base directly under the heritage node.
+    for child in heritage.children:
+        if child.type not in _UNWRAPPED_BASE_TYPES:
+            continue
+        parent = bare_type_name(node_text(child, src))
+        if parent:
+            out.append(
+                HeritageRelation(child_name=name, parent_name=parent, kind="extends", line=line)
+            )
 
 
 def _extract_ts_js_heritage(

--- a/tests/unit/ingestion/test_heritage_type_names.py
+++ b/tests/unit/ingestion/test_heritage_type_names.py
@@ -11,9 +11,8 @@ to expose: type arguments survived into the parent name in six languages, a
 qualifier was emitted as a parent in its own right in three, and two dropped a
 qualified parent entirely.
 
-Two languages still produce no edge, and neither is a type-name defect. Pascal's
-grammar is not installed here. JavaScript's extractor looks for a clause node
-only TypeScript's grammar emits.
+Pascal still produces no edge, and that is not a type-name defect: its grammar
+is not installed here.
 """
 
 from __future__ import annotations
@@ -96,9 +95,9 @@ CASES: list[tuple[str, str, str, str, list[tuple[str, str]]]] = [
         "ns.Both<Arg>",
         [("Both", "extends")],
     ),
-    # --- javascript: a grammar-shape gap, not a type-name one --------------
-    ("javascript", "js", "class Child extends {p} {{}}\n", "Bare", []),
-    ("javascript", "js", "class Child extends {p} {{}}\n", "ns.Qual", []),
+    # --- javascript: no type arguments to mishandle -------------------------
+    ("javascript", "js", "class Child extends {p} {{}}\n", "Bare", [("Bare", "extends")]),
+    ("javascript", "js", "class Child extends {p} {{}}\n", "ns.Qual", [("Qual", "extends")]),
     # --- swift -------------------------------------------------------------
     ("swift", "swift", "class Child: {p} {{}}\n", "Bare", [("Bare", "extends")]),
     ("swift", "swift", "class Child: {p} {{}}\n", "Gen<Arg>", [("Gen", "extends")]),


### PR DESCRIPTION
`class Child extends Base {}` in a `.js` file produced **zero** heritage
relations. Not a wrong parent — none at all, for every JavaScript file, always.

## The cause

`_extract_ts_js_heritage` finds the `class_heritage` node, then looks for
`extends_clause` / `implements_clause` children of it. TypeScript's grammar
emits those wrappers. JavaScript's does not — it puts the keyword and the base
directly under `class_heritage`:

```
class_declaration
  class
  identifier            'Child'
  class_heritage
    extends
    identifier          'Base'
  class_body
```

So the inner loop matched nothing and returned. The spec's `heritage_node_types`
was already correct and the query captured the class correctly; the defect was
entirely the extractor's assumption about clause shape.

## The fix

The clause search is unchanged and gains a second shape rather than a language
test: where the heritage node holds no clause child, it *is* the clause. A
TypeScript tree always has the wrapper, so it cannot reach the new branch.

Only an `identifier` or a `member_expression` is accepted as an unwrapped base.
`extends` takes an arbitrary expression there, but nothing else in that position
can name a class — and a type annotation in a `.js` file is precisely what a
grammar that cannot read it turns into an expression. `extends
React.Component<any>` parses as a comparison whose right-hand side swallows the
class body, which is where every bad parent name in the first cut came from.

`svelte` and `vue` route to this same extractor, so they were checked rather
than assumed: both declare `shares_grammar_with="typescript"` and their
component scripts parse under the TypeScript grammar regardless of a `lang`
attribute, so they already took the clause path and do not move.

## Gates

**Strictly additive.** Heritage relations over a 22-repo corpus spanning java,
kotlin, cpp, go, python, typescript, csharp, ruby, swift, php, scala and dart:
every repo byte-identical. TypeScript in particular — zod and dub — unchanged,
which is the risk that mattered, since it shares the extractor.

Every moved row classified, across the JavaScript corpus:

| bucket | rows |
|---|---|
| ADDED | 1828 |
| everything else, including REMOVED | 0 |

Nothing was lost, renamed, collapsed or dropped anywhere.

| repo | before | after |
|---|---|---|
| preact | 214 | 670 |
| react (`extends` kind only) | 116 | 1480 |
| svelte | 274 | 282 |
| vue | 178 | 178 |
| vue-element-admin | 0 | 0 |

Two of those need saying plainly rather than being read off the table. react's
*total* goes 601 → 1965, but 439 `derive` + 33 `trait_impl` + 8 `trait_bound`
of that come from its Rust compiler crate; the JavaScript delta is the `extends`
row. And vue-element-admin genuinely has no class inheritance — zero
`class … extends` across its 90 `.js` and 131 `.vue` files — so 0 → 0 is the
right answer there, not a miss.

The svelte repo's `+8` are all `.js` files inside it (`SvelteDate extends Date`,
`SvelteMap extends Map`, `CustomButton extends HTMLButtonElement`). No `.svelte`
or `.vue` source moved, which is what makes them controls.

**Parent names.** All 1828 added parent names are identifiers. A 30-row sample
was read against the source line each came from and every one is a
`class X extends Y` whose `Y` is the correctly reduced base — including
`stream.Writable` → `Writable` and `React.PureComponent` → `PureComponent`.

Before the base-shape constraint, 9 of 1837 rows (0.5%, all in react) carried a
parent name spanning several lines. Those 9 are the entire difference the
constraint makes; no real parent was lost to it.

## Known divergence

`class X extends mixin(Base)` now yields no relation in JavaScript, where
TypeScript emits the string `mixin(Base)` as a parent today. That is the
conservative direction — no edge rather than one that can never resolve — and
it cost nothing measurable here: no call-expression parent appeared anywhere in
the corpus. Making TypeScript agree is a separate change, since it would move
TypeScript.
