### PR TITLE
fix(graph): capture C# generic method calls

### DIFF
--- a/packages/core/src/repowise/core/ingestion/queries/csharp.scm
+++ b/packages/core/src/repowise/core/ingestion/queries/csharp.scm
@@ -177,9 +177,16 @@
 ; Calls
 ; ---------------------------------------------------------------------------
 
-; Simple call: Method(args)
+; Simple call: Method(args) and Method<T>(args).
+; A type argument list wraps the name in a `generic_name`, so matching only
+; `(identifier)` drops every generic call. The capture sits inside each branch
+; so the target is the bare name either way — capturing the alternation itself
+; would name the target `Method<T>`, which no index holds.
 (invocation_expression
-  function: (identifier) @call.target
+  function: [
+    (identifier) @call.target
+    (generic_name (identifier) @call.target)
+  ]
   arguments: (argument_list) @call.arguments
 ) @call.site
 
@@ -190,14 +197,20 @@
 (invocation_expression
   function: (member_access_expression
     expression: [(identifier) "this"] @call.receiver
-    name: (identifier) @call.target
+    name: [
+      (identifier) @call.target
+      (generic_name (identifier) @call.target)
+    ]
   )
   arguments: (argument_list) @call.arguments
 ) @call.site
 
-; Constructor: new ClassName(args)
+; Constructor: new ClassName(args) and new ClassName<T>(args)
 (object_creation_expression
-  type: (identifier) @call.target
+  type: [
+    (identifier) @call.target
+    (generic_name (identifier) @call.target)
+  ]
   arguments: (argument_list) @call.arguments
 ) @call.site
 


### PR DESCRIPTION
A C# type argument list wraps the called name in a `generic_name` node. The
call patterns matched only `(identifier)` there, so every `Foo<T>()`,
`x.Foo<T>()` and `new Foo<T>()` matched no pattern and produced no `CallSite`
at all.

That is worse than an unresolved call. Recall is reported as resolved over
captured, so these sites were never in the denominator: they were absent from
the graph rather than counted as missed, and no resolution work could reach
them. Generic calls are ordinary in a DI-heavy C# codebase (`GetService<T>()`,
`Assert.IsType<T>()`), so the population is not small.

## Measured on Ocelot (754 `.cs` files)

| | before | after |
|---|---:|---:|
| call sites | 16,311 | 18,260 |
| resolved calls | 4,842 | 4,981 |
| graph edges | 22,049 | 22,161 |

1,949 call sites recovered and 139 resolved calls gained, with **zero resolved
calls lost**. Losslessness is checked as a sha256 over every
(file, caller, callee, confidence, line, origin) row sorted, not as a count,
so a strategy that started firing on a different site would show up. Origin
counts move only upward: `same_file` 3,042 to 3,085, `import_merged` 923 to
1,009, `global_unique` 402 to 409.

Counting the AST directly, 22,582 of Ocelot's invocation expressions exist and
1,440 of them were being dropped for this reason alone.

## Shape of the fix

The capture sits inside each alternation branch rather than on the alternation
node. Capturing the alternation would name the target `Foo<T>`, which no index
holds, so the call would be captured and then never resolve.

Plain calls are unaffected: an `(identifier)` callee still matches the first
branch exactly as before.

## Checks

- 2,155 ingestion unit tests pass, 1 skipped
- `ruff check .` clean
- resolved-call set diffed before and after on Ocelot: 0 lost, 139 gained
