### PR TITLE
test(graph): exempt two qualifier splits the guard does not govern

### DIFF
--- a/tests/unit/test_no_bare_type_name_copies.py
+++ b/tests/unit/test_no_bare_type_name_copies.py
@@ -71,9 +71,15 @@ _KNOWN: dict[str, int] = {
     # Splits our own `path::Class::method` symbol IDs, which we mint. The
     # separator is ours rather than the language's, so the shared helper would
     # be answering about a type where these ask about an ID. `models.py` holds
-    # the one both resolvers used to duplicate.
-    _PREFIX + "call_resolver.py": 2,
+    # the one both resolvers used to duplicate. `call_resolver.py`'s third is
+    # the tail of an import's module path — a module name, not a type.
+    _PREFIX + "call_resolver.py": 3,
     _PREFIX + "models.py": 1,
+    # Reads the head to decide whether taking a bare name is safe at all: a
+    # qualifier that is a type rather than a package must not be discarded.
+    # It guards the shared helper and then calls it, so it asks the opposite
+    # question.
+    _PREFIX + "languages/receiver_types.py": 1,
     # Normalises the method name out of `#selector(Type.method)`. The last
     # segment here is a member, not a type.
     _PREFIX + "dynamic_hints/swift.py": 1,


### PR DESCRIPTION
`test_no_bare_type_name_copies.py` fails on `main`. The guard counts every
qualifier-splitting expression in the type-resolving modules and fails when a
file holds more than its allowance, and receiver typing added two:

- `call_resolver.py:1021` takes the tail of an import's module path.
- `receiver_types.py:84` reads the head of a raw type to decide whether taking
  a bare name is safe at all.

Neither is a second answer to "what is this type's bare name", which is what
the guard exists to catch. The first wants a module name. The second is a
guard *for* the shared helper and calls it immediately afterwards, so
converting it would be circular.

Both are recorded as exemptions with their reason, in the form the file
already uses. No production code changes, so the two files receiver typing is
still being worked on are untouched here.

Verified: `tests/unit/test_no_bare_type_name_copies.py` 7 passed, and
`ruff check` clean on the changed file.