### PR TITLE
fix(graph): record Go interface embedding as inheritance

### DIFF
--- a/packages/core/src/repowise/core/ingestion/extractors/heritage/go.py
+++ b/packages/core/src/repowise/core/ingestion/extractors/heritage/go.py
@@ -46,16 +46,20 @@ def _extract_go_heritage(
 
     elif type_node.type == "interface_type":
         for child in type_node.children:
-            if child.type in ("{", "}", "\n"):
+            if child.type != "type_elem":
                 continue
-            if child.type in ("type_identifier", "qualified_type"):
-                bare = bare_type_name(node_text(child, src))
-                if bare:
-                    out.append(
-                        HeritageRelation(
-                            child_name=name,
-                            parent_name=bare,
-                            kind="extends",
-                            line=line,
-                        )
+            text = node_text(child, src).strip()
+            # A type set (`~int | string`) wears the same node as an embed but
+            # is a generic bound, carrying no methods to inherit.
+            if "|" in text or "~" in text:
+                continue
+            bare = bare_type_name(text)
+            if bare:
+                out.append(
+                    HeritageRelation(
+                        child_name=name,
+                        parent_name=bare,
+                        kind="extends",
+                        line=line,
                     )
+                )

--- a/tests/unit/ingestion/test_heritage_type_names.py
+++ b/tests/unit/ingestion/test_heritage_type_names.py
@@ -58,6 +58,23 @@ CASES: list[tuple[str, str, str, str, list[tuple[str, str]]]] = [
     ("go", "go", "type Child struct {{\n\t{p}\n}}\n", "Gen[Arg]", [("Gen", "mixin")]),
     ("go", "go", "type Child struct {{\n\t{p}\n}}\n", "ns.Qual", [("Qual", "mixin")]),
     ("go", "go", "type Child struct {{\n\t{p}\n}}\n", "ns.Both[Arg]", [("Both", "mixin")]),
+    # --- go: interface embedding -------------------------------------------
+    # The same relation through a different node — the grammar wraps each
+    # embed in a `type_elem`.
+    ("go", "go", "type Child interface {{\n\t{p}\n}}\n", "Bare", [("Bare", "extends")]),
+    ("go", "go", "type Child interface {{\n\t{p}\n}}\n", "Gen[Arg]", [("Gen", "extends")]),
+    ("go", "go", "type Child interface {{\n\t{p}\n}}\n", "ns.Qual", [("Qual", "extends")]),
+    ("go", "go", "type Child interface {{\n\t{p}\n}}\n", "ns.Both[Arg]", [("Both", "extends")]),
+    # A type set is a generic bound, not an embed: it carries no methods.
+    ("go", "go", "type Child interface {{\n\t{p}\n}}\n", "~int | string", []),
+    # ...and skipping one must not cost the embed sitting beside it.
+    (
+        "go",
+        "go",
+        "type Child interface {{\n\t~int | string\n\t{p}\n}}\n",
+        "Bare",
+        [("Bare", "extends")],
+    ),
     # --- rust --------------------------------------------------------------
     ("rust", "rs", "struct Child;\nimpl {p} for Child {{}}\n", "Bare", [("Bare", "trait_impl")]),
     (


### PR DESCRIPTION
A Go interface that embeds another produced no inheritance relation at all.
Not a wrong parent, none: `type ReadSeekCloser interface { io.Closer;
ReadSeeker }` yielded nothing, for every Go repository, always.

## Cause

The extractor looked for the embedded type as a direct child of
`interface_type`. The grammar wraps each one in a `type_elem`, so the branch
never matched and returned empty. Struct embedding was unaffected and is
where every Go heritage relation we have today comes from.

## The fix

Descend into the wrapper. A type set (`~int | string`) wears the same node
without carrying methods to inherit, so it is skipped.

The version-fallback shape the first draft carried was dropped after checking
the parser versions we actually pin: every one of them wraps, so the fallback
could not fire.

## Measured

Four Go repositories, chosen because they span the range of how much the
idiom is used: hugo (177 embeds), syft (14), tld (7), gitleaks (2).

Before, **0 of those 200 embeds reached parsed heritage**. After, 196 do. Of
the remaining four, two are `error`, which is filtered as a builtin parent
exactly as intended, and two are generic instantiations the extractor now
reduces to the bare parent name.

Resolved graph edges, before against after:

| repo | extends | imports | method_implements | lost |
|---|---|---|---|---|
| hugo | 246 -> 405 | identical | identical | 0 |
| syft | 68 -> 74 | identical | identical | 0 |
| tld | 20 -> 27 | identical | identical | 0 |
| gitleaks | 3 -> 3 | identical | identical | 0 |

**No repository loses an edge, and nothing outside `extends` moves.**
gitleaks gains nothing because both its embeds name types outside the
repository, which is the correct result rather than a miss.

Precision: 30 of the new edges sampled and hand checked, all correct, two
confirmed against the source. Classifying all 172 leaves 5 that are wrong,
so 167 of 172. All five are the same known shape, an embed whose package
qualifier is dropped before lookup so it can match a same named local type,
and all five land at the confidence we already reserve for a name guess.
That shape predates this change on struct embedding and is recorded
separately; fixing it needs the qualifier to survive into resolution, which
is a wider change than this one.

## Blast radius

`mixin` and `extends` already resolve to the same edge type, and `extends` is
already in the reachability set, so no vocabulary changes. The structural
interface satisfaction pass keeps its own parse and is untouched: it emits
concrete to interface edges while these are interface to interface, so the
two cannot collide.

The new edges give an embedded interface an incoming edge, which is the
conservative direction for dead code: it suppresses false findings on
interfaces that are used only by being embedded.

## Tests

Five rows added to the heritage characterisation table covering bare,
generic, qualified, generic and qualified, a type set on its own, and a type
set sitting beside a real embed. `tests/unit/ingestion` 2208 passed,
`ruff check` clean on both changed files.

Note that `main` currently fails `tests/unit/test_no_bare_type_name_copies.py`
for unrelated reasons. #1640 fixes that and should land first.