### PR TITLE
feat(graph): resolve a call on a field by typing it from its class

### DIFF
--- a/packages/core/src/repowise/core/ingestion/call_resolver.py
+++ b/packages/core/src/repowise/core/ingestion/call_resolver.py
@@ -35,6 +35,7 @@ from .languages.receiver_types import (
     RECEIVER_TYPE_LANGUAGES,
     Declaration,
     scan_declarations,
+    types_by_class,
     types_in_span,
 )
 from .models import (
@@ -72,6 +73,12 @@ class _LanguageCallStrategies:
 _NO_LANGUAGE_STRATEGIES = _LanguageCallStrategies()
 
 _TYPED_RECEIVER = ("_resolve_typed_receiver",)
+
+# Which symbols own a class scope, and which of them swallow one. A class span
+# contains every method body inside it, so both sets are needed to tell a field
+# from a local.
+_TYPE_KINDS = frozenset({"class", "struct", "interface", "enum", "trait", "impl"})
+_FUNCTION_KINDS = frozenset({"function", "method"})
 
 _JVM_STRATEGIES = _LanguageCallStrategies(
     free=("_resolve_jvm_same_package",),
@@ -188,7 +195,8 @@ class CallResolver:
         self._source_text: dict[str, str] = {}
         self._declarations: dict[str, tuple[Declaration, ...]] = {}
         self._symbol_spans: dict[str, dict[str, tuple[int, int]]] = {}
-        self._body_types: dict[tuple[str, str], dict[str, str]] = {}
+        self._body_types: dict[tuple[str, str], dict[str, str | None]] = {}
+        self._field_types: dict[str, dict[str, dict[str, str | None]]] = {}
         self._external_names: dict[str, frozenset[str]] = {}
         self._method_name_set: frozenset[str] | None = None
 
@@ -914,23 +922,18 @@ class CallResolver:
 
         return None
 
-    def _resolve_typed_receiver(
-        self,
-        file_path: str,
-        call: CallSite,
-        caller_id: str,
-    ) -> ResolvedCall | None:
-        """Resolve ``local.method()`` by typing the local from its declaration.
+    def _typed_receiver_language(self, file_path: str, call: CallSite) -> str | None:
+        """The language receiver typing may run in here, or None to decline.
 
-        Emits nothing unless the inferred type declares the method, which is
-        what makes a text scan safe: a mis-inference reaches no index and
-        yields no edge.
+        Shared by both typed strategies so the cheap refusals happen once and
+        in the same order: a receiver that names no local, a language with no
+        declaration shapes, and a method name no class in the repo declares.
         """
         receiver_name = call.receiver_name or ""
-        # Lowercase-initial only. A capitalised receiver already names a type
-        # and every tier above has tried it; an underscore one is a field,
-        # whose declaration is not in this body.
-        if not receiver_name[:1].islower() or receiver_name in ("self", "this"):
+        # A capitalised receiver already names a type and every tier above has
+        # tried it. An underscore one cannot be anything but a name.
+        head = receiver_name[:1]
+        if not (head.islower() or head == "_") or receiver_name in ("self", "this"):
             return None
 
         parsed = self._parsed_files.get(file_path)
@@ -938,16 +941,27 @@ class CallResolver:
         if language not in RECEIVER_TYPE_LANGUAGES:
             return None
 
-        # Scanning a body is the expensive half, so refuse before it rather
-        # than after. Nothing here can resolve unless some class declares a
-        # method of this name; the gate above only proves some *symbol* does,
-        # which a free function satisfies.
+        # Reading a file is the expensive half, so refuse before it rather than
+        # after. Nothing here can resolve unless some class declares a method of
+        # this name; the gate above only proves some *symbol* does, which a free
+        # function satisfies.
         if call.target_name not in self._method_names():
             return None
+        return language
 
-        type_name = self._declared_types_in(file_path, caller_id, language).get(receiver_name)
-        if type_name is None:
-            return None
+    def _typed_receiver_target(
+        self,
+        file_path: str,
+        call: CallSite,
+        caller_id: str,
+        type_name: str,
+    ) -> tuple[str, str] | None:
+        """The symbol ``type_name.method()`` names, and the scope that held it.
+
+        The scope is returned rather than an edge so that each caller stamps
+        its own origin literal, which is what keeps a field-typed edge separable
+        from a body-typed one after the build.
+        """
         key = (type_name, call.target_name)
 
         # An import statement binds the name outright, so it settles which type
@@ -955,9 +969,7 @@ class CallResolver:
         bound = self._import_names.get(file_path, {}).get(type_name)
         if bound is not None and not bound.startswith("external:"):
             sym_id = self._file_methods.get(bound, {}).get(key)
-            if sym_id is None:
-                return None
-            return ResolvedCall(caller_id, sym_id, 0.88, call.line, "receiver_typed_import")
+            return None if sym_id is None else (sym_id, "import")
 
         # Bound to something outside the repo and there is no edge to find,
         # however many local classes share the simple name. A compatibility
@@ -971,30 +983,87 @@ class CallResolver:
         # a repo that keeps near-duplicate implementations side by side.
         sym_id = self._file_methods.get(file_path, {}).get(key)
         if sym_id is not None:
-            return ResolvedCall(caller_id, sym_id, 0.93, call.line, "receiver_typed_same_file")
+            return sym_id, "same_file"
 
-        # Only the JVM registers both a member strategy and this fallback, so
+        # Only the JVM registers both a member strategy and these fallbacks, so
         # the scope that answers here is its same-package one. A second
         # language pairing the two needs an origin word of its own.
         typed_call = replace(call, receiver_name=type_name)
         for strategy in self._strategies_for(file_path).member:
             hit = getattr(self, strategy)(file_path, typed_call, caller_id)
             if hit is not None:
-                return ResolvedCall(
-                    caller_id,
-                    hit.callee_id,
-                    0.90,
-                    call.line,
-                    "receiver_typed_same_package",
-                )
+                return hit.callee_id, "same_package"
 
-        match = self._receiver_pair_match(file_path, key)
-        if match is None:
+        return self._receiver_pair_match(file_path, key)
+
+    def _resolve_typed_receiver(
+        self,
+        file_path: str,
+        call: CallSite,
+        caller_id: str,
+    ) -> ResolvedCall | None:
+        """Resolve ``x.method()`` by typing ``x`` from its declaration.
+
+        The declaration is in the calling body when ``x`` is a local or a
+        parameter, and at the enclosing class's own scope when it is a field —
+        the dependency-injection shape, held on a field and called throughout
+        the class.
+
+        Emits nothing unless the inferred type declares the method, which is
+        what makes a text scan safe: a mis-inference reaches no index and
+        yields no edge.
+        """
+        language = self._typed_receiver_language(file_path, call)
+        if language is None:
             return None
-        sym_id, tier = match
+
+        receiver_name = call.receiver_name or ""
+        # A local shadows a field, so the body answers first and its answer
+        # stands — including when that answer is "declared twice, no usable
+        # type". Only a name the body never mentions reaches class scope.
+        body_types = self._declared_types_in(file_path, caller_id, language)
+        from_field = receiver_name not in body_types
+        if from_field:
+            class_id = caller_id.rpartition("::")[0]
+            type_name = (
+                self._field_types_in(file_path, language).get(class_id, {}).get(receiver_name)
+            )
+        else:
+            type_name = body_types[receiver_name]
+        if type_name is None:
+            return None
+
+        found = self._typed_receiver_target(file_path, call, caller_id, type_name)
+        if found is None:
+            return None
+        sym_id, tier = found
+        if from_field:
+            return self._field_typed_call(caller_id, sym_id, tier, call.line)
+        return self._body_typed_call(caller_id, sym_id, tier, call.line)
+
+    def _body_typed_call(
+        self, caller_id: str, sym_id: str, tier: str, line: int
+    ) -> ResolvedCall:
+        """Stamp an edge whose receiver was typed from the calling body."""
+        if tier == "same_file":
+            return ResolvedCall(caller_id, sym_id, 0.93, line, "receiver_typed_same_file")
+        if tier == "same_package":
+            return ResolvedCall(caller_id, sym_id, 0.90, line, "receiver_typed_same_package")
         if tier == "import":
-            return ResolvedCall(caller_id, sym_id, 0.88, call.line, "receiver_typed_import")
-        return ResolvedCall(caller_id, sym_id, 0.75, call.line, "receiver_typed_global")
+            return ResolvedCall(caller_id, sym_id, 0.88, line, "receiver_typed_import")
+        return ResolvedCall(caller_id, sym_id, 0.75, line, "receiver_typed_global")
+
+    def _field_typed_call(
+        self, caller_id: str, sym_id: str, tier: str, line: int
+    ) -> ResolvedCall:
+        """Stamp an edge whose receiver was typed from the enclosing class."""
+        if tier == "same_file":
+            return ResolvedCall(caller_id, sym_id, 0.93, line, "receiver_field_same_file")
+        if tier == "same_package":
+            return ResolvedCall(caller_id, sym_id, 0.90, line, "receiver_field_same_package")
+        if tier == "import":
+            return ResolvedCall(caller_id, sym_id, 0.88, line, "receiver_field_import")
+        return ResolvedCall(caller_id, sym_id, 0.75, line, "receiver_field_global")
 
     def _method_names(self) -> frozenset[str]:
         """Every name declared as a method of some class, built once."""
@@ -1032,7 +1101,7 @@ class CallResolver:
         file_path: str,
         caller_id: str,
         language: str,
-    ) -> dict[str, str]:
+    ) -> dict[str, str | None]:
         """``{name: type}`` for the body of one function."""
         key = (file_path, caller_id)
         types = self._body_types.get(key)
@@ -1049,6 +1118,31 @@ class CallResolver:
             self._body_types.clear()
         self._body_types[key] = types
         return types
+
+    def _field_types_in(
+        self,
+        file_path: str,
+        language: str,
+    ) -> dict[str, dict[str, str | None]]:
+        """``{class_id: {name: type}}`` for the fields one file's classes declare."""
+        by_class = self._field_types.get(file_path)
+        if by_class is not None:
+            return by_class
+
+        parsed = self._parsed_files.get(file_path)
+        symbols = parsed.symbols if parsed else ()
+        class_spans = {
+            s.id: (s.start_line, s.end_line) for s in symbols if s.kind in _TYPE_KINDS
+        }
+        by_class = types_by_class(
+            self._declarations_for(file_path, language),
+            class_spans,
+            [(s.start_line, s.end_line) for s in symbols if s.kind in _FUNCTION_KINDS],
+        )
+        if len(self._field_types) >= _SOURCE_CACHE_FILES:
+            self._field_types.clear()
+        self._field_types[file_path] = by_class
+        return by_class
 
     def _declarations_for(self, file_path: str, language: str) -> tuple[Declaration, ...]:
         """Every declaration in one file, scanned once however many bodies ask."""

--- a/packages/core/src/repowise/core/ingestion/languages/receiver_types.py
+++ b/packages/core/src/repowise/core/ingestion/languages/receiver_types.py
@@ -1,9 +1,10 @@
-"""What type is the local a call is made on.
+"""What type is the receiver a call is made on.
 
 ``user.save()`` names no type, so member resolution has nothing to look up.
-The declaration that gives ``user`` its type is almost always inside the same
-function — a parameter, a local, a catch or loop binding — and the languages
-here write it as ``T name``.
+The declaration that gives ``user`` its type is either inside the same function
+— a parameter, a local, a catch or loop binding — or, when the receiver is a
+field, at the enclosing class's own scope. Both are written ``T name``, so one
+scan finds both and only the span they are read back over differs.
 
 The scan is allowed to be wrong. Nothing it returns becomes an edge until the
 resolver has checked that the type actually declares the method, so a
@@ -11,8 +12,8 @@ mis-inference costs a missing edge and never a wrong one. That check is what
 licenses matching declarations with a regex instead of a type checker.
 
 Split in two on purpose. ``scan_declarations`` reads a whole file once and is
-the expensive half; ``types_in_span`` narrows the result to one function body
-and is nearly free. Scanning per body instead would re-read every line that
+the expensive half; ``types_in_span`` and ``types_by_class`` narrow the result
+and are nearly free. Scanning per body instead would re-read every line that
 two spans share, and a class body contains all of its methods'.
 
 Adding a language means adding its shapes to ``_LANGUAGE_PATTERNS`` and
@@ -23,6 +24,7 @@ from __future__ import annotations
 
 import re
 from bisect import bisect_left, bisect_right
+from collections.abc import Iterable, Mapping
 from typing import NamedTuple
 
 from ..language_data import get_builtin_types
@@ -39,8 +41,12 @@ _TYPE = r"[A-Z]\w*(?:\.\w+)*(?:<(?:[^<>]|<[^<>]*>)*>)?(?:\[\])*"
 # list, or an enhanced-for colon. Requiring one of those is what keeps the
 # pattern off ``(Foo) bar`` and ``foo(Bar.BAZ, qux)``, which have no space in
 # the same place.
+# The closer is captured because it is the only thing separating a field from
+# a parameter at class scope — `T name;` against `T name,`. Some constructors
+# and static methods are extracted as no symbol at all, so their parameter
+# lists sit at class scope with nothing else to tell them apart.
 _TYPED_DECLARATION = re.compile(
-    rf"(?<![\w.])(?P<type>{_TYPE})\s+(?P<name>[a-z_]\w*)\s*(?=[=;,):])"
+    rf"(?<![\w.])(?P<type>{_TYPE})\s+(?P<name>[a-z_]\w*)\s*(?=(?P<closer>[=;,):]))"
 )
 
 _INFERRED_FROM_NEW = re.compile(
@@ -64,11 +70,21 @@ RECEIVER_TYPE_LANGUAGES = frozenset(_LANGUAGE_PATTERNS)
 
 
 class Declaration(NamedTuple):
-    """One name given one type, at one line."""
+    """One name given one type, at one line.
+
+    ``closer`` is the punctuation that ended the declaration, or empty where
+    the shape has none. Only class scope reads it.
+    """
 
     line: int
     name: str
     type_name: str
+    closer: str = ""
+
+
+# What can end a field. `var` has no place here at all: it is a local-only
+# shape in both languages, so it carries no closer and class scope drops it.
+_FIELD_CLOSERS = frozenset({";", "="})
 
 
 def _nests_in_a_builtin(raw: str, language: str) -> bool:
@@ -117,21 +133,39 @@ def scan_declarations(text: str, language: str) -> tuple[Declaration, ...]:
             if type_name is None:
                 continue
             found.append(
-                Declaration(bisect_right(starts, match.start()), match.group("name"), type_name)
+                Declaration(
+                    bisect_right(starts, match.start()),
+                    match.group("name"),
+                    type_name,
+                    match.groupdict().get("closer") or "",
+                )
             )
 
     found.sort()
     return tuple(found)
 
 
+def _record(types: dict[str, str | None], declaration: Declaration) -> None:
+    """Add one declaration to a scope, or mark the name unanswerable.
+
+    A name declared twice with two types maps to ``None`` rather than being
+    dropped. A caller has to tell "this scope says nothing about the name"
+    from "this scope says something unusable about it", because only the first
+    of those may fall through to a wider scope.
+    """
+    if declaration.name not in types:
+        types[declaration.name] = declaration.type_name
+    elif types[declaration.name] != declaration.type_name:
+        types[declaration.name] = None
+
+
 def types_in_span(
     declarations: tuple[Declaration, ...],
     start_line: int,
     end_line: int,
-) -> dict[str, str]:
+) -> dict[str, str | None]:
     """``{name: type}`` for the declarations inside one function body."""
-    types: dict[str, str] = {}
-    ambiguous: set[str] = set()
+    types: dict[str, str | None] = {}
 
     # Bisected rather than skipped over: a file's bodies each ask once, so
     # walking from the front every time is quadratic in a large file, and that
@@ -140,15 +174,52 @@ def types_in_span(
     for declaration in declarations[first:]:
         if declaration.line > end_line:
             break
-        if declaration.name in ambiguous:
-            continue
-        previous = types.get(declaration.name)
-        if previous is None:
-            types[declaration.name] = declaration.type_name
-        elif previous != declaration.type_name:
-            # One name declared twice with two types — a shadowing inner
-            # scope, or a line the scan misread. Neither has an answer.
-            del types[declaration.name]
-            ambiguous.add(declaration.name)
+        _record(types, declaration)
 
     return types
+
+
+def _merged(spans: Iterable[tuple[int, int]]) -> tuple[tuple[int, int], ...]:
+    """The spans as non-overlapping, ascending intervals."""
+    merged: list[list[int]] = []
+    for start, end in sorted(spans):
+        if merged and start <= merged[-1][1]:
+            merged[-1][1] = max(merged[-1][1], end)
+        else:
+            merged.append([start, end])
+    return tuple((start, end) for start, end in merged)
+
+
+def types_by_class(
+    declarations: tuple[Declaration, ...],
+    class_spans: Mapping[str, tuple[int, int]],
+    function_spans: Iterable[tuple[int, int]],
+) -> dict[str, dict[str, str | None]]:
+    """``{class_id: {name: type}}`` for the fields each class declares.
+
+    A class span contains every method body inside it, so a declaration is a
+    field only if it lies inside the class and inside none of the file's
+    functions. Nested classes go to the innermost class containing them, so an
+    inner class's fields never answer for the outer one.
+    """
+    if not class_spans:
+        return {}
+
+    bodies = _merged(function_spans)
+    body_starts = [start for start, _ in bodies]
+    # Innermost first, so the first containing span is the owner.
+    ordered = sorted(class_spans.items(), key=lambda item: item[1][1] - item[1][0])
+
+    by_class: dict[str, dict[str, str | None]] = {}
+    for declaration in declarations:
+        if declaration.closer not in _FIELD_CLOSERS:
+            continue
+        index = bisect_right(body_starts, declaration.line) - 1
+        if index >= 0 and declaration.line <= bodies[index][1]:
+            continue
+        for class_id, (start, end) in ordered:
+            if start <= declaration.line <= end:
+                _record(by_class.setdefault(class_id, {}), declaration)
+                break
+
+    return by_class

--- a/packages/core/src/repowise/core/ingestion/models.py
+++ b/packages/core/src/repowise/core/ingestion/models.py
@@ -356,6 +356,14 @@ ResolutionOrigin = Literal[
     "receiver_typed_same_package",  # 0.90 (JVM)
     "receiver_typed_import",  # 0.88
     "receiver_typed_global",  # 0.75
+    # The same four scopes again, for a receiver typed from the enclosing
+    # class's fields rather than from the calling body. Kept apart from the
+    # four above because they are a different scan over a different scope, and
+    # an origin that cannot separate them cannot be audited.
+    "receiver_field_same_file",  # 0.93
+    "receiver_field_same_package",  # 0.90 (JVM)
+    "receiver_field_import",  # 0.88
+    "receiver_field_global",  # 0.75
 ]
 
 RESOLUTION_ORIGIN_VALUES: frozenset[str] = frozenset(get_args(ResolutionOrigin))

--- a/tests/unit/ingestion/test_call_resolver_strategies.py
+++ b/tests/unit/ingestion/test_call_resolver_strategies.py
@@ -334,3 +334,85 @@ class TestLanguageDispatch:
             "same_package",
         ) in edges
         assert order == ["_resolve_go_same_package"]
+
+
+class TestFieldTypedReceiver:
+    """A receiver typed from the enclosing class rather than the calling body.
+
+    The ordering is the contract: a local of the same name shadows the field,
+    so the body's answer has to win outright.
+    """
+
+    def test_a_private_field_types_its_receiver(self, tmp_path: Path) -> None:
+        parsed = _parse_all(
+            tmp_path,
+            {
+                "Api.cs": (
+                    "csharp",
+                    "public class Api\n{\n"
+                    "    private readonly RouteFinder _finder;\n"
+                    "    public int Run() { return _finder.Find(); }\n"
+                    "}\n",
+                ),
+                "RouteFinder.cs": (
+                    "csharp",
+                    "public class RouteFinder\n{\n    public int Find() { return 1; }\n}\n",
+                ),
+            },
+        )
+        assert (
+            "Api.cs::Api::Run",
+            "RouteFinder.cs::RouteFinder::Find",
+            0.75,
+            "receiver_field_global",
+        ) in _edges(parsed, tmp_path)
+
+    def test_a_local_shadowing_a_field_wins(self, tmp_path: Path) -> None:
+        parsed = _parse_all(
+            tmp_path,
+            {
+                "Api.cs": (
+                    "csharp",
+                    "public class Api\n{\n"
+                    "    private readonly RouteFinder _thing;\n"
+                    "    public int Run() { OtherFinder _thing = Make(); return _thing.Find(); }\n"
+                    "}\n",
+                ),
+                "RouteFinder.cs": (
+                    "csharp",
+                    "public class RouteFinder\n{\n    public int Find() { return 1; }\n}\n",
+                ),
+                "OtherFinder.cs": (
+                    "csharp",
+                    "public class OtherFinder\n{\n    public int Find() { return 2; }\n}\n",
+                ),
+            },
+        )
+        edges = _edges(parsed, tmp_path)
+        assert (
+            "Api.cs::Api::Run",
+            "OtherFinder.cs::OtherFinder::Find",
+            0.75,
+            "receiver_typed_global",
+        ) in edges
+        assert not [e for e in edges if e[3].startswith("receiver_field_")]
+
+    def test_a_field_whose_type_lacks_the_method_yields_no_edge(self, tmp_path: Path) -> None:
+        """The validator is the whole safety argument for a text scan."""
+        parsed = _parse_all(
+            tmp_path,
+            {
+                "Api.cs": (
+                    "csharp",
+                    "public class Api\n{\n"
+                    "    private readonly RouteFinder _finder;\n"
+                    "    public int Run() { return _finder.Missing(); }\n"
+                    "}\n",
+                ),
+                "RouteFinder.cs": (
+                    "csharp",
+                    "public class RouteFinder\n{\n    public int Find() { return 1; }\n}\n",
+                ),
+            },
+        )
+        assert not [e for e in _edges(parsed, tmp_path) if e[3].startswith("receiver_field_")]

--- a/tests/unit/ingestion/test_receiver_types.py
+++ b/tests/unit/ingestion/test_receiver_types.py
@@ -11,13 +11,22 @@ import pytest
 from repowise.core.ingestion.languages.receiver_types import (
     RECEIVER_TYPE_LANGUAGES,
     scan_declarations,
+    types_by_class,
     types_in_span,
 )
 
 
-def declared_types(body: str, language: str) -> dict[str, str]:
+def declared_types(body: str, language: str) -> dict[str, str | None]:
     """The two halves composed over a whole body, which is what a caller sees."""
     return types_in_span(scan_declarations(body, language), 1, 10_000)
+
+
+def fields(source: str, language: str, methods: list[tuple[int, int]]) -> dict[str, str | None]:
+    """One class spanning the whole text, with *methods* as its bodies."""
+    lines = source.count("\n") + 1
+    return types_by_class(
+        scan_declarations(source, language), {"f.cs::C": (1, lines)}, methods
+    ).get("f.cs::C", {})
 
 
 class TestJavaShapes:
@@ -110,8 +119,15 @@ class TestRefusals:
         assert "item" not in declared_types(body, "java")
 
     def test_two_types_for_one_name_yields_neither(self) -> None:
-        body = "void run() { Reader source = a(); if (x) { Writer source = b(); } }"
-        assert "source" not in declared_types(body, "java")
+        """And the name stays in the scope, mapped to nothing.
+
+        A caller has to tell "this scope never mentions the name" from "this
+        scope mentions it and has no answer", because only the first may fall
+        through to a wider scope. Both types here are deliberately repo-shaped:
+        with builtins this case never reaches the conflict at all.
+        """
+        body = "void run() { CacheLoader source = a(); if (x) { NodeFactory source = b(); } }"
+        assert declared_types(body, "java") == {"source": None}
 
     def test_a_cast_is_not_a_declaration(self) -> None:
         assert declared_types("void run() { var n = (Node) raw; }", "java") == {}
@@ -125,6 +141,58 @@ class TestRefusals:
     def test_an_unregistered_language_yields_nothing(self) -> None:
         body = "func run(w *TimerWheel) { }"
         assert declared_types(body, "go") == {}
+
+
+class TestClassScope:
+    """What counts as a field, given that a class span contains every method.
+
+    The refusals are again the load-bearing half: a local read as a field
+    answers for every call in the class rather than for one body.
+    """
+
+    def test_a_private_field(self) -> None:
+        source = "class C {\nprivate readonly IRouteCreator _creator;\n}"
+        assert fields(source, "csharp", [])["_creator"] == "IRouteCreator"
+
+    def test_a_java_field_without_the_underscore_convention(self) -> None:
+        source = "class C {\nprivate final CacheLoader loader;\n}"
+        assert fields(source, "java", [])["loader"] == "CacheLoader"
+
+    def test_a_local_inside_a_method_is_not_a_field(self) -> None:
+        source = "class C {\nvoid run() {\nCacheLoader loader = a();\n}\n}"
+        assert fields(source, "java", [(2, 4)]) == {}
+
+    def test_a_parameter_at_class_scope_is_not_a_field(self) -> None:
+        """Some constructors and static methods are extracted as no symbol at
+        all, so their parameter lists sit at class scope with only the closing
+        punctuation to tell them apart from a field."""
+        source = "class C {\npublic C(ITestOutputHelper output, IRouteCreator maker) { }\n}"
+        assert fields(source, "csharp", []) == {}
+
+    def test_a_field_with_an_initialiser(self) -> None:
+        source = "class C {\nstatic final NodeFactory factory = build();\n}"
+        assert fields(source, "java", [])["factory"] == "NodeFactory"
+
+    def test_an_inner_class_field_answers_for_the_inner_class(self) -> None:
+        source = "class C {\nprivate CacheLoader outer;\nclass D {\nprivate NodeFactory inner;\n}\n}"
+        by_class = types_by_class(
+            scan_declarations(source, "java"),
+            {"f.java::C": (1, 6), "f.java::C::D": (3, 5)},
+            [],
+        )
+        assert by_class["f.java::C"] == {"outer": "CacheLoader"}
+        assert by_class["f.java::C::D"] == {"inner": "NodeFactory"}
+
+    def test_a_var_local_is_never_a_field(self) -> None:
+        source = "class C {\nvar maker = new RouteCreator();\n}"
+        assert fields(source, "csharp", []) == {}
+
+    def test_two_types_for_one_field_name_yields_neither(self) -> None:
+        source = "class C {\nprivate CacheLoader thing;\nprivate NodeFactory thing;\n}"
+        assert fields(source, "java", []) == {"thing": None}
+
+    def test_a_file_with_no_class_yields_nothing(self) -> None:
+        assert types_by_class(scan_declarations("int x;", "java"), {}, []) == {}
 
 
 def test_the_language_set_is_what_the_patterns_declare() -> None:


### PR DESCRIPTION
A receiver held on a field — injected once and called throughout the class —
names no type at the call site, and its declaration is not in the calling body,
so the existing body-scoped receiver typing never reached it. On a
dependency-injection-heavy C# tree that is 1,987 missed member calls; on
caffeine, 1,858.

## What changed

The declaration scan already found these. It matches `T name` closed by `;`
and its name pattern admits a leading underscore, so `private readonly IFoo
_foo;` was always in its output — only the span it was read back over was
wrong. This adds the span, not a scan, which is why the diff is small.

A declaration is a field when it lies inside the class and inside none of the
file's functions, innermost class winning so a nested class keeps its own.
Two rules that class scope needs and a body scope did not:

- Some constructors and static methods are extracted as no symbol at all, so
  their parameter lists sit at class scope and read as fields. A declaration
  now carries the punctuation that closed it, and class scope admits only
  `;` and `=` — a field, never a parameter.
- A local shadows a field, so the body answers first and its answer stands
  even when that answer is "declared twice, no usable type". Such a name now
  maps to `None` rather than being dropped, so a caller can tell a scope that
  says nothing from one that says something unusable.

Validation is unchanged and is still the whole safety argument: the inferred
type must declare the method before an edge is emitted, so a misread costs a
missing edge and never a wrong one.

Four resolution origins are added rather than reusing the body-typed four,
because an edge that cannot say which scope typed its receiver cannot be
audited afterwards.

## Numbers

Strictly additive by construction and by measurement — a sha256 row diff over
every (file, caller, callee, confidence, line, origin):

| repo | language | resolved calls | added | removed |
|---|---|---|---:|---:|
| Ocelot | c# | 5,266 → 6,232 | +966 | 0 |
| caffeine | java | 65,735 → 66,784 | +1,049 | 0 |
| eShopOnWeb | c# | 279 → 340 | +61 | 0 |
| CleanArchitecture | c# | 326 → 350 | +24 | 0 |
| spring-petclinic | java | 364 → 382 | +18 | 0 |
| gitleaks (go), zod (ts) | — | unchanged | byte-identical | 0 |

Against the population where an edge exists to be found at all — the receiver
is typed from a field *and* that type declares the method — the mechanism
takes 966/966 on Ocelot, 61/61 on eShopOnWeb, 18/18 on spring-petclinic,
1,061/1,097 on caffeine, 24/27 on CleanArchitecture.

The rest of the field population is out of reach of any type inference: the
declared type is not in the repo. `Mock` 503 sites on Ocelot,
`IServiceCollection` 66, `IRepository`, `ILogger`, `IMediator`,
`Long2ObjectMap` 228 on caffeine. Those callees are external and no
resolution strategy can reach them.

**Precision**, hand-audited against the real sources, 30 edges per language:
**29/30 on C#, 29/30 on Java**. The single failure in each is the same
pre-existing defect and not this change's: the method indexes are keyed
`(class, method)` with no parameter list, so a class declaring two same-named
methods yields whichever the index kept — `_logger.Dispose()` lands on
`Dispose(bool)`, and a five-argument `newNode(...)` lands on the
six-parameter overload. Filed separately; fixing it moves edges that resolve
today, on every repo, so it is its own measured change.

**Cost**, by isolated substitution in one process (production, then the same
build with class scope stubbed empty), because a before/after pair of full
builds is swamped by machine state:

| repo | build | added by this change |
|---|---:|---:|
| caffeine | 4.123s | +6.71% (0.259s) |
| Ocelot | 2.229s | +3.11% (0.067s) |
| eShopOnWeb | 0.690s | +2.53% |
| ktor, exposed (kotlin) | 10.8s, 10.0s | flat |

The field half is nearly free: reading and scanning a file once is already
paid for, and class scope is one more dict built per file over declarations
already in hand.

**Downstream**: node count identical on caffeine and Ocelot, only `calls`
moves, every other edge type unchanged. Ocelot's symbol centrality reorganises
— 340 → 484 symbols score at all, and the request pipeline
(`MultiplexingMiddleware::Invoke`, `DownstreamUrlCreatorMiddleware::Invoke`,
`DiscoveryDownstreamRouteFinder::Get`) enters the top 50 while test
scaffolding and benchmark fixtures leave. In a tree where production classes
talk to each other exclusively through injected fields, most of that graph did
not previously exist.

Change-risk scores cannot move: every feature in `analysis/change_risk/` is
git-derived and the package reads no graph, no edge and no centrality.

## Scope

Java and C# only, the two languages that register declaration shapes. Kotlin,
Go, Swift, Rust and C++ are untouched — their control repos are byte-identical
— and are not excluded; nothing has been measured for them. Adding a language
is still "add its shapes, add its registration, run the gates", and field
typing now comes with it.

Fields inherited from a base class in another file are a known ceiling and are
not resolved here. They need a cross-file scan of an ancestor's source and are
worth about four points of the remaining population.

Re-index required: edges change.

## Tests

`tests/unit/ingestion` 2,220 passed, 1 skipped. Nine new class-scope cases
weighted toward the refusals, since a refusal is what keeps a text scan safe,
and three resolver-level cases pinning the field path, the shadowing
precedence and the validator's refusal. One existing test was strengthened: it
meant to cover a name declared twice with two types, but both types were
builtins and were refused before the conflict was ever reached.
