### PR TITLE
feat(graph): resolve a python call by typing its receiver from the body

### DIFF
--- a/packages/core/src/repowise/core/ingestion/call_resolver.py
+++ b/packages/core/src/repowise/core/ingestion/call_resolver.py
@@ -32,6 +32,7 @@ from typing import Any
 import structlog
 
 from .languages.receiver_types import (
+    IMPLICIT_FIELD_LANGUAGES,
     RECEIVER_TYPE_LANGUAGES,
     Declaration,
     scan_declarations,
@@ -100,6 +101,7 @@ _LANGUAGE_CALL_STRATEGIES: dict[str, _LanguageCallStrategies] = {
     "java": replace(_JVM_STRATEGIES, member_fallback=_TYPED_RECEIVER),
     "kotlin": _JVM_STRATEGIES,
     "csharp": _LanguageCallStrategies(member_fallback=_TYPED_RECEIVER),
+    "python": _LanguageCallStrategies(member_fallback=_TYPED_RECEIVER),
     "cpp": _CPP_STRATEGIES,
     "c": _CPP_STRATEGIES,
 }
@@ -1022,14 +1024,15 @@ class CallResolver:
         # stands — including when that answer is "declared twice, no usable
         # type". Only a name the body never mentions reaches class scope.
         body_types = self._declared_types_in(file_path, caller_id, language)
-        from_field = receiver_name not in body_types
+        type_name = body_types.get(receiver_name)
+        from_field = (
+            receiver_name not in body_types and language in IMPLICIT_FIELD_LANGUAGES
+        )
         if from_field:
             class_id = caller_id.rpartition("::")[0]
             type_name = (
                 self._field_types_in(file_path, language).get(class_id, {}).get(receiver_name)
             )
-        else:
-            type_name = body_types[receiver_name]
         if type_name is None:
             return None
 

--- a/packages/core/src/repowise/core/ingestion/languages/receiver_types.py
+++ b/packages/core/src/repowise/core/ingestion/languages/receiver_types.py
@@ -56,17 +56,60 @@ _INFERRED_FROM_NEW = re.compile(
 # Truncating at ``//`` also truncates a URL inside a string literal. That can
 # only ever lose a declaration, never invent one, which is the safe direction.
 _LINE_COMMENT = re.compile(r"//.*")
+_HASH_COMMENT = re.compile(r"#.*")
+
+# Python writes its documentation as a string literal in the body, which a
+# comment strip does not reach. Prose is the one false-positive source the
+# C-family shape never had — ``context: The caller`` reads as an annotation —
+# so triple-quoted runs are blanked, keeping their newlines so line numbers
+# survive.
+_DOCSTRING = re.compile(r"(\"\"\"|''')(?:.|\n)*?\1")
 
 _NEWLINE = re.compile(r"\n")
+
+# Python annotates after the name, not before it: ``x: T``, ``def f(x: T)``.
+# The closer is what keeps the pattern off prose, and it is the reason a
+# generic annotation is refused rather than mis-read — ``x: Optional[T]`` is
+# followed by ``[``, so it matches nothing, which is right, since the value is
+# an Optional and not a T.
+_PY_TYPE = r"[A-Z]\w*(?:\.\w+)*"
+_PY_ANNOTATED = re.compile(
+    rf"(?<![\w.])(?P<name>[a-z_]\w*)\s*:\s*(?P<type>{_PY_TYPE})\s*(?=(?P<closer>[=,)\]\n]))"
+)
+
+# ``x = T(...)``, the only shape unannotated Python offers. Bare-named on
+# purpose: ``x = Foo.bar(...)`` is a call on a class rather than a
+# construction, and typing ``x`` as ``Foo`` from it would simply be wrong.
+# Anchored to the start of a statement because ``dispatch(logger=Emitter())``
+# is otherwise read as declaring ``logger``, which then answers for a
+# ``logger`` that came from somewhere else entirely. The C family is safe from
+# that shape only because its equivalent needs the ``var`` keyword.
+_PY_CONSTRUCTED = re.compile(
+    r"(?m)^[ \t]*(?P<name>[a-z_]\w*)\s*=\s*(?P<type>[A-Z]\w*)\s*\("
+)
 
 _C_FAMILY = (_TYPED_DECLARATION, _INFERRED_FROM_NEW)
 
 _LANGUAGE_PATTERNS: dict[str, tuple[re.Pattern[str], ...]] = {
     "csharp": _C_FAMILY,
     "java": _C_FAMILY,
+    "python": (_PY_ANNOTATED, _PY_CONSTRUCTED),
 }
 
 RECEIVER_TYPE_LANGUAGES = frozenset(_LANGUAGE_PATTERNS)
+
+# Languages where a field can be named with no qualifier, which is the only
+# thing that lets a class-scope declaration answer for a bare receiver. Python
+# writes ``self.foo.bar()``, whose receiver is dotted and which our grammar
+# queries mint no call site for at all — so class scope has nothing there to
+# answer, and consulting it could only bind a bare local name to a field.
+IMPLICIT_FIELD_LANGUAGES = frozenset({"csharp", "java"})
+
+_LANGUAGE_COMMENTS: dict[str, re.Pattern[str]] = {
+    "csharp": _LINE_COMMENT,
+    "java": _LINE_COMMENT,
+    "python": _HASH_COMMENT,
+}
 
 
 class Declaration(NamedTuple):
@@ -115,7 +158,12 @@ def scan_declarations(text: str, language: str) -> tuple[Declaration, ...]:
     if not patterns:
         return ()
 
-    cleaned = _LINE_COMMENT.sub("", text)
+    cleaned = text
+    if language == "python":
+        cleaned = _DOCSTRING.sub(lambda m: "\n" * m.group(0).count("\n"), cleaned)
+    comment = _LANGUAGE_COMMENTS.get(language)
+    if comment is not None:
+        cleaned = comment.sub("", cleaned)
     # Scanned by the regex engine rather than a Python loop over characters:
     # the loop costs more than the declaration scan it exists to serve.
     starts = [0, *(newline.end() for newline in _NEWLINE.finditer(cleaned))]

--- a/tests/unit/ingestion/test_call_resolver_strategies.py
+++ b/tests/unit/ingestion/test_call_resolver_strategies.py
@@ -416,3 +416,77 @@ class TestFieldTypedReceiver:
             },
         )
         assert not [e for e in _edges(parsed, tmp_path) if e[3].startswith("receiver_field_")]
+
+
+class TestPythonTypedReceiver:
+    """Python reaches the same strategy through its own declaration shapes."""
+
+    def test_a_constructed_local_types_its_receiver(self, tmp_path: Path) -> None:
+        parsed = _parse_all(
+            tmp_path,
+            {
+                "run.py": (
+                    "python",
+                    "def run():\n    graph = DependencyGraph()\n    graph.add_arc(1)\n",
+                ),
+                "graph.py": (
+                    "python",
+                    "class DependencyGraph:\n    def add_arc(self, obj):\n        return obj\n",
+                ),
+            },
+        )
+        assert (
+            "run.py::run",
+            "graph.py::DependencyGraph::add_arc",
+            0.75,
+            "receiver_typed_global",
+        ) in _edges(parsed, tmp_path)
+
+    def test_an_annotated_parameter_types_its_receiver(self, tmp_path: Path) -> None:
+        parsed = _parse_all(
+            tmp_path,
+            {
+                "run.py": (
+                    "python",
+                    "def run(graph: DependencyGraph):\n    graph.add_arc(1)\n",
+                ),
+                "graph.py": (
+                    "python",
+                    "class DependencyGraph:\n    def add_arc(self, obj):\n        return obj\n",
+                ),
+            },
+        )
+        assert (
+            "run.py::run",
+            "graph.py::DependencyGraph::add_arc",
+            0.75,
+            "receiver_typed_global",
+        ) in _edges(parsed, tmp_path)
+
+    def test_a_python_class_attribute_never_types_a_bare_receiver(
+        self, tmp_path: Path
+    ) -> None:
+        """A Python field is reached as ``self.graph``, never as ``graph``.
+
+        So a bare receiver naming a class attribute is a different name, and
+        binding the two would be a wrong edge rather than a missed one.
+        """
+        parsed = _parse_all(
+            tmp_path,
+            {
+                "api.py": (
+                    "python",
+                    "class Api:\n"
+                    "    graph: DependencyGraph\n"
+                    "    def run(self):\n"
+                    "        graph.add_arc(1)\n",
+                ),
+                "graph.py": (
+                    "python",
+                    "class DependencyGraph:\n    def add_arc(self, obj):\n        return obj\n",
+                ),
+            },
+        )
+        edges = _edges(parsed, tmp_path)
+        assert not [e for e in edges if str(e[3]).startswith("receiver_field_")]
+        assert not [e for e in edges if str(e[3]).startswith("receiver_typed_")]

--- a/tests/unit/ingestion/test_receiver_types.py
+++ b/tests/unit/ingestion/test_receiver_types.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import pytest
 
 from repowise.core.ingestion.languages.receiver_types import (
+    IMPLICIT_FIELD_LANGUAGES,
     RECEIVER_TYPE_LANGUAGES,
     scan_declarations,
     types_by_class,
@@ -97,6 +98,90 @@ class TestCsharpShapes:
     def test_pattern_match_binding(self) -> None:
         body = "public void Go() { if (thing is Placeholder p) { p.Name(); } }"
         assert declared_types(body, "csharp")["p"] == "Placeholder"
+
+
+class TestPythonShapes:
+    """Python annotates after the name and constructs without a keyword.
+
+    Neither shape is ``T name``, so nothing the C family matches applies here.
+    """
+
+    def test_annotated_parameter(self) -> None:
+        body = "def run(self, crawler: Crawler):\n    crawler.stop()"
+        assert declared_types(body, "python")["crawler"] == "Crawler"
+
+    def test_annotated_assignment(self) -> None:
+        body = "def run():\n    record: LogRecord = caplog.records[0]"
+        assert declared_types(body, "python")["record"] == "LogRecord"
+
+    def test_construction(self) -> None:
+        body = "def run():\n    graph = DependencyGraph()\n    graph.add_arc(x)"
+        assert declared_types(body, "python")["graph"] == "DependencyGraph"
+
+    def test_a_parameter_in_a_multi_line_signature(self) -> None:
+        body = "def run(\n    self,\n    jar: CookieJar,\n): ..."
+        assert declared_types(body, "python")["jar"] == "CookieJar"
+
+
+class TestPythonRefusals:
+    """Prose is the false-positive source the C-family shape never had."""
+
+    def test_a_docstring_is_not_a_declaration(self) -> None:
+        """``context: The caller`` reads as an annotation until docstrings go."""
+        body = '''def run():
+    """Do the thing.
+
+    Args:
+        context: Crawler that owns this run.
+    """
+    context.stop()'''
+        assert "context" not in declared_types(body, "python")
+
+    def test_a_hash_comment_is_not_a_declaration(self) -> None:
+        body = "def run():\n    # loader: SpiderLoader once lived here\n    pass"
+        assert declared_types(body, "python") == {}
+
+    def test_a_generic_annotation_is_refused(self) -> None:
+        """``x: Optional[Crawler]`` is an Optional, not a Crawler.
+
+        Unwrapping the payload would type ``x`` as something it provably is
+        not, and the validator would happily accept the result.
+        """
+        body = "def run(a: Optional[Crawler], b: list[Spider]):\n    a.stop()"
+        types = declared_types(body, "python")
+        assert "a" not in types
+        assert "b" not in types
+
+    def test_a_factory_call_is_not_a_construction(self) -> None:
+        """``x = Foo.bar()`` calls a class; it does not build a ``Foo``."""
+        body = "def run():\n    result = GroupResult.restore(id)\n    result.get()"
+        assert "result" not in declared_types(body, "python")
+
+    def test_a_keyword_argument_is_not_a_construction(self) -> None:
+        """``f(logger=Emitter())`` binds a parameter of ``f``, not a local.
+
+        Read as a declaration it answers for a ``logger`` that came from
+        somewhere else, which is a wrong edge rather than a missed one. The C
+        family never had this shape because its equivalent needs ``var``.
+        """
+        body = "def run():\n    logger = get_logger()\n    dispatch(logger=Emitter())"
+        assert declared_types(body, "python") == {}
+
+    def test_a_lowercase_callee_is_not_a_construction(self) -> None:
+        body = "def run():\n    spider = build_spider()\n    spider.crawl()"
+        assert declared_types(body, "python") == {}
+
+    def test_two_types_for_one_name_yields_neither(self) -> None:
+        body = "def run():\n    thing = Crawler()\n    thing = SpiderLoader()"
+        assert declared_types(body, "python") == {"thing": None}
+
+    def test_python_never_reaches_class_scope(self) -> None:
+        """A Python field is written ``self.foo``, so no bare receiver names one.
+
+        The declaration is still found — it is the resolver that declines to
+        ask class scope for a language whose fields are always qualified.
+        """
+        assert "python" not in IMPLICIT_FIELD_LANGUAGES
 
 
 class TestRefusals:
@@ -197,9 +282,9 @@ class TestClassScope:
 
 def test_the_language_set_is_what_the_patterns_declare() -> None:
     """Excluding a language means removing its shapes, not gating a caller."""
-    assert set(RECEIVER_TYPE_LANGUAGES) == {"csharp", "java"}
+    assert set(RECEIVER_TYPE_LANGUAGES) == {"csharp", "java", "python"}
 
 
-@pytest.mark.parametrize("language", ["java", "csharp"])
+@pytest.mark.parametrize("language", ["java", "csharp", "python"])
 def test_an_empty_body_is_not_an_error(language: str) -> None:
     assert declared_types("", language) == {}


### PR DESCRIPTION
Python calls on a local or a parameter did not resolve. `user.save()` names no
type, so member resolution had nothing to look up, and the receiver-type scan
that already serves Java and C# matches `T name` — a shape Python never writes.
The language registered no declaration patterns at all.

## What changed

Two Python shapes are now recognised inside the calling function's body:

- **annotated** — `x: T`, including `def f(x: T)` and `x: T = ...`
- **constructed** — `x = T(...)`, the only shape unannotated code offers

The safety argument is unchanged and is what licenses a regex here: **the
inferred type must declare the method before an edge is emitted**, so a
mis-inference costs a missing edge and never a wrong one.

The strategy is dispatched from the `member_fallback` slot, which runs after
every pre-existing tier, so it only ever sees a call nothing else claimed.

## Results

Zero edges removed on every repo, by sha256 row diff over
`(file, caller, callee, confidence, line, origin)` — not by count.

| repo | resolved calls | added | removed |
|---|---|---:|---:|
| django | 44,585 → 45,997 | +1,412 | 0 |
| celery | 7,769 → 8,363 | +594 | 0 |
| scrapy | 6,542 → 7,038 | +490 | 0 |
| flask | 461 → 485 | +24 | 0 |
| caffeine (java), Ocelot (c#), gitleaks (go) | unchanged | byte-identical | 0 |
| zod, hono (ts), preact (js), sinatra (rb) | unchanged | byte-identical | 0 |

The seven repos in unregistered languages returning byte-identical output is the
free check that the language gate holds.

Node counts are pinned identical on all three measured repos and only `calls`
moves. Centrality reorganises toward production code: `Crawler::crawl`,
`URLResolver::resolve`, `CsrfViewMiddleware::process_view` and
`Query::build_where` enter the top 50; test helpers such as `get_raw_crawler`
and `make_mw` leave.

## Precision

90 edges hand-audited across three samples, **all correct**. The third sample
targets the annotated shape alone, because it is 147 of 2,502 added edges and a
random sample would carry one or two rows of it — the two shapes are separately
removable, so each earned its own verdict.

Three existing precision rules were carried over unchanged and each held in a
language with no packages and a very different import model: refuse a member
type of a builtin, check the caller's own file before the package, refuse a name
an import binds outside the repo.

One rule was added. `dispatch(logger=Emitter())` was read as declaring `logger`,
which then answered for a `logger` that came from somewhere else — a wrong edge,
and one the C-family shape never risked because its equivalent needs the `var`
keyword. Construction is now anchored to the start of a statement. That fix
changed **zero edges corpus-wide**, verified by sha256, so the audited build and
the shipped build are the same build.

Prose is the other false-positive source the C-family shape never had: a
docstring writes `context: The caller`, which reads as an annotation. Comments
and triple-quoted runs are blanked before scanning, and a generic annotation is
refused rather than unwrapped — `x: Optional[T]` names an `Optional`, not a `T`.

## Deliberate limits

- **Class scope is gated off for Python.** A Python field is reached as
  `self.foo`, so a bare receiver can never name one; asking class scope could
  only bind a local to a field it does not name. Separately, `python.scm`
  captures a receiver only when it is a bare identifier, so `self._foo.bar()`
  produces no call site at all today — 11–14% of invocations across the Python
  corpus. That is a capture gap, not a resolution one.
- **TypeScript, JavaScript and Ruby ship nothing**, each excluded on a measured
  size gate rather than an assumption. The reachable population is 0.56% of
  method-local misses on zod, 0.30% on hono, 0.18% on sinatra and 0% on preact,
  against 10.9–20.2% across the Python repos. zod's most common unresolved
  receiver is a module namespace at 4,287 sites, whose type no declaration
  describes; that needs return-type resolution, which is a different mechanism.
  Ruby has no type-annotation syntax in any form.

## Cost, stated both ways

The scan is not slow — 0.26s over all 3.52 MB of celery's Python, against 0.27s
over 5.3 MB of caffeine's Java. But celery's graph build is 0.163s while its
parse is 2.67s, so the same absolute cost reads very differently by denominator:

| repo | cost | of graph build | of parse + build |
|---|---:|---:|---:|
| django | 1.660s | +52.5% | +9.1% |
| celery | 0.278s | +170.9% | +9.8% |
| scrapy | 0.214s | +163.0% | +10.9% |
| flask | 0.045s | +129.5% | +9.1% |

**This exceeds the 15% graph-build budget the earlier receiver-typing work was
measured against, and that is the open question on this PR.** Against parse plus
graph build the figure is 8.5–10.9% on every repo in the corpus, including the
Java and C# repos already carrying this mechanism. A single-pass scan was
measured at 43% cheaper and declined, because it changes no verdict and costs
the module its per-language clarity.

Measured with one untimed warmup build first and the minimum of three timed
runs in a single process, since machine state otherwise swamps the effect.

## Follow-ups found, not fixed

Each changes edges that resolve today, so each is its own measured change:

1. A re-exported import makes an import binding name the wrong file.
   `from django.template import Engine` binds to `django/template/__init__.py`,
   which re-exports `Engine` and declares no method of it, so the pair lookup
   refuses. Counted exactly: django 929 sites, scrapy 82, celery 8, flask 5.
   **This is the whole of the recall shortfall on django** — measured against
   the population the precision rules permit, the mechanism takes 95–100%.
2. An aliased external import escapes the external-name refusal, because the
   binding carries the exported name and the local alias is never consulted.
   The fix only tightens a refusal, but it moves existing Java and C# edges.
3. A class defined inside a function leaks its annotations into that function's
   scope. Not Python-specific — an anonymous inner class in a Java or C# method
   body is the same shape.

## Tests

`tests/unit/ingestion`: 2,236 passed, 1 skipped. 13 new cases in
`test_receiver_types.py`, nine of them refusals, plus 3 resolver-level cases
pinning both shapes and the class-scope gate. `ruff check` clean. mypy shows the
same 5 pre-existing errors in `call_resolver.py`, all outside this diff.

Re-index required: edges change.
