### PR TITLE
fix(pipeline): report a failed framework pass instead of swallowing it

### DIFF
--- a/packages/cli/src/repowise/cli/commands/dead_code_cmd.py
+++ b/packages/cli/src/repowise/cli/commands/dead_code_cmd.py
@@ -183,8 +183,14 @@ def dead_code_command(
 
         tech_items = detect_tech_stack(repo_path)
         graph_builder.add_framework_edges([item.name for item in tech_items])
-    except Exception:
-        pass
+    except Exception as fw_exc:
+        # Silence here is the worst of the three sites: the comment above says
+        # these edges exist to stop false positives, so a swallowed failure
+        # hands the user a longer report and calls it the answer.
+        notices.print(
+            f"[yellow]Framework edge detection skipped: {fw_exc}; "
+            "convention-loaded files may report as unreachable.[/yellow]"
+        )
 
     # Git metadata (best effort)
     git_meta_map: dict = {}

--- a/packages/core/src/repowise/core/pipeline/incremental.py
+++ b/packages/core/src/repowise/core/pipeline/incremental.py
@@ -178,6 +178,9 @@ def build_repo_graph(
         log(f"[yellow]Skipped {skipped} file(s) that failed to parse.[/yellow]")
 
     # Add framework-aware synthetic edges (conftest, Django, FastAPI, Flask).
+    # Best-effort, but not silent: the update path has to report the failure the
+    # init path reports, or an index degrades differently depending on how it
+    # was built and nothing says which.
     try:
         from repowise.core.generation.editor_files.tech_stack import detect_tech_stack
 
@@ -185,8 +188,12 @@ def build_repo_graph(
         fw_count = graph_builder.add_framework_edges([item.name for item in tech_items])
         if fw_count:
             log(f"Framework edges added: [cyan]{fw_count}[/cyan]")
-    except Exception:
-        pass  # framework edge detection is best-effort
+    except Exception as fw_exc:
+        logger.warning("framework_edges_failed", error=str(fw_exc))
+        log(
+            f"[yellow]Framework edge detection skipped: {fw_exc}; framework-invoked "
+            "symbols will have no callers in the graph and may read as dead.[/yellow]"
+        )
 
     # Add dynamic-hint edges, mirroring the init pipeline's ingestion phase.
     # Without this the update-built graph was missing every dynamic edge the

--- a/packages/core/src/repowise/core/pipeline/phases/ingestion.py
+++ b/packages/core/src/repowise/core/pipeline/phases/ingestion.py
@@ -609,15 +609,34 @@ async def _run_ingestion(
         )
     await asyncio.to_thread(graph_builder.build, progress)
 
-    # Add framework-aware synthetic edges (conftest, Django, FastAPI, Flask)
+    # Add framework-aware synthetic edges (conftest, Django, FastAPI, Flask).
+    # Two failures with two different costs, reported separately rather than as
+    # one silent pass: the stack also feeds the persisted tech list and the
+    # editor files, so losing it costs more than losing the edges. Keeping the
+    # edge call outside its try is deliberate — the handlers that read no stack
+    # (conftest, gtest, Flutter, Android) still run when detection failed.
     tech_items: list = []
     try:
         from repowise.core.generation.editor_files.tech_stack import detect_tech_stack
 
         tech_items = detect_tech_stack(repo_path)
+    except Exception as tech_exc:
+        logger.warning("tech_stack_detection_failed", error=str(tech_exc))
+        emit_warning(
+            progress,
+            f"Tech stack detection skipped ({tech_exc}); the repo's frameworks will be "
+            "missing from the index, along with every edge that depends on them.",
+        )
+
+    try:
         graph_builder.add_framework_edges([item.name for item in tech_items])
-    except Exception:
-        pass  # framework edge detection is best-effort
+    except Exception as fw_exc:
+        logger.warning("framework_edges_failed", error=str(fw_exc))
+        emit_warning(
+            progress,
+            f"Framework edge detection skipped ({fw_exc}); framework-invoked "
+            "symbols will have no callers in the graph and may read as dead.",
+        )
 
     # ---- Dynamic hints wiring (after static graph is fully built) ----------
     if progress:
@@ -827,7 +846,12 @@ async def reparse_for_resume(
         from repowise.core.generation.editor_files.tech_stack import detect_tech_stack
 
         tech_items = detect_tech_stack(repo_path)
-    except Exception:
-        pass
+    except Exception as tech_exc:
+        logger.warning("tech_stack_detection_failed", error=str(tech_exc))
+        emit_warning(
+            progress,
+            f"Tech stack detection skipped ({tech_exc}); the repo's frameworks will be "
+            "missing from the index.",
+        )
 
     return parsed_files, file_infos, repo_structure, source_map, tech_items

--- a/tests/unit/pipeline/test_framework_edge_failure_visible.py
+++ b/tests/unit/pipeline/test_framework_edge_failure_visible.py
@@ -1,0 +1,124 @@
+"""A framework pass that fails must say what it cost, not pass silently.
+
+Both halves of the pass used to sit under one bare ``except Exception: pass``.
+There are 22 framework handlers behind it, so every convention-wired edge in
+the repo could vanish leaving a log-clean run and an index that looks
+complete, and a framework-invoked symbol with no caller reads as dead. The
+two halves also fail differently: losing the tech stack loses the recorded
+frameworks as well as the edges, so each reports its own cost.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from repowise.core.pipeline.phases.ingestion import _run_ingestion
+
+
+class _RecordingProgress:
+    """Only the channel a default CLI run renders. See ``emit_warning``."""
+
+    def __init__(self) -> None:
+        self.messages: list[tuple[str, str]] = []
+
+    def on_message(self, level: str, text: str) -> None:
+        self.messages.append((level, text))
+
+    def __getattr__(self, _name: str):
+        return lambda *a, **k: None
+
+    def warnings(self) -> list[str]:
+        return [text for level, text in self.messages if level == "warning"]
+
+
+def _capture_warnings(monkeypatch) -> list[tuple[str, dict]]:
+    """Collect the module logger's warning events and their fields.
+
+    ``caplog`` sees nothing here: the structlog filtering bound logger drops
+    the record before stdlib logging is reached, which is the same reason
+    ``emit_warning`` exists at all. The fields are kept because an event name
+    with no ``error=`` is a log nobody can act on.
+    """
+    from repowise.core.pipeline.phases import ingestion as module
+
+    events: list[tuple[str, dict]] = []
+
+    class _Recorder:
+        def warning(self, event: str, **kw) -> None:
+            events.append((event, kw))
+
+        def __getattr__(self, _name: str):
+            return lambda *a, **k: None
+
+    monkeypatch.setattr(module, "logger", _Recorder())
+    return events
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    (tmp_path / "app.py").write_text("def handler():\n    return 1\n", encoding="utf-8")
+    return tmp_path
+
+
+async def _ingest(repo: Path, progress: _RecordingProgress):
+    return await _run_ingestion(
+        repo,
+        exclude_patterns=None,
+        skip_tests=False,
+        skip_infra=False,
+        progress=progress,
+    )
+
+
+async def test_tech_stack_failure_is_logged_and_surfaced(repo, monkeypatch):
+    from repowise.core.generation.editor_files import tech_stack
+
+    def _boom(*_a, **_k):
+        raise RuntimeError("stack probe exploded")
+
+    monkeypatch.setattr(tech_stack, "detect_tech_stack", _boom)
+
+    progress = _RecordingProgress()
+    events = _capture_warnings(monkeypatch)
+    result = await _ingest(repo, progress)
+
+    # Best-effort stays best-effort: the build completes and still parsed the
+    # file, and the tech list downstream consumers read is empty, not unbound.
+    parsed_files, _infos, _structure, _sources, _builder, _stats, tech_items = result
+    assert len(parsed_files) == 1
+    assert tech_items == []
+    assert ("tech_stack_detection_failed", {"error": "stack probe exploded"}) in events
+    assert any("Tech stack detection skipped" in w for w in progress.warnings())
+
+
+async def test_framework_edge_failure_is_logged_and_surfaced(repo, monkeypatch):
+    # Patch the mixin that declares the method, not the class that inherits it,
+    # so teardown does not leave a same-valued shadow behind on GraphBuilder.
+    from repowise.core.ingestion.graph._edges import EdgesMixin
+
+    def _boom(*_a, **_k):
+        raise RuntimeError("handler exploded")
+
+    monkeypatch.setattr(EdgesMixin, "add_framework_edges", _boom)
+
+    progress = _RecordingProgress()
+    events = _capture_warnings(monkeypatch)
+    result = await _ingest(repo, progress)
+
+    assert len(result[0]) == 1
+    assert ("framework_edges_failed", {"error": "handler exploded"}) in events
+    assert any("Framework edge detection skipped" in w for w in progress.warnings())
+
+
+async def test_a_healthy_run_adds_no_framework_warning(repo):
+    progress = _RecordingProgress()
+    result = await _ingest(repo, progress)
+
+    assert result is not None
+    assert not [
+        w
+        for w in progress.warnings()
+        if "Tech stack detection skipped" in w or "Framework edge detection skipped" in w
+    ]


### PR DESCRIPTION
The framework-edge pass sat under a bare `except Exception: pass`. There are 22 handlers behind it, so every convention-wired edge in a repo could vanish with no log, no user-visible warning, and an index that looks complete. A framework-invoked symbol with no caller then reads as dead code.

The dynamic-hints block twelve lines below already handles a best-effort pass properly — `logger.warning` plus `emit_warning` naming what will be missing — so this mirrors it rather than inventing a second shape. `emit_warning`'s own docstring mandates that pairing: the structured log carries the machine-readable fields, and `on_message` is the only channel a default CLI run actually renders.

## Split into two halves

The `try` also covered `detect_tech_stack`, whose result feeds the persisted tech stack and the editor files, not only the framework edges. Two failures with two different costs, so each reports its own.

Keeping `add_framework_edges` outside the detection `try` is a deliberate behaviour change on the failure path: the handlers that read no stack — conftest, gtest, Flutter, Android — used to go down with detection and now survive it.

## Three instances, not one

The same swallow appeared three times. All three now report on the channel their caller already uses:

- `pipeline/phases/ingestion.py` — the init path, and the resume prefix in the same file.
- `pipeline/incremental.py:180` — the update path. Left alone, an index would degrade differently depending on how it was built, with nothing saying which.
- `commands/dead_code_cmd.py:181` — the worst of the three. The comment directly above it says those edges exist to stop dead-code false positives, so a silent failure hands the user a longer report and calls it the answer.

Two further silent swallows in the ingestion phase (`_read_one`, `reparse_for_resume`'s traversal) are per-file and high-volume, so `emit_warning` is the wrong instrument for them; left alone.

Best-effort stays best-effort: every failure is now visible, none is fatal.

## Tests

Three cases against a real `_run_ingestion`, forcing each half to raise and asserting the structured event *with its `error=` field*, the user-visible progress message, and that the build still completes with the file parsed and `tech_items` bound to `[]` rather than unbound. A healthy-path case asserts no new warning.

Confirmed quiet on three real repos — flask, gitleaks and eShopOnWeb — zero framework or tech-stack warnings on a normal run.
