### PR TITLE
fix(dead-code): keep only genuinely narrow scopes in the uncalled-symbol pool

### DIFF
--- a/docs/reference/COMPUTED_GLOSSARY.md
+++ b/docs/reference/COMPUTED_GLOSSARY.md
@@ -190,7 +190,7 @@ workspace overlays, MCP responses, and CLI output.
 | Dead-code finding | A graph/git finding persisted to `dead_code_findings`. | `DeadCodeAnalyzer` | `{kind: "unused_export", file_path: "src/api.py", confidence: 0.7}` |
 | Unreachable file | File with no incoming imports, not an entry point/test/config/contract/whitelisted file. | `_detect_unreachable_files()` | `src/legacy_adapter.py` |
 | Unused export | Public symbol in an imported file that no importer names. | `_detect_unused_exports()` | `symbol_name: "OldClient"` |
-| Unused internal | Private/internal symbol with no incoming `calls` edges. | `_detect_unused_internals()` | `_parse_legacy_token` |
+| Unused internal | Private symbol with no incoming `calls` edges. | `_detect_unused_internals()` | `_parse_legacy_token` |
 | Zombie package | Monorepo top-level package with no external package importers. | `_detect_zombie_packages()` | `packages/old-sdk` |
 | Dead-code confidence | Heuristic certainty based on age, recent commits, importers, dynamic imports, and deprecation hints. | `DeadCodeAnalyzer` | `1.0` for year-old unreachable file |
 | Safe-to-delete flag | Whether confidence passes delete threshold and dynamic patterns do not block deletion. | `_make_unreachable_finding()` and other passes | `safe_to_delete: true` |

--- a/packages/cli/src/repowise/cli/commands/dead_code_cmd.py
+++ b/packages/cli/src/repowise/cli/commands/dead_code_cmd.py
@@ -46,7 +46,7 @@ from repowise.core.analysis.dead_code.risk_factors import RISK_CAP_CONFIDENCE
 @click.option(
     "--include-internals/--no-include-internals",
     default=False,
-    help="Detect unused private/internal symbols (higher false-positive rate, off by default).",
+    help="Detect unused private symbols (higher false-positive rate, off by default).",
 )
 @click.option(
     "--include-zombie-packages/--no-include-zombie-packages",

--- a/packages/core/src/repowise/core/analysis/dead_code/analyzer.py
+++ b/packages/core/src/repowise/core/analysis/dead_code/analyzer.py
@@ -1331,7 +1331,7 @@ class DeadCodeAnalyzer:
         dynamic_patterns: tuple[str, ...],
         whitelist: set[str],
     ) -> list[DeadCodeFindingData]:
-        """Detect private/internal symbols with zero incoming call edges.
+        """Detect private symbols with zero incoming call edges.
 
         On by default. These carry a higher false-positive rate than the other
         detectors, which is why they land at a lower confidence. Disable with
@@ -1352,7 +1352,12 @@ class DeadCodeAnalyzer:
             # private symbols used across a package's files carry real
             # ``calls`` edges and no longer read as universally uncalled. The
             # blanket exemption that Phase 2 added has been lifted.
-            if node_data.get("visibility") not in ("private", "internal"):
+            # ``internal`` is not narrow: assembly-wide in C#, module-wide in
+            # Swift and Kotlin, crate-wide in Rust. A legitimate user can sit
+            # anywhere in the module, so a missing inbound call edge is not
+            # evidence of deadness. Nothing else observes ``internal`` either,
+            # which drops an unmodified C# top-level type out of both passes.
+            if node_data.get("visibility") != "private":
                 continue
             file_path = node_data.get("file_path", "")
             if not file_path:


### PR DESCRIPTION
> Stacked on #1644. Review that one first; this branch contains its commit.

`_detect_unused_internals` admits a symbol on `visibility in ("private", "internal")` and reports it when no `calls` edge lands on it.

`internal` is not narrow. It is assembly-wide in C#, module-wide in Swift and Kotlin, crate-wide in Rust. A legitimate user can sit in any file of the module, so a missing inbound call edge is not evidence of deadness. In Swift it is also the *default*, so it labels nearly every symbol in the repo — which is why the pass spends most of its findings there.

## Measured

Full dead-code finding diff from a real in-process build (walk, parse, graph, production `DeadCodeAnalyzer`) on seven repos. Per language, not pooled.

| repo | language | before | after |
|---|---|---|---|
| Alamofire | swift | 139 | 21 |
| swift-nio | swift | 1,294 | 337 |
| Ocelot | csharp | 115 | 105 |
| CleanArchitecture | csharp | 170 | 168 |
| eShopOnWeb | csharp | 114 | 114 |
| gitleaks | go | 17 | 17 |
| flask | python | 12 | 12 |

`c`, `cpp`, `javascript`, `ruby` and `shell` are also exactly unmoved, as are `unreachable_file`, `unused_export` and `zombie_package` on every repo. **Zero new findings anywhere.** The controls — languages with no `internal` concept — do not move at all.

## What stops being found

72 removed findings read by hand (Alamofire 30, swift-nio 30, Ocelot 10, CleanArchitecture 2). **Three are genuinely dead**: swift-nio's empty `enum LowLevelThreadOperations {}`, and Ocelot's two `internal class Usings {}` global-using holders. The rest are alive.

The cheap oracle overstated this and the correction is worth stating. "The name appears in no other file" flagged 12 of Alamofire's 30 as candidates; on reading, all 12 are used inside their own file — public nested enums (`AFError.RequiredComponent`, `URLEncodedFormEncoder.NilEncoding`), a `private final class Inner` instantiated three times, a stdlib `extension Collection<String>` that is not a symbol at all, a storyboard-wired `HostingController`. Ocelot's one candidate, `RouteKeyCreatorHelpers`, is an extension-method container: the class is not the API, its member is.

## The precision half of the bar was not met, and this change cannot meet it

The bar asked for ≥90% genuine among the surviving findings. I read 14 of swift-nio's 30 survivors and Ocelot's only survivor. **Every one is a false positive**, all by one mechanism: a `private` symbol used inside its own file through `self.` / `Self.` or a bare constructor — `uniquifyIfNeeded` (7 same-file call sites), the whole `SocketOptionProvider` `_get*`/`_set*` family, `initializeAndRegisterNewChannel` (9 sites), Ocelot's `CallbackWrapper` (instantiated 9 lines above its own declaration).

That is the implicit-receiver resolution gap, not the candidate pool. It is pre-existing, this change neither causes nor worsens it, and no pool membership rule can fix it — the edges do not exist to be found. Swift is the worse case: `call_resolver.py` registers per-language strategies for go, java, kotlin, csharp, cpp and c, and Swift is absent from that list and from `_IMPLICIT_RECEIVER_LANGUAGES` entirely.

**I am shipping on the reduction, not on the precision**, and flagging that explicitly: 1,058 findings removed corpus-wide, ~96% of them false on audit, against 3 genuine losses. Holding this until Swift receiver resolution lands is a defensible alternative and I am happy to take that call instead.

## One named cost

`_detect_unused_exports` gates on `== "public"` and this pass now gates on `== "private"`, so `internal` is a band no detector observes. The visible case is an unmodified C# top-level type, which the parent commit correctly records as `internal`: it used to sit in this pool and now sits in neither. Small, real, deliberate.

Rust is unaffected: the pass skips the language 17 lines above this gate, so `pub(crate)` never reached the test. Kotlin's `internal` is the same category as Swift's but must be written explicitly, so its loss is small.

## Also

`docs/reference/COMPUTED_GLOSSARY.md` and the `--include-internals` help string said "private/internal"; both now say "private". No test asserted an `internal` symbol produces a finding.
