### PR TITLE
test(graph): exempt the fourth qualifier split the guard does not govern

### DIFF
--- a/tests/unit/test_no_bare_type_name_copies.py
+++ b/tests/unit/test_no_bare_type_name_copies.py
@@ -71,9 +71,10 @@ _KNOWN: dict[str, int] = {
     # Splits our own `path::Class::method` symbol IDs, which we mint. The
     # separator is ours rather than the language's, so the shared helper would
     # be answering about a type where these ask about an ID. `models.py` holds
-    # the one both resolvers used to duplicate. `call_resolver.py`'s third is
-    # the tail of an import's module path — a module name, not a type.
-    _PREFIX + "call_resolver.py": 3,
+    # the one both resolvers used to duplicate. Three of `call_resolver.py`'s
+    # four are symbol IDs; the fourth takes the tail of an import's module
+    # path, which is a module name, not a type.
+    _PREFIX + "call_resolver.py": 4,
     _PREFIX + "models.py": 1,
     # Reads the head to decide whether taking a bare name is safe at all: a
     # qualifier that is a type rather than a package must not be discarded.


### PR DESCRIPTION
**`main` is red on Python 3.11, 3.12 and 3.13.** Those two tests are the only failures in the run.

```
FAILED tests/unit/test_no_bare_type_name_copies.py::test_no_new_bare_type_name_expressions
FAILED tests/unit/test_no_bare_type_name_copies.py::test_known_copies_still_exist
  assert not {'.../call_resolver.py': (3, 4)}
```

#1643 added a fourth qualifier-splitting expression to `call_resolver.py` against a `_KNOWN` allowance of 3.

## Why this is a count change, not a conversion

All four sites are in the two categories `_KNOWN` already exempts, and neither is asking what the shared helper answers.

| line | expression | what it splits |
|---|---|---|
| 1032 | `caller_id.rpartition("::")` | our own symbol ID |
| 1201 | `symbol_id.split("::")` | our own symbol ID |
| 1207 | `symbol_id.split("::")` | our own symbol ID |
| 1093 | `imp.module_path.rsplit(".", 1)` | an import's module path |

The `::` separator is ours rather than any language's, so routing those through `bare_type_name` would have it answering about a type where the caller is asking about an ID. The fourth, in `_externally_bound_names`, takes the tail of a module path to get a module name — also not a type. That last category is already named in `_KNOWN`'s comment; the comment is updated to say three of the four are symbol IDs rather than two.

Same call the guard's own docstring asks for, and the same one #1640 made for the previous pair.

## Scope

Test-only diff: one integer and one comment. It cannot collide with the receiver-typing work still touching `call_resolver.py`.
