### PR TITLE
perf(graph): stop re-reading the repo during graph build

### DIFF
--- a/packages/core/src/repowise/core/fs_walk.py
+++ b/packages/core/src/repowise/core/fs_walk.py
@@ -377,6 +377,25 @@ class WalkSnapshot:
                     yield dirpath / name
 
 
+def glob_via(
+    snapshot: WalkSnapshot | None,
+    root: Path | str,
+    patterns: str | Iterable[str],
+    *,
+    prune_nested_git: bool = True,
+) -> Iterator[Path]:
+    """:func:`iter_glob`, answered from *snapshot* when the caller has one.
+
+    The seam for scans that run several queries against one tree and are
+    reached from a context that can hold the walk. Yield order and matching
+    are identical either way, so a caller cannot behave differently for
+    having been given a snapshot.
+    """
+    if snapshot is not None:
+        return snapshot.iter_glob(root, patterns)
+    return iter_glob(root, patterns, prune_nested_git=prune_nested_git)
+
+
 def iter_glob(
     root: Path | str,
     patterns: str | Iterable[str],

--- a/packages/core/src/repowise/core/ingestion/graph/_resolvers.py
+++ b/packages/core/src/repowise/core/ingestion/graph/_resolvers.py
@@ -102,7 +102,7 @@ class ResolveMixin:
         if progress:
             progress.on_phase_start(phase, None)
         try:
-            cs_texts = collect_csharp_source_texts(self._parsed_files)
+            cs_texts = collect_csharp_source_texts(self._parsed_files, self._source_map)
             type_to_file = build_csharp_type_to_file(self._parsed_files)
             added = resolve_csharp_member_reads(self._graph, cs_texts, type_to_file)
             log.info("member_read_edges", language="csharp", added=added)
@@ -141,7 +141,7 @@ class ResolveMixin:
             progress.on_phase_start(phase, None)
         try:
             jvm_index = get_or_build_jvm_index(ctx)
-            texts = collect_jvm_source_texts(self._parsed_files)
+            texts = collect_jvm_source_texts(self._parsed_files, self._source_map)
             added = resolve_jvm_same_package_refs(self._graph, jvm_index, texts)
             log.info("same_package_edges", added=added)
         except Exception as exc:
@@ -178,7 +178,7 @@ class ResolveMixin:
             progress.on_phase_start(phase, None)
         try:
             index = get_or_build_index(ctx)
-            cs_texts = collect_csharp_source_texts(self._parsed_files)
+            cs_texts = collect_csharp_source_texts(self._parsed_files, self._source_map)
             repo = getattr(index, "repo_path", None) if index is not None else None
             added = resolve_csharp_same_namespace_refs(
                 self._graph, index, cs_texts, repo
@@ -410,7 +410,7 @@ class ResolveMixin:
             progress.on_phase_start(phase, None)
         try:
             swift_targets = get_or_build_swift_targets(ctx)
-            texts = collect_swift_source_texts(self._parsed_files)
+            texts = collect_swift_source_texts(self._parsed_files, self._source_map)
             added = resolve_swift_same_module_refs(self._graph, swift_targets, texts)
             log.info("same_module_edges", language="swift", added=added)
         except Exception as exc:

--- a/packages/core/src/repowise/core/ingestion/languages/csharp_member_reads.py
+++ b/packages/core/src/repowise/core/ingestion/languages/csharp_member_reads.py
@@ -38,9 +38,9 @@ behind a feature flag if it ever proves noisy.
 from __future__ import annotations
 
 import re
-from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from ..source_text import source_text
 from ..type_names import bare_type_name
 
 if TYPE_CHECKING:
@@ -180,16 +180,22 @@ def build_csharp_type_to_file(parsed_files: dict[str, Any]) -> dict[str, str]:
     return result
 
 
-def collect_csharp_source_texts(parsed_files: dict[str, Any]) -> dict[str, str]:
-    """Read each parsed C# file's source from disk, keyed by repo path."""
+def collect_csharp_source_texts(
+    parsed_files: dict[str, Any], source_map: dict[str, bytes] | None = None
+) -> dict[str, str]:
+    """Text of each parsed C# file, keyed by repo path.
+
+    ``utf-8-sig``, unlike the JVM and Swift collectors: C# files are routinely
+    written with a BOM, and the scans below must not see it inside the first
+    identifier of the file.
+    """
     out: dict[str, str] = {}
     for path, parsed in parsed_files.items():
         if parsed.file_info.language != "csharp":
             continue
-        try:
-            out[path] = Path(parsed.file_info.abs_path).read_text(
-                encoding="utf-8-sig", errors="ignore"
-            )
-        except OSError:
-            continue
+        text = source_text(
+            path, parsed.file_info.abs_path, source_map, encoding="utf-8-sig"
+        )
+        if text is not None:
+            out[path] = text
     return out

--- a/packages/core/src/repowise/core/ingestion/languages/jvm_same_package.py
+++ b/packages/core/src/repowise/core/ingestion/languages/jvm_same_package.py
@@ -157,6 +157,8 @@ def resolve_jvm_same_package_refs(
     )
 
 
-def collect_jvm_source_texts(parsed_files: dict[str, Any]) -> dict[str, str]:
-    """Read each parsed JVM file's source from disk, keyed by repo path."""
-    return collect_source_texts(parsed_files, _JVM_LANGUAGES)
+def collect_jvm_source_texts(
+    parsed_files: dict[str, Any], source_map: dict[str, bytes] | None = None
+) -> dict[str, str]:
+    """Text of each parsed JVM file, keyed by repo path."""
+    return collect_source_texts(parsed_files, _JVM_LANGUAGES, source_map)

--- a/packages/core/src/repowise/core/ingestion/languages/scope_scan.py
+++ b/packages/core/src/repowise/core/ingestion/languages/scope_scan.py
@@ -12,8 +12,9 @@ from __future__ import annotations
 import re
 from collections.abc import Callable, Collection, Iterable
 from dataclasses import dataclass, field
-from pathlib import Path
 from typing import TYPE_CHECKING, Any
+
+from repowise.core.ingestion.source_text import source_text
 
 if TYPE_CHECKING:
     import networkx as nx
@@ -112,17 +113,16 @@ def emit_scope_edges(
 
 
 def collect_source_texts(
-    parsed_files: dict[str, Any], languages: Collection[str]
+    parsed_files: dict[str, Any],
+    languages: Collection[str],
+    source_map: dict[str, bytes] | None = None,
 ) -> dict[str, str]:
-    """Read each parsed file of *languages* from disk, keyed by repo path."""
+    """Text of each parsed file of *languages*, keyed by repo path."""
     out: dict[str, str] = {}
     for path, parsed in parsed_files.items():
         if parsed.file_info.language not in languages:
             continue
-        try:
-            out[path] = Path(parsed.file_info.abs_path).read_text(
-                encoding="utf-8", errors="ignore"
-            )
-        except OSError:
-            continue
+        text = source_text(path, parsed.file_info.abs_path, source_map)
+        if text is not None:
+            out[path] = text
     return out

--- a/packages/core/src/repowise/core/ingestion/languages/swift_same_module.py
+++ b/packages/core/src/repowise/core/ingestion/languages/swift_same_module.py
@@ -144,6 +144,8 @@ def resolve_swift_same_module_refs(
     )
 
 
-def collect_swift_source_texts(parsed_files: dict[str, Any]) -> dict[str, str]:
-    """Read each parsed Swift file's source from disk, keyed by repo path."""
-    return collect_source_texts(parsed_files, ("swift",))
+def collect_swift_source_texts(
+    parsed_files: dict[str, Any], source_map: dict[str, bytes] | None = None
+) -> dict[str, str]:
+    """Text of each parsed Swift file, keyed by repo path."""
+    return collect_source_texts(parsed_files, ("swift",), source_map)

--- a/packages/core/src/repowise/core/ingestion/resolvers/context.py
+++ b/packages/core/src/repowise/core/ingestion/resolvers/context.py
@@ -60,6 +60,28 @@ class ResolverContext:
         default=None, init=False, repr=False, compare=False
     )
 
+    # One pruned walk of the repo, replayed for every resolver glob that asks
+    # for it. Built on first use and never from ``path_set``: these scans look
+    # for files the traverser does not index — ``META-INF/services`` entries,
+    # ``spring.factories``, ``*.sln`` — so a snapshot of the indexed set would
+    # answer "absent" for exactly the files they exist to find.
+    _walk_snapshot_cache: Any | None = field(
+        default=None, init=False, repr=False, compare=False
+    )
+
+    @property
+    def walk_snapshot(self) -> Any | None:
+        """Shared :class:`~repowise.core.fs_walk.WalkSnapshot`, or None."""
+        if self._walk_snapshot_cache is None:
+            if self.repo_path is None:
+                return None
+            from repowise.core.fs_walk import WalkSnapshot
+
+            self._walk_snapshot_cache = WalkSnapshot(
+                self.repo_path, prune_nested_git=self.prune_nested_git
+            )
+        return self._walk_snapshot_cache
+
     @property
     def sorted_paths(self) -> tuple[str, ...]:
         """Deterministically ordered view of ``path_set`` (cached)."""

--- a/packages/core/src/repowise/core/ingestion/resolvers/context.py
+++ b/packages/core/src/repowise/core/ingestion/resolvers/context.py
@@ -71,14 +71,24 @@ class ResolverContext:
 
     @property
     def walk_snapshot(self) -> Any | None:
-        """Shared :class:`~repowise.core.fs_walk.WalkSnapshot`, or None."""
+        """Shared :class:`~repowise.core.fs_walk.WalkSnapshot`, or None.
+
+        Rooted at the *resolved* repo path, because every scan that asks for
+        this resolves its own root first; rooting it anywhere else would leave
+        the snapshot correct but unused — a query it cannot place falls back to
+        a live walk, which is exactly the cost this removes.
+        """
         if self._walk_snapshot_cache is None:
             if self.repo_path is None:
                 return None
             from repowise.core.fs_walk import WalkSnapshot
 
+            try:
+                root = self.repo_path.resolve()
+            except OSError:
+                root = self.repo_path
             self._walk_snapshot_cache = WalkSnapshot(
-                self.repo_path, prune_nested_git=self.prune_nested_git
+                root, prune_nested_git=self.prune_nested_git
             )
         return self._walk_snapshot_cache
 

--- a/packages/core/src/repowise/core/ingestion/resolvers/cpp_workspace.py
+++ b/packages/core/src/repowise/core/ingestion/resolvers/cpp_workspace.py
@@ -367,7 +367,11 @@ def build_cpp_workspace_index(ctx: ResolverContext) -> CppWorkspaceIndex:
 
     repo_path = ctx.repo_path.resolve()
     path_set = set(ctx.path_set)
-    source_map = ctx.source_map
+    # ``getattr``, not attribute access: the call resolver builds these
+    # indexes from a minimal stand-in context that carries neither field
+    # (``call_resolver._Ctx``). A miss means disk and a live walk, which
+    # is what that path did before.
+    source_map = getattr(ctx, "source_map", None)
 
     cmake_files = discover_cmake_reactor(repo_path)
     file_api_targets = parse_cmake_file_api_reply(repo_path)

--- a/packages/core/src/repowise/core/ingestion/resolvers/cpp_workspace.py
+++ b/packages/core/src/repowise/core/ingestion/resolvers/cpp_workspace.py
@@ -49,6 +49,7 @@ from ..external_systems.cmake import (
     discover_cmake_reactor,
     parse_cmake_file_api_reply,
 )
+from ..source_text import decode_source
 
 if TYPE_CHECKING:
     from .context import ResolverContext
@@ -238,15 +239,19 @@ _PROJECT_EXPORT_MACRO_RE = re.compile(
 _EXPORT_LIKE_NAME_RE = re.compile(r"^[A-Z][A-Z0-9_]{2,}_(?:EXPORT|API|PUBLIC|DLL|VISIBLE)$")
 
 
+def _export_macros_in(text: str) -> tuple[str, ...]:
+    # Limit to the first ~8KB — export macros are nearly always near the top.
+    return tuple({m.group(1) for m in _PROJECT_EXPORT_MACRO_RE.finditer(text[:8192])})
+
+
 @lru_cache(maxsize=8192)
 def _scan_header_for_export_macros(abs_path: str) -> tuple[str, ...]:
+    """:func:`_export_macros_in` for a header the source map did not have."""
     try:
         text = Path(abs_path).read_text(encoding="utf-8", errors="ignore")
     except OSError:
         return ()
-    # Limit to the first ~8KB — export macros are nearly always near the top.
-    head = text[:8192]
-    return tuple({m.group(1) for m in _PROJECT_EXPORT_MACRO_RE.finditer(head)})
+    return _export_macros_in(text)
 
 
 def _classify_dir(root_dir: str) -> dict[str, bool]:
@@ -362,6 +367,7 @@ def build_cpp_workspace_index(ctx: ResolverContext) -> CppWorkspaceIndex:
 
     repo_path = ctx.repo_path.resolve()
     path_set = set(ctx.path_set)
+    source_map = ctx.source_map
 
     cmake_files = discover_cmake_reactor(repo_path)
     file_api_targets = parse_cmake_file_api_reply(repo_path)
@@ -409,8 +415,11 @@ def build_cpp_workspace_index(ctx: ResolverContext) -> CppWorkspaceIndex:
                 if len(header_candidates) > 200:
                     break
     for rel in header_candidates:
-        abs_p = str((repo_path / rel).resolve())
-        macros.update(_scan_header_for_export_macros(abs_p))
+        data = source_map.get(rel) if source_map is not None else None
+        if data is not None:
+            macros.update(_export_macros_in(decode_source(data)))
+        else:
+            macros.update(_scan_header_for_export_macros(str((repo_path / rel).resolve())))
     _scan_header_for_export_macros.cache_clear()
 
     # Filter out anything that doesn't look like an export marker name.

--- a/packages/core/src/repowise/core/ingestion/resolvers/dart.py
+++ b/packages/core/src/repowise/core/ingestion/resolvers/dart.py
@@ -43,7 +43,9 @@ def _pubspec_map(ctx: ResolverContext) -> dict[str, str]:
             continue
         if repo is None:
             continue
-        text = source_text(path, repo / path, ctx.source_map, errors="replace")
+        text = source_text(
+            path, repo / path, getattr(ctx, "source_map", None), errors="replace"
+        )
         if text is None:
             continue
         m = _PUBSPEC_NAME_RE.search(text)

--- a/packages/core/src/repowise/core/ingestion/resolvers/dart.py
+++ b/packages/core/src/repowise/core/ingestion/resolvers/dart.py
@@ -21,6 +21,7 @@ import posixpath
 import re
 from typing import TYPE_CHECKING
 
+from ..source_text import source_text
 from .module_name_index import get_or_build_module_index, lookup_module
 
 if TYPE_CHECKING:
@@ -42,9 +43,8 @@ def _pubspec_map(ctx: ResolverContext) -> dict[str, str]:
             continue
         if repo is None:
             continue
-        try:
-            text = (repo / path).read_text(encoding="utf-8", errors="replace")
-        except OSError:
+        text = source_text(path, repo / path, ctx.source_map, errors="replace")
+        if text is None:
             continue
         m = _PUBSPEC_NAME_RE.search(text)
         if m:

--- a/packages/core/src/repowise/core/ingestion/resolvers/dotnet/index.py
+++ b/packages/core/src/repowise/core/ingestion/resolvers/dotnet/index.py
@@ -4,11 +4,12 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import structlog
 
-from repowise.core.fs_walk import iter_glob
+from repowise.core.fs_walk import glob_via
+from repowise.core.ingestion.source_text import source_text
 
 from .global_usings import collect_project_global_usings
 from .msbuild import (
@@ -156,7 +157,9 @@ class DotNetProjectIndex:
         return package_id in self.package_refs.get(csproj, set())
 
 
-def _walk_repo_cs_files(repo_path: Path, *, prune_nested_git: bool = True) -> list[Path]:
+def _walk_repo_cs_files(
+    repo_path: Path, *, prune_nested_git: bool = True, snapshot: Any | None = None
+) -> list[Path]:
     """Single repo-wide rglob for ``*.cs`` files, dedup by resolved path.
 
     Lives at module scope (not nested inside ``build_index``) so it's
@@ -165,7 +168,7 @@ def _walk_repo_cs_files(repo_path: Path, *, prune_nested_git: bool = True) -> li
     """
     seen: set[Path] = set()
     out: list[Path] = []
-    for cs in iter_glob(repo_path, "*.cs", prune_nested_git=prune_nested_git):
+    for cs in glob_via(snapshot, repo_path, "*.cs", prune_nested_git=prune_nested_git):
         if path_has_dotnet_scan_skip_dir(cs, repo_path):
             continue
         try:
@@ -214,7 +217,13 @@ def _bucket_files_by_project(
     return out
 
 
-def build_index(repo_path: Path, *, prune_nested_git: bool = True) -> DotNetProjectIndex:
+def build_index(
+    repo_path: Path,
+    *,
+    prune_nested_git: bool = True,
+    snapshot: Any | None = None,
+    source_map: dict[str, bytes] | None = None,
+) -> DotNetProjectIndex:
     """Walk *repo_path* and construct a fully-populated DotNetProjectIndex.
 
     Performance note: a previous version of this function walked the
@@ -227,12 +236,20 @@ def build_index(repo_path: Path, *, prune_nested_git: bool = True) -> DotNetProj
     ONE master walk, reads each file ONCE, and dispatches the cached
     texts to both the namespace-map pass and per-project global-usings
     collection. No data-quality loss — same regexes, same outputs.
+
+    That master read is now itself avoidable: ingestion already read every
+    indexed ``.cs`` file, so *source_map* answers most of it and only the
+    files the traverser skipped reach the disk. *snapshot* does the same for
+    the three walks — .csproj, .sln, .cs — which become dict replays of the
+    context's single walk.
     """
     repo_path = repo_path.resolve()
     index = DotNetProjectIndex(repo_path=repo_path)
 
     # ---- 1. Parse every .csproj ----
-    for csproj_path in find_csproj_files(repo_path, prune_nested_git=prune_nested_git):
+    for csproj_path in find_csproj_files(
+        repo_path, prune_nested_git=prune_nested_git, snapshot=snapshot
+    ):
         proj = parse_csproj(csproj_path)
         if proj is None:
             continue
@@ -241,7 +258,9 @@ def build_index(repo_path: Path, *, prune_nested_git: bool = True) -> DotNetProj
         index.package_refs[proj.path] = set(proj.package_references)
 
     # ---- 2. Walk .sln files (informational; surfaces orphaned .csprojs) ----
-    index.sln_paths = find_sln_files(repo_path, prune_nested_git=prune_nested_git)
+    index.sln_paths = find_sln_files(
+        repo_path, prune_nested_git=prune_nested_git, snapshot=snapshot
+    )
     for sln in index.sln_paths:
         for entry in parse_sln(sln):
             if entry.csproj not in index.projects:
@@ -255,13 +274,21 @@ def build_index(repo_path: Path, *, prune_nested_git: bool = True) -> DotNetProj
                     index.package_refs.setdefault(proj.path, set()).update(proj.package_references)
 
     # ---- 3. Single master walk: enumerate .cs files & read each once ----
-    all_cs_files = _walk_repo_cs_files(repo_path, prune_nested_git=prune_nested_git)
+    all_cs_files = _walk_repo_cs_files(
+        repo_path, prune_nested_git=prune_nested_git, snapshot=snapshot
+    )
     cs_texts: dict[Path, str] = {}
     for f in all_cs_files:
+        # ``_walk_repo_cs_files`` resolves every path and *repo_path* is
+        # resolved too, so a file the traverser indexed keys the map exactly.
+        # Files it skipped — and anything outside the root — miss and read.
         try:
-            cs_texts[f] = f.read_text(encoding="utf-8-sig", errors="replace")
-        except OSError:
-            continue
+            rel: str | None = f.relative_to(repo_path).as_posix()
+        except ValueError:
+            rel = None
+        text = source_text(rel, f, source_map, encoding="utf-8-sig", errors="replace")
+        if text is not None:
+            cs_texts[f] = text
 
     # Build the file → project map by longest-prefix match. The bucketer
     # walks each file's parent chain (deepest-first) against a dict of
@@ -326,6 +353,11 @@ def get_or_build_index(ctx: ResolverContext) -> DotNetProjectIndex | None:
     cached = getattr(ctx, _INDEX_KEY, None)
     if cached is not None:
         return cached
-    index = build_index(ctx.repo_path, prune_nested_git=ctx.prune_nested_git)
+    index = build_index(
+        ctx.repo_path,
+        prune_nested_git=ctx.prune_nested_git,
+        snapshot=ctx.walk_snapshot,
+        source_map=ctx.source_map,
+    )
     setattr(ctx, _INDEX_KEY, index)
     return index

--- a/packages/core/src/repowise/core/ingestion/resolvers/dotnet/index.py
+++ b/packages/core/src/repowise/core/ingestion/resolvers/dotnet/index.py
@@ -356,8 +356,8 @@ def get_or_build_index(ctx: ResolverContext) -> DotNetProjectIndex | None:
     index = build_index(
         ctx.repo_path,
         prune_nested_git=ctx.prune_nested_git,
-        snapshot=ctx.walk_snapshot,
-        source_map=ctx.source_map,
+        snapshot=getattr(ctx, "walk_snapshot", None),
+        source_map=getattr(ctx, "source_map", None),
     )
     setattr(ctx, _INDEX_KEY, index)
     return index

--- a/packages/core/src/repowise/core/ingestion/resolvers/dotnet/msbuild.py
+++ b/packages/core/src/repowise/core/ingestion/resolvers/dotnet/msbuild.py
@@ -10,11 +10,12 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any
 from xml.etree import ElementTree as ET
 
 import structlog
 
-from repowise.core.fs_walk import iter_glob
+from repowise.core.fs_walk import glob_via
 
 log = structlog.get_logger(__name__)
 
@@ -113,10 +114,14 @@ def parse_csproj(csproj_path: Path) -> MSBuildProject | None:
     return project
 
 
-def find_csproj_files(repo_path: Path, *, prune_nested_git: bool = True) -> list[Path]:
+def find_csproj_files(
+    repo_path: Path, *, prune_nested_git: bool = True, snapshot: Any | None = None
+) -> list[Path]:
     """Return all .csproj files under *repo_path*, skipping bin/obj output."""
     out: list[Path] = []
-    for csproj in iter_glob(repo_path, "*.csproj", prune_nested_git=prune_nested_git):
+    for csproj in glob_via(
+        snapshot, repo_path, "*.csproj", prune_nested_git=prune_nested_git
+    ):
         if path_has_dotnet_scan_skip_dir(csproj, repo_path):
             continue
         out.append(csproj)

--- a/packages/core/src/repowise/core/ingestion/resolvers/dotnet/solution.py
+++ b/packages/core/src/repowise/core/ingestion/resolvers/dotnet/solution.py
@@ -13,10 +13,11 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 import structlog
 
-from repowise.core.fs_walk import iter_glob
+from repowise.core.fs_walk import glob_via
 
 from .msbuild import path_has_dotnet_scan_skip_dir
 
@@ -60,9 +61,11 @@ def parse_sln(sln_path: Path) -> list[SolutionEntry]:
     return out
 
 
-def find_sln_files(repo_path: Path, *, prune_nested_git: bool = True) -> list[Path]:
+def find_sln_files(
+    repo_path: Path, *, prune_nested_git: bool = True, snapshot: Any | None = None
+) -> list[Path]:
     out: list[Path] = []
-    for sln in iter_glob(repo_path, "*.sln", prune_nested_git=prune_nested_git):
+    for sln in glob_via(snapshot, repo_path, "*.sln", prune_nested_git=prune_nested_git):
         if path_has_dotnet_scan_skip_dir(sln, repo_path):
             continue
         out.append(sln)

--- a/packages/core/src/repowise/core/ingestion/resolvers/go_workspace.py
+++ b/packages/core/src/repowise/core/ingestion/resolvers/go_workspace.py
@@ -134,7 +134,10 @@ def _scan_go_file(text: str) -> tuple[str, bool, bool, bool, bool]:
 def _read_text(ctx: ResolverContext, rel_path: str) -> str:
     if ctx.repo_path is None:
         return ""
-    return source_text(rel_path, ctx.repo_path / rel_path, ctx.source_map) or ""
+    # ``getattr``: the call resolver builds this index from a stand-in
+    # context with no source map (``call_resolver._Ctx``).
+    source_map = getattr(ctx, "source_map", None)
+    return source_text(rel_path, ctx.repo_path / rel_path, source_map) or ""
 
 
 def _import_path_for_dir(

--- a/packages/core/src/repowise/core/ingestion/resolvers/go_workspace.py
+++ b/packages/core/src/repowise/core/ingestion/resolvers/go_workspace.py
@@ -23,6 +23,7 @@ from typing import TYPE_CHECKING
 
 import structlog
 
+from ..source_text import source_text
 from .go import read_go_modules
 
 if TYPE_CHECKING:
@@ -133,10 +134,7 @@ def _scan_go_file(text: str) -> tuple[str, bool, bool, bool, bool]:
 def _read_text(ctx: ResolverContext, rel_path: str) -> str:
     if ctx.repo_path is None:
         return ""
-    try:
-        return (ctx.repo_path / rel_path).read_text(encoding="utf-8", errors="ignore")
-    except OSError:
-        return ""
+    return source_text(rel_path, ctx.repo_path / rel_path, ctx.source_map) or ""
 
 
 def _import_path_for_dir(

--- a/packages/core/src/repowise/core/ingestion/resolvers/jvm_gradle.py
+++ b/packages/core/src/repowise/core/ingestion/resolvers/jvm_gradle.py
@@ -15,11 +15,12 @@ import re
 from dataclasses import dataclass, field
 from functools import lru_cache
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import structlog
 
-from repowise.core.fs_walk import iter_glob
+from repowise.core.fs_walk import glob_via
+from repowise.core.ingestion.source_text import decode_source
 
 if TYPE_CHECKING:
     from .context import ResolverContext
@@ -251,20 +252,17 @@ def _detect_plugins(module_dir: Path) -> frozenset[str]:
 # Package extraction (cached per file)
 # ---------------------------------------------------------------------------
 
-@lru_cache(maxsize=8192)
-def _extract_file_info(abs_path: str) -> tuple[str, tuple[str, ...], bool, bool]:
+def _extract_text_info(
+    abs_path: str, text: str | None
+) -> tuple[str, tuple[str, ...], bool, bool]:
     """Return (package_decl, top_level_types, is_module_info, is_package_info).
 
-    Reads the file once and caches the result. Cheap line scan, no AST.
+    Cheap line scan, no AST. *text* of None means the file was unreadable.
     """
-    path = Path(abs_path)
-    name = path.name
+    name = Path(abs_path).name
     is_module_info = name == "module-info.java"
     is_package_info = name == "package-info.java"
-
-    try:
-        text = path.read_text(encoding="utf-8", errors="ignore")
-    except OSError:
+    if text is None:
         return "", (), is_module_info, is_package_info
 
     package = ""
@@ -284,12 +282,26 @@ def _extract_file_info(abs_path: str) -> tuple[str, tuple[str, ...], bool, bool]
     return package, tuple(top_level), is_module_info, is_package_info
 
 
+@lru_cache(maxsize=8192)
+def _extract_file_info(abs_path: str) -> tuple[str, tuple[str, ...], bool, bool]:
+    """:func:`_extract_text_info` for a file the source map did not have."""
+    try:
+        text: str | None = Path(abs_path).read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        text = None
+    return _extract_text_info(abs_path, text)
+
+
 # ---------------------------------------------------------------------------
 # Index building
 # ---------------------------------------------------------------------------
 
 def build_jvm_gradle_index(
-    repo_path: Path | None, *, prune_nested_git: bool = True
+    repo_path: Path | None,
+    *,
+    prune_nested_git: bool = True,
+    snapshot: Any | None = None,
+    source_map: dict[str, bytes] | None = None,
 ) -> JvmGradleIndex:
     """Walk Gradle config + JVM sources to build the package-resolution index."""
     index = JvmGradleIndex()
@@ -351,14 +363,23 @@ def build_jvm_gradle_index(
                     continue
                 rel_roots.append(rel)
 
-                for jvm_file in iter_glob(root_path, "*", prune_nested_git=prune_nested_git):
+                for jvm_file in glob_via(
+                    snapshot, root_path, "*", prune_nested_git=prune_nested_git
+                ):
                     if jvm_file.suffix not in _JVM_EXTENSIONS or not jvm_file.is_file():
                         continue
                     try:
                         rel_file = jvm_file.relative_to(resolved_repo).as_posix()
                     except ValueError:
                         continue
-                    package, _types, _is_mod, _is_pkg = _extract_file_info(str(jvm_file.resolve()))
+                    abs_file = str(jvm_file.resolve())
+                    data = source_map.get(rel_file) if source_map is not None else None
+                    if data is not None:
+                        package, _types, _is_mod, _is_pkg = _extract_text_info(
+                            abs_file, decode_source(data)
+                        )
+                    else:
+                        package, _types, _is_mod, _is_pkg = _extract_file_info(abs_file)
                     if not package:
                         continue
                     index.package_to_files.setdefault(package, []).append(rel_file)
@@ -382,7 +403,12 @@ def get_or_build_jvm_gradle_index(ctx: ResolverContext) -> JvmGradleIndex:
     cached = getattr(ctx, "_jvm_gradle_index", None)
     if cached is not None:
         return cached
-    index = build_jvm_gradle_index(ctx.repo_path, prune_nested_git=ctx.prune_nested_git)
+    index = build_jvm_gradle_index(
+        ctx.repo_path,
+        prune_nested_git=ctx.prune_nested_git,
+        snapshot=ctx.walk_snapshot,
+        source_map=ctx.source_map,
+    )
     ctx._jvm_gradle_index = index  # type: ignore[attr-defined]
     return index
 

--- a/packages/core/src/repowise/core/ingestion/resolvers/jvm_gradle.py
+++ b/packages/core/src/repowise/core/ingestion/resolvers/jvm_gradle.py
@@ -406,8 +406,8 @@ def get_or_build_jvm_gradle_index(ctx: ResolverContext) -> JvmGradleIndex:
     index = build_jvm_gradle_index(
         ctx.repo_path,
         prune_nested_git=ctx.prune_nested_git,
-        snapshot=ctx.walk_snapshot,
-        source_map=ctx.source_map,
+        snapshot=getattr(ctx, "walk_snapshot", None),
+        source_map=getattr(ctx, "source_map", None),
     )
     ctx._jvm_gradle_index = index  # type: ignore[attr-defined]
     return index

--- a/packages/core/src/repowise/core/ingestion/resolvers/jvm_workspace.py
+++ b/packages/core/src/repowise/core/ingestion/resolvers/jvm_workspace.py
@@ -18,11 +18,12 @@ import re
 from dataclasses import dataclass, field
 from functools import lru_cache
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import structlog
 
-from repowise.core.fs_walk import iter_glob
+from repowise.core.fs_walk import glob_via
+from repowise.core.ingestion.source_text import decode_source
 
 if TYPE_CHECKING:
     from .context import ResolverContext
@@ -206,30 +207,28 @@ class JvmWorkspaceIndex:
         return bool(len(parts) == 1 and parts[0] in _JAVA_LANG_TYPES)
 
 
-@lru_cache(maxsize=16384)
-def _scan_jvm_file(abs_path: str) -> tuple[str, tuple[str, ...]]:
-    """Return (package_fqn, top_level_type_names) for a JVM source file.
+def _scan_jvm_text(abs_path: str, text: str) -> tuple[str, tuple[str, ...]]:
+    """Return (package_fqn, top_level_type_names) from already-read text.
 
-    Reads the file once and caches the result. Cheap line scan — no AST.
+    Cheap line scan — no AST.
     """
-    try:
-        text = Path(abs_path).read_text(encoding="utf-8", errors="ignore")
-    except OSError:
-        return "", ()
-
-    package = ""
     if abs_path.endswith(".scala"):
         package = _scala_package(text)
     else:
         pkg_match = _PACKAGE_RE.search(text)
-        if pkg_match:
-            package = pkg_match.group(1)
+        package = pkg_match.group(1) if pkg_match else ""
 
-    types: list[str] = []
-    for m in _TOP_LEVEL_TYPE_RE.finditer(text):
-        types.append(m.group(1))
+    return package, tuple(m.group(1) for m in _TOP_LEVEL_TYPE_RE.finditer(text))
 
-    return package, tuple(types)
+
+@lru_cache(maxsize=16384)
+def _scan_jvm_file(abs_path: str) -> tuple[str, tuple[str, ...]]:
+    """:func:`_scan_jvm_text` for a file the source map did not have."""
+    try:
+        text = Path(abs_path).read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return "", ()
+    return _scan_jvm_text(abs_path, text)
 
 
 def _scala_package(text: str) -> str:
@@ -260,7 +259,7 @@ _JPMS_PROVIDES_RE = re.compile(
 
 
 def _scan_jpms_provides(
-    repo_path: Path, *, prune_nested_git: bool = True
+    repo_path: Path, *, prune_nested_git: bool = True, snapshot: Any | None = None
 ) -> dict[str, tuple[str, ...]]:
     """Scan ``module-info.java`` files for ``provides X with Y, Z`` directives.
 
@@ -271,7 +270,9 @@ def _scan_jpms_provides(
     the warmup fast.
     """
     out: dict[str, list[str]] = {}
-    for mi in iter_glob(repo_path, "module-info.java", prune_nested_git=prune_nested_git):
+    for mi in glob_via(
+        snapshot, repo_path, "module-info.java", prune_nested_git=prune_nested_git
+    ):
         if not mi.is_file():
             continue
         try:
@@ -287,12 +288,12 @@ def _scan_jpms_provides(
 
 
 def _scan_meta_inf_services(
-    repo_path: Path, *, prune_nested_git: bool = True
+    repo_path: Path, *, prune_nested_git: bool = True, snapshot: Any | None = None
 ) -> dict[str, tuple[str, ...]]:
     """Scan META-INF/services/ directories for SPI declarations."""
     services: dict[str, list[str]] = {}
-    for services_dir in iter_glob(
-        repo_path, "META-INF/services", prune_nested_git=prune_nested_git
+    for services_dir in glob_via(
+        snapshot, repo_path, "META-INF/services", prune_nested_git=prune_nested_git
     ):
         if not services_dir.is_dir():
             continue
@@ -321,14 +322,14 @@ def _scan_meta_inf_services(
 
 
 def _scan_spring_autoconfig(
-    repo_path: Path, *, prune_nested_git: bool = True
+    repo_path: Path, *, prune_nested_git: bool = True, snapshot: Any | None = None
 ) -> dict[str, tuple[str, ...]]:
     """Scan spring.factories and Boot 3 AutoConfiguration.imports."""
     result: dict[str, list[str]] = {}
 
     # spring.factories (Boot 2 style)
-    for factories in iter_glob(
-        repo_path, "META-INF/spring.factories", prune_nested_git=prune_nested_git
+    for factories in glob_via(
+        snapshot, repo_path, "META-INF/spring.factories", prune_nested_git=prune_nested_git
     ):
         if not factories.is_file():
             continue
@@ -358,8 +359,8 @@ def _scan_spring_autoconfig(
             result.setdefault(rel, []).extend(current_values)
 
     # Boot 3 style: META-INF/spring/*.imports
-    for imports_file in iter_glob(
-        repo_path, "META-INF/spring/*.imports", prune_nested_git=prune_nested_git
+    for imports_file in glob_via(
+        snapshot, repo_path, "META-INF/spring/*.imports", prune_nested_git=prune_nested_git
     ):
         if not imports_file.is_file():
             continue
@@ -382,9 +383,11 @@ def _scan_spring_autoconfig(
 def build_jvm_workspace_index(ctx: ResolverContext) -> JvmWorkspaceIndex:
     """Build the JVM workspace index from all ``.java`` and ``.kt`` files in the path set.
 
-    One walk over the path set; each file read at most once (via
-    ``_scan_jvm_file`` LRU cache). The index groups files by package
-    and builds FQN → file mappings.
+    One pass over the path set, taking each file's text from the source map
+    the pipeline already filled and falling back to disk per file. The three
+    resource scans below share the context's single walk rather than each
+    walking the tree again — on a large JVM repo those walks, not the file
+    scan, were the bulk of this function.
     """
     index = JvmWorkspaceIndex()
 
@@ -392,6 +395,8 @@ def build_jvm_workspace_index(ctx: ResolverContext) -> JvmWorkspaceIndex:
         return index
 
     repo_path = ctx.repo_path.resolve()
+    source_map = ctx.source_map
+    snapshot = ctx.walk_snapshot
 
     # Group files by package
     pkg_files: dict[str, list[str]] = {}
@@ -402,7 +407,13 @@ def build_jvm_workspace_index(ctx: ResolverContext) -> JvmWorkspaceIndex:
             continue
 
         abs_path = str((repo_path / path).resolve())
-        package, top_types = _scan_jvm_file(abs_path)
+        # The map lookup is here, not inside the cached scan: an lru_cache
+        # cannot take a dict, and the fallback still wants its cache.
+        data = source_map.get(path) if source_map is not None else None
+        if data is not None:
+            package, top_types = _scan_jvm_text(abs_path, decode_source(data))
+        else:
+            package, top_types = _scan_jvm_file(abs_path)
         if not package:
             continue
 
@@ -432,8 +443,12 @@ def build_jvm_workspace_index(ctx: ResolverContext) -> JvmWorkspaceIndex:
     # (cheap glob, O(matching files)). Both populate ``services``; later
     # phases treat any FQN listed there as reachable.
     try:
-        services = _scan_meta_inf_services(repo_path, prune_nested_git=ctx.prune_nested_git)
-        jpms = _scan_jpms_provides(repo_path, prune_nested_git=ctx.prune_nested_git)
+        services = _scan_meta_inf_services(
+            repo_path, prune_nested_git=ctx.prune_nested_git, snapshot=snapshot
+        )
+        jpms = _scan_jpms_provides(
+            repo_path, prune_nested_git=ctx.prune_nested_git, snapshot=snapshot
+        )
         merged: dict[str, list[str]] = {k: list(v) for k, v in services.items()}
         for iface, impls in jpms.items():
             merged.setdefault(iface, []).extend(impls)
@@ -442,7 +457,7 @@ def build_jvm_workspace_index(ctx: ResolverContext) -> JvmWorkspaceIndex:
         pass
     with contextlib.suppress(Exception):
         index.autoconfig_imports = _scan_spring_autoconfig(
-            repo_path, prune_nested_git=ctx.prune_nested_git
+            repo_path, prune_nested_git=ctx.prune_nested_git, snapshot=snapshot
         )
 
     _scan_jvm_file.cache_clear()

--- a/packages/core/src/repowise/core/ingestion/resolvers/jvm_workspace.py
+++ b/packages/core/src/repowise/core/ingestion/resolvers/jvm_workspace.py
@@ -395,8 +395,12 @@ def build_jvm_workspace_index(ctx: ResolverContext) -> JvmWorkspaceIndex:
         return index
 
     repo_path = ctx.repo_path.resolve()
-    source_map = ctx.source_map
-    snapshot = ctx.walk_snapshot
+    # ``getattr``, not attribute access: the call resolver builds these
+    # indexes from a minimal stand-in context that carries neither field
+    # (``call_resolver._Ctx``). A miss means disk and a live walk, which
+    # is what that path did before.
+    source_map = getattr(ctx, "source_map", None)
+    snapshot = getattr(ctx, "walk_snapshot", None)
 
     # Group files by package
     pkg_files: dict[str, list[str]] = {}

--- a/packages/core/src/repowise/core/ingestion/source_text.py
+++ b/packages/core/src/repowise/core/ingestion/source_text.py
@@ -1,0 +1,59 @@
+"""One reader for file text the ingestion pipeline has already read.
+
+The pipeline reads every indexed file, hands the bytes to
+``GraphBuilder.set_source_map``, and they reach the resolvers as
+``ResolverContext.source_map``. The scans that run during ``build()`` used to
+re-open the repo anyway. This is the single place that prefers those bytes.
+
+Two things a caller must not get wrong, which is why they live here rather than
+at each site:
+
+* **The codec is the caller's, not a default.** JVM and Swift scans decode
+  utf-8, C# decodes utf-8-sig — only C# strips a BOM — and a couple of the
+  .NET readers pass ``errors="replace"`` where the rest pass ``"ignore"``.
+  Decoding a caller's bytes with another caller's codec silently changes what
+  its regexes match, and therefore which edges it emits.
+* **``Path.read_text`` translates newlines and ``bytes.decode`` does not.**
+  Text mode maps ``\\r\\n`` and lone ``\\r`` to ``\\n``; the raw bytes in the
+  source map still carry the ``\\r``. Every CRLF file — which on Windows is
+  most of a C# checkout — would decode to different text than the disk read it
+  replaces. :func:`decode_source` normalises, so a map hit and a disk fallback
+  produce the same string for the same file.
+
+The fallback is not optional. ``pipeline/incremental.py`` fills the map only
+when its caller asks for sources, so it can be partial or absent entirely.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def decode_source(data: bytes, *, encoding: str = "utf-8", errors: str = "ignore") -> str:
+    """Decode *data* the way ``Path.read_text(encoding, errors)`` would."""
+    text = data.decode(encoding, errors=errors)
+    if "\r" in text:
+        text = text.replace("\r\n", "\n").replace("\r", "\n")
+    return text
+
+
+def source_text(
+    rel_path: str | None,
+    abs_path: str | Path,
+    source_map: dict[str, bytes] | None,
+    *,
+    encoding: str = "utf-8",
+    errors: str = "ignore",
+) -> str | None:
+    """Text of one file, from *source_map* if it holds it, else from disk.
+
+    Returns None when the file is neither in the map nor readable.
+    """
+    if source_map is not None and rel_path is not None:
+        data = source_map.get(rel_path)
+        if data is not None:
+            return decode_source(data, encoding=encoding, errors=errors)
+    try:
+        return Path(abs_path).read_text(encoding=encoding, errors=errors)
+    except OSError:
+        return None

--- a/tests/unit/ingestion/test_source_text.py
+++ b/tests/unit/ingestion/test_source_text.py
@@ -1,0 +1,70 @@
+"""A source-map hit and a disk read must produce the same string.
+
+Every scan that moved onto the source map keeps a disk fallback, so the two
+paths run against the same repo in the same build. If they decode differently
+the scan sees different text for the same file depending on whether the
+pipeline happened to fill the map — which shows up as edges appearing and
+disappearing, not as an error.
+
+The failure this pins is not hypothetical: ``Path.read_text`` opens in text
+mode and translates newlines, ``bytes.decode`` does not, and CRLF is the
+majority line ending in a Windows-authored C# or Swift checkout.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from repowise.core.ingestion.source_text import decode_source, source_text
+
+CASES = [
+    ("lf", b"class A {}\nclass B {}\n"),
+    ("crlf", b"class A {}\r\nclass B {}\r\n"),
+    ("cr", b"class A {}\rclass B {}\r"),
+    ("mixed", b"a\r\nb\rc\n"),
+    ("bom_lf", b"\xef\xbb\xbfclass A {}\n"),
+    ("bom_crlf", b"\xef\xbb\xbfclass A {}\r\n"),
+    ("non_ascii", "// café ☕\r\nclass A {}\r\n".encode()),
+    ("invalid_utf8", b"class A {}\r\n\xff\xfe\r\n"),
+    ("empty", b""),
+]
+
+
+@pytest.mark.parametrize("label,data", CASES, ids=[c[0] for c in CASES])
+@pytest.mark.parametrize("encoding", ["utf-8", "utf-8-sig"])
+@pytest.mark.parametrize("errors", ["ignore", "replace"])
+def test_map_hit_matches_disk_read(tmp_path, label, data, encoding, errors):
+    f = tmp_path / "Sample.cs"
+    f.write_bytes(data)
+
+    from_map = source_text(
+        "Sample.cs", f, {"Sample.cs": data}, encoding=encoding, errors=errors
+    )
+    from_disk = source_text("Sample.cs", f, None, encoding=encoding, errors=errors)
+
+    assert from_map == from_disk
+    assert from_map == f.read_text(encoding=encoding, errors=errors)
+
+
+def test_a_miss_falls_back_to_disk():
+    """An empty or partial map must not read as an empty file."""
+    import tempfile
+    from pathlib import Path
+
+    with tempfile.TemporaryDirectory() as d:
+        f = Path(d) / "Other.cs"
+        f.write_bytes(b"class Other {}\r\n")
+        assert source_text("Other.cs", f, {}) == "class Other {}\n"
+        assert source_text("Other.cs", f, {"Unrelated.cs": b"x"}) == "class Other {}\n"
+
+
+def test_unreadable_file_returns_none(tmp_path):
+    assert source_text("gone.cs", tmp_path / "gone.cs", None) is None
+    assert source_text("gone.cs", tmp_path / "gone.cs", {}) is None
+
+
+def test_only_utf_8_sig_strips_the_bom():
+    """The codecs differ by caller, and only C# asks for the BOM to go."""
+    data = b"\xef\xbb\xbfclass A {}\n"
+    assert decode_source(data, encoding="utf-8").startswith("﻿")
+    assert decode_source(data, encoding="utf-8-sig").startswith("class")


### PR DESCRIPTION
The pipeline reads every indexed file and hands the bytes to
`GraphBuilder.set_source_map`. Its own comment says it does that "so the
language warmups that scan file text during `build()` don't re-read the repo".
Almost nothing used it, and several scans walked the whole tree again on top of
that.

Both are the same defect — I/O ingestion has already done — so both move behind
one seam.

## What changed

**Bytes.** `ingestion/source_text.py` reads a file from the source map and
falls back to disk on a miss. The fallback is mandatory, not defensive:
`pipeline/incremental.py` fills the map only when its caller asks for sources,
so it can be partial or absent. Callers routed through it: the JVM/Swift and
C# text collectors, the JVM workspace and Gradle file scans, the .NET master
read, and the Go, Dart and C++ workspace readers.

**Directory entries.** `ResolverContext.walk_snapshot` is one pruned walk of
the repo, replayed through the `WalkSnapshot` in `fs_walk.py` that already
existed for the dynamic-hint extractors and is documented for exactly this. The
JVM index walked the tree four times (META-INF services, JPMS `module-info`,
`spring.factories`, Boot 3 `.imports`) and the .NET index three (`.csproj`,
`.sln`, `.cs`); those are now dict replays of a single walk. The snapshot is a
live walk and is never built from the indexed path set — these scans look for
files the traverser does not index.

## Why, from our own numbers

The build-time attribution had `get_or_build_jvm_index` at 44.1% of ktor's
graph build and pointed at the source map. Splitting the index into its parts
first showed that framing was wrong:

| inside ktor's 5.01s JVM index | seconds | share of build |
|---|---:|---:|
| `_scan_spring_autoconfig` (two walks) | 1.975 | 18.0% |
| `_scan_meta_inf_services` (one walk) | 1.111 | 10.1% |
| `_scan_jpms_provides` (one walk) | 0.976 | 8.9% |
| per-file disk read | 0.536 | 4.9% |
| per-file regex scan | 0.365 | 3.3% |

**4.06s of the 4.70s is repeated directory walking, not file reading.** The
source map reaches 0.54s of it. Same shape on exposed and caffeine. Both halves
ship here because both are the same waste.

## Result

Build time, `measure_build_phases.py --instrument-only`. ktor is min-of-4
because a ktor build drifts by more than a phase costs (observed before spread
10.95–14.45s); the other three are single runs and labelled so.

| repo | before | after | change | n |
|---|---:|---:|---:|---:|
| ktor | 10.953s | 7.380s | **−32.6%** | 4 |
| exposed | 10.891s | 9.411s | −13.6% | 1 |
| caffeine | 4.456s | 3.639s | −18.3% | 1 |
| Ocelot | 2.464s | 2.182s | −11.5% | 1 |

Per-target rows are differences measured *within a single build*, so run-to-run
drift cannot enter them: the JVM workspace index falls 59–63% on all three JVM
repos, the .NET index 26%, and the text collectors 89–98%.

## Correctness

Reading bytes you already hold cannot change an edge, so the gate is that
nothing moves. Both populations, with the source map on — the configuration the
new path actually runs in:

- **`imports` / `extends` / `implements` / `method_implements`: 15 repos,
  219,122 edges, all byte-identical.**
- **Resolved calls (pair, confidence, line, origin): 7 repos, 111,258 calls,
  0 lost, 0 gained.**

Corpus spans jvm, c#, swift, go and c++ — including languages whose readers
changed but whose behaviour must not — plus python and typescript controls.

Two decode hazards are handled explicitly, because either would have changed
edges silently:

- **The codec stays the caller's.** utf-8 for JVM and Swift, utf-8-sig for C#
  (the only one that strips a BOM), and `errors="replace"` where the .NET
  readers used it. A shared default would change what each scan's regexes match.
- **`Path.read_text` translates newlines and `bytes.decode` does not.** Text
  mode maps CRLF and lone CR to LF; the raw bytes still carry the CR. 857 of
  874 Ocelot files and 743 of 743 swift-nio files are CRLF, so a naive decode
  would have changed the text of nearly every file in a Windows-authored
  checkout. `decode_source` normalises.

`tests/unit/ingestion/test_source_text.py` pins map-hit against disk-read across
both codecs, both error modes, BOMs, lone CR, mixed endings, invalid UTF-8 and
the empty file. 364 targeted ingestion tests pass; `ruff check` clean.

## Known limits

- The call resolver builds the JVM, C++ and Go indexes from a minimal stand-in
  context of its own that carries neither field, so `build_jvm_workspace_index`
  still runs a second time per build without the map or the shared walk —
  `_scan_jvm_file` calls fall 4640 → 2320 on ktor, exactly half. Filed
  separately; the new fields are read with `getattr` so that path behaves
  exactly as before.
- Only the walks the measured repos exercise were moved. Ruby, Swift SPM, Go,
  Scala and F# still issue their own `iter_glob`; `glob_via` is the seam they
  would use.