### PR TITLE
feat(graph): resolve inherited calls in C# again

### DIFF
--- a/packages/core/src/repowise/core/ingestion/call_resolver.py
+++ b/packages/core/src/repowise/core/ingestion/call_resolver.py
@@ -58,18 +58,19 @@ _IMPLICIT_RECEIVER_LANGUAGES = frozenset({"java", "csharp", "cpp", "kotlin"})
 # its ancestors. Both shapes — an explicit ``self``/``this`` receiver and an
 # implicit one — end in the same walk.
 #
-# C# is absent, and it is an exclusion rather than an omission: the method
-# indexes are keyed ``(class, method)`` with no parameter list, so a class
-# declaring several overloads of one name keeps whichever the index kept. Its
-# precision audit came back 7/30, every failure the same wrong-overload
-# pairing. C++ is absent because its heritage binds a qualified external
+# C++ is absent because its heritage binds a qualified external
 # parent to a same-named local type, which puts unrelated siblings in one
 # hierarchy before this walk even runs. Java is absent because `java.scm`'s
 # bare-call pattern also matches `this.field.m()`, which no receiver-carrying
 # pattern claims, so such a call arrives here indistinguishable from a real
 # implicit receiver — and its measured population on two Java repos was zero,
 # so the tier could only cost.
-_INHERITED_LANGUAGES = frozenset({"kotlin", "python", "typescript", "swift"})
+#
+# C# is present, and was once wrongly removed: a name's overloads all share one
+# symbol id, so a declaration line read back out of the graph names an
+# arbitrary overload. That reads as a wrong target and is not one — the id
+# these calls resolve to is the id C# binds.
+_INHERITED_LANGUAGES = frozenset({"kotlin", "python", "typescript", "swift", "csharp"})
 
 # Ancestors within four hops: ``heritage_ancestors`` bounds expansion, not
 # reach, so 3 reaches 4.

--- a/packages/core/src/repowise/core/ingestion/parser_helpers.py
+++ b/packages/core/src/repowise/core/ingestion/parser_helpers.py
@@ -830,9 +830,19 @@ TYPE_HEAD_EXTRACTORS: dict[str, Callable[[Node, str], str | None]] = {
 
 
 def _count_arguments(arg_node: Node) -> int:
-    """Count the number of arguments in an argument/argument_list node."""
+    """Count the number of arguments in an argument/argument_list node.
+
+    Comments are children of the argument list, so an argument annotated with
+    a trailing ``// name`` counted twice. Grammars spell the node type several
+    ways (``comment``, ``line_comment``, ``block_comment``), hence the
+    substring test rather than a fixed set.
+    """
     skip_types = frozenset({"(", ")", ",", "[", "]"})
-    return sum(1 for child in arg_node.children if child.type not in skip_types)
+    return sum(
+        1
+        for child in arg_node.children
+        if child.type not in skip_types and "comment" not in child.type
+    )
 
 
 def _find_enclosing_symbol(

--- a/tests/unit/ingestion/parser/test_misc.py
+++ b/tests/unit/ingestion/parser/test_misc.py
@@ -93,3 +93,42 @@ class TestLanguageConfigs:
             assert result in ("public", "private", "protected", "internal"), (
                 f"{lang} visibility_fn returned unexpected: {result}"
             )
+
+
+class TestArgumentCount:
+    """``CallSite.argument_count`` counts arguments, not comment tokens."""
+
+    def _calls(self, source: bytes, path: str, language: str) -> dict[str, int | None]:
+        parser = ASTParser()
+        parsed = parser.parse_file(_make_file_info(path, language), source)
+        return {c.target_name: c.argument_count for c in parsed.calls}
+
+    def test_csharp_inline_comments_are_not_arguments(self) -> None:
+        source = b"""\
+public class C
+{
+    void Run()
+    {
+        Target(
+            first,  // Action<A, B> one,
+            second, // Action<C> two,
+            third);
+        Plain(a, b);
+        None();
+    }
+}
+"""
+        counts = self._calls(source, "C.cs", "csharp")
+        assert counts["Target"] == 3
+        assert counts["Plain"] == 2
+        assert counts["None"] == 0
+
+    def test_python_inline_comment_is_not_an_argument(self) -> None:
+        source = b"""\
+def run():
+    target(
+        first,  # one
+        second,
+    )
+"""
+        assert self._calls(source, "m.py", "python")["target"] == 2

--- a/tests/unit/ingestion/test_dispatch_edges.py
+++ b/tests/unit/ingestion/test_dispatch_edges.py
@@ -335,3 +335,56 @@ def test_a_python_bare_call_is_not_read_as_an_implicit_receiver(tmp_path: Path) 
         "python",
     )
     assert not _calls_by_origin(graph, "enclosing_inherited")
+
+
+def test_a_csharp_bare_call_reaches_an_inherited_method(tmp_path: Path) -> None:
+    """C# resolves a bare call by neither package nor imported name, so an
+    inherited member is only reachable through the ancestor walk. A decoy
+    declares the name too, so a global-name guess cannot answer instead."""
+    graph = _build(
+        tmp_path,
+        {
+            "Base.cs": (
+                "namespace App.Base;\n\npublic class Base\n{\n"
+                "    protected int Helper() => 1;\n}\n"
+            ),
+            "Mid.cs": "namespace App.Mid;\n\npublic class Mid : Base\n{\n}\n",
+            "Child.cs": (
+                "namespace App.Web;\n\npublic class Child : Mid\n{\n"
+                "    public int Run() => Helper();\n}\n"
+            ),
+            "Decoy.cs": (
+                "namespace App.Other;\n\npublic class Decoy\n{\n"
+                "    public int Helper() => 9;\n}\n"
+            ),
+        },
+        "csharp",
+    )
+    assert ("Child.cs::Child::Run", "Base.cs::Base::Helper") in _calls_by_origin(
+        graph, "enclosing_inherited"
+    )
+
+
+def test_a_csharp_overload_set_resolves_to_the_one_id_it_shares(tmp_path: Path) -> None:
+    """Overloads of one name in one class carry one symbol id, so a call
+    reaching any of them lands on the same node. Pins the property the
+    inherited tier relies on: there is nothing to choose between."""
+    graph = _build(
+        tmp_path,
+        {
+            "Steps.cs": (
+                "namespace App;\n\npublic class Steps\n{\n"
+                "    protected int Given() => 0;\n"
+                "    protected int Given(int a) => a;\n"
+                "    protected int Given(int a, int b) => a + b;\n}\n"
+            ),
+            "Test.cs": (
+                "namespace App;\n\npublic class Test : Steps\n{\n"
+                "    public int Run() => Given(1, 2);\n}\n"
+            ),
+        },
+        "csharp",
+    )
+    assert ("Test.cs::Test::Run", "Steps.cs::Steps::Given") in _calls_by_origin(
+        graph, "enclosing_inherited"
+    )


### PR DESCRIPTION
## What

**A call a C# class cannot answer itself is now resolved against its ancestors**, as it already was for Kotlin, Python, TypeScript and Swift. On the Ocelot corpus repository that is **1,834 more resolved calls, 6,232 to 8,066**, with nothing lost anywhere.

**`CallSite.argument_count` no longer counts comments as arguments.** Comments are children of the argument-list node, so an argument annotated with a trailing `// name` counted twice and a six-argument call read as nine. The field has no consumer yet, so no edge moves.

## Why C# had been switched off, and why that was wrong

C# was removed from the inherited-call tier on a hand precision check that came back 7 correct out of 30, every failure reading as "right ancestor, wrong overload".

That reading was an artefact of how the check was made, not a property of the edges. A symbol id is `path::Class::name` and carries **no parameter list**, so every overload of a name in a class is a separate parsed symbol sharing **one id**, and `GraphBuilder.add_file` merges them into one node whose declaration line is whichever overload was parsed last. The check read that line back out of the graph and compared it against the call. On Ocelot, 1,403 of the 1,834 affected rows point at a name with two to seven overloads, so for three quarters of them the line shown names an arbitrary member of the set.

The edges were right; the line was not. Re-checked by hand on a fresh sample, judging the resolved id and the whole declared overload set rather than one line: **30 of 30 correct**. The same correction takes the Swift override audit from 28/30 to 30/30.

The audit harness now carries the full overload set on every row so the artefact cannot recur.

## Measurements

Resolved-call snapshots before and after on 18 repositories, diffed by sha256 over `(file, caller, callee, confidence, line, origin)`, with every difference required to land in a named bucket.

| | |
|---|---|
| Ocelot resolved calls | **6,232 → 8,066** (+1,834) |
| Calls lost, all 18 repositories | **0** |
| Rows re-originated or unexplained | **0** |
| Other 17 repositories | byte-identical |
| Heritage / imports edges | byte-identical on all 18 |
| Ocelot node count | 9,705 → 9,705 |
| Cost, Ocelot | 9.4% of graph build, 5.2% of parse + build |

All 1,834 new rows carry `enclosing_inherited` (1,822) or `self_inherited` (12). The two other C# repositories in the corpus gain nothing, which is the expected control: their inherited populations were measured at zero and seven, and the seven are the ambiguity refusal declining to guess between two ancestors.

Cost was taken as four configurations in one process with an untimed warmup and the minimum of three runs, and the four are ordered — removing both halves is fastest, full is slowest.

## Deliberately not done

**No parameter count was added to `Symbol`, so no re-index is required.** That was the obvious fix and it was measured before being written: across all 1,834 inherited edges the call's argument count already fits an existing overload, and refuses none. A new symbol field would have cost every user a re-index and bought nothing on this population.

**Symbol ids still collapse overloads.** That is the real defect underneath, it reaches further than the call graph — the collapse is persisted, so a symbol lookup returns one overload's body and an unused overload cannot be reported as dead — and fixing it moves every symbol id in the product. It is tracked separately.

## Risk

The inherited tier is asked last on both code paths, so it can only answer a call nothing else claimed. That is why nothing is lost, and it is measured rather than assumed. Two guard tests cover the new C# behaviour, including one pinning that an overload set resolves to the single id it shares; both fail without the change.

Adversarial review raised one genuine hazard, which is pre-existing rather than introduced here: a type declared across several files — a C# `partial class`, a Swift `extension` in a second file — can look as though it does not declare a method it does declare, sending the walk to an ancestor. Measured across five repositories it exposes zero edges once restricted to languages that can actually split a type, and it is tracked separately.

## Tests

`ruff check .` clean. Green: ingestion 2,306 passed; dispatch 17; analysis, dead code, pipeline, coupling and health 2,156; providers 56.

`tests/unit/test_no_bare_type_name_copies.py` fails, and it **fails identically on `main` at 8362dbef** with this branch's changes reverted — `call_resolver.py` holds 7 qualifier splits against an allowance of 4. This branch adds none of them: its only change to that file is a comment and one entry in a frozenset. Being fixed separately.
