### PR TITLE
fix(ci): restore the two guards that went red on main

### DIFF
--- a/packages/server/src/repowise/server/services/c4_builder/labels.py
+++ b/packages/server/src/repowise/server/services/c4_builder/labels.py
@@ -59,6 +59,11 @@ _EDGE_VERB: dict[str, str] = {
 # surface the single highest-priority verb rather than concatenating tokens.
 _VERB_PRIORITY: tuple[str, ...] = (
     "calls",
+    # Below "calls": a pair with both holds a direct invocation, which is the
+    # more precise claim. Above the heritage verbs, because where a pair has
+    # both, the dispatch says what actually runs and "implements" only says
+    # the types line up.
+    "dispatches to",
     "inherits from",
     "implements",
     "imports",

--- a/tests/unit/test_no_bare_type_name_copies.py
+++ b/tests/unit/test_no_bare_type_name_copies.py
@@ -71,10 +71,10 @@ _KNOWN: dict[str, int] = {
     # Splits our own `path::Class::method` symbol IDs, which we mint. The
     # separator is ours rather than the language's, so the shared helper would
     # be answering about a type where these ask about an ID. `models.py` holds
-    # the one both resolvers used to duplicate. Three of `call_resolver.py`'s
-    # four are symbol IDs; the fourth takes the tail of an import's module
+    # the one both resolvers used to duplicate. Six of `call_resolver.py`'s
+    # seven are symbol IDs; the seventh takes the tail of an import's module
     # path, which is a module name, not a type.
-    _PREFIX + "call_resolver.py": 4,
+    _PREFIX + "call_resolver.py": 7,
     _PREFIX + "models.py": 1,
     # Reads the head to decide whether taking a bare name is safe at all: a
     # qualifier that is a type rather than a package must not be discarded.


### PR DESCRIPTION
`main` is red at `8362dbef` on three tests, in two unrelated places. Both are
vocabulary guards catching a real omission, so neither is a flaky test to
silence.

### `test_no_bare_type_name_copies` (two failures)

The guard counts qualifier-splitting expressions living outside the type-name
module. Three new ones appeared in `call_resolver.py`, against an allowance of
four.

All three split our own `path::Class::method` symbol ids. The separator is
ours rather than a language's, so they ask what an id is made of, not what a
type is called — the category `_KNOWN` already exempts, alongside the one site
that takes the tail of an import's module path. So the fix is the count and
the reason, not a conversion.

Six of the seven are now symbol ids; the seventh is the module path. Verified
against the tree after rebasing onto #1651, which also touches this file and
adds none.

This is the fourth time this guard has caught a change to the resolver. That
is the guard working: the allowance moves, the rule does not.

### `test_c4_edge_verb_coverage::test_every_verb_can_be_ranked`

`dispatches_to` reached the C4 verb map without a rank in `_VERB_PRIORITY`. An
aggregated edge picks the highest-ranked verb it carries, so an unranked one
can never win — the relation would have rendered as whatever else the pair
happened to carry, silently, which is the exact failure mode that test was
written for after `framework` and `dynamic_uses` did it for their whole life.

Ranked below `calls`, because a pair holding both has a direct invocation and
that is the more precise claim, and above the heritage verbs, because where a
pair has both, the dispatch says what actually runs while `implements` only
says the types line up.

### Verification

`tests/unit/server`, `tests/unit/generation` and `tests/unit/test_no_bare_type_name_copies.py`
— every consumer of `relation_label` and of the guard — pass: 3,672 tests.
`ruff check` clean on both changed files.