### PR TITLE
feat(graph): link a framework-wired symbol to the symbol it is wired to

### DIFF
--- a/packages/core/src/repowise/core/analysis/knowledge_graph.py
+++ b/packages/core/src/repowise/core/analysis/knowledge_graph.py
@@ -215,7 +215,9 @@ def _slugify(text: str) -> str:
 # ranking, neither of which moves a node or edge count.
 # "3": `references` joined the map, so C/C++ dispatch tables and registration
 # macros reach the export instead of being dropped.
-KG_BUILDER_VERSION = "3"
+# "4": `framework_binds` joined the map, so a container-wired symbol pair
+# reaches the export instead of being dropped.
+KG_BUILDER_VERSION = "4"
 
 # An unmapped type is dropped from the export entirely (see the
 # `if not kg_type: continue` below), which is silent. Six real types used to be
@@ -242,6 +244,7 @@ _EDGE_TYPE_MAP: dict[str, str] = {
     "implements": "depends_on",
     "method_implements": "depends_on",
     "dispatches_to": "depends_on",
+    "framework_binds": "depends_on",
     "reads": "depends_on",
     "references": "depends_on",
 }

--- a/packages/core/src/repowise/core/generation/onboarding/subkinds/key_concepts.py
+++ b/packages/core/src/repowise/core/generation/onboarding/subkinds/key_concepts.py
@@ -109,6 +109,7 @@ _RELATION_VERB: dict[str, str] = {
     "implements": "implements",
     "method_implements": "implements",
     "dispatches_to": "dispatches to",
+    "framework_binds": "is wired to",
     "reads": "reads from",
     # Named rather than called: a dispatch-table entry, a callback field, an
     # argument to a registration macro. "references" is the honest verb, since

--- a/packages/core/src/repowise/core/ingestion/framework_edges/base.py
+++ b/packages/core/src/repowise/core/ingestion/framework_edges/base.py
@@ -61,26 +61,20 @@ def _add_edge_if_new(graph: nx.DiGraph, source: str, target: str) -> bool:
     return True
 
 
-# A symbol edge asserts more than the file edge above it, so it is worth more
-# than "somewhere in that file". Below `same_file` (0.95) because the framework
-# can rebind at runtime and we are reading a convention, at the level of the
-# heritage-walk origins because, like them, the binding follows a documented
-# rule and checks no signature.
+# Below `same_file` (0.95) because the framework can rebind at run time, level
+# with the heritage-walk origins because the binding follows a documented rule
+# and checks no signature.
 FRAMEWORK_BIND_CONFIDENCE = 0.90
 
 
 def add_symbol_edge(graph: nx.DiGraph, source: str, target: str) -> bool:
     """Link two *symbol* nodes the framework wires together.
 
-    Separate from ``_add_edge_if_new`` rather than a flag on it, because the
-    two disagree about what "already there" means. That one is first-wins over
-    the whole graph, which is right for a file pair; here it would let
-    containment win silently — a networkx ``DiGraph`` holds one edge per
-    ordered pair, and ``defines`` already occupies (file, symbol), so a handler
-    reaching from a file to a symbol it declares would be dropped without a
-    trace. Both ends are required to be existing symbol nodes for the same
-    reason: a typo'd id would otherwise mint a bare node with no attributes
-    that every later consumer has to defend against.
+    Not a flag on ``_add_edge_if_new``: a ``DiGraph`` holds one edge per ordered
+    pair and ``defines`` already occupies (file, symbol), so that helper's
+    first-wins guard would let containment silently swallow a symbol edge.
+    Both ends must already be symbol nodes, so a wrong id cannot mint a bare
+    node with no attributes for every later consumer to defend against.
     """
     if source == target:
         return False
@@ -131,12 +125,9 @@ def build_type_to_symbol(
 ) -> dict[str, str]:
     """Map a declared type name → its symbol id, for names declared exactly once.
 
-    The symbol-level twin of :func:`_build_class_to_file`, and deliberately
-    stricter than it: that one keeps the first file to declare a name, which is
-    tolerable when the answer is "somewhere in this file" and is not when the
-    answer names a symbol. A name two files declare is dropped, so an ambiguous
-    injection stays unclaimed rather than being bound to whichever file was
-    walked first.
+    Stricter than :func:`_build_class_to_file`, which keeps the first declarer:
+    an ambiguous name must stay unclaimed rather than bind to whichever file the
+    walk reached first.
     """
     seen: dict[str, str | None] = {}
     for _path, parsed in parsed_files.items():

--- a/packages/core/src/repowise/core/ingestion/framework_edges/base.py
+++ b/packages/core/src/repowise/core/ingestion/framework_edges/base.py
@@ -61,6 +61,45 @@ def _add_edge_if_new(graph: nx.DiGraph, source: str, target: str) -> bool:
     return True
 
 
+# A symbol edge asserts more than the file edge above it, so it is worth more
+# than "somewhere in that file". Below `same_file` (0.95) because the framework
+# can rebind at runtime and we are reading a convention, at the level of the
+# heritage-walk origins because, like them, the binding follows a documented
+# rule and checks no signature.
+FRAMEWORK_BIND_CONFIDENCE = 0.90
+
+
+def add_symbol_edge(graph: nx.DiGraph, source: str, target: str) -> bool:
+    """Link two *symbol* nodes the framework wires together.
+
+    Separate from ``_add_edge_if_new`` rather than a flag on it, because the
+    two disagree about what "already there" means. That one is first-wins over
+    the whole graph, which is right for a file pair; here it would let
+    containment win silently — a networkx ``DiGraph`` holds one edge per
+    ordered pair, and ``defines`` already occupies (file, symbol), so a handler
+    reaching from a file to a symbol it declares would be dropped without a
+    trace. Both ends are required to be existing symbol nodes for the same
+    reason: a typo'd id would otherwise mint a bare node with no attributes
+    that every later consumer has to defend against.
+    """
+    if source == target:
+        return False
+    for node in (source, target):
+        data = graph.nodes.get(node)
+        if data is None or data.get("node_type") != "symbol":
+            return False
+    if graph.has_edge(source, target):
+        return False
+    graph.add_edge(
+        source,
+        target,
+        edge_type="framework_binds",
+        confidence=FRAMEWORK_BIND_CONFIDENCE,
+        imported_names=[],
+    )
+    return True
+
+
 def read_text(parsed: Any, encoding: str = "utf-8") -> str:
     """Read a parsed file's source text, returning ``""`` on read failure.
 
@@ -85,6 +124,28 @@ def _build_class_to_file(
             if sym.kind in ("class", "interface", "struct", "record", "enum", "trait"):
                 result.setdefault(sym.name, path)
     return result
+
+
+def build_type_to_symbol(
+    parsed_files: dict[str, Any], languages: tuple[str, ...]
+) -> dict[str, str]:
+    """Map a declared type name → its symbol id, for names declared exactly once.
+
+    The symbol-level twin of :func:`_build_class_to_file`, and deliberately
+    stricter than it: that one keeps the first file to declare a name, which is
+    tolerable when the answer is "somewhere in this file" and is not when the
+    answer names a symbol. A name two files declare is dropped, so an ambiguous
+    injection stays unclaimed rather than being bound to whichever file was
+    walked first.
+    """
+    seen: dict[str, str | None] = {}
+    for _path, parsed in parsed_files.items():
+        if parsed.file_info.language not in languages:
+            continue
+        for sym in parsed.symbols:
+            if sym.kind in ("class", "interface", "struct", "record", "enum", "trait"):
+                seen[sym.name] = None if sym.name in seen else sym.id
+    return {name: sid for name, sid in seen.items() if sid is not None}
 
 
 def _build_function_to_file(

--- a/packages/core/src/repowise/core/ingestion/framework_edges/express.py
+++ b/packages/core/src/repowise/core/ingestion/framework_edges/express.py
@@ -15,6 +15,7 @@ from .base import (
     _add_edge_if_new,
     _build_class_to_file,
     _build_ts_var_to_file,
+    add_symbol_edge,
     read_text,
 )
 
@@ -57,13 +58,6 @@ def _match_paren(text: str, open_idx: int) -> int:
     return -1
 
 
-def _add_reads_edge(graph: nx.DiGraph, source: str, target: str) -> bool:
-    if source == target or not graph.has_node(source) or not graph.has_node(target):
-        return False
-    if graph.has_edge(source, target):
-        return False
-    graph.add_edge(source, target, edge_type="reads", imported_names=[])
-    return True
 
 
 def _has_express_imports(parsed_files: dict[str, Any]) -> bool:
@@ -120,7 +114,7 @@ def _add_express_edges(
                     arg_blob = _STRING_LITERAL_RE.sub("", text[m.end() : close])
                     for ident in _ARG_IDENT_RE.finditer(arg_blob):
                         sym_id = local_funcs.get(ident.group(0))
-                        if sym_id and _add_reads_edge(graph, module_sym, sym_id):
+                        if sym_id and add_symbol_edge(graph, module_sym, sym_id):
                             count += 1
 
         # ---- NestJS: @Module({ controllers: [...], providers: [...], imports: [...] }) ----

--- a/packages/core/src/repowise/core/ingestion/framework_edges/express.py
+++ b/packages/core/src/repowise/core/ingestion/framework_edges/express.py
@@ -58,8 +58,6 @@ def _match_paren(text: str, open_idx: int) -> int:
     return -1
 
 
-
-
 def _has_express_imports(parsed_files: dict[str, Any]) -> bool:
     for parsed in parsed_files.values():
         if parsed.file_info.language not in ("typescript", "javascript"):

--- a/packages/core/src/repowise/core/ingestion/framework_edges/pytest_edges.py
+++ b/packages/core/src/repowise/core/ingestion/framework_edges/pytest_edges.py
@@ -8,6 +8,7 @@ names are fixture requests resolved at run time.
 from __future__ import annotations
 
 import re
+from fnmatch import fnmatch
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -26,23 +27,42 @@ if TYPE_CHECKING:
 # `@pytest_asyncio.fixture` are both accepted: pytest resolves the decorator by
 # identity, not by module path.
 _FIXTURE_DECORATOR_RE = re.compile(r"^@(?:[\w.]+\.)?fixture\b")
-# `@pytest.fixture(name="app")` renames the fixture: the function stays
-# `fixture_app` and tests ask for `app`. Matching the function name here would
-# both miss the real name and claim a wrong one.
-_FIXTURE_NAME_KWARG_RE = re.compile(r"""\bname\s*=\s*["']([^"']+)["']""")
-# The parameter names a test declares itself. `parametrize` supplies them, so
-# they are not fixture requests — and a parametrize argument that happens to
-# share a fixture's name would otherwise mint a wrong edge.
 _PARAMETRIZE_RE = re.compile(r"^@(?:[\w.]+\.)?parametrize\b")
 _QUOTED_RE = re.compile(r"""["']([^"']*)["']""")
+# `@pytest.fixture(name="app")` registers `fixture_app` as `app`. Read as a
+# top-level keyword only: a `name=` nested in a params list is not the
+# fixture's name.
 _NAME_KWARG_ARG_RE = re.compile(r"""^name\s*=\s*["']([^"']+)["']$""")
 
 _TEST_FILE_RE = re.compile(r"(?:^|/)(?:test_[^/]*|[^/]*_test)\.py$")
 
-# pytest collects methods only from classes named `Test*`. A `class Harness`
-# with a `test_connection` method is never run, so its parameters are ordinary
-# arguments its own callers pass.
-_TEST_CLASS_PREFIX = "Test"
+# pytest collects methods only from classes matching `python_classes`, so a
+# `class Harness` with a `test_connection` method is never run and its
+# parameters are ordinary arguments its callers pass. The setting is read
+# rather than assumed: celery configures `test_*`, and assuming the default
+# refused 346 of its 359 bindings.
+_DEFAULT_TEST_CLASS_GLOBS = ("Test*",)
+_PYTHON_CLASSES_RE = re.compile(
+    r"^\s*python_classes\s*=\s*(.+?)\s*$", re.MULTILINE
+)
+
+
+def _test_class_globs(repo_path: Path | None) -> tuple[str, ...]:
+    """The ``python_classes`` globs this project collects test classes by."""
+    if repo_path is None:
+        return _DEFAULT_TEST_CLASS_GLOBS
+    for name in ("pyproject.toml", "pytest.ini", "tox.ini", "setup.cfg"):
+        try:
+            text = (repo_path / name).read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+        match = _PYTHON_CLASSES_RE.search(text)
+        if not match:
+            continue
+        globs = tuple(match.group(1).strip().strip("\"'").split())
+        if globs:
+            return globs
+    return _DEFAULT_TEST_CLASS_GLOBS
 
 
 def _call_arguments(text: str) -> list[str]:
@@ -181,7 +201,9 @@ def _requested_fixtures(sym: Any) -> list[str]:
     return names
 
 
-def _add_fixture_injection_edges(graph: nx.DiGraph, parsed_files: dict[str, Any]) -> int:
+def _add_fixture_injection_edges(
+    graph: nx.DiGraph, parsed_files: dict[str, Any], repo_path: Path | None = None
+) -> int:
     """Link each test function to the fixture it asks for by name.
 
     Scope follows pytest's own rule, innermost first: the test's own class, then
@@ -202,6 +224,8 @@ def _add_fixture_injection_edges(graph: nx.DiGraph, parsed_files: dict[str, Any]
         if declared:
             conftests[Path(path).parent.as_posix()] = declared
 
+    class_globs = _test_class_globs(repo_path)
+
     count = 0
     for path, parsed in parsed_files.items():
         if parsed.file_info.language != "python" or not _TEST_FILE_RE.search(path):
@@ -219,7 +243,9 @@ def _add_fixture_injection_edges(graph: nx.DiGraph, parsed_files: dict[str, Any]
         for sym in parsed.symbols:
             if sym.kind not in ("function", "method") or not sym.name.startswith("test_"):
                 continue
-            if sym.parent_name and not sym.parent_name.startswith(_TEST_CLASS_PREFIX):
+            if sym.parent_name and not any(
+                fnmatch(sym.parent_name, g) for g in class_globs
+            ):
                 continue
             for name in _requested_fixtures(sym):
                 target = (
@@ -247,7 +273,7 @@ class _FixtureInjectionHandler:
         ctx: ResolverContext,
         path_set: set[str],
     ) -> int:
-        return _add_fixture_injection_edges(graph, parsed_files)
+        return _add_fixture_injection_edges(graph, parsed_files, ctx.repo_path)
 
 
 class _ConftestHandler:

--- a/packages/core/src/repowise/core/ingestion/framework_edges/pytest_edges.py
+++ b/packages/core/src/repowise/core/ingestion/framework_edges/pytest_edges.py
@@ -1,6 +1,8 @@
 """pytest conftest convention edges.
 
-Split out of ``framework_edges.py`` (PR 3.5) — behaviour-preserving move.
+Two conventions, both invisible to a static import graph: a ``conftest.py`` is
+imported by collection rather than by any statement, and a test's parameter
+names are fixture requests resolved at run time.
 """
 
 from __future__ import annotations
@@ -20,11 +22,9 @@ from .base import (
 if TYPE_CHECKING:
     import networkx as nx
 
-# `@fixture`, `@pytest.fixture`, `@pytest.fixture(scope="module")`, and the
-# aliased `@pytest_asyncio.fixture`. Anchored at the attribute tail so a
-# user-defined `@my.fixture` is accepted too — pytest resolves the decorator by
-# identity, not by module, and a name that ends in `fixture` and is used as one
-# is one far more often than not.
+# Matched at the attribute tail rather than on `pytest.`, so `@my.fixture` and
+# `@pytest_asyncio.fixture` are both accepted: pytest resolves the decorator by
+# identity, not by module path.
 _FIXTURE_DECORATOR_RE = re.compile(r"^@(?:[\w.]+\.)?fixture\b")
 # `@pytest.fixture(name="app")` renames the fixture: the function stays
 # `fixture_app` and tests ask for `app`. Matching the function name here would
@@ -34,10 +34,59 @@ _FIXTURE_NAME_KWARG_RE = re.compile(r"""\bname\s*=\s*["']([^"']+)["']""")
 # they are not fixture requests — and a parametrize argument that happens to
 # share a fixture's name would otherwise mint a wrong edge.
 _PARAMETRIZE_RE = re.compile(r"^@(?:[\w.]+\.)?parametrize\b")
-_PARAM_NAMES_RE = re.compile(r"""["']([^"']+)["']""")
-_SIGNATURE_PARAMS_RE = re.compile(r"\(([^)]*)\)")
+_QUOTED_RE = re.compile(r"""["']([^"']*)["']""")
+_NAME_KWARG_ARG_RE = re.compile(r"""^name\s*=\s*["']([^"']+)["']$""")
 
 _TEST_FILE_RE = re.compile(r"(?:^|/)(?:test_[^/]*|[^/]*_test)\.py$")
+
+# pytest collects methods only from classes named `Test*`. A `class Harness`
+# with a `test_connection` method is never run, so its parameters are ordinary
+# arguments its own callers pass.
+_TEST_CLASS_PREFIX = "Test"
+
+
+def _call_arguments(text: str) -> list[str]:
+    """Top-level arguments of the first call in *text*, unsplit by nesting.
+
+    A plain `split(",")` cannot do this and neither can one regex: a default
+    value, a subscripted annotation and a nested `dict(...)` all contain the
+    characters the split keys on. Depth counting with string awareness is the
+    smallest thing that reads `def t(a, cb: Callable[[int], str], o=(1, 2))`
+    correctly.
+    """
+    start = text.find("(")
+    if start == -1:
+        return []
+    depth = 0
+    quote: str | None = None
+    args: list[str] = []
+    current: list[str] = []
+    for ch in text[start:]:
+        if quote:
+            current.append(ch)
+            if ch == quote:
+                quote = None
+            continue
+        if ch in "\"'":
+            quote = ch
+            current.append(ch)
+            continue
+        if ch in "([{":
+            depth += 1
+            if depth == 1:
+                continue
+        elif ch in ")]}":
+            depth -= 1
+            if depth == 0:
+                args.append("".join(current))
+                return [a.strip() for a in args if a.strip()]
+        elif ch == "," and depth == 1:
+            args.append("".join(current))
+            current = []
+            continue
+        current.append(ch)
+    # Unbalanced — a truncated signature. Return nothing rather than a guess.
+    return []
 
 
 def _add_conftest_edges(graph: nx.DiGraph, path_set: set[str]) -> int:
@@ -61,17 +110,37 @@ def _add_conftest_edges(graph: nx.DiGraph, path_set: set[str]) -> int:
     return count
 
 
-def _declared_fixtures(parsed: Any) -> dict[str, str]:
-    """``{fixture name: symbol id}`` for every fixture *parsed* declares."""
-    out: dict[str, str] = {}
+def _registered_name(sym: Any, decorator: str) -> str:
+    """The name pytest registers the fixture under.
+
+    ``name=`` must be read as a top-level keyword, not found anywhere in the
+    text: ``@pytest.fixture(params=[dict(name="alice")])`` otherwise registers
+    the fixture as ``alice``, which both loses the real request and mints a
+    fabricated one.
+    """
+    for arg in _call_arguments(decorator):
+        match = _NAME_KWARG_ARG_RE.match(arg)
+        if match:
+            return match.group(1)
+    return sym.name
+
+
+def _declared_fixtures(parsed: Any) -> dict[tuple[str | None, str], str]:
+    """``{(owning class or None, fixture name): symbol id}``.
+
+    Keyed by scope rather than by name alone. A fixture declared inside a test
+    class serves that class only, and flattening the two makes every sibling
+    class share it — which is a wrong edge whichever way the collision is
+    resolved.
+    """
+    out: dict[tuple[str | None, str], str] = {}
     for sym in parsed.symbols:
         if sym.kind not in ("function", "method"):
             continue
         for dec in sym.decorators:
             if not _FIXTURE_DECORATOR_RE.match(dec.strip()):
                 continue
-            named = _FIXTURE_NAME_KWARG_RE.search(dec)
-            out.setdefault(named.group(1) if named else sym.name, sym.id)
+            out.setdefault((sym.parent_name, _registered_name(sym, dec)), sym.id)
             break
     return out
 
@@ -79,24 +148,32 @@ def _declared_fixtures(parsed: Any) -> dict[str, str]:
 def _requested_fixtures(sym: Any) -> list[str]:
     """The parameter names *sym* asks pytest to inject.
 
-    Reads the recorded signature rather than re-parsing the file: the parse the
-    pipeline already did is the same one, and a second `ast.parse` of every test
-    file is the cost this pass exists inside a build to avoid.
+    Reads the recorded signature rather than re-parsing: a second pass over
+    every test file is the cost of running inside the build rather than beside
+    it.
     """
-    match = _SIGNATURE_PARAMS_RE.search(sym.signature or "")
-    if not match:
-        return []
     supplied: set[str] = set()
     for dec in sym.decorators:
-        if _PARAMETRIZE_RE.match(dec.strip()):
-            # First string group is the argnames spec; pytest also accepts a
-            # comma-joined single string.
-            for token in _PARAM_NAMES_RE.findall(dec):
+        if not _PARAMETRIZE_RE.match(dec.strip()):
+            continue
+        # Only the first argument is the argnames spec. Reading the whole
+        # decorator instead makes every parametrize *value* look like a name
+        # the test supplies, so a real fixture request whose name is also a
+        # common literal is silently refused.
+        args = _call_arguments(dec)
+        if args:
+            for token in _QUOTED_RE.findall(args[0]):
                 supplied.update(p.strip() for p in token.split(","))
+
     names = []
-    for raw in match.group(1).split(","):
-        name = raw.split(":")[0].split("=")[0].strip()
-        if not name or name.startswith("*") or name in ("self", "cls"):
+    for raw in _call_arguments(sym.signature or ""):
+        # A defaulted parameter is never injected: pytest skips any argument
+        # whose default is not empty. The arguments are already split at top
+        # level, so an `=` here is a default and not part of an annotation.
+        if "=" in raw or raw.startswith("*"):
+            continue
+        name = raw.split(":")[0].strip()
+        if not name or name in ("self", "cls", "/"):
             continue
         if name in supplied:
             continue
@@ -107,22 +184,21 @@ def _requested_fixtures(sym: Any) -> list[str]:
 def _add_fixture_injection_edges(graph: nx.DiGraph, parsed_files: dict[str, Any]) -> int:
     """Link each test function to the fixture it asks for by name.
 
-    The pairing is the whole point. The conftest hint above already computes
-    both halves — which fixtures a conftest declares, which parameter names a
-    test asks for — and then keeps only the file pair, so "this fixture is used
-    by nobody" and "editing this fixture touches these tests" are both
-    unanswerable today.
-
-    Scope follows pytest's own rule: a fixture declared in the test's own module
-    wins, then the nearest ``conftest.py`` at or above it. Nothing else is
+    Scope follows pytest's own rule, innermost first: the test's own class, then
+    its module, then the nearest ``conftest.py`` at or above it. Nothing else is
     searched, so a plugin-provided fixture stays unclaimed rather than being
     bound to a same-named local one.
     """
+    # Only a conftest's module-level fixtures are visible to other files; one
+    # declared inside a class there serves that class alone.
     conftests: dict[str, dict[str, str]] = {}
     for path, parsed in parsed_files.items():
         if Path(path).name != "conftest.py":
             continue
-        declared = _declared_fixtures(parsed)
+        declared = {
+            name: sid for (owner, name), sid in _declared_fixtures(parsed).items()
+            if owner is None
+        }
         if declared:
             conftests[Path(path).parent.as_posix()] = declared
 
@@ -141,14 +217,18 @@ def _add_fixture_injection_edges(graph: nx.DiGraph, parsed_files: dict[str, Any]
         )
 
         for sym in parsed.symbols:
-            if not sym.name.startswith("test_"):
+            if sym.kind not in ("function", "method") or not sym.name.startswith("test_"):
+                continue
+            if sym.parent_name and not sym.parent_name.startswith(_TEST_CLASS_PREFIX):
                 continue
             for name in _requested_fixtures(sym):
-                target = own.get(name)
-                if target is None:
-                    target = next(
+                target = (
+                    own.get((sym.parent_name, name))
+                    or own.get((None, name))
+                    or next(
                         (conftests[d][name] for d in chain if name in conftests[d]), None
                     )
+                )
                 if target and add_symbol_edge(graph, sym.id, target):
                     count += 1
     return count

--- a/packages/core/src/repowise/core/ingestion/framework_edges/pytest_edges.py
+++ b/packages/core/src/repowise/core/ingestion/framework_edges/pytest_edges.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from ..resolvers import ResolverContext
+from ..type_names import strip_type_arguments
 from .base import (
     DetectionContext,
     FrameworkHandler,
@@ -169,7 +170,9 @@ def _fixture_scopes(parsed: Any, class_name: str | None) -> list[str | None]:
         return [None]
     parents: dict[str, list[str]] = {}
     for rel in parsed.heritage:
-        parents.setdefault(rel.child_name, []).append(rel.parent_name.split("<")[0].strip())
+        parents.setdefault(rel.child_name, []).append(
+            strip_type_arguments(rel.parent_name).strip()
+        )
 
     scopes: list[str | None] = []
     seen: set[str] = set()

--- a/packages/core/src/repowise/core/ingestion/framework_edges/pytest_edges.py
+++ b/packages/core/src/repowise/core/ingestion/framework_edges/pytest_edges.py
@@ -79,13 +79,29 @@ def _call_arguments(text: str) -> list[str]:
         return []
     depth = 0
     quote: str | None = None
+    escaped = False
+    comment = False
     args: list[str] = []
     current: list[str] = []
     for ch in text[start:]:
+        if comment:
+            # A signature spanning several lines carries its comments, and an
+            # apostrophe or a stray bracket in one used to swallow the rest of
+            # the parameter list.
+            if ch == "\n":
+                comment = False
+            continue
         if quote:
             current.append(ch)
-            if ch == quote:
+            if escaped:
+                escaped = False
+            elif ch == "\\":
+                escaped = True
+            elif ch == quote:
                 quote = None
+            continue
+        if ch == "#":
+            comment = True
             continue
         if ch in "\"'":
             quote = ch
@@ -107,6 +123,66 @@ def _call_arguments(text: str) -> list[str]:
         current.append(ch)
     # Unbalanced — a truncated signature. Return nothing rather than a guess.
     return []
+
+
+def _has_default(param: str) -> bool:
+    """Whether a single parameter carries a default value."""
+    depth = 0
+    quote: str | None = None
+    escaped = False
+    for i, ch in enumerate(param):
+        if quote:
+            if escaped:
+                escaped = False
+            elif ch == "\\":
+                escaped = True
+            elif ch == quote:
+                quote = None
+            continue
+        if ch in "\"'":
+            quote = ch
+        elif ch in "([{":
+            depth += 1
+        elif ch in ")]}":
+            depth -= 1
+        elif (
+            ch == "="
+            and depth == 0
+            # A comparison or walrus is not a default.
+            and param[i - 1 : i] not in ("=", "<", ">", "!", ":")
+            and param[i + 1 : i + 2] != "="
+        ):
+            return True
+    return False
+
+
+def _fixture_scopes(parsed: Any, class_name: str | None) -> list[str | None]:
+    """The class scopes a test in *class_name* can see a fixture through.
+
+    A subclass sees its base's fixtures, which is the commonest class-scoped
+    arrangement there is -- scoping the lookup to the declaring class alone
+    fixes a rare wrong edge by introducing a frequent missing one. Walked from
+    the file's own heritage, so a base in another module is out of reach and
+    stays unclaimed.
+    """
+    if class_name is None:
+        return [None]
+    parents: dict[str, list[str]] = {}
+    for rel in parsed.heritage:
+        parents.setdefault(rel.child_name, []).append(rel.parent_name.split("<")[0].strip())
+
+    scopes: list[str | None] = []
+    seen: set[str] = set()
+    queue = [class_name]
+    while queue:
+        current = queue.pop(0)
+        if current in seen:
+            continue
+        seen.add(current)
+        scopes.append(current)
+        queue.extend(parents.get(current, ()))
+    scopes.append(None)
+    return scopes
 
 
 def _add_conftest_edges(graph: nx.DiGraph, path_set: set[str]) -> int:
@@ -187,10 +263,10 @@ def _requested_fixtures(sym: Any) -> list[str]:
 
     names = []
     for raw in _call_arguments(sym.signature or ""):
-        # A defaulted parameter is never injected: pytest skips any argument
-        # whose default is not empty. The arguments are already split at top
-        # level, so an `=` here is a default and not part of an annotation.
-        if "=" in raw or raw.startswith("*"):
+        # A defaulted parameter is never injected -- pytest skips any argument
+        # whose default is not empty. The `=` has to be found at depth zero:
+        # `client: Annotated[int, Field(ge=0)]` has no default and is injected.
+        if raw.startswith("*") or _has_default(raw):
             continue
         name = raw.split(":")[0].strip()
         if not name or name in ("self", "cls", "/"):
@@ -247,13 +323,12 @@ def _add_fixture_injection_edges(
                 fnmatch(sym.parent_name, g) for g in class_globs
             ):
                 continue
+            scopes = _fixture_scopes(parsed, sym.parent_name)
             for name in _requested_fixtures(sym):
-                target = (
-                    own.get((sym.parent_name, name))
-                    or own.get((None, name))
-                    or next(
-                        (conftests[d][name] for d in chain if name in conftests[d]), None
-                    )
+                target = next(
+                    (own[(s, name)] for s in scopes if (s, name) in own), None
+                ) or next(
+                    (conftests[d][name] for d in chain if name in conftests[d]), None
                 )
                 if target and add_symbol_edge(graph, sym.id, target):
                     count += 1

--- a/packages/core/src/repowise/core/ingestion/framework_edges/pytest_edges.py
+++ b/packages/core/src/repowise/core/ingestion/framework_edges/pytest_edges.py
@@ -5,6 +5,7 @@ Split out of ``framework_edges.py`` (PR 3.5) — behaviour-preserving move.
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -13,10 +14,30 @@ from .base import (
     DetectionContext,
     FrameworkHandler,
     _add_edge_if_new,
+    add_symbol_edge,
 )
 
 if TYPE_CHECKING:
     import networkx as nx
+
+# `@fixture`, `@pytest.fixture`, `@pytest.fixture(scope="module")`, and the
+# aliased `@pytest_asyncio.fixture`. Anchored at the attribute tail so a
+# user-defined `@my.fixture` is accepted too — pytest resolves the decorator by
+# identity, not by module, and a name that ends in `fixture` and is used as one
+# is one far more often than not.
+_FIXTURE_DECORATOR_RE = re.compile(r"^@(?:[\w.]+\.)?fixture\b")
+# `@pytest.fixture(name="app")` renames the fixture: the function stays
+# `fixture_app` and tests ask for `app`. Matching the function name here would
+# both miss the real name and claim a wrong one.
+_FIXTURE_NAME_KWARG_RE = re.compile(r"""\bname\s*=\s*["']([^"']+)["']""")
+# The parameter names a test declares itself. `parametrize` supplies them, so
+# they are not fixture requests — and a parametrize argument that happens to
+# share a fixture's name would otherwise mint a wrong edge.
+_PARAMETRIZE_RE = re.compile(r"^@(?:[\w.]+\.)?parametrize\b")
+_PARAM_NAMES_RE = re.compile(r"""["']([^"']+)["']""")
+_SIGNATURE_PARAMS_RE = re.compile(r"\(([^)]*)\)")
+
+_TEST_FILE_RE = re.compile(r"(?:^|/)(?:test_[^/]*|[^/]*_test)\.py$")
 
 
 def _add_conftest_edges(graph: nx.DiGraph, path_set: set[str]) -> int:
@@ -40,6 +61,115 @@ def _add_conftest_edges(graph: nx.DiGraph, path_set: set[str]) -> int:
     return count
 
 
+def _declared_fixtures(parsed: Any) -> dict[str, str]:
+    """``{fixture name: symbol id}`` for every fixture *parsed* declares."""
+    out: dict[str, str] = {}
+    for sym in parsed.symbols:
+        if sym.kind not in ("function", "method"):
+            continue
+        for dec in sym.decorators:
+            if not _FIXTURE_DECORATOR_RE.match(dec.strip()):
+                continue
+            named = _FIXTURE_NAME_KWARG_RE.search(dec)
+            out.setdefault(named.group(1) if named else sym.name, sym.id)
+            break
+    return out
+
+
+def _requested_fixtures(sym: Any) -> list[str]:
+    """The parameter names *sym* asks pytest to inject.
+
+    Reads the recorded signature rather than re-parsing the file: the parse the
+    pipeline already did is the same one, and a second `ast.parse` of every test
+    file is the cost this pass exists inside a build to avoid.
+    """
+    match = _SIGNATURE_PARAMS_RE.search(sym.signature or "")
+    if not match:
+        return []
+    supplied: set[str] = set()
+    for dec in sym.decorators:
+        if _PARAMETRIZE_RE.match(dec.strip()):
+            # First string group is the argnames spec; pytest also accepts a
+            # comma-joined single string.
+            for token in _PARAM_NAMES_RE.findall(dec):
+                supplied.update(p.strip() for p in token.split(","))
+    names = []
+    for raw in match.group(1).split(","):
+        name = raw.split(":")[0].split("=")[0].strip()
+        if not name or name.startswith("*") or name in ("self", "cls"):
+            continue
+        if name in supplied:
+            continue
+        names.append(name)
+    return names
+
+
+def _add_fixture_injection_edges(graph: nx.DiGraph, parsed_files: dict[str, Any]) -> int:
+    """Link each test function to the fixture it asks for by name.
+
+    The pairing is the whole point. The conftest hint above already computes
+    both halves — which fixtures a conftest declares, which parameter names a
+    test asks for — and then keeps only the file pair, so "this fixture is used
+    by nobody" and "editing this fixture touches these tests" are both
+    unanswerable today.
+
+    Scope follows pytest's own rule: a fixture declared in the test's own module
+    wins, then the nearest ``conftest.py`` at or above it. Nothing else is
+    searched, so a plugin-provided fixture stays unclaimed rather than being
+    bound to a same-named local one.
+    """
+    conftests: dict[str, dict[str, str]] = {}
+    for path, parsed in parsed_files.items():
+        if Path(path).name != "conftest.py":
+            continue
+        declared = _declared_fixtures(parsed)
+        if declared:
+            conftests[Path(path).parent.as_posix()] = declared
+
+    count = 0
+    for path, parsed in parsed_files.items():
+        if parsed.file_info.language != "python" or not _TEST_FILE_RE.search(path):
+            continue
+
+        own = _declared_fixtures(parsed)
+        # Nearest-first: the deepest conftest directory that is a prefix of this
+        # file's directory shadows the ones above it, as pytest does.
+        chain = sorted(
+            (d for d in conftests if path.startswith(f"{d}/") or d == "."),
+            key=len,
+            reverse=True,
+        )
+
+        for sym in parsed.symbols:
+            if not sym.name.startswith("test_"):
+                continue
+            for name in _requested_fixtures(sym):
+                target = own.get(name)
+                if target is None:
+                    target = next(
+                        (conftests[d][name] for d in chain if name in conftests[d]), None
+                    )
+                if target and add_symbol_edge(graph, sym.id, target):
+                    count += 1
+    return count
+
+
+class _FixtureInjectionHandler:
+    """A test's parameter names are fixture requests pytest resolves at run time."""
+
+    def detect(self, dctx: DetectionContext) -> bool:
+        return any(p.file_info.language == "python" for p in dctx.parsed_files.values())
+
+    def add_edges(
+        self,
+        graph: nx.DiGraph,
+        parsed_files: dict[str, Any],
+        ctx: ResolverContext,
+        path_set: set[str],
+    ) -> int:
+        return _add_fixture_injection_edges(graph, parsed_files)
+
+
 class _ConftestHandler:
     """pytest ``conftest.py`` fixtures are imported implicitly by collection."""
 
@@ -56,4 +186,4 @@ class _ConftestHandler:
         return _add_conftest_edges(graph, path_set)
 
 
-HANDLERS: list[FrameworkHandler] = [_ConftestHandler()]
+HANDLERS: list[FrameworkHandler] = [_ConftestHandler(), _FixtureInjectionHandler()]

--- a/packages/core/src/repowise/core/ingestion/framework_edges/spring.py
+++ b/packages/core/src/repowise/core/ingestion/framework_edges/spring.py
@@ -129,7 +129,29 @@ def _is_spring_data_repo(parsed: Any) -> bool:
     return False
 
 
-def _scan_lombok_ctor_params(text: str) -> list[str]:
+def _owner_at_offset(parsed: Any, text: str, offset: int) -> str | None:
+    """The innermost declared type whose body contains *offset*.
+
+    The injection regexes scan whole-file text with no scope awareness, so the
+    owner has to come from the match position. Taking the type the file is
+    named for instead attributes a nested ``@Configuration``'s injections to the
+    outer class -- and finds nothing at all in a file whose stem names no type.
+    """
+    line = text.count("\n", 0, offset) + 1
+    best: str | None = None
+    best_span = None
+    for sym in parsed.symbols:
+        if sym.kind not in ("class", "interface", "record", "enum"):
+            continue
+        if not (sym.start_line <= line <= sym.end_line):
+            continue
+        span = sym.end_line - sym.start_line
+        if best_span is None or span < best_span:
+            best, best_span = sym.id, span
+    return best
+
+
+def _scan_lombok_ctor_params(text: str) -> list[tuple[str, int]]:
     """Return Lombok-synthesized constructor param types (head identifiers).
 
     For a class annotated ``@RequiredArgsConstructor`` (or ``@Data``), this
@@ -143,7 +165,7 @@ def _scan_lombok_ctor_params(text: str) -> list[str]:
     if not (is_rac or is_aac):
         return []
 
-    params: list[str] = []
+    params: list[tuple[str, int]] = []
     for m in _JAVA_FINAL_FIELD_RE.finditer(text):
         is_final = bool(m.group(1))
         type_head = m.group(2)
@@ -152,28 +174,13 @@ def _scan_lombok_ctor_params(text: str) -> list[str]:
                          "List", "Map", "Set", "Collection"):
             continue
         if is_aac or (is_rac and is_final):
-            params.append(type_head)
+            params.append((type_head, m.start()))
     return params
-
-
-def _declaring_type_symbol(parsed: Any, path: str) -> str | None:
-    """The symbol id of the type *path* is named for.
-
-    Java and Kotlin both put the public type in a file of its own name, so the
-    stem is the reliable discriminator when a file also declares helper types.
-    A file whose stem names no type is skipped rather than guessed at.
-    """
-    stem = Path(path).stem
-    for sym in parsed.symbols:
-        if sym.name == stem and sym.kind in ("class", "interface", "record", "enum"):
-            return sym.id
-    return None
 
 
 def _bind_injected_symbol(
     graph: nx.DiGraph, type_to_symbol: dict[str, str], owner: str | None, type_name: str
 ) -> int:
-    """Link an injecting class's declaration to the injected type's declaration."""
     if owner is None:
         return 0
     target = type_to_symbol.get(type_name.split("<")[0].strip())
@@ -190,10 +197,6 @@ def _add_spring_edges(
 ) -> int:
     count = 0
     class_to_file = _build_class_to_file(parsed_files, ("java", "kotlin"))
-    # Injection names a type, and a type is a symbol. The file-level edges below
-    # say the two files are related; these say which two declarations, which is
-    # what makes an injected-only collaborator stop reading as constructed by
-    # nobody.
     type_to_symbol = build_type_to_symbol(parsed_files, ("java", "kotlin"))
 
     # Build interface → list of impl files map from heritage
@@ -248,12 +251,12 @@ def _add_spring_edges(
             node["framework_role"] = node.get("framework_role") or "spring_stereotype"
             node["is_entry_point"] = True
 
-        owner_symbol = _declaring_type_symbol(parsed, path)
-
         # 2a. Field injection (@Autowired / @Inject / @Resource)
         for m in _SPRING_INJECT_FIELD_RE.finditer(text):
             type_name = m.group(1).split("<")[0].strip()
-            count += _bind_injected_symbol(graph, type_to_symbol, owner_symbol, type_name)
+            count += _bind_injected_symbol(
+                graph, type_to_symbol, _owner_at_offset(parsed, text, m.start()), type_name
+            )
             for target in _resolve_type(type_name):
                 if target in path_set and _add_edge_if_new(graph, path, target):
                     count += 1
@@ -272,14 +275,21 @@ def _add_spring_edges(
                 type_name = pm.group(1)
                 if type_name in ("String", "Integer", "Long", "Boolean", "Double", "Float"):
                     continue
-                count += _bind_injected_symbol(graph, type_to_symbol, owner_symbol, type_name)
+                count += _bind_injected_symbol(
+                    graph,
+                    type_to_symbol,
+                    _owner_at_offset(parsed, text, ctor_match.start()),
+                    type_name,
+                )
                 for target in _resolve_type(type_name):
                     if target in path_set and _add_edge_if_new(graph, path, target):
                         count += 1
 
         # 2c. Lombok @RequiredArgsConstructor / @AllArgsConstructor / @Data
-        for type_name in _scan_lombok_ctor_params(text):
-            count += _bind_injected_symbol(graph, type_to_symbol, owner_symbol, type_name)
+        for type_name, offset in _scan_lombok_ctor_params(text):
+            count += _bind_injected_symbol(
+                graph, type_to_symbol, _owner_at_offset(parsed, text, offset), type_name
+            )
             for target in _resolve_type(type_name):
                 if target in path_set and _add_edge_if_new(graph, path, target):
                     count += 1

--- a/packages/core/src/repowise/core/ingestion/framework_edges/spring.py
+++ b/packages/core/src/repowise/core/ingestion/framework_edges/spring.py
@@ -35,6 +35,8 @@ from .base import (
     FrameworkHandler,
     _add_edge_if_new,
     _build_class_to_file,
+    add_symbol_edge,
+    build_type_to_symbol,
     read_text,
 )
 
@@ -154,6 +156,32 @@ def _scan_lombok_ctor_params(text: str) -> list[str]:
     return params
 
 
+def _declaring_type_symbol(parsed: Any, path: str) -> str | None:
+    """The symbol id of the type *path* is named for.
+
+    Java and Kotlin both put the public type in a file of its own name, so the
+    stem is the reliable discriminator when a file also declares helper types.
+    A file whose stem names no type is skipped rather than guessed at.
+    """
+    stem = Path(path).stem
+    for sym in parsed.symbols:
+        if sym.name == stem and sym.kind in ("class", "interface", "record", "enum"):
+            return sym.id
+    return None
+
+
+def _bind_injected_symbol(
+    graph: nx.DiGraph, type_to_symbol: dict[str, str], owner: str | None, type_name: str
+) -> int:
+    """Link an injecting class's declaration to the injected type's declaration."""
+    if owner is None:
+        return 0
+    target = type_to_symbol.get(type_name.split("<")[0].strip())
+    if target is None:
+        return 0
+    return 1 if add_symbol_edge(graph, owner, target) else 0
+
+
 def _add_spring_edges(
     graph: nx.DiGraph,
     parsed_files: dict[str, Any],
@@ -162,6 +190,11 @@ def _add_spring_edges(
 ) -> int:
     count = 0
     class_to_file = _build_class_to_file(parsed_files, ("java", "kotlin"))
+    # Injection names a type, and a type is a symbol. The file-level edges below
+    # say the two files are related; these say which two declarations, which is
+    # what makes an injected-only collaborator stop reading as constructed by
+    # nobody.
+    type_to_symbol = build_type_to_symbol(parsed_files, ("java", "kotlin"))
 
     # Build interface → list of impl files map from heritage
     impl_map: dict[str, list[str]] = {}
@@ -215,9 +248,12 @@ def _add_spring_edges(
             node["framework_role"] = node.get("framework_role") or "spring_stereotype"
             node["is_entry_point"] = True
 
+        owner_symbol = _declaring_type_symbol(parsed, path)
+
         # 2a. Field injection (@Autowired / @Inject / @Resource)
         for m in _SPRING_INJECT_FIELD_RE.finditer(text):
             type_name = m.group(1).split("<")[0].strip()
+            count += _bind_injected_symbol(graph, type_to_symbol, owner_symbol, type_name)
             for target in _resolve_type(type_name):
                 if target in path_set and _add_edge_if_new(graph, path, target):
                     count += 1
@@ -236,12 +272,14 @@ def _add_spring_edges(
                 type_name = pm.group(1)
                 if type_name in ("String", "Integer", "Long", "Boolean", "Double", "Float"):
                     continue
+                count += _bind_injected_symbol(graph, type_to_symbol, owner_symbol, type_name)
                 for target in _resolve_type(type_name):
                     if target in path_set and _add_edge_if_new(graph, path, target):
                         count += 1
 
         # 2c. Lombok @RequiredArgsConstructor / @AllArgsConstructor / @Data
         for type_name in _scan_lombok_ctor_params(text):
+            count += _bind_injected_symbol(graph, type_to_symbol, owner_symbol, type_name)
             for target in _resolve_type(type_name):
                 if target in path_set and _add_edge_if_new(graph, path, target):
                     count += 1

--- a/packages/core/src/repowise/core/ingestion/framework_edges/spring.py
+++ b/packages/core/src/repowise/core/ingestion/framework_edges/spring.py
@@ -67,8 +67,12 @@ _SPRING_BEAN_METHOD_KOTLIN_RE = re.compile(
 
 # Lombok constructor-synthesis annotations. RAC = constructor over every
 # ``final`` (and ``@NonNull``) field; AAC = constructor over every field.
-_LOMBOK_RAC_ANNOT = ("@RequiredArgsConstructor", "@AllArgsConstructor")
-_LOMBOK_DATA_VALUE = ("@Data", "@Value")
+_LOMBOK_RAC_ANNOT = ("@RequiredArgsConstructor", "@AllArgsConstructor", "@Data")
+# Lombok's `@Value` makes a class immutable and takes no argument; Spring's
+# takes a property expression and sits on a field. Matching the bare spelling
+# is what separates them — reading `@Value("${app.name}")` as Lombok turns
+# every field in the class into a constructor parameter.
+_LOMBOK_VALUE_RE = re.compile(r"@Value\s*(?![(\w])")
 
 # Spring Data repository base interfaces — any interface extending one of
 # these has Spring-generated impls at runtime and must be treated as an
@@ -158,10 +162,8 @@ def _scan_lombok_ctor_params(text: str) -> list[tuple[str, int]]:
     is every ``final`` field's head type; for ``@AllArgsConstructor`` (or
     ``@Value``), every field's head type. Builtin types are filtered.
     """
-    is_rac = any(a in text for a in _LOMBOK_RAC_ANNOT) or any(
-        a in text for a in _LOMBOK_DATA_VALUE if a == "@Data"
-    )
-    is_aac = "@AllArgsConstructor" in text or "@Value" in text
+    is_rac = any(a in text for a in _LOMBOK_RAC_ANNOT)
+    is_aac = "@AllArgsConstructor" in text or bool(_LOMBOK_VALUE_RE.search(text))
     if not (is_rac or is_aac):
         return []
 

--- a/packages/core/src/repowise/core/ingestion/framework_edges/spring.py
+++ b/packages/core/src/repowise/core/ingestion/framework_edges/spring.py
@@ -30,6 +30,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from ..resolvers import ResolverContext
+from ..type_names import strip_type_arguments
 from .base import (
     DetectionContext,
     FrameworkHandler,
@@ -185,7 +186,7 @@ def _bind_injected_symbol(
 ) -> int:
     if owner is None:
         return 0
-    target = type_to_symbol.get(type_name.split("<")[0].strip())
+    target = type_to_symbol.get(strip_type_arguments(type_name).strip())
     if target is None:
         return 0
     return 1 if add_symbol_edge(graph, owner, target) else 0

--- a/packages/core/src/repowise/core/ingestion/models.py
+++ b/packages/core/src/repowise/core/ingestion/models.py
@@ -291,6 +291,14 @@ EdgeType = Literal[
     "dispatches_to",
     "co_changes",
     "framework",
+    # The symbol-level sibling of `framework`, which is file → file and always
+    # will be. A framework handler emits this when it can name *both* ends as
+    # symbols — a test function and the fixture it asks for by parameter name,
+    # a class and the collaborator injected into it. Deliberately not `calls`:
+    # nothing here is a call the parser could have seen, and letting it read as
+    # one would put an inferred wiring hop into execution flows as if it were
+    # source.
+    "framework_binds",
     # A data reference rather than a call. Two `_add_reads_edge` helpers emit
     # it at different layers: C# member access file → file, Express
     # route/middleware wiring symbol → symbol.
@@ -466,6 +474,11 @@ SYMBOL_USE_EDGE_TYPES: frozenset[str] = frozenset(
         # answers for, and that call lands on the base. Without this the whole
         # implementation side of an interface reads as called by nobody.
         "dispatches_to",
+        # A fixture nobody calls and a collaborator nobody constructs are both
+        # used — by the container, which no parser sees. Without this they read
+        # as reached by nobody, which is the same mistake `references` fixed for
+        # dispatch tables.
+        "framework_binds",
         "reads",
         # Naming a function is using it. A handler sitting in a dispatch table
         # is never called anywhere a parser can see, and treating that as "no

--- a/packages/core/src/repowise/core/ingestion/models.py
+++ b/packages/core/src/repowise/core/ingestion/models.py
@@ -291,17 +291,15 @@ EdgeType = Literal[
     "dispatches_to",
     "co_changes",
     "framework",
-    # The symbol-level sibling of `framework`, which is file → file and always
-    # will be. A framework handler emits this when it can name *both* ends as
-    # symbols — a test function and the fixture it asks for by parameter name,
-    # a class and the collaborator injected into it. Deliberately not `calls`:
-    # nothing here is a call the parser could have seen, and letting it read as
-    # one would put an inferred wiring hop into execution flows as if it were
-    # source.
+    # The symbol-level sibling of `framework`, emitted when a handler can name
+    # both ends as symbols. Deliberately not `calls`: nothing here is a call the
+    # parser could have seen, and letting it read as one would put an inferred
+    # wiring hop into an execution flow as if it were source.
     "framework_binds",
-    # A data reference rather than a call. Two `_add_reads_edge` helpers emit
-    # it at different layers: C# member access file → file, Express
-    # route/middleware wiring symbol → symbol.
+    # A data reference rather than a call: C# member access, file → file. It
+    # used to name two unrelated things — the Express route wiring emitted it
+    # symbol → symbol — which is why one consumer set could not say which layer
+    # it meant. That producer now emits `framework_binds`.
     "reads",
     # Dynamic-dispatch hints. `dynamic_hints` extractors emit a `DynamicKind`
     # sub-type and `EdgesMixin.add_dynamic_edges` prefixes it, so `url_route`
@@ -475,9 +473,7 @@ SYMBOL_USE_EDGE_TYPES: frozenset[str] = frozenset(
         # implementation side of an interface reads as called by nobody.
         "dispatches_to",
         # A fixture nobody calls and a collaborator nobody constructs are both
-        # used — by the container, which no parser sees. Without this they read
-        # as reached by nobody, which is the same mistake `references` fixed for
-        # dispatch tables.
+        # used — by the container, which no parser sees.
         "framework_binds",
         "reads",
         # Naming a function is using it. A handler sitting in a dispatch table

--- a/packages/server/src/repowise/server/services/c4_builder/labels.py
+++ b/packages/server/src/repowise/server/services/c4_builder/labels.py
@@ -41,6 +41,8 @@ _EDGE_VERB: dict[str, str] = {
     "dynamic_uses": "uses",
     "dynamic_url_route": "uses",
     "framework": "uses",
+    # Symbol-level wiring; same verb as its file-level sibling on purpose.
+    "framework_binds": "uses",
     "reads": "uses",
     # A type reference without an import: named, but not imported.
     "type_use": "references",
@@ -65,6 +67,9 @@ _VERB_PRIORITY: tuple[str, ...] = (
     # the types line up.
     "dispatches to",
     "inherits from",
+    # Ranked beside "implements": both describe a base and the code that
+    # answers for it, and where a pair carries both, either reads correctly.
+    "dispatches to",
     "implements",
     "imports",
     # Below "imports": where a pair has both, the static import is the more

--- a/packages/server/src/repowise/server/services/c4_builder/labels.py
+++ b/packages/server/src/repowise/server/services/c4_builder/labels.py
@@ -67,9 +67,6 @@ _VERB_PRIORITY: tuple[str, ...] = (
     # the types line up.
     "dispatches to",
     "inherits from",
-    # Ranked beside "implements": both describe a base and the code that
-    # answers for it, and where a pair carries both, either reads correctly.
-    "dispatches to",
     "implements",
     "imports",
     # Below "imports": where a pair has both, the static import is the more

--- a/tests/unit/analysis/test_kg_skip_logic.py
+++ b/tests/unit/analysis/test_kg_skip_logic.py
@@ -210,7 +210,7 @@ class TestFingerprintDeterminism:
         one: whoever bumps the constant updates this line and sees, in the
         diff, that they are asking every existing store to re-curate.
         """
-        assert knowledge_graph.KG_BUILDER_VERSION == "3"
+        assert knowledge_graph.KG_BUILDER_VERSION == "4"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/ingestion/test_express_framework_edges.py
+++ b/tests/unit/ingestion/test_express_framework_edges.py
@@ -138,8 +138,8 @@ class TestExpressLocalMiddlewareReads:
         module_sym = "routes.ts::__module__"
         for name in ("logRequest", "validateRequest", "handler"):
             sym_id = f"routes.ts::{name}"
-            assert graph.has_edge(module_sym, sym_id), f"missing reads edge to {name}"
-            assert graph[module_sym][sym_id]["edge_type"] == "reads"
+            assert graph.has_edge(module_sym, sym_id), f"missing wiring edge to {name}"
+            assert graph[module_sym][sym_id]["edge_type"] == "framework_binds"
 
     def test_app_use_middleware_gets_reads_edge(self, tmp_path: Path) -> None:
         (tmp_path / "mw.ts").write_text(
@@ -150,7 +150,7 @@ class TestExpressLocalMiddlewareReads:
         )
         graph = _build_graph_with_framework_edges(tmp_path)
         assert graph.has_edge("mw.ts::__module__", "mw.ts::authGuard")
-        assert graph["mw.ts::__module__"]["mw.ts::authGuard"]["edge_type"] == "reads"
+        assert graph["mw.ts::__module__"]["mw.ts::authGuard"]["edge_type"] == "framework_binds"
 
     def test_defines_edge_preserved(self, tmp_path: Path) -> None:
         (tmp_path / "routes.ts").write_text(
@@ -173,7 +173,7 @@ class TestExpressLocalMiddlewareReads:
         graph = _build_graph_with_framework_edges(tmp_path)
         handler = "routes.ts::handler"
         assert graph.has_edge("routes.ts::__module__", handler)
-        assert graph["routes.ts::__module__"][handler]["edge_type"] == "reads"
+        assert graph["routes.ts::__module__"][handler]["edge_type"] == "framework_binds"
         assert graph.has_edge("routes.ts::__module__", "routes.ts::requireRole")
 
     def test_commonjs_multiline_route_reads_edges(self, tmp_path: Path) -> None:
@@ -196,8 +196,8 @@ class TestExpressLocalMiddlewareReads:
         module_sym = "routes.js::__module__"
         for name in ("logRequest", "validateRequest"):
             sym_id = f"routes.js::{name}"
-            assert graph.has_edge(module_sym, sym_id), f"missing reads edge to {name}"
-            assert graph[module_sym][sym_id]["edge_type"] == "reads"
+            assert graph.has_edge(module_sym, sym_id), f"missing wiring edge to {name}"
+            assert graph[module_sym][sym_id]["edge_type"] == "framework_binds"
 
     def test_non_route_receiver_in_express_file_no_reads_edge(self, tmp_path: Path) -> None:
         (tmp_path / "svc.ts").write_text(

--- a/tests/unit/ingestion/test_pytest_fixture_edges.py
+++ b/tests/unit/ingestion/test_pytest_fixture_edges.py
@@ -246,6 +246,26 @@ class TestRefusals:
 
         assert _bound(_build(tmp_path)) == set()
 
+    def test_the_projects_own_python_classes_setting_is_honoured(
+        self, tmp_path: Path
+    ) -> None:
+        # celery collects `test_*` classes, not pytest's default `Test*`.
+        # Assuming the default refuses almost every binding such a repo has.
+        (tmp_path / "pyproject.toml").write_text(
+            '[tool.pytest.ini_options]\npython_classes = "test_*"\n'
+        )
+        (tmp_path / "conftest.py").write_text(
+            "import pytest\n\n\n@pytest.fixture\ndef client():\n    return 1\n"
+        )
+        (tmp_path / "test_api.py").write_text(
+            "class test_api:\n    def test_get(self, client):\n        assert client\n"
+        )
+
+        assert (
+            "test_api.py::test_api::test_get",
+            "conftest.py::client",
+        ) in _bound(_build(tmp_path))
+
     def test_name_is_read_as_a_top_level_keyword_only(self, tmp_path: Path) -> None:
         # A `name=` nested in a params list is not the fixture's name.
         (tmp_path / "conftest.py").write_text(

--- a/tests/unit/ingestion/test_pytest_fixture_edges.py
+++ b/tests/unit/ingestion/test_pytest_fixture_edges.py
@@ -1,0 +1,215 @@
+"""A test function is linked to the fixture it asks for by parameter name.
+
+The refusals matter more than the happy path here: a parameter name is an
+ordinary identifier, so anything that claims one without evidence mints a wrong
+edge, and every test below that asserts *absence* was written for a shape the
+corpus actually contains.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+
+import networkx as nx
+
+from repowise.core.ingestion import GraphBuilder
+from repowise.core.ingestion.framework_edges import add_framework_edges
+from repowise.core.ingestion.models import FileInfo, ParsedFile
+from repowise.core.ingestion.parser import ASTParser
+from repowise.core.ingestion.resolvers.context import ResolverContext
+
+
+def _file_info(rel: str, abs_path: str) -> FileInfo:
+    return FileInfo(
+        path=rel,
+        abs_path=abs_path,
+        language="python",
+        size_bytes=100,
+        git_hash="",
+        last_modified=datetime.now(),
+        is_test=False,
+        is_config=False,
+        is_api_contract=False,
+        is_entry_point=False,
+    )
+
+
+def _build(repo: Path) -> nx.DiGraph:
+    parser = ASTParser()
+    parsed: dict[str, ParsedFile] = {}
+    for src in sorted(repo.rglob("*.py")):
+        rel = src.resolve().relative_to(repo.resolve()).as_posix()
+        parsed[rel] = parser.parse_file(_file_info(rel, str(src.resolve())), src.read_bytes())
+
+    builder = GraphBuilder(repo)
+    for pf in parsed.values():
+        builder.add_file(pf)
+    graph = builder.build()
+
+    path_set = set(parsed)
+    stem_map: dict[str, list[str]] = {}
+    for p in path_set:
+        stem_map.setdefault(Path(p).stem.lower(), []).append(p)
+    ctx = ResolverContext(
+        path_set=path_set, stem_map=stem_map, graph=graph, repo_path=repo
+    )
+    add_framework_edges(graph, parsed, ctx, [])
+    return graph
+
+
+def _bound(graph: nx.DiGraph) -> set[tuple[str, str]]:
+    return {
+        (s, t)
+        for s, t, d in graph.edges(data=True)
+        if d.get("edge_type") == "framework_binds"
+    }
+
+
+class TestFixtureInjection:
+    def test_conftest_fixture_is_linked_to_the_test_that_asks_for_it(
+        self, tmp_path: Path
+    ) -> None:
+        (tmp_path / "conftest.py").write_text(
+            "import pytest\n\n\n@pytest.fixture\ndef client():\n    return 1\n"
+        )
+        (tmp_path / "test_api.py").write_text("def test_get(client):\n    assert client\n")
+
+        assert ("test_api.py::test_get", "conftest.py::client") in _bound(_build(tmp_path))
+
+    def test_a_fixture_in_the_tests_own_module_wins_over_the_conftest(
+        self, tmp_path: Path
+    ) -> None:
+        (tmp_path / "conftest.py").write_text(
+            "import pytest\n\n\n@pytest.fixture\ndef client():\n    return 1\n"
+        )
+        (tmp_path / "test_api.py").write_text(
+            "import pytest\n\n\n@pytest.fixture\ndef client():\n    return 2\n\n\n"
+            "def test_get(client):\n    assert client\n"
+        )
+
+        bound = _bound(_build(tmp_path))
+        assert ("test_api.py::test_get", "test_api.py::client") in bound
+        assert ("test_api.py::test_get", "conftest.py::client") not in bound
+
+    def test_the_nearest_conftest_wins(self, tmp_path: Path) -> None:
+        (tmp_path / "conftest.py").write_text(
+            "import pytest\n\n\n@pytest.fixture\ndef client():\n    return 1\n"
+        )
+        sub = tmp_path / "sub"
+        sub.mkdir()
+        (sub / "conftest.py").write_text(
+            "import pytest\n\n\n@pytest.fixture\ndef client():\n    return 2\n"
+        )
+        (sub / "test_api.py").write_text("def test_get(client):\n    assert client\n")
+
+        bound = _bound(_build(tmp_path))
+        assert ("sub/test_api.py::test_get", "sub/conftest.py::client") in bound
+        assert ("sub/test_api.py::test_get", "conftest.py::client") not in bound
+
+    def test_a_conftest_below_the_test_does_not_serve_it(self, tmp_path: Path) -> None:
+        sub = tmp_path / "sub"
+        sub.mkdir()
+        (sub / "conftest.py").write_text(
+            "import pytest\n\n\n@pytest.fixture\ndef client():\n    return 1\n"
+        )
+        (tmp_path / "test_api.py").write_text("def test_get(client):\n    assert client\n")
+
+        assert _bound(_build(tmp_path)) == set()
+
+    def test_the_name_keyword_renames_the_fixture(self, tmp_path: Path) -> None:
+        # `@pytest.fixture(name="app")` on `fixture_app` means tests ask for
+        # `app`. Binding on the function name would miss it and claim a wrong
+        # one; flask writes fixtures this way.
+        (tmp_path / "conftest.py").write_text(
+            'import pytest\n\n\n@pytest.fixture(name="app")\n'
+            "def fixture_app():\n    return 1\n"
+        )
+        (tmp_path / "test_api.py").write_text(
+            "def test_get(app):\n    assert app\n\n\n"
+            "def test_other(fixture_app):\n    assert fixture_app\n"
+        )
+
+        bound = _bound(_build(tmp_path))
+        assert ("test_api.py::test_get", "conftest.py::fixture_app") in bound
+        assert ("test_api.py::test_other", "conftest.py::fixture_app") not in bound
+
+    def test_a_parametrize_argument_is_not_a_fixture_request(self, tmp_path: Path) -> None:
+        # The test supplies `value` itself. Without this refusal a parametrize
+        # argument that happens to share a fixture's name mints a wrong edge.
+        (tmp_path / "conftest.py").write_text(
+            "import pytest\n\n\n@pytest.fixture\ndef value():\n    return 1\n"
+        )
+        (tmp_path / "test_api.py").write_text(
+            "import pytest\n\n\n"
+            '@pytest.mark.parametrize("value", [1, 2])\n'
+            "def test_get(value):\n    assert value\n"
+        )
+
+        assert _bound(_build(tmp_path)) == set()
+
+    def test_an_undecorated_function_is_not_a_fixture(self, tmp_path: Path) -> None:
+        (tmp_path / "conftest.py").write_text("def client():\n    return 1\n")
+        (tmp_path / "test_api.py").write_text("def test_get(client):\n    assert client\n")
+
+        assert _bound(_build(tmp_path)) == set()
+
+    def test_a_non_test_function_asks_for_nothing(self, tmp_path: Path) -> None:
+        # Only `test_*` functions get their parameters injected by pytest. A
+        # helper's parameters are ordinary arguments its callers supply.
+        (tmp_path / "conftest.py").write_text(
+            "import pytest\n\n\n@pytest.fixture\ndef client():\n    return 1\n"
+        )
+        (tmp_path / "test_api.py").write_text(
+            "def helper(client):\n    return client\n"
+        )
+
+        assert _bound(_build(tmp_path)) == set()
+
+    def test_a_module_that_is_not_a_test_file_asks_for_nothing(self, tmp_path: Path) -> None:
+        (tmp_path / "conftest.py").write_text(
+            "import pytest\n\n\n@pytest.fixture\ndef client():\n    return 1\n"
+        )
+        (tmp_path / "helpers.py").write_text("def test_get(client):\n    assert client\n")
+
+        assert _bound(_build(tmp_path)) == set()
+
+    def test_a_repo_with_no_fixtures_gains_nothing(self, tmp_path: Path) -> None:
+        (tmp_path / "test_api.py").write_text("def test_get():\n    assert True\n")
+        (tmp_path / "app.py").write_text("def run(config):\n    return config\n")
+
+        assert _bound(_build(tmp_path)) == set()
+
+    def test_the_edge_carries_a_confidence(self, tmp_path: Path) -> None:
+        # An unlabelled arrow is what the origin vocabulary exists to stop; a
+        # framework binding is an inference and has to say so.
+        (tmp_path / "conftest.py").write_text(
+            "import pytest\n\n\n@pytest.fixture\ndef client():\n    return 1\n"
+        )
+        (tmp_path / "test_api.py").write_text("def test_get(client):\n    assert client\n")
+
+        graph = _build(tmp_path)
+        data = graph["test_api.py::test_get"]["conftest.py::client"]
+        assert data["edge_type"] == "framework_binds"
+        assert data["confidence"] == 0.90
+
+
+class TestFixtureIsNotDeadCode:
+    def test_a_fixture_used_only_by_injection_has_an_incoming_use_edge(
+        self, tmp_path: Path
+    ) -> None:
+        # The point of putting the type in SYMBOL_USE_EDGE_TYPES: before this,
+        # nothing in the graph pointed at a fixture at all.
+        (tmp_path / "conftest.py").write_text(
+            "import pytest\n\n\n@pytest.fixture\ndef client():\n    return 1\n"
+        )
+        (tmp_path / "test_api.py").write_text("def test_get(client):\n    assert client\n")
+
+        from repowise.core.ingestion.models import REACHABILITY_USE_EDGE_TYPES
+
+        graph = _build(tmp_path)
+        target = "conftest.py::client"
+        assert any(
+            graph[pred][target].get("edge_type") in REACHABILITY_USE_EDGE_TYPES
+            for pred in graph.predecessors(target)
+        )

--- a/tests/unit/ingestion/test_pytest_fixture_edges.py
+++ b/tests/unit/ingestion/test_pytest_fixture_edges.py
@@ -1,9 +1,7 @@
 """A test function is linked to the fixture it asks for by parameter name.
 
-The refusals matter more than the happy path here: a parameter name is an
-ordinary identifier, so anything that claims one without evidence mints a wrong
-edge, and every test below that asserts *absence* was written for a shape the
-corpus actually contains.
+The refusals matter more than the happy path: a parameter name is an ordinary
+identifier, so anything claiming one without evidence mints a wrong edge.
 """
 
 from __future__ import annotations
@@ -135,8 +133,8 @@ class TestFixtureInjection:
         assert ("test_api.py::test_other", "conftest.py::fixture_app") not in bound
 
     def test_a_parametrize_argument_is_not_a_fixture_request(self, tmp_path: Path) -> None:
-        # The test supplies `value` itself. Without this refusal a parametrize
-        # argument that happens to share a fixture's name mints a wrong edge.
+        # A parametrize argument that happens to share a fixture's name would
+        # otherwise mint a wrong edge.
         (tmp_path / "conftest.py").write_text(
             "import pytest\n\n\n@pytest.fixture\ndef value():\n    return 1\n"
         )
@@ -181,8 +179,6 @@ class TestFixtureInjection:
         assert _bound(_build(tmp_path)) == set()
 
     def test_the_edge_carries_a_confidence(self, tmp_path: Path) -> None:
-        # An unlabelled arrow is what the origin vocabulary exists to stop; a
-        # framework binding is an inference and has to say so.
         (tmp_path / "conftest.py").write_text(
             "import pytest\n\n\n@pytest.fixture\ndef client():\n    return 1\n"
         )
@@ -194,12 +190,132 @@ class TestFixtureInjection:
         assert data["confidence"] == 0.90
 
 
+class TestRefusals:
+    """Each of these mints a wrong edge without the rule it names."""
+
+    def test_a_module_level_assignment_asks_for_nothing(self, tmp_path: Path) -> None:
+        # `test_client = TestClient(app)` is a variable, and its recorded
+        # signature is the assignment line — so a parameter-list read finds
+        # `app` in it and calls a data constant a caller of the fixture.
+        (tmp_path / "conftest.py").write_text(
+            "import pytest\n\n\n@pytest.fixture\ndef app():\n    return 1\n"
+        )
+        (tmp_path / "test_api.py").write_text(
+            "from client import TestClient\n\ntest_client = TestClient(app)\n"
+        )
+
+        assert _bound(_build(tmp_path)) == set()
+
+    def test_a_defaulted_parameter_is_not_injected(self, tmp_path: Path) -> None:
+        (tmp_path / "conftest.py").write_text(
+            "import pytest\n\n\n@pytest.fixture\ndef client():\n    return 1\n"
+        )
+        (tmp_path / "test_api.py").write_text(
+            "def test_get(client=None):\n    assert client is None\n"
+        )
+
+        assert _bound(_build(tmp_path)) == set()
+
+    def test_a_class_scoped_fixture_does_not_serve_a_sibling_class(
+        self, tmp_path: Path
+    ) -> None:
+        (tmp_path / "test_api.py").write_text(
+            "import pytest\n\n\n"
+            "class TestA:\n"
+            "    @pytest.fixture\n"
+            "    def client(self):\n        return 1\n\n"
+            "    def test_a(self, client):\n        assert client\n\n\n"
+            "class TestB:\n"
+            "    def test_b(self, client):\n        assert client\n"
+        )
+
+        bound = _bound(_build(tmp_path))
+        assert ("test_api.py::TestA::test_a", "test_api.py::TestA::client") in bound
+        assert ("test_api.py::TestB::test_b", "test_api.py::TestA::client") not in bound
+
+    def test_a_method_of_a_class_pytest_never_collects_asks_for_nothing(
+        self, tmp_path: Path
+    ) -> None:
+        # pytest collects methods only from `Test*` classes.
+        (tmp_path / "conftest.py").write_text(
+            "import pytest\n\n\n@pytest.fixture\ndef client():\n    return 1\n"
+        )
+        (tmp_path / "test_api.py").write_text(
+            "class Harness:\n    def test_connection(self, client):\n        return client\n"
+        )
+
+        assert _bound(_build(tmp_path)) == set()
+
+    def test_name_is_read_as_a_top_level_keyword_only(self, tmp_path: Path) -> None:
+        # A `name=` nested in a params list is not the fixture's name.
+        (tmp_path / "conftest.py").write_text(
+            "import pytest\n\n\n"
+            '@pytest.fixture(params=[dict(name="alice")])\n'
+            "def user(request):\n    return request.param\n"
+        )
+        (tmp_path / "test_api.py").write_text(
+            "def test_u(user):\n    assert user\n\n\n"
+            "def test_v(alice):\n    assert alice\n"
+        )
+
+        bound = _bound(_build(tmp_path))
+        assert ("test_api.py::test_u", "conftest.py::user") in bound
+        assert ("test_api.py::test_v", "conftest.py::user") not in bound
+
+    def test_a_parametrize_value_does_not_refuse_a_real_request(
+        self, tmp_path: Path
+    ) -> None:
+        # Only the first argument names parameters. Reading the whole decorator
+        # made every parametrize *value* look like a supplied name, so a fixture
+        # called `client` became unreachable in any test parametrized over the
+        # string "client".
+        (tmp_path / "conftest.py").write_text(
+            "import pytest\n\n\n@pytest.fixture\ndef client():\n    return 1\n"
+        )
+        (tmp_path / "test_api.py").write_text(
+            "import pytest\n\n\n"
+            '@pytest.mark.parametrize("method", ["client", "server"])\n'
+            "def test_dispatch(method, client):\n    assert client\n"
+        )
+
+        bound = _bound(_build(tmp_path))
+        assert ("test_api.py::test_dispatch", "conftest.py::client") in bound
+
+    def test_an_annotation_containing_a_bracket_does_not_truncate_the_list(
+        self, tmp_path: Path
+    ) -> None:
+        (tmp_path / "conftest.py").write_text(
+            "import pytest\n\n\n@pytest.fixture\ndef client():\n    return 1\n\n\n"
+            "@pytest.fixture\ndef later():\n    return 2\n"
+        )
+        (tmp_path / "test_api.py").write_text(
+            "from typing import Any, Callable\n\n\n"
+            "def test_get(cb: Callable[[int], str], client, later):\n"
+            "    assert client and later and cb\n"
+        )
+
+        bound = _bound(_build(tmp_path))
+        assert ("test_api.py::test_get", "conftest.py::client") in bound
+        assert ("test_api.py::test_get", "conftest.py::later") in bound
+
+    def test_a_nested_default_call_does_not_leak_a_keyword_as_a_request(
+        self, tmp_path: Path
+    ) -> None:
+        (tmp_path / "conftest.py").write_text(
+            "import pytest\n\n\n@pytest.fixture\ndef client():\n    return 1\n"
+        )
+        (tmp_path / "test_api.py").write_text(
+            "def test_get(tmp_path, opts=dict(a=1, client=2)):\n    assert opts\n"
+        )
+
+        assert _bound(_build(tmp_path)) == set()
+
+
 class TestFixtureIsNotDeadCode:
     def test_a_fixture_used_only_by_injection_has_an_incoming_use_edge(
         self, tmp_path: Path
     ) -> None:
-        # The point of putting the type in SYMBOL_USE_EDGE_TYPES: before this,
-        # nothing in the graph pointed at a fixture at all.
+        # Before this, nothing in the graph pointed at a fixture at all.
         (tmp_path / "conftest.py").write_text(
             "import pytest\n\n\n@pytest.fixture\ndef client():\n    return 1\n"
         )

--- a/tests/unit/ingestion/test_pytest_fixture_edges.py
+++ b/tests/unit/ingestion/test_pytest_fixture_edges.py
@@ -233,6 +233,72 @@ class TestRefusals:
         assert ("test_api.py::TestA::test_a", "test_api.py::TestA::client") in bound
         assert ("test_api.py::TestB::test_b", "test_api.py::TestA::client") not in bound
 
+    def test_a_base_test_class_serves_its_subclass(self, tmp_path: Path) -> None:
+        # Scoping the lookup to the declaring class alone fixes a rare wrong
+        # edge by introducing a frequent missing one: a base class holding the
+        # shared fixtures is the commonest class-scoped arrangement there is.
+        (tmp_path / "test_api.py").write_text(
+            "import pytest\n\n\n"
+            "class TestBase:\n"
+            "    @pytest.fixture\n"
+            "    def client(self):\n        return 1\n\n\n"
+            "class TestChild(TestBase):\n"
+            "    def test_a(self, client):\n        assert client\n"
+        )
+
+        assert (
+            "test_api.py::TestChild::test_a",
+            "test_api.py::TestBase::client",
+        ) in _bound(_build(tmp_path))
+
+    def test_an_annotation_containing_an_equals_is_not_a_default(
+        self, tmp_path: Path
+    ) -> None:
+        (tmp_path / "conftest.py").write_text(
+            "import pytest\n\n\n@pytest.fixture\ndef client():\n    return 1\n"
+        )
+        (tmp_path / "test_api.py").write_text(
+            "from typing import Annotated, Literal\n\n\n"
+            "def test_get(client: Annotated[int, Field(ge=0)]):\n    assert client\n\n\n"
+            "def test_two(client: Literal['a=b']):\n    assert client\n"
+        )
+
+        bound = _bound(_build(tmp_path))
+        assert ("test_api.py::test_get", "conftest.py::client") in bound
+        assert ("test_api.py::test_two", "conftest.py::client") in bound
+
+    def test_a_comment_in_a_multiline_signature_does_not_swallow_it(
+        self, tmp_path: Path
+    ) -> None:
+        # An apostrophe or a stray bracket in a per-parameter comment used to
+        # take the whole list with it.
+        (tmp_path / "conftest.py").write_text(
+            "import pytest\n\n\n@pytest.fixture\ndef client():\n    return 1\n"
+        )
+        (tmp_path / "test_api.py").write_text(
+            "def test_get(\n    client,  # don't drop me, see foo(\n):\n    assert client\n"
+        )
+
+        assert (
+            "test_api.py::test_get",
+            "conftest.py::client",
+        ) in _bound(_build(tmp_path))
+
+    def test_an_escaped_quote_in_a_default_does_not_swallow_the_list(
+        self, tmp_path: Path
+    ) -> None:
+        (tmp_path / "conftest.py").write_text(
+            "import pytest\n\n\n@pytest.fixture\ndef client():\n    return 1\n"
+        )
+        (tmp_path / "test_api.py").write_text(
+            'def test_get(client, label="it\\"s"):\n    assert client and label\n'
+        )
+
+        assert (
+            "test_api.py::test_get",
+            "conftest.py::client",
+        ) in _bound(_build(tmp_path))
+
     def test_a_method_of_a_class_pytest_never_collects_asks_for_nothing(
         self, tmp_path: Path
     ) -> None:

--- a/tests/unit/ingestion/test_spring_framework_edges.py
+++ b/tests/unit/ingestion/test_spring_framework_edges.py
@@ -150,3 +150,91 @@ class TestSpringGate:
         ctx = _ctx(tmp_path, parsed)
         count = add_framework_edges(graph, parsed, ctx, tech_stack=[])
         assert count == 0
+
+
+def _build_graph(repo: Path):
+    """A real graph, so the symbol-level edges have symbol nodes to land on."""
+    from repowise.core.ingestion import GraphBuilder
+
+    parsed = _build_parsed(repo)
+    builder = GraphBuilder(repo)
+    for pf in parsed.values():
+        builder.add_file(pf)
+    graph = builder.build()
+    add_framework_edges(graph, parsed, _ctx(repo, parsed), tech_stack=["spring"])
+    return graph
+
+
+def _bound(graph) -> set[tuple[str, str]]:
+    return {
+        (s, t)
+        for s, t, d in graph.edges(data=True)
+        if d.get("edge_type") == "framework_binds"
+    }
+
+
+class TestSpringSymbolEdges:
+    def test_injection_links_the_two_declarations(self, tmp_path: Path) -> None:
+        (tmp_path / "UserService.java").write_text(
+            "import org.springframework.stereotype.Service;\n"
+            "@Service\npublic class UserService {}\n"
+        )
+        (tmp_path / "UserController.java").write_text(
+            "import org.springframework.beans.factory.annotation.Autowired;\n"
+            "import org.springframework.web.bind.annotation.RestController;\n"
+            "@RestController\npublic class UserController {\n"
+            "  @Autowired private UserService userService;\n"
+            "}\n"
+        )
+
+        bound = _bound(_build_graph(tmp_path))
+        assert (
+            "UserController.java::UserController",
+            "UserService.java::UserService",
+        ) in bound
+
+    def test_a_nested_configuration_owns_its_own_injection(self, tmp_path: Path) -> None:
+        # The injection regexes read whole-file text. Attributing every hit to
+        # the type the file is named for gives the outer class an injection it
+        # does not declare, and nested @Configuration classes are a standard
+        # idiom.
+        (tmp_path / "PaymentGateway.java").write_text(
+            "import org.springframework.stereotype.Service;\n"
+            "@Service\npublic class PaymentGateway {}\n"
+        )
+        (tmp_path / "AppConfig.java").write_text(
+            "import org.springframework.context.annotation.Configuration;\n"
+            "import org.springframework.beans.factory.annotation.Autowired;\n"
+            "@Configuration\npublic class AppConfig {\n"
+            "  @Configuration\n"
+            "  static class Inner {\n"
+            "    @Autowired private PaymentGateway gateway;\n"
+            "  }\n"
+            "}\n"
+        )
+
+        bound = _bound(_build_graph(tmp_path))
+        target = "PaymentGateway.java::PaymentGateway"
+        assert ("AppConfig.java::AppConfig", target) not in bound
+        assert any(src.startswith("AppConfig.java::") for src, dst in bound if dst == target)
+
+    def test_an_ambiguous_type_name_stays_unclaimed(self, tmp_path: Path) -> None:
+        # Two files declaring `UserService` cannot settle which one is injected,
+        # and picking whichever was walked first is a coin flip.
+        for sub in ("a", "b"):
+            d = tmp_path / sub
+            d.mkdir()
+            (d / "UserService.java").write_text(
+                "import org.springframework.stereotype.Service;\n"
+                "@Service\npublic class UserService {}\n"
+            )
+        (tmp_path / "UserController.java").write_text(
+            "import org.springframework.beans.factory.annotation.Autowired;\n"
+            "import org.springframework.web.bind.annotation.RestController;\n"
+            "@RestController\npublic class UserController {\n"
+            "  @Autowired private UserService userService;\n"
+            "}\n"
+        )
+
+        bound = _bound(_build_graph(tmp_path))
+        assert not [d for _s, d in bound if d.endswith("::UserService")]

--- a/tests/unit/ingestion/test_spring_framework_edges.py
+++ b/tests/unit/ingestion/test_spring_framework_edges.py
@@ -238,3 +238,27 @@ class TestSpringSymbolEdges:
 
         bound = _bound(_build_graph(tmp_path))
         assert not [d for _s, d in bound if d.endswith("::UserService")]
+
+    def test_springs_value_annotation_is_not_lomboks(self, tmp_path: Path) -> None:
+        # Lombok's @Value makes a class immutable and takes no argument;
+        # Spring's takes a property expression. Reading one as the other turns
+        # every field in the class into a constructor parameter.
+        (tmp_path / "MailService.java").write_text(
+            "import org.springframework.stereotype.Service;\n"
+            "@Service\npublic class MailService {}\n"
+        )
+        (tmp_path / "User.java").write_text("public class User {}\n")
+        (tmp_path / "UserResource.java").write_text(
+            "import org.springframework.web.bind.annotation.RestController;\n"
+            "import org.springframework.beans.factory.annotation.Value;\n"
+            "@RestController\npublic class UserResource {\n"
+            '  @Value("${app.name}")\n'
+            "  private String applicationName;\n"
+            "  private final User cachedUser = null;\n"
+            "  public UserResource(MailService mailService) {}\n"
+            "}\n"
+        )
+
+        bound = _bound(_build_graph(tmp_path))
+        assert ("UserResource.java::UserResource", "MailService.java::MailService") in bound
+        assert ("UserResource.java::UserResource", "User.java::User") not in bound


### PR DESCRIPTION
A framework handler could only ever relate two file paths. So a pytest fixture
nobody calls, and a Spring collaborator nobody constructs, both read as reached
by nobody — and the pairing was there all along: the conftest hint already
computes which fixtures a conftest declares and which parameter names a test
asks for, then throws the pairing away at the file boundary.

This adds `framework_binds`, the symbol-level sibling of `framework`, emitted
when a handler can name **both** ends as symbols.

**2,354 edges across 16 repos. No existing edge of any other type moves on 15
of them**, and the sixteenth is fully attributed to the `@Value` fix below.
Controls carrying no framework — leveldb, gitleaks, fmt — gain nothing.

## What ships

| producer | what it links |
|---|---|
| pytest fixture injection | a test function to the fixture it asks for by parameter name |
| Spring field / constructor / Lombok injection | an injecting class to the collaborator injected into it |
| Express route wiring | unchanged behaviour; it already ran symbol → symbol and was labelled `reads` |

ASP.NET routing was evaluated and deliberately **not** built: a `[HttpGet]`
action has one end in the repo and the other is the framework itself, so an edge
is the wrong shape for it.

## Deliberately not a call

`framework_binds` is not `calls`, and that is the load-bearing decision rather
than the confidence value. Nothing here is a call the parser could have seen, so
letting it read as one would put an inferred wiring hop into an execution flow
as if it were source. It carries `confidence=0.90` — below `same_file`, because a
container can rebind at run time; level with the heritage-walk origins, because
like them it follows a documented rule and checks no signature.

`reads` now means one thing again. It was two edge types wearing one name — the
C# member scan emits it file → file, the Express route wiring emitted it
symbol → symbol — and the second is what this new type describes.

## Precision

Hand-audited, 30 rows per framework, each row read with both declarations in
context: **celery 30/30, flask 30/30, Spring 21/21** (all 22 Spring edges, after
a first round of 21/22).

Two adversarial review rounds against the real parser found twelve ways to claim
an edge without evidence, and **four of those were introduced by the first
round's own fixes**, including one outright regression. Every one is now a test.
The refusals are the interesting half:

- a module-level assignment read as a test function — the recorded signature of
  `test_client = TestClient(app)` is the assignment line, so a parameter-list
  read finds `app` in it
- a defaulted parameter, which pytest never injects
- a class-scoped fixture serving its sibling classes
- a method of a class pytest never collects
- `name=` nested inside a `params` list taken as the fixture's registered name
- a parametrize *value* refusing a real request that shared its spelling
- a comment, an escaped quote, or an `=` inside an annotation swallowing the
  whole parameter list

...and, in the other direction, a base test class must still serve its
subclasses, which scoping the lookup too tightly had broken.

## Two bugs found by auditing, both older than this change

**Spring's `@Value` was being read as Lombok's.** They share a spelling and
nothing else: Lombok's makes a class immutable and takes no argument, Spring's
takes a property expression and sits on a field. A class with one property
injection had every field turned into a constructor parameter and every field
type wired to it. Narrowing the rule removes wrong edges and adds none — the
entire measured consequence is one file-level edge and one symbol-level edge on
one sample app.

**pytest's `python_classes` setting was assumed rather than read.** Assuming the
default `Test*` refused **346 of celery's 359 bindings**, because celery
configures `test_*`.

## Cost

The pass runs after the graph build rather than inside it, so a percentage of
build time would measure against something it never touches. In absolute
seconds, against parse + build + pass: **0.034s (1.0%) on celery, 0.007s (1.0%)
on flask, 0.001s (0.2%) on spring-petclinic**. All configurations came out
ordered.

## Dead code does not move, and that is expected

Stated before the numbers were taken, not after. Nothing new is reported and
nothing stops being reported, for two structural reasons: the unused-internals
pass skips methods entirely, and the analyzer already carries ~180 framework
decorator patterns as a private skip-list consulted by both symbol passes. The
edges are banked for the phase that lifts the method skip; the duplication
between graph and skip-list is what this change starts to unpick.
