### PR TITLE
test(ci): exempt pytest's own collection rule from the test-path guard

### DIFF
--- a/packages/core/src/repowise/core/ingestion/framework_edges/pytest_edges.py
+++ b/packages/core/src/repowise/core/ingestion/framework_edges/pytest_edges.py
@@ -35,6 +35,17 @@ _QUOTED_RE = re.compile(r"""["']([^"']*)["']""")
 # fixture's name.
 _NAME_KWARG_ARG_RE = re.compile(r"""^name\s*=\s*["']([^"']+)["']$""")
 
+# pytest's own `python_files` default, and deliberately not the shared
+# `is_test_path`. A fixture is injected only into a file pytest actually
+# collects, so this has to answer "does pytest run this?" — a narrower question
+# than "is this test-related code", which also claims `conftest.py`, a
+# `tests/helpers.py` and every non-Python spec layout. Widening it would inject
+# fixture parameters into files that are never collected.
+#
+# Ceiling: `python_files` is configurable and this assumes the default, unlike
+# `_DEFAULT_TEST_CLASS_GLOBS` below, which reads the setting because assuming it
+# cost 346 of celery's 359 bindings. No corpus repo overrides `python_files`, so
+# the same mistake is not yet demonstrable here.
 _TEST_FILE_RE = re.compile(r"(?:^|/)(?:test_[^/]*|[^/]*_test)\.py$")
 
 # pytest collects methods only from classes matching `python_classes`, so a

--- a/tests/unit/test_no_test_path_copies.py
+++ b/tests/unit/test_no_test_path_copies.py
@@ -88,6 +88,12 @@ _KNOWN: frozenset[str] = frozenset(
         # handler under an OpenAPI `spec/` is a real service contract, and
         # over-excluding drops it from the workspace contract map entirely.
         "packages/core/src/repowise/core/workspace/extractors/base.py",
+        # pytest's own `python_files` rule, not ours: a fixture is injected
+        # only into a file pytest collects, so this asks "does pytest run
+        # this?" rather than "is this test-related code". The shared rules also
+        # claim `conftest.py` and `tests/helpers.py`, and giving those fixture
+        # parameters would be wrong.
+        "packages/core/src/repowise/core/ingestion/framework_edges/pytest_edges.py",
     }
 )
 


### PR DESCRIPTION
`main` is red on `test_no_new_test_path_predicates`, on both 3.11 and 3.13, and it is the only failure in the run.

The pytest fixture pass added `_TEST_FILE_RE` to `framework_edges/pytest_edges.py`, and the guard counts any new test-path pattern outside `repowise.core.test_paths` as another copy of "is this path a test?".

## Why an allowlist entry rather than a conversion

It is a deliberate divergence, which is what `_KNOWN` is for. A fixture is injected only into a file pytest actually **collects**, so the question here is "does pytest run this?" — pytest's own `python_files` rule. The shared predicate answers the wider "is this test-related code", and also claims `conftest.py`, a `tests/helpers.py` and every non-Python spec layout. Converting would give fixture parameters to files pytest never collects, which is a wrong edge rather than a tidier one.

That is the same call the two entries already in `_KNOWN` made, and the guard's own message asks for exactly this: say why in the code, then add it.

## What is in the diff

- The reason, written into the code it exempts as well as into the allowlist.
- A ceiling recorded beside it: this assumes pytest's `python_files` default, unlike `_DEFAULT_TEST_CLASS_GLOBS` a few lines below which reads the setting from config. That constant reads it because assuming the default refused 346 of celery's 359 bindings. No corpus repo overrides `python_files`, so the same mistake is not demonstrable here yet — but it is the same shape, and worth someone finding written down rather than rediscovering.

## Verification

`tests/unit/test_no_test_path_copies.py` green (6 passed), including `test_known_copies_still_exist`, which fails on a stale entry and so keeps the list honest. Framework-edge and id tests green (116 passed, 1 skipped). `ruff check` clean on both files.