### PR TITLE
fix(graph): give a Java call on its own field a receiver

### DIFF
--- a/packages/core/src/repowise/core/ingestion/queries/java.scm
+++ b/packages/core/src/repowise/core/ingestion/queries/java.scm
@@ -80,6 +80,29 @@
   arguments: (argument_list) @call.arguments
 ) @call.site
 
+; Method call on the caller's own field: this.field.method(args).
+; The pattern above constrains ``object`` to a bare identifier and the bare
+; pattern constrains nothing, so without this a field receiver arrives with no
+; receiver at all — which the resolver reads as an implicit receiver on the
+; caller's own class.
+;
+; ``this``/``super`` only, which is the rule every sibling grammar keeps: a
+; captured receiver must name something in the *caller's* scope, because the
+; receiver strategies type a field against the caller's class. Lifting the
+; nearest name out of ``a.b.method()`` would offer ``b`` — which belongs to
+; ``a``'s type — to be typed as a field of the caller, and bind a same-named
+; one. ``Outer.this.method()`` declines on its own, since a qualified ``this``
+; is a ``this`` node and not an ``identifier``, and that is right: it is an
+; implicit receiver.
+(method_invocation
+  object: (field_access
+    object: [(this) (super)]
+    field: (identifier) @call.receiver
+  )
+  name: (identifier) @call.target
+  arguments: (argument_list) @call.arguments
+) @call.site
+
 ; Chained method call: obj.method1().method2(args)
 (method_invocation
   object: (method_invocation)

--- a/tests/unit/ingestion/parser/test_java.py
+++ b/tests/unit/ingestion/parser/test_java.py
@@ -36,6 +36,31 @@ public class Calculator {
 """
 
 
+FIELD_RECEIVER_SOURCE = b"""package com.repowise.sample;
+
+public class Clinic {
+
+    private final OwnerRepository owners;
+    private final Basket basket;
+
+    public void report() {
+        this.owners.findAll();
+        super.audit.record();
+        this.basket.items.size();
+    }
+
+    class Inner {
+        void run() {
+            Clinic.this.reset();
+        }
+    }
+
+    void reset() {
+    }
+}
+"""
+
+
 class TestJavaParser:
     def test_finds_class(self, parser: ASTParser) -> None:
         fi = _make_file_info("java_pkg/Calculator.java", "java")
@@ -57,3 +82,31 @@ class TestJavaParser:
         assert len(result.imports) >= 2
         module_paths = [i.module_path for i in result.imports]
         assert any("ArrayList" in p for p in module_paths)
+
+    def test_own_field_receiver_is_captured(self, parser: ASTParser) -> None:
+        """``this.field.m()`` must carry ``field``, not arrive receiver-less.
+
+        The bare-call pattern matches every invocation, so a shape no
+        receiver-carrying pattern claims reads as an implicit receiver on the
+        caller's own class and binds by bare name.
+        """
+        fi = _make_file_info("java_pkg/Calculator.java", "java")
+        result = parser.parse_file(fi, FIELD_RECEIVER_SOURCE)
+        by_target = {c.target_name: c for c in result.calls if c.receiver_name}
+        assert by_target["findAll"].receiver_name == "owners"
+        assert by_target["record"].receiver_name == "audit"
+
+    def test_other_objects_field_is_not_a_receiver(self, parser: ASTParser) -> None:
+        """Only a name in the caller's own scope may be captured.
+
+        ``items`` in ``this.basket.items.size()`` is a field of ``Basket``, and
+        the receiver strategies type a field against the *caller's* class — so
+        capturing it would offer it to be bound to a same-named field of the
+        caller. ``Outer.this.m()`` is a real implicit receiver and keeps none.
+        """
+        fi = _make_file_info("java_pkg/Calculator.java", "java")
+        result = parser.parse_file(fi, FIELD_RECEIVER_SOURCE)
+        for target in ("size", "reset"):
+            assert all(
+                c.receiver_name is None for c in result.calls if c.target_name == target
+            ), target


### PR DESCRIPTION
`java.scm`'s bare-call pattern constrains nothing on a `method_invocation`'s `object` field, and tree-sitter has no way to say a field is absent — so it matches every call, not only the receiver-less ones.

`this.owners.findAll()` had no receiver-carrying pattern to claim it, so it arrived with no receiver at all and read as an implicit receiver on the caller's own class, binding `findAll` by bare name to whatever happened to declare it. `csharp.scm`, `kotlin.scm` and `cpp.scm` all constrain their receiver field and do not have this.

The fix adds the missing pattern rather than trying to narrow the bare one, which no query can do.

## Why `this`/`super` and not any field access

The first version captured the nearest field of **any** `field_access`, which reaches 1,175 sites. That is wrong, and review caught it.

The receiver strategies type a field against the **caller's** class. So `a.b.m()` would offer `b` — a field of `a`'s type, not of the caller — to that lookup, and where the caller declares a same-named field it would bind there instead. It is a *new* path: before this change the shape carried no receiver and never reached the typed tier at all, so the wide pattern could mint a wrong edge where there had been none.

Every sibling grammar keeps one rule that the wide version had broken: **a captured receiver must name something in the caller's own scope.** cpp constrains to a bare identifier; csharp and kotlin to identifier-or-`this`. `this`/`super` is the only Java spelling that makes the captured name provably a field of the caller's class.

The cost is most of the population — 74 sites of 1,175, and on caffeine 12 of 890. Reaching `a.b.m()` soundly needs the call site to record that the receiver came through `this`, which is a model change and belongs on its own.

`Outer.this.m()` declines the match on its own, because a qualified `this` is a `this` node and not an `identifier`. That is the right outcome: it really is an implicit receiver.

## Measurement

Strictly additive on 11 repos — caffeine, ktor, exposed, spring-petclinic, jhipster-sample-app, javalin, upickle, sinatra, plus leveldb, gitleaks and celery as controls.

| Gate | Result |
|---|---|
| Resolved calls | **0 lost** on every repo; 34 rows move |
| Symbols | **0 lost** on every repo |
| Heritage / imports | byte-identical on all 11 |
| Dead-code findings | 0 stopped, 0 newly reported on all 11 |
| Controls | byte-identical |

Symbols are gated separately and on purpose: a capture change can delete a symbol nothing resolves to and leave every edge gate green, so an edge diff alone is not evidence.

`new_target` is 0 everywhere, and that is the honest framing — this buys evidence, not reach. What it buys is that 74 member calls stop being indistinguishable from implicit-receiver calls, and the rows that do move carry a receiver-typed origin at 0.88–0.90 instead of a bare-name guess.

## Precision

Every row in the one bucket that can hold a wrong edge was read by hand, since a count is not a verdict there. All three bind to the field's declared type, and all three displace a wrong bare-name guess:

| Site | Receiver | Declared as | Now binds | Displaced |
|---|---|---|---|---|
| `SumProcedure.java:65` | `sum` | `Sum` | `Sum::speciesNew` | `IntegerSum::speciesNew` |
| `SumProcedure.java:78` | `sum` | `Sum` | `Sum::add` | `IntegerSum::add` |
| `PathMatcherBenchmark.java:43` | `pathMatcher` | `PathMatcher` | `PathMatcher::add` | `OldPathMatcher::add` |

A seeded 30-row sample of caffeine's field-access sites: 29 captured a receiver and all 29 are the right name; the 30th is the `Outer.this` refusal. 13 of the 30 resolve to nothing, every one an external receiver (`System.out`, `TimeUnit.NANOSECONDS`), which is the right answer and was the answer before.

## Tests

Two guards, one for each half of the rule — that a call on the caller's own field carries it, and that a call on another object's field does not. Targeted suites green: parser and dead-code 493 passed, call-resolution 555 passed. `ruff check` clean.