### PR TITLE
fix(graph): stop a third-party JVM import taking a same-named repo class

### DIFF
--- a/packages/core/src/repowise/core/ingestion/resolvers/java.py
+++ b/packages/core/src/repowise/core/ingestion/resolvers/java.py
@@ -94,11 +94,19 @@ def resolve_java_import_all(
     if namespace_class == "external":
         return (ctx.add_external_node(module_path),)
 
-    # Try stem lookup (class name)
+    # Match on the class name alone, but only among the files of the package
+    # the import actually names: a repo-wide match discards the package, so a
+    # third-party type binds to any same-named repo class.
     local = parts[-1]
-    result = ctx.stem_lookup(local.lower())
-    if result and (result.endswith(".java") or result.endswith(".kt")):
-        return (result,)
+    if len(parts) > 1:
+        scoped = jvm_index.file_in_package_by_stem(".".join(parts[:-1]), local)
+        if scoped and (scoped.endswith(".java") or scoped.endswith(".kt")):
+            return (scoped,)
+    else:
+        # A single-segment import carries no package to check against.
+        result = ctx.stem_lookup(local.lower())
+        if result and (result.endswith(".java") or result.endswith(".kt")):
+            return (result,)
 
     # Try matching package path as directory structure
     if len(parts) > 1:

--- a/packages/core/src/repowise/core/ingestion/resolvers/jvm_workspace.py
+++ b/packages/core/src/repowise/core/ingestion/resolvers/jvm_workspace.py
@@ -17,7 +17,7 @@ import contextlib
 import re
 from dataclasses import dataclass, field
 from functools import lru_cache
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING, Any
 
 import structlog
@@ -170,6 +170,25 @@ class JvmWorkspaceIndex:
             if files:
                 return files
         return ()
+
+    def file_in_package_by_stem(self, pkg_fqn: str, name: str) -> str | None:
+        """Match a simple name against the files of one package only.
+
+        The name-only fallback in the import resolvers searched the whole
+        repo, so a third-party ``com.google.common.cache.CacheStats`` bound to
+        any file called ``CacheStats``. The package the import names is the
+        only local evidence for a file, so the search is scoped to it. A
+        Kotlin top-level function, whose file the type scan records no type
+        for, still resolves — its package matches.
+        """
+        pkg = self.packages.get(pkg_fqn)
+        if pkg is None:
+            return None
+        target = name.lower()
+        for path in pkg.files:
+            if PurePosixPath(path).stem.lower() == target:
+                return path
+        return None
 
     def wildcard_expand(self, pkg_fqn: str) -> tuple[str, ...]:
         """Expand ``import pkg.*`` → all files in the package."""

--- a/packages/core/src/repowise/core/ingestion/resolvers/kotlin.py
+++ b/packages/core/src/repowise/core/ingestion/resolvers/kotlin.py
@@ -84,10 +84,18 @@ def resolve_kotlin_import_all(
     if namespace_class == "external":
         return (ctx.add_external_node(module_path),)
 
-    # Try stem lookup on the class/function name
-    result = ctx.stem_lookup(local.lower())
-    if result and (result.endswith(".kt") or result.endswith(".kts") or result.endswith(".java")):
-        return (result,)
+    # Match on the class/function name alone, but only among the files of the
+    # package the import actually names: a repo-wide match discards the
+    # package, so a third-party type binds to any same-named repo class.
+    if len(parts) > 1:
+        scoped = jvm_index.file_in_package_by_stem(".".join(parts[:-1]), local)
+        if scoped and (scoped.endswith(".kt") or scoped.endswith(".kts") or scoped.endswith(".java")):
+            return (scoped,)
+    else:
+        # A single-segment import carries no package to check against.
+        result = ctx.stem_lookup(local.lower())
+        if result and (result.endswith(".kt") or result.endswith(".kts") or result.endswith(".java")):
+            return (result,)
 
     # Try matching the package path as a directory structure
     if len(parts) > 1:

--- a/packages/core/src/repowise/core/ingestion/resolvers/scala.py
+++ b/packages/core/src/repowise/core/ingestion/resolvers/scala.py
@@ -87,10 +87,18 @@ def resolve_scala_import_all(
     if build_match is not None:
         return (build_match,)
 
-    # Stem lookup on the type/object name
-    result = ctx.stem_lookup(local.lower())
-    if result and result.endswith(".scala"):
-        return (result,)
+    # Match on the type/object name alone, but only among the files of the
+    # package the import actually names: a repo-wide match discards the
+    # package, so a third-party type binds to any same-named repo class.
+    if len(parts) > 1:
+        scoped = jvm_index.file_in_package_by_stem(".".join(parts[:-1]), local)
+        if scoped and scoped.endswith(".scala"):
+            return (scoped,)
+    else:
+        # A single-segment import carries no package to check against.
+        result = ctx.stem_lookup(local.lower())
+        if result and result.endswith(".scala"):
+            return (result,)
 
     # Package path as directory structure
     if len(parts) > 1:

--- a/tests/unit/ingestion/test_java_resolver.py
+++ b/tests/unit/ingestion/test_java_resolver.py
@@ -86,11 +86,46 @@ class TestJavaImportResolution:
         targets = resolve_java_import_all("com.foo.Constants", "Main.java", ctx)
         assert a in targets
 
-    def test_stem_fallback(self, tmp_path: Path) -> None:
-        a = _make_java(tmp_path, "src/Util.java", "com.foo", "Util")
-        ctx = _ctx(tmp_path, [a])
+    def test_name_match_needs_the_importing_package(self, tmp_path: Path) -> None:
+        # A file in com.foo cannot answer an import of com.bar.Util. The name
+        # alone used to be enough, which is how a third-party type bound to a
+        # same-named repo class.
+        _make_java(tmp_path, "src/Util.java", "com.foo", "Util")
+        ctx = _ctx(tmp_path, ["src/Util.java"])
         result = resolve_java_import("com.bar.Util", "Main.java", ctx)
-        assert result == a
+        assert result == "external:com.bar.Util"
+
+    def test_third_party_import_does_not_take_a_same_named_local_class(
+        self, tmp_path: Path
+    ) -> None:
+        local = _make_java(
+            tmp_path,
+            "src/main/java/com/acme/cache/stats/CacheStats.java",
+            "com.acme.cache.stats",
+            "CacheStats",
+        )
+        ctx = _ctx(tmp_path, [local])
+        targets = resolve_java_import_all(
+            "com.google.common.cache.CacheStats",
+            "src/test/java/com/acme/guava/CompatTest.java",
+            ctx,
+        )
+        assert targets == ("external:com.google.common.cache.CacheStats",)
+
+    def test_name_match_inside_the_named_package_still_resolves(
+        self, tmp_path: Path
+    ) -> None:
+        # The package scan reads a file's package but records no type for it —
+        # here the class name differs from the file name, so the exact-FQN
+        # lookup misses and only the name match can answer.
+        # The path deliberately does not mirror the package, so the directory
+        # fallback below cannot answer either.
+        full = tmp_path / "src/Widgets.java"
+        full.parent.mkdir(parents=True, exist_ok=True)
+        full.write_text("package com.foo;\n\nclass Internal {}\n")
+        ctx = _ctx(tmp_path, ["src/Widgets.java"])
+        result = resolve_java_import("com.foo.Widgets", "Main.java", ctx)
+        assert result == "src/Widgets.java"
 
     def test_package_fan_out_single_import(self, tmp_path: Path) -> None:
         """A single-class import resolves to the specific file, not all package files."""

--- a/tests/unit/ingestion/test_kotlin_resolver.py
+++ b/tests/unit/ingestion/test_kotlin_resolver.py
@@ -57,11 +57,26 @@ class TestKotlinIndex:
         assert result == rel
 
     def test_falls_through_without_gradle(self, tmp_path: Path) -> None:
+        # No build file, no package clause, and a path that does not mirror
+        # the package — neither signal places the file where the import says,
+        # so the name alone must not bind it.
         (tmp_path / "src").mkdir()
         (tmp_path / "src" / "Foo.kt").write_text("class Foo\n")
         ctx = _ctx(tmp_path, ["src/Foo.kt"])
         result = resolve_kotlin_import("com.example.Foo", "main.kt", ctx)
-        assert result == "src/Foo.kt"
+        assert result == "external:com.example.Foo"
+
+    def test_falls_through_without_gradle_on_a_matching_path(
+        self, tmp_path: Path
+    ) -> None:
+        # Same shape, still no build file and no package clause, but the path
+        # mirrors the package: the directory fallback answers.
+        src = tmp_path / "src" / "com" / "example"
+        src.mkdir(parents=True)
+        (src / "Foo.kt").write_text("class Foo\n")
+        ctx = _ctx(tmp_path, ["src/com/example/Foo.kt"])
+        result = resolve_kotlin_import("com.example.Foo", "main.kt", ctx)
+        assert result == "src/com/example/Foo.kt"
 
     def test_single_module_root_build_gradle(self, tmp_path: Path) -> None:
         (tmp_path / "build.gradle.kts").write_text("// single module\n")
@@ -106,3 +121,31 @@ class TestKotlinStdlibFiltering:
         ctx = _ctx(tmp_path, ["src/kotlinutil/Helper.kt"])
         result = resolve_kotlin_import("kotlinutil.Helper", "Main.kt", ctx)
         assert result == "src/kotlinutil/Helper.kt"
+
+    def test_third_party_import_does_not_take_a_same_named_local_class(
+        self, tmp_path: Path
+    ) -> None:
+        # com.google.* carries no external-namespace short-circuit, so only the
+        # package check stops this binding.
+        repo_file = tmp_path / "src" / "cache" / "CacheStats.kt"
+        repo_file.parent.mkdir(parents=True)
+        repo_file.write_text("package com.acme.cache\n\nclass CacheStats\n")
+        ctx = _ctx(tmp_path, ["src/cache/CacheStats.kt"])
+        result = resolve_kotlin_import(
+            "com.google.common.cache.CacheStats", "Main.kt", ctx
+        )
+        assert result == "external:com.google.common.cache.CacheStats"
+
+    def test_top_level_function_in_the_named_package_still_resolves(
+        self, tmp_path: Path
+    ) -> None:
+        # A file declaring only top-level functions records no type, so the
+        # exact-FQN lookup misses; the package is what identifies the file.
+        # Its path does not mirror the package, so the directory fallback
+        # cannot answer either.
+        repo_file = tmp_path / "src" / "CommentRoutes.kt"
+        repo_file.parent.mkdir(parents=True)
+        repo_file.write_text("package com.acme.domain\n\nfun commentRoutes() {}\n")
+        ctx = _ctx(tmp_path, ["src/CommentRoutes.kt"])
+        result = resolve_kotlin_import("com.acme.domain.commentRoutes", "Main.kt", ctx)
+        assert result == "src/CommentRoutes.kt"

--- a/tests/unit/ingestion/test_scala_resolver.py
+++ b/tests/unit/ingestion/test_scala_resolver.py
@@ -75,11 +75,26 @@ class TestScalaIndex:
         assert result == rel
 
     def test_no_build_file_falls_through(self, tmp_path: Path) -> None:
+        # No build file, no package clause, and a path that does not mirror
+        # the package — neither signal places the file where the import says,
+        # so the name alone must not bind it.
         (tmp_path / "src").mkdir()
         (tmp_path / "src" / "Foo.scala").write_text("class Foo\n")
         ctx = _ctx(tmp_path, ["src/Foo.scala"])
         result = resolve_scala_import("com.example.Foo", "main.scala", ctx)
-        assert result == "src/Foo.scala"
+        assert result == "external:com.example.Foo"
+
+    def test_no_build_file_falls_through_on_a_matching_path(
+        self, tmp_path: Path
+    ) -> None:
+        # Same shape, still no build file and no package clause, but the path
+        # mirrors the package: the directory fallback answers.
+        src = tmp_path / "src" / "com" / "example"
+        src.mkdir(parents=True)
+        (src / "Foo.scala").write_text("class Foo\n")
+        ctx = _ctx(tmp_path, ["src/com/example/Foo.scala"])
+        result = resolve_scala_import("com.example.Foo", "main.scala", ctx)
+        assert result == "src/com/example/Foo.scala"
 
 
 def _make_scala(repo: Path, rel_path: str, package: str, decl: str) -> str:
@@ -172,3 +187,14 @@ class TestScalaWorkspaceResolution:
         ctx = _ctx(tmp_path, [core, app])
         result = resolve_scala_import("com.example.core.Engine", app, ctx)
         assert result == core
+
+    def test_third_party_import_does_not_take_a_same_named_local_class(
+        self, tmp_path: Path
+    ) -> None:
+        local = _make_scala(
+            tmp_path, "core/src/main/scala/com/acme/json/Reader.scala",
+            "com.acme.json", "class Reader",
+        )
+        ctx = _ctx(tmp_path, [local])
+        result = resolve_scala_import("io.circe.parser.Reader", "Main.scala", ctx)
+        assert result == "external:io.circe.parser.Reader"


### PR DESCRIPTION
## What

A Java, Kotlin or Scala import that names a package the repo does not declare no
longer binds to a repo file that merely shares the class's simple name.

When the exact fully-qualified lookup, the member-FQN lookup and the build-tool
index all miss, the resolvers fell back to matching the import's last segment
against **every file in the repo**, discarding the package entirely. So
`import com.google.common.cache.CacheStats` in a Guava-compatibility test
resolved to the project's own `cache/stats/CacheStats.java`, and the import-name
map handed that wrong file to every consumer downstream — merged-import
resolution, scoped-import resolution and receiver typing alike.

The name match is now scoped to the files the JVM workspace index records under
the import's own package, which is the only local evidence that a file is the
one named. Anything else resolves to an external node.

## Why it is three files

`kotlin.py` and `scala.py` carry the same fallback as `java.py` against the same
index, so the fix is one shared `JvmWorkspaceIndex.file_in_package_by_stem`
called from all three rather than a Java-only patch that leaves the other two
holding it. Kotlin turned out to hold more of the affected population than Java.

## What it deliberately does not refuse

- **Single-segment imports** (`import Foo`, legal Kotlin from the default
  package) keep the repo-wide match — there is no package to check against.
- **Wildcard and static-member imports** return before this tier.
- **Build-tool index hits** (Gradle, sbt/Mill) run before it and are untouched,
  so a source layout the package scan misreads is still rescued by the build
  file.
- **The path-substring fallback below it** is unchanged; it already requires the
  import's package to appear as a directory path.

The scoped match is kept rather than the tier deleted because some name-only
bindings are correct: a Kotlin file of top-level functions records no type, so
the exact lookup cannot answer it and only a name match can. Those files declare
the right package, so they still resolve.

## Measurement

Corpus of 19 repositories, resolved calls and graph edges diffed by sha256 over
the full row tuple, every moved row put in a named bucket.

- 260 name-only bindings refused across four JVM repositories; **1,152 resolved
  calls removed, 0 gained, 0 rows unbucketed**.
- The 14 non-JVM repositories are **byte-identical** on both calls and edges.
- File and symbol node counts pinned; only external nodes rise (+66).
- **122 of 122 hand-audited rows were wrong before** — 30 sampled removed call
  edges plus 92 sampled refused imports, each read against the real source at
  both ends. The wrong bindings included Guava, JMH, Hibernate, Gradle, cache2k,
  Netty, Jetty, Apache HttpCore, SLF4J, OkHttp, JUnit, Spring Boot, WebRTC and
  R2DBC types, plus intra-repository confusions such as a server-side
  `ContentNegotiation` bound to the client-side file.
- Some imports do better than being refused: they fall through to the path
  fallback and land on the correct file, which the diff records separately.
- Build time is unchanged within noise on every repository measured.

## Tests

Three existing tests asserted the old behaviour on a file that declares no
package and sits at a path that does not mirror one; they now assert the
refusal, each with a companion test covering the matching-path case the
directory fallback still answers. Six tests in these files fail without the
change.

## Known remaining gap

The heritage resolver has its own global-unique tier that does not consult the
import, so a class whose `implements` clause names a third-party type can still
reach a same-named local class — now at confidence 0.50 rather than 0.90. Four
edges across the corpus. That fix belongs to the heritage resolver, changes
edges on every JVM repository, and is left to its own change.
