### PR TITLE
feat(graph): separate a method passed as a value from a method called

### DIFF
--- a/packages/core/src/repowise/core/ingestion/graph/_resolvers.py
+++ b/packages/core/src/repowise/core/ingestion/graph/_resolvers.py
@@ -22,6 +22,11 @@ log = structlog.get_logger(__name__)
 #: files. See ``_add_reference_edges``.
 _MIN_REFERENCE_CONFIDENCE = 0.85
 
+#: Symbol kinds a resolved reference may land on, by how the name was spelled.
+#: See ``_add_reference_edges`` for why a bare name is restricted to functions.
+_BARE_REFERENCE_KINDS = frozenset({"function"})
+_QUALIFIED_REFERENCE_KINDS = frozenset({"function", "method"})
+
 
 class ResolveMixin:
     """Symbol-level edge resolution passes run during ``build()``."""
@@ -599,14 +604,19 @@ class ResolveMixin:
         building a second index over every parsed file would double that cost
         for nothing.
 
-        Only free functions produce an edge, never methods. A bare identifier
-        cannot name a member function in C++ — that needs ``&Class::method`` —
-        so a plain name resolving to a method is always a collision rather
-        than a reference, and C++ names its getters exactly like the locals
-        that feed them. Measured on leveldb, admitting methods turned
-        ``value``, ``status``, ``level``, ``key`` and ``offset`` into fifteen
-        edges, every one of them wrong. Every shape the issue reports is a
-        free function, so nothing real is lost.
+        **What may be named depends on how it was written, not on the
+        language.** A receiver-less name produces an edge only to a free
+        function: a bare identifier cannot name a member in the languages that
+        spell a reference that way, so a plain name resolving to a method is a
+        collision rather than a reference, and C++ names its getters exactly
+        like the locals that feed them. Measured on leveldb, admitting methods
+        there turned ``value``, ``status``, ``level``, ``key`` and ``offset``
+        into fifteen edges, every one of them wrong.
+
+        A name that arrived with a receiver went through an operator only a
+        callable accepts — ``Foo::bar``, ``pkg.Handler`` in argument position —
+        so a method is the expected target and refusing one would discard the
+        whole idiom.
 
         A ``calls`` edge already covering the same pair wins and is left alone:
         it is the stronger claim, and downgrading it here would lose the fact
@@ -623,21 +633,30 @@ class ResolveMixin:
         for path, parsed in self._parsed_files.items():
             if not parsed.references:
                 continue
-            for rc in resolver.resolve_file(path, parsed.references):
-                if rc.confidence < _MIN_REFERENCE_CONFIDENCE:
+            bare = [r for r in parsed.references if not r.receiver_name]
+            qualified = [r for r in parsed.references if r.receiver_name]
+            batches = (
+                (bare, _BARE_REFERENCE_KINDS),
+                (qualified, _QUALIFIED_REFERENCE_KINDS),
+            )
+            for sites, allowed_kinds in batches:
+                if not sites:
                     continue
-                if rc.caller_id not in self._graph or rc.callee_id not in self._graph:
-                    continue
-                if self._graph.nodes[rc.callee_id].get("kind") != "function":
-                    continue
-                if self._graph.has_edge(rc.caller_id, rc.callee_id):
-                    continue
-                self._graph.add_edge(
-                    rc.caller_id,
-                    rc.callee_id,
-                    edge_type="references",
-                    confidence=rc.confidence,
-                    resolution_origin=rc.origin,
-                )
-                total += 1
+                for rc in resolver.resolve_file(path, sites):
+                    if rc.confidence < _MIN_REFERENCE_CONFIDENCE:
+                        continue
+                    if rc.caller_id not in self._graph or rc.callee_id not in self._graph:
+                        continue
+                    if self._graph.nodes[rc.callee_id].get("kind") not in allowed_kinds:
+                        continue
+                    if self._graph.has_edge(rc.caller_id, rc.callee_id):
+                        continue
+                    self._graph.add_edge(
+                        rc.caller_id,
+                        rc.callee_id,
+                        edge_type="references",
+                        confidence=rc.confidence,
+                        resolution_origin=rc.origin,
+                    )
+                    total += 1
         log.info("Reference edges resolved", total=total)

--- a/packages/core/src/repowise/core/ingestion/parser.py
+++ b/packages/core/src/repowise/core/ingestion/parser.py
@@ -110,7 +110,7 @@ _TS_JS_LANGUAGES = ("typescript", "javascript", "svelte", "vue")
 # Languages whose query defines the ``@reference.*`` captures. Every other
 # language would only scan the whole match list to find nothing, so the check
 # is here rather than inside ``_extract_references``.
-_REFERENCE_LANGUAGES = ("cpp", "c")
+_REFERENCE_LANGUAGES = ("cpp", "c", "go", "rust", "kotlin")
 
 
 @cache
@@ -1160,15 +1160,20 @@ class ASTParser:
     ) -> list[CallSite]:
         """Extract sites that name a function without calling it.
 
-        Three C/C++ shapes carry a function by name and never call it where a
-        parser can see: a dispatch-table entry, a callback field, and an
-        argument to a registration macro. Each leaves the named function with
-        no inbound edge, which read as a ``safe_to_delete`` unused export and
-        took out whole handler and interop layers (#1602).
+        Six shapes carry a function by name and never call it where a parser
+        can see: a dispatch-table entry, a callback field, an argument to a
+        registration macro, a func value in argument position, a struct-field
+        initialiser, and a ``::`` callable reference. Each leaves the named
+        function with no inbound edge, which read as a ``safe_to_delete``
+        unused export and took out whole handler and interop layers (#1602).
+
+        ``@reference.receiver`` is optional; capturing it is what lets
+        ``_add_reference_edges`` restrict a bare name to free functions and
+        allow a qualified name to reach a method.
 
         Self-gating on the reference captures, so a language whose query
         defines none produces nothing and pays two dict lookups. Two guards
-        keep these broad syntactic positions from claiming ordinary code:
+        keep the broad syntactic positions from claiming ordinary code:
 
         * A macro argument requires a SCREAMING_CASE callee and must be that
           macro's only argument. Uppercase alone is not enough: assertion
@@ -1197,13 +1202,18 @@ class ASTParser:
         callable_ids = {s.id for s in symbols if s.kind in ("function", "method")}
 
         references: list[CallSite] = []
-        seen: set[tuple[int, str]] = set()
+        seen: set[tuple[int, str, str | None]] = set()
 
         for capture_dict in matches:
             plain_nodes = capture_dict.get("reference.name", [])
             table_nodes = capture_dict.get("reference.table", [])
             if not plain_nodes and not table_nodes:
                 continue
+
+            receiver_nodes = capture_dict.get("reference.receiver", [])
+            receiver = (
+                _node_text(receiver_nodes[0], src).strip() if receiver_nodes else None
+            ) or None
 
             via_nodes = capture_dict.get("reference.via", [])
             if via_nodes:
@@ -1224,13 +1234,13 @@ class ASTParser:
                 enclosing = _find_enclosing_symbol(line, symbol_ranges)
                 if is_table and enclosing in callable_ids:
                     continue
-                if (line, name) in seen:
+                if (line, name, receiver) in seen:
                     continue
-                seen.add((line, name))
+                seen.add((line, name, receiver))
                 references.append(
                     CallSite(
                         target_name=name,
-                        receiver_name=None,
+                        receiver_name=receiver,
                         caller_symbol_id=enclosing,
                         line=line,
                         argument_count=None,

--- a/packages/core/src/repowise/core/ingestion/queries/go.scm
+++ b/packages/core/src/repowise/core/ingestion/queries/go.scm
@@ -77,19 +77,18 @@
   arguments: (argument_list) @call.arguments
 ) @call.site
 
-; Package-qualified function value passed as call argument: f(pkg.Handler, ...)
+; Qualified function value passed as call argument: f(pkg.Handler, ...)
 ; Rescues functions used as first-class values — passed as callbacks, middleware,
-; or handlers rather than called directly. Without this, pkg.Func referenced
-; only in argument position (never in function: position) has no call edges
-; and is incorrectly flagged as an unused export.
+; or handlers rather than called directly. A reference and not a call: nothing
+; here says ``Handler`` runs, only that something holds a handle to it.
 (call_expression
   arguments: (argument_list
     (selector_expression
-      operand: (_) @call.receiver
-      field: (field_identifier) @call.target
+      operand: (_) @reference.receiver
+      field: (field_identifier) @reference.name
     )
   )
-) @call.site
+)
 
 ; ---------------------------------------------------------------------------
 ; Type references — drive file-level ``type_use`` edges

--- a/packages/core/src/repowise/core/ingestion/queries/kotlin.scm
+++ b/packages/core/src/repowise/core/ingestion/queries/kotlin.scm
@@ -73,6 +73,37 @@
 ) @call.site
 
 ; ---------------------------------------------------------------------------
+; Callable references — a function named without being called
+; ---------------------------------------------------------------------------
+; The operator is matched literally because the installed grammar gives
+; ``Foo::bar`` and ``Foo.bar`` the same node shape, and the token is the only
+; thing separating them. ``::`` also precedes a property (``Foo::name``) and
+; the reserved ``::class``; neither is filtered here, because the symbol kind
+; settles it at resolution and no symbol is ever named ``class``.
+
+; Qualified: list.map(Foo::bar), register(A::process)
+(navigation_expression
+  (identifier) @reference.receiver
+  "::"
+  (identifier) @reference.name
+)
+
+; Bound to the enclosing instance: val f = this::handle
+(navigation_expression
+  (this_expression) @reference.receiver
+  "::"
+  (identifier) @reference.name
+)
+
+; Unqualified: list.map(::transform). Also catches a qualified spelling whose
+; receiver the grammar parsed as a type rather than an expression, which then
+; arrives receiver-less and so reaches only top-level functions. A ceiling in
+; the safe direction: it costs an edge, it cannot invent one.
+(callable_reference
+  (identifier) @reference.name
+)
+
+; ---------------------------------------------------------------------------
 ; Type references — drive file-level ``type_use`` edges
 ; ---------------------------------------------------------------------------
 ; Kotlin types appear in primary-ctor positions (``class Foo(val x: Bar)``),

--- a/packages/core/src/repowise/core/ingestion/queries/rust.scm
+++ b/packages/core/src/repowise/core/ingestion/queries/rust.scm
@@ -278,9 +278,21 @@
 ; to prevent false-positive dead code flags on functions passed by name.
 (call_expression
   arguments: (arguments
-    (identifier) @call.target
+    (identifier) @reference.name
   )
-) @call.site
+)
+
+; Associated function or method as a callback argument: register(Foo::bar),
+; iter.map(Type::method). A separate pattern because the bare one above matches
+; only an (identifier), and this shape is the one that can name a method.
+(call_expression
+  arguments: (arguments
+    (scoped_identifier
+      path: (_) @reference.receiver
+      name: (identifier) @reference.name
+    )
+  )
+)
 
 ; Type argument in turbofish: func::<MyType>(...), Channel::<MyType>::new()
 ; Creates a reference edge so MyType is not flagged as unused.
@@ -294,15 +306,15 @@
 ; Captures the final identifier as a reference to prevent false dead code flags.
 (field_initializer
   value: (scoped_identifier
-    path: (_) @call.receiver
-    name: (identifier) @call.target
+    path: (_) @reference.receiver
+    name: (identifier) @reference.name
   )
-) @call.site
+)
 
 ; Plain identifier in struct field initializer: Foo { field: my_func }
 (field_initializer
-  value: (identifier) @call.target
-) @call.site
+  value: (identifier) @reference.name
+)
 
 ; ---------------------------------------------------------------------------
 ; Type references — track types used in signatures to prevent false dead code

--- a/tests/unit/ingestion/test_value_reference_edges.py
+++ b/tests/unit/ingestion/test_value_reference_edges.py
@@ -1,0 +1,295 @@
+"""A method or function passed as a value, in Go, Rust and Kotlin.
+
+``list.map(Foo::bar)``, ``register(pkg.Handler)`` and ``Config { on_tick:
+my_func }`` all name something callable and never call it. Go and Rust already
+captured these shapes, but as ``@call.site`` with no argument list, so they
+reached the graph as ordinary ``calls`` edges — a value reference
+indistinguishable from an invocation, and an execution flow that steps through
+a handler nothing has yet run. Java spells it ``Foo::bar`` and has the same
+defect; it is untouched here.
+
+Two halves are pinned here. The shapes must produce a ``references`` edge and
+must **not** produce a ``calls`` edge; and the receiver decides what may be
+named, because a bare identifier sits in a position a local also occupies.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from repowise.core.ingestion import ASTParser, FileTraverser, GraphBuilder
+
+
+def _build(repo: Path):
+    traverser = FileTraverser(repo)
+    parser = ASTParser()
+    builder = GraphBuilder(repo_path=repo)
+    for fi in traverser.traverse():
+        builder.add_file(parser.parse_file(fi, Path(fi.abs_path).read_bytes()))
+    return builder.build()
+
+
+def _edges_of_type(graph, kind: str) -> set[tuple[str, str]]:
+    return {(u, v) for u, v, d in graph.edges(data=True) if d.get("edge_type") == kind}
+
+
+def _inbound(graph, symbol_id: str, kind: str) -> set[str]:
+    if not graph.has_node(symbol_id):
+        return set()
+    return {
+        pred
+        for pred in graph.predecessors(symbol_id)
+        if graph[pred][symbol_id].get("edge_type") == kind
+    }
+
+
+class TestKotlinCallableReferences:
+    def test_qualified_reference_reaches_a_method(self, tmp_path: Path) -> None:
+        (tmp_path / "handlers.kt").write_text(
+            "package app\n"
+            "class Handlers {\n"
+            "    fun onTick(n: Int): Int = n\n"
+            "}\n"
+            "class Runner {\n"
+            "    fun run(h: Handlers, xs: List<Int>) {\n"
+            "        xs.map(Handlers::onTick)\n"
+            "    }\n"
+            "}\n"
+        )
+        graph = _build(tmp_path)
+        assert _inbound(graph, "handlers.kt::Handlers::onTick", "references")
+        assert not _inbound(graph, "handlers.kt::Handlers::onTick", "calls")
+
+    def test_unqualified_reference_reaches_a_top_level_function(
+        self, tmp_path: Path
+    ) -> None:
+        (tmp_path / "pipeline.kt").write_text(
+            "package app\n"
+            "fun transform(n: Int): Int = n + 1\n"
+            "fun run(xs: List<Int>) {\n"
+            "    xs.map(::transform)\n"
+            "}\n"
+        )
+        graph = _build(tmp_path)
+        assert _inbound(graph, "pipeline.kt::transform", "references")
+
+    def test_plain_member_access_is_not_a_reference(self, tmp_path: Path) -> None:
+        """``Foo.bar`` and ``Foo::bar`` are one node shape apart from the token.
+
+        The grammar gives them the same tree, so the query matches ``::``
+        literally. Without that, every qualified property read would mint an
+        edge.
+        """
+        (tmp_path / "config.kt").write_text(
+            "package app\n"
+            "object Defaults {\n"
+            "    fun timeout(): Int = 30\n"
+            "}\n"
+            "fun read(): Int = Defaults.timeout()\n"
+        )
+        graph = _build(tmp_path)
+        assert not _edges_of_type(graph, "references")
+
+
+class TestGoFunctionValues:
+    @staticmethod
+    def _layout(tmp_path: Path, setup_body: str) -> None:
+        (tmp_path / "go.mod").write_text("module example.com/app\n\ngo 1.21\n")
+        (tmp_path / "handlers").mkdir()
+        (tmp_path / "handlers" / "handlers.go").write_text(
+            "package handlers\n\nfunc Index() {}\n"
+        )
+        (tmp_path / "server.go").write_text(
+            "package app\n"
+            "\n"
+            'import "example.com/app/handlers"\n'
+            "\n"
+            "func Register(f func()) {}\n"
+            "\n"
+            "func Setup() {\n"
+            f"{setup_body}"
+            "}\n"
+        )
+
+    def test_qualified_func_value_in_argument_position(self, tmp_path: Path) -> None:
+        self._layout(tmp_path, "\tRegister(handlers.Index)\n")
+        graph = _build(tmp_path)
+        assert _inbound(graph, "handlers/handlers.go::Index", "references")
+        assert not _inbound(graph, "handlers/handlers.go::Index", "calls")
+
+    def test_an_ordinary_qualified_call_is_still_a_call(self, tmp_path: Path) -> None:
+        self._layout(tmp_path, "\thandlers.Index()\n")
+        graph = _build(tmp_path)
+        assert _inbound(graph, "handlers/handlers.go::Index", "calls")
+        assert not _inbound(graph, "handlers/handlers.go::Index", "references")
+
+
+class TestRustFunctionValues:
+    def test_callback_argument_is_a_reference(self, tmp_path: Path) -> None:
+        (tmp_path / "main.rs").write_text(
+            "fn my_handler() {}\n"
+            "fn register(f: fn()) {}\n"
+            "fn setup() {\n"
+            "    register(my_handler);\n"
+            "}\n"
+        )
+        graph = _build(tmp_path)
+        assert _inbound(graph, "main.rs::my_handler", "references")
+        assert not _inbound(graph, "main.rs::my_handler", "calls")
+
+    def test_associated_function_as_a_callback_argument(self, tmp_path: Path) -> None:
+        """``register(Foo::bar)`` — the shape a bare-identifier pattern misses.
+
+        Rust spells "pass this method" with a path, so the pattern matching a
+        lone identifier never sees the idiom the whole change is about.
+        """
+        (tmp_path / "main.rs").write_text(
+            "struct Foo;\n"
+            "impl Foo {\n"
+            "    fn bar() {}\n"
+            "}\n"
+            "fn register(f: fn()) {}\n"
+            "fn setup() {\n"
+            "    register(Foo::bar);\n"
+            "}\n"
+        )
+        graph = _build(tmp_path)
+        assert _inbound(graph, "main.rs::Foo::bar", "references")
+        assert not _inbound(graph, "main.rs::Foo::bar", "calls")
+
+    def test_struct_field_initialiser_is_a_reference(self, tmp_path: Path) -> None:
+        (tmp_path / "main.rs").write_text(
+            "fn on_tick() {}\n"
+            "struct Config { tick: fn() }\n"
+            "fn make() -> Config {\n"
+            "    Config { tick: on_tick }\n"
+            "}\n"
+        )
+        graph = _build(tmp_path)
+        assert _inbound(graph, "main.rs::on_tick", "references")
+
+    def test_a_macro_invocation_is_still_a_call(self, tmp_path: Path) -> None:
+        """Macros carry no argument capture either, and are not value references.
+
+        The two are separated by the pattern, not by the absence of an argument
+        list — reading that absence as "this is a value" would reclassify every
+        ``println!`` in the corpus.
+        """
+        (tmp_path / "main.rs").write_text(
+            "macro_rules! shout { () => {} }\n"
+            "fn run() {\n"
+            "    shout!();\n"
+            "}\n"
+        )
+        graph = _build(tmp_path)
+        assert not _edges_of_type(graph, "references")
+
+
+class TestReceiverDecidesWhatMayBeNamed:
+    """A bare identifier admits only functions; a qualified name admits methods.
+
+    This is what keeps the C/C++ rule that bought #1602's precision — there a
+    plain name resolving to a method is a collision, since naming a member
+    needs ``&Class::method`` — while letting ``Foo::bar`` reach the method it
+    plainly names.
+    """
+
+    def test_bare_rust_identifier_does_not_reach_a_method(self, tmp_path: Path) -> None:
+        (tmp_path / "main.rs").write_text(
+            "struct Store;\n"
+            "impl Store {\n"
+            "    fn value(&self) -> i32 { 1 }\n"
+            "}\n"
+            "fn take(x: i32) {}\n"
+            "fn run(s: &Store) {\n"
+            "    let value = s.value();\n"
+            "    take(value);\n"
+            "}\n"
+        )
+        graph = _build(tmp_path)
+        assert not _inbound(graph, "main.rs::Store::value", "references")
+
+    def test_qualified_kotlin_reference_does_reach_a_method(
+        self, tmp_path: Path
+    ) -> None:
+        (tmp_path / "app.kt").write_text(
+            "package app\n"
+            "class Store {\n"
+            "    fun value(): Int = 1\n"
+            "}\n"
+            "class Runner {\n"
+            "    fun run(xs: List<Store>) {\n"
+            "        xs.map(Store::value)\n"
+            "    }\n"
+            "}\n"
+        )
+        graph = _build(tmp_path)
+        assert _inbound(graph, "app.kt::Store::value", "references")
+
+
+class TestKotlinCeilings:
+    """Shapes `::` reaches that this deliberately does not turn into an edge."""
+
+    def test_a_property_reference_produces_no_edge(self, tmp_path: Path) -> None:
+        """`Foo::name` is a handle on a property, and a property is not called.
+
+        Nothing filters it at capture; the symbol kind settles it at
+        resolution, which is where the same rule already serves every other
+        shape.
+        """
+        (tmp_path / "app.kt").write_text(
+            "package app\n"
+            "class Foo {\n"
+            "    val name: String = \"\"\n"
+            "}\n"
+            "fun read(xs: List<Foo>) {\n"
+            "    xs.map(Foo::name)\n"
+            "}\n"
+        )
+        graph = _build(tmp_path)
+        assert not _edges_of_type(graph, "references")
+
+    def test_a_nested_qualifier_is_not_captured(self, tmp_path: Path) -> None:
+        """`A.B::c` puts a navigation_expression in the receiver slot.
+
+        A stated ceiling rather than a defect: it had no capture before either,
+        and closing it means matching a receiver of arbitrary depth.
+        """
+        (tmp_path / "app.kt").write_text(
+            "package app\n"
+            "object A {\n"
+            "    object B {\n"
+            "        fun c(): Int = 1\n"
+            "    }\n"
+            "}\n"
+            "fun read() {\n"
+            "    listOf(1).map(A.B::c)\n"
+            "}\n"
+        )
+        graph = _build(tmp_path)
+        assert not _edges_of_type(graph, "references")
+
+
+class TestControls:
+    @pytest.mark.parametrize(
+        ("name", "body"),
+        [
+            (
+                "app.py",
+                "def handler():\n    pass\n\ndef setup():\n    register(handler)\n",
+            ),
+            (
+                "app.ts",
+                "function handler() {}\nfunction setup() { register(handler); }\n",
+            ),
+        ],
+    )
+    def test_languages_without_the_captures_gain_nothing(
+        self, tmp_path: Path, name: str, body: str
+    ) -> None:
+        """The pass is self-gating on the captures, not on a language list."""
+        (tmp_path / name).write_text(body)
+        graph = _build(tmp_path)
+        assert not _edges_of_type(graph, "references")


### PR DESCRIPTION
A function passed as a value is not a function being called. Go and Rust
already captured the shapes that carry one — a callback argument, a
struct-field initialiser — but as a call site with no argument list, so a
handle on a function reached the graph as an ordinary `calls` edge. An
execution flow then stepped into a handler nothing had yet run, and no
consumer could tell an invocation from a reference.

These now route through the existing `references` edge type, Rust gains the
path form `register(Foo::bar)` that had no capture at all, and Kotlin's `::`
callable references are captured for the first time.

## What the numbers say

Measured on 14 repos, before and after, from a pristine worktree at the same
base commit.

| | |
|---|---|
| `calls` edges withdrawn | **4,192** |
| ...of which the callee was **not callable** | **4,192** |
| `references` edges added | 204 |
| edges that resisted classification | **0** |
| every other edge type, 14 repos | **identical** |
| symbol ids, 14 repos | **byte-identical**, 0 lost, 0 gained |
| dead-code findings started | **0** (2 stopped) |

The withdrawal is the point, and it is a precision result rather than a loss.
The call path applies no gate on what a callee *is*, so these captures had been
minting edges to symbols that cannot be called. Grouped by the callee's kind:
property 2,799, constant 724, method 628, variable 563, module 188, class 105,
impl 20. Not one of the seven can be the target of a call.

Read as source, that meant `fmt.Println(version.Version)` was recorded as
*calling* a package-level variable, and `return Ok(Some(session_id))` bound a
local to a struct field that happened to share its name.

## What a reference may name

The pre-existing rule was "only free functions, never methods", which is right
for C and C++ — naming a member there needs `&Class::method`, so a plain name
resolving to a method is a collision, and admitting them once turned `value`,
`status`, `level`, `key` and `offset` into fifteen wrong edges (#1602).

That rule is now about the shape rather than the language: a receiver-less name
reaches only a function; a name that arrived with a receiver went through an
operator only a callable accepts, so it may reach a method. Every C/C++
reference capture is receiver-less, so this reproduces the old behaviour
exactly — the 12 tests covering it pass unchanged.

## Per language

| language | result |
|---|---|
| **Rust** | ships — callback arguments, struct-field initialisers, and the `Foo::bar` path form |
| **Kotlin** | ships — `::` callable references, no coverage before, strictly additive (0 calls withdrawn) |
| **Go** | ships the conversion only: 83 wrong edges removed, 0 added |
| **Java** | **deferred**, not excluded — `queries/java.scm` has uncommitted edits in another branch. caffeine is byte-identical here, which is what proves it untouched |
| C#, Python, Swift | **not built** — `+=` handlers, `property()` and `#selector` are 21, 9 and 1 sites across the whole corpus, too few to audit |

Precision, hand-audited at 30 rows per language: **Kotlin 29/30, Rust 29/30**.
Go adds no edges, so there is nothing to audit there; its 83 removals were
characterised exhaustively instead and are 100% package-level variables.

Cost is 2.98–4.58% of graph build (goose, ktor, exposed), measured in one
process with a warmup and the configurations checked for ordering. gitleaks
gets no figure — a 0.303s build cannot price a pass.

## Deliberately not in this change

Rust's type-position captures — parameter types, return types, trait bounds,
turbofish type arguments — mint the same class of wrong edge, roughly 3,634
sites on one repo, recording a function as calling a *type*. They belong with
the `type_use` edge type that already exists, and this change is about values,
not types.

## Notes for review

- No new edge type. `references` already carried this exact semantic and was
  already registered everywhere it needed to be, so there is no vocabulary
  change, no `KG_BUILDER_VERSION` bump and no migration.
- Macro invocations also carry no argument capture and were left as calls;
  treating the absence of an argument list as "this is a value" would have
  reclassified every `println!` in the corpus.
- Two ceilings are recorded rather than closed: a nested qualifier (`A.B::c`)
  and a generic Rust receiver (`MyBox::<u8>::make`) resolve to nothing, and a
  bare `::name` that denotes a property or a local can still bind to a
  same-named function. Both cost an edge; neither can invent one.
