### PR TITLE
fix(dead-code): count every use of a private symbol, not only a call

### DIFF
--- a/packages/core/src/repowise/core/analysis/dead_code/analyzer.py
+++ b/packages/core/src/repowise/core/analysis/dead_code/analyzer.py
@@ -1412,11 +1412,13 @@ class DeadCodeAnalyzer:
                 ):
                     continue
 
-            # Any inbound use, not only a call. An override reached through the
-            # base it answers for, a collaborator the container constructs, and
-            # a handler named in a dispatch table each carry a symbol-level edge
-            # of their own; reading only ``calls`` here reported all three as
-            # unused.
+            # Any inbound use, not only a call. A base class that is subclassed
+            # rather than instantiated, a collaborator the container constructs,
+            # and a handler named as a value rather than invoked each carry a
+            # symbol-level edge of their own; reading only ``calls`` here
+            # reported all three as unused. The set is shared with the
+            # unused-export pass, so it also carries types this population can
+            # never hold — a method or an interface is filtered out above.
             is_used = any(
                 self.graph.get_edge_data(pred, node, {}).get("edge_type")
                 in REACHABILITY_USE_EDGE_TYPES

--- a/packages/core/src/repowise/core/analysis/dead_code/analyzer.py
+++ b/packages/core/src/repowise/core/analysis/dead_code/analyzer.py
@@ -1412,11 +1412,17 @@ class DeadCodeAnalyzer:
                 ):
                     continue
 
-            has_callers = any(
-                self.graph.get_edge_data(pred, node, {}).get("edge_type") == "calls"
+            # Any inbound use, not only a call. An override reached through the
+            # base it answers for, a collaborator the container constructs, and
+            # a handler named in a dispatch table each carry a symbol-level edge
+            # of their own; reading only ``calls`` here reported all three as
+            # unused.
+            is_used = any(
+                self.graph.get_edge_data(pred, node, {}).get("edge_type")
+                in REACHABILITY_USE_EDGE_TYPES
                 for pred in self.graph.predecessors(node)
             )
-            if has_callers:
+            if is_used:
                 continue
 
             # Dispatch-table pattern: a private helper imported by name
@@ -1453,7 +1459,7 @@ class DeadCodeAnalyzer:
                     symbol_name=sym_name,
                     symbol_kind=node_data.get("kind"),
                     confidence=0.65,
-                    reason=f"Private symbol '{sym_name}' has no callers",
+                    reason=f"Private symbol '{sym_name}' is not used anywhere",
                     last_commit_at=git_meta.get("last_commit_at")
                     if isinstance(git_meta.get("last_commit_at"), datetime)
                     else None,
@@ -1467,7 +1473,7 @@ class DeadCodeAnalyzer:
                     if node_data.get("start_line")
                     else None,
                     package=self._get_package(file_path),
-                    evidence=[f"No CALL edges to '{sym_name}'"],
+                    evidence=[f"No call, reference or override reaches '{sym_name}'"],
                     safe_to_delete=False,
                     primary_owner=git_meta.get("primary_owner_name"),
                     age_days=git_meta.get("age_days"),

--- a/packages/core/src/repowise/core/ingestion/models.py
+++ b/packages/core/src/repowise/core/ingestion/models.py
@@ -458,10 +458,11 @@ FILE_DEPENDENCY_EDGE_TYPES: frozenset[str] = frozenset(
 # Symbol → symbol references. "Something reaches this symbol", so containment
 # is excluded: a class containing a method is not the method being used.
 #
-# `reads` is the one type that spans both layers, which is why it is the one
-# member of both sets. Two extractors share the name: `csharp_member_reads`
-# emits it file → file (596 rows locally) and `framework_edges/express` emits
-# it symbol → symbol from a `path::__module__` node (1 row).
+# `reads` is a member here for a reason that no longer holds: its symbol-level
+# producer moved to `framework_binds`, so `csharp_member_reads` is the only one
+# left and it emits file → file. A file node can never be a symbol node's
+# predecessor, so membership is inert rather than wrong. Retiring it moves the
+# vocabulary and belongs to a diff that can measure that.
 SYMBOL_USE_EDGE_TYPES: frozenset[str] = frozenset(
     {
         "calls",

--- a/tests/unit/dead_code/test_unused_internal.py
+++ b/tests/unit/dead_code/test_unused_internal.py
@@ -87,6 +87,154 @@ def test_unused_internal_explicit_opt_out():
     assert internals == []
 
 
+def test_unused_internal_skipped_when_subclassed():
+    """A private base class reached only via ``extends`` is still used."""
+    g = _build_graph(
+        nodes={
+            "pkg/base.py": {
+                "is_entry_point": False,
+                "is_test": False,
+                "is_api_contract": False,
+                "symbol_count": 1,
+                "symbols": [
+                    {
+                        "name": "_BaseThing",
+                        "kind": "class",
+                        "visibility": "private",
+                        "decorators": [],
+                        "start_line": 1,
+                        "end_line": 12,
+                        "complexity_estimate": 1,
+                    },
+                ],
+            },
+            "pkg/child.py": {
+                "is_entry_point": False,
+                "is_test": False,
+                "is_api_contract": False,
+                "symbol_count": 1,
+                "symbols": [
+                    {
+                        "name": "Thing",
+                        "kind": "class",
+                        "visibility": "public",
+                        "decorators": [],
+                        "start_line": 1,
+                        "end_line": 8,
+                        "complexity_estimate": 1,
+                    },
+                ],
+            },
+        },
+        edges=[
+            (
+                "pkg/child.py::Thing",
+                "pkg/base.py::_BaseThing",
+                {"edge_type": "extends"},
+            ),
+        ],
+    )
+    analyzer = DeadCodeAnalyzer(g, git_meta_map={})
+    report = analyzer.analyze(
+        {
+            "detect_unreachable_files": False,
+            "detect_unused_exports": False,
+            "detect_zombie_packages": False,
+            "min_confidence": 0.0,
+        }
+    )
+    names = {f.symbol_name for f in report.findings if f.kind == DeadCodeKind.UNUSED_INTERNAL}
+    assert "_BaseThing" not in names
+
+
+def test_unused_internal_skipped_when_referenced_as_a_value():
+    """A private helper named in a dispatch table is used without being called."""
+    g = _build_graph(
+        nodes={
+            "pkg/handlers.py": {
+                "is_entry_point": False,
+                "is_test": False,
+                "is_api_contract": False,
+                "symbol_count": 2,
+                "symbols": [
+                    {
+                        "name": "_handle",
+                        "kind": "function",
+                        "visibility": "private",
+                        "decorators": [],
+                        "start_line": 1,
+                        "end_line": 6,
+                        "complexity_estimate": 1,
+                    },
+                    {
+                        "name": "register",
+                        "kind": "function",
+                        "visibility": "public",
+                        "decorators": [],
+                        "start_line": 8,
+                        "end_line": 12,
+                        "complexity_estimate": 1,
+                    },
+                ],
+            },
+        },
+        edges=[
+            (
+                "pkg/handlers.py::register",
+                "pkg/handlers.py::_handle",
+                {"edge_type": "references"},
+            ),
+        ],
+    )
+    analyzer = DeadCodeAnalyzer(g, git_meta_map={})
+    report = analyzer.analyze(
+        {
+            "detect_unreachable_files": False,
+            "detect_unused_exports": False,
+            "detect_zombie_packages": False,
+            "min_confidence": 0.0,
+        }
+    )
+    names = {f.symbol_name for f in report.findings if f.kind == DeadCodeKind.UNUSED_INTERNAL}
+    assert "_handle" not in names
+
+
+def test_unused_internal_still_flagged_with_only_containment_edges():
+    """A ``defines`` / ``has_method`` containment edge alone must not count as use."""
+    g = _build_graph(
+        nodes={
+            "pkg/lonely.py": {
+                "is_entry_point": False,
+                "is_test": False,
+                "is_api_contract": False,
+                "symbol_count": 1,
+                "symbols": [
+                    {
+                        "name": "_orphan",
+                        "kind": "function",
+                        "visibility": "private",
+                        "decorators": [],
+                        "start_line": 1,
+                        "end_line": 6,
+                        "complexity_estimate": 1,
+                    },
+                ],
+            },
+        },
+    )
+    analyzer = DeadCodeAnalyzer(g, git_meta_map={})
+    report = analyzer.analyze(
+        {
+            "detect_unreachable_files": False,
+            "detect_unused_exports": False,
+            "detect_zombie_packages": False,
+            "min_confidence": 0.0,
+        }
+    )
+    names = {f.symbol_name for f in report.findings if f.kind == DeadCodeKind.UNUSED_INTERNAL}
+    assert "_orphan" in names
+
+
 def test_unused_internal_skipped_when_imported_by_name():
     """A private helper imported by name into a sibling module (typical
     dispatch-table pattern: ``HANDLERS = {"python": _extract_py, ...}``)


### PR DESCRIPTION
## What

`_detect_unused_internals` reports a private symbol with no incoming **call**
edge as unused. A symbol can be used without being called:

- a base class is **subclassed** rather than instantiated,
- a collaborator is **constructed by a container**,
- a handler is **named as a value** rather than invoked.

Each of those already carries its own symbol-level edge, and this pass read none
of them — it tested `edge_type == "calls"` and nothing else, while the sibling
unused-export pass has read the whole reachability set for as long as those edge
types have existed. The internal pass now asks the same question.

## Result

Measured on a 21-repo corpus, with the framework and dynamic passes on, against
a baseline taken at this branch's own base commit:

| | count |
|---|---:|
| findings that **start** | **0** |
| findings that **stop** | **6** |
| edge types that move, on any repo | **0** |
| corpus total | 4,403 → 4,397 |

Strictly subtractive, and every removal is attributed to the edge that rescued
it rather than counted:

| edge type | findings | what it was |
|---|---:|---|
| `extends` | 3 | a private base class that is subclassed |
| `references` | 3 | a function named as a value rather than invoked |

Read off the graph node by node. Nothing was rescued by an edge type whose only
producers are file-level, and nothing by an edge type whose endpoints this
pass's population cannot hold.

## Also here

The finding's own `reason` and `evidence` said *"has no callers"* and *"No CALL
edges"*, which the wider test no longer supports. Both now say what is actually
checked. Nothing matches on the old strings — no renderer, tool output, golden
test or persisted column.

Two comment corrections, both found by review rather than by a gate: the note
explaining why `reads` sits in both edge-type sets described a symbol-level
producer that has since moved, and the new comment here originally named an
override rescue that this pass structurally cannot see.

## Tests

Three regression tests, two of which fail if the change is reverted — verified,
not assumed. The third pins the invariant in the other direction: a containment
edge (`defines` / `has_method`) must **not** become a rescue, since every
candidate has one.

`tests/unit/dead_code`, `tests/unit/analysis` and `tests/unit/ingestion`:
3,264 passed, 1 skipped. `ruff check` clean on every touched file.
