### PR TITLE
feat(graph): resolve a method on a type imported through a re-export

### DIFF
--- a/packages/core/src/repowise/core/ingestion/call_resolver.py
+++ b/packages/core/src/repowise/core/ingestion/call_resolver.py
@@ -271,7 +271,11 @@ class CallResolver:
         for path, name_to_file in self._import_names.items():
             file_syms = self._file_symbols.get(path, {})
             for name, source_file in name_to_file.items():
-                if name not in file_syms:
+                # An origin outside the repo names no file any reader of this
+                # map can look up, and the wildcard pass below already refuses
+                # one. Holding the invariant in one pass and not its twin is
+                # what makes a later reader look safe when it is not.
+                if name not in file_syms and not source_file.startswith("external:"):
                     self._barrel_origins[path][name] = source_file
 
         # Track wildcard re-exports, which forward every symbol of the imported
@@ -1087,6 +1091,16 @@ class CallResolver:
         bound = self._import_names.get(file_path, {}).get(type_name)
         if bound is not None and not bound.startswith("external:"):
             sym_id = self._file_methods.get(bound, {}).get(key)
+            if sym_id is None:
+                # An import names the module it was written against, which in
+                # Python is usually a package ``__init__`` that re-exports the
+                # type rather than declaring it. Free calls already chase that
+                # chain; without it here the import settles which type this is
+                # and then refuses every method of it. ``!= bound`` because a
+                # mutual re-export can leave an entry pointing at its own file.
+                origin = self._barrel_origins.get(bound, {}).get(type_name)
+                if origin is not None and origin != bound:
+                    sym_id = self._file_methods.get(origin, {}).get(key)
             return None if sym_id is None else (sym_id, "import")
 
         # Bound to something outside the repo and there is no edge to find,

--- a/packages/core/src/repowise/core/ingestion/call_resolver.py
+++ b/packages/core/src/repowise/core/ingestion/call_resolver.py
@@ -1095,20 +1095,19 @@ class CallResolver:
                 # An import names the module it was written against, which in
                 # Python is usually a package ``__init__`` that re-exports the
                 # type rather than declaring it. Free calls already chase that
-                # chain; without it here the import settles which type this is
-                # and then refuses every method of it.
+                # chain; without it the import settles which type this is and
+                # then refuses every method of it.
                 #
-                # Keyed on the *exported* name, as the free-call chase is. The
-                # re-export map is keyed by each file's own local names, so an
-                # alias asks the bound file about a name that means something
-                # else there — ``from lib import Foo as Bar`` would look up
-                # whatever ``lib`` happens to call ``Bar``. ``!= bound`` because
-                # a mutual re-export can leave an entry naming its own file.
+                # Keyed on the *exported* name, as the free-call chase is: the
+                # map holds each file's own local names, so an alias would ask
+                # the bound file about a name that means something else there.
+                # ``!= bound`` because a mutual re-export can leave an entry
+                # naming its own file.
                 binding = self._import_bindings.get(file_path, {}).get(type_name)
                 exported = (binding.exported_name if binding else None) or type_name
-                origin = self._barrel_origins.get(bound, {}).get(exported)
-                if origin is not None and origin != bound:
-                    sym_id = self._file_methods.get(origin, {}).get(
+                declaring = self._barrel_origins.get(bound, {}).get(exported)
+                if declaring is not None and declaring != bound:
+                    sym_id = self._file_methods.get(declaring, {}).get(
                         (exported, call.target_name)
                     )
             return None if sym_id is None else (sym_id, "import")

--- a/packages/core/src/repowise/core/ingestion/call_resolver.py
+++ b/packages/core/src/repowise/core/ingestion/call_resolver.py
@@ -1096,11 +1096,21 @@ class CallResolver:
                 # Python is usually a package ``__init__`` that re-exports the
                 # type rather than declaring it. Free calls already chase that
                 # chain; without it here the import settles which type this is
-                # and then refuses every method of it. ``!= bound`` because a
-                # mutual re-export can leave an entry pointing at its own file.
-                origin = self._barrel_origins.get(bound, {}).get(type_name)
+                # and then refuses every method of it.
+                #
+                # Keyed on the *exported* name, as the free-call chase is. The
+                # re-export map is keyed by each file's own local names, so an
+                # alias asks the bound file about a name that means something
+                # else there — ``from lib import Foo as Bar`` would look up
+                # whatever ``lib`` happens to call ``Bar``. ``!= bound`` because
+                # a mutual re-export can leave an entry naming its own file.
+                binding = self._import_bindings.get(file_path, {}).get(type_name)
+                exported = (binding.exported_name if binding else None) or type_name
+                origin = self._barrel_origins.get(bound, {}).get(exported)
                 if origin is not None and origin != bound:
-                    sym_id = self._file_methods.get(origin, {}).get(key)
+                    sym_id = self._file_methods.get(origin, {}).get(
+                        (exported, call.target_name)
+                    )
             return None if sym_id is None else (sym_id, "import")
 
         # Bound to something outside the repo and there is no edge to find,

--- a/tests/unit/ingestion/test_call_resolver_strategies.py
+++ b/tests/unit/ingestion/test_call_resolver_strategies.py
@@ -490,3 +490,84 @@ class TestPythonTypedReceiver:
         edges = _edges(parsed, tmp_path)
         assert not [e for e in edges if str(e[3]).startswith("receiver_field_")]
         assert not [e for e in edges if str(e[3]).startswith("receiver_typed_")]
+
+
+class TestImportedTypeThroughAReExport:
+    """An import binds the package, not the module that declares the type.
+
+    ``from pkg import Engine`` names ``pkg/__init__.py``, which re-exports
+    ``Engine`` and declares no method of it. Treating that as settling the type
+    and then refusing costs every method call on it.
+    """
+
+    def _repo(self) -> dict[str, tuple[str, str]]:
+        return {
+            "app.py": (
+                "python",
+                "from pkg import Engine\n\n"
+                "def run():\n"
+                "    engine = Engine()\n"
+                "    engine.render(1)\n",
+            ),
+            "pkg/__init__.py": ("python", "from pkg.engine import Engine\n"),
+            "pkg/engine.py": (
+                "python",
+                "class Engine:\n    def render(self, obj):\n        return obj\n",
+            ),
+        }
+
+    def test_a_re_exported_type_still_resolves_its_method(self, tmp_path: Path) -> None:
+        parsed = _parse_all(tmp_path, self._repo())
+        _link_imports(
+            parsed,
+            {
+                "app.py": {"pkg": "pkg/__init__.py"},
+                "pkg/__init__.py": {"pkg.engine": "pkg/engine.py"},
+            },
+        )
+        assert (
+            "app.py::run",
+            "pkg/engine.py::Engine::render",
+            0.88,
+            "receiver_typed_import",
+        ) in _edges(parsed, tmp_path)
+
+    def test_a_re_export_chain_does_not_invent_a_method(self, tmp_path: Path) -> None:
+        """Following the chain must not weaken the validator above it."""
+        files = self._repo()
+        files["app.py"] = (
+            "python",
+            "from pkg import Engine\n\n"
+            "def run():\n"
+            "    engine = Engine()\n"
+            "    engine.missing(1)\n",
+        )
+        parsed = _parse_all(tmp_path, files)
+        _link_imports(
+            parsed,
+            {
+                "app.py": {"pkg": "pkg/__init__.py"},
+                "pkg/__init__.py": {"pkg.engine": "pkg/engine.py"},
+            },
+        )
+        assert not [
+            e for e in _edges(parsed, tmp_path) if str(e[3]).startswith("receiver_typed_")
+        ]
+
+    def test_an_origin_outside_the_repo_is_never_recorded(self, tmp_path: Path) -> None:
+        """A re-export map holding an unreadable path makes a reader look safe."""
+        parsed = _parse_all(
+            tmp_path,
+            {
+                "app.py": ("python", "from thirdparty import Engine\n\ndef run():\n    pass\n"),
+            },
+        )
+        for imp in parsed["app.py"].imports:
+            imp.resolved_file = "external:thirdparty"
+        resolver = CallResolver(parsed, {p: set() for p in parsed}, repo_path=str(tmp_path))
+        recorded = [
+            origin
+            for origins in resolver._barrel_origins.values()
+            for origin in origins.values()
+        ]
+        assert not [o for o in recorded if o.startswith("external:")]

--- a/tests/unit/ingestion/test_call_resolver_strategies.py
+++ b/tests/unit/ingestion/test_call_resolver_strategies.py
@@ -532,6 +532,38 @@ class TestImportedTypeThroughAReExport:
             "receiver_typed_import",
         ) in _edges(parsed, tmp_path)
 
+    def test_a_bound_file_that_declares_the_pair_answers_directly(
+        self, tmp_path: Path
+    ) -> None:
+        """The chain is a fallback, not a first choice.
+
+        This is the shape the import tier always handled, and it had no test —
+        so nothing pinned that the chase runs only after a direct hit misses.
+        """
+        parsed = _parse_all(
+            tmp_path,
+            {
+                "app.py": (
+                    "python",
+                    "from pkg.engine import Engine\n\n"
+                    "def run():\n"
+                    "    engine = Engine()\n"
+                    "    engine.render(1)\n",
+                ),
+                "pkg/engine.py": (
+                    "python",
+                    "class Engine:\n    def render(self, obj):\n        return obj\n",
+                ),
+            },
+        )
+        _link_imports(parsed, {"app.py": {"pkg.engine": "pkg/engine.py"}})
+        assert (
+            "app.py::run",
+            "pkg/engine.py::Engine::render",
+            0.88,
+            "receiver_typed_import",
+        ) in _edges(parsed, tmp_path)
+
     def test_a_re_export_chain_does_not_invent_a_method(self, tmp_path: Path) -> None:
         """Following the chain must not weaken the validator above it."""
         files = self._repo()

--- a/tests/unit/ingestion/test_call_resolver_strategies.py
+++ b/tests/unit/ingestion/test_call_resolver_strategies.py
@@ -554,6 +554,46 @@ class TestImportedTypeThroughAReExport:
             e for e in _edges(parsed, tmp_path) if str(e[3]).startswith("receiver_typed_")
         ]
 
+    def test_an_alias_does_not_read_the_bound_file_s_own_binding(
+        self, tmp_path: Path
+    ) -> None:
+        """The chain is keyed by each file's own local names, so an alias must
+        be translated back before it is used as a key.
+
+        Here ``consumer`` calls ``lib.Renderer`` under the name ``Engine``,
+        while ``lib`` itself binds that same name to an unrelated class. Asking
+        ``lib`` about ``Engine`` answers about the wrong one.
+        """
+        parsed = _parse_all(
+            tmp_path,
+            {
+                "consumer.py": (
+                    "python",
+                    "from lib import Renderer as Engine\n\n"
+                    "def run():\n"
+                    "    engine = Engine()\n"
+                    "    engine.render(1)\n",
+                ),
+                "lib.py": (
+                    "python",
+                    "from other import Engine\n\nclass Renderer:\n    pass\n",
+                ),
+                "other.py": (
+                    "python",
+                    "class Engine:\n    def render(self, obj):\n        return obj\n",
+                ),
+            },
+        )
+        _link_imports(
+            parsed,
+            {"consumer.py": {"lib": "lib.py"}, "lib.py": {"other": "other.py"}},
+        )
+        assert not [
+            e
+            for e in _edges(parsed, tmp_path)
+            if e[1] == "other.py::Engine::render" and str(e[3]).startswith("receiver_")
+        ]
+
     def test_an_origin_outside_the_repo_is_never_recorded(self, tmp_path: Path) -> None:
         """A re-export map holding an unreadable path makes a reader look safe."""
         parsed = _parse_all(


### PR DESCRIPTION
## The defect

An import settles which type a receiver name is, so the resolver looked for the
method on the file the import bound and refused outright when it was not there.
That is right for a language whose import names the declaring file. Python's
usually does not — `from django.template import Engine` binds
`django/template/__init__.py`, which re-exports `Engine` from `.engine` and
declares no method of it — so every method call on the value was refused.

The resolver already builds a re-export map at startup and free calls already
chase it. The typed receiver strategy simply never asked.

## The change

Two hunks, both in `call_resolver.py`.

When the import-bound file declares no `(type, method)` pair, follow the
re-export chain once and try the file it names. Nothing is emitted unless that
file declares the method, so the validator that makes a text-scanned receiver
type safe is unchanged, and the strategy still sits in the fallback slot that
only ever sees a call every other tier declined.

The chase is keyed on the **exported** name rather than the caller's local one,
because the map holds each file's own local names — `from lib import Renderer as
Engine` would otherwise ask `lib` about whatever *it* calls `Engine`. That is a
real wrong edge, found by review rather than by the corpus, and it has a test.

Second hunk: the map's direct pass now refuses to record an origin outside the
repository. Its wildcard pass eleven lines below already refused one, and an
invariant held in one pass and not its twin is what makes a later reader look
safe when it is not.

## Result, 20 repos

**1,666 calls gained, 0 lost, 0 retargeted, 0 rows unbucketed.** django +880,
pydantic +366, fastapi +324, scrapy +83, celery +8, flask +5.

**Fourteen of the twenty are byte-identical on resolved calls**, including all
five Java and C# repos — they run the changed function and it declines, because
a JVM import already names the declaring file. Six repos in TypeScript,
JavaScript, Go and C++ are the controls and are byte-identical too.

Every other population holds on all twenty: heritage and import edges are
byte-identical with the source map lent to the builder, symbol ids are 0-lost
and 0-gained, and file, symbol and external node counts are pinned. Dead-code
findings move zero on ten repos.

**Precision: 120 of 120.** Thirty rows hand-audited on each of django, pydantic,
fastapi and scrapy, read against the real source at both ends, each row carrying
the call in context, the caller's import, the re-export it followed, and the
full set of declarations sharing the callee's name.

Cost is +5.1% to +6.2% of graph build and +0.6% to +1.6% of parse and build,
ordered on every repo and smaller than the spread between runs on all three
timed.

## What it does not do

The population belongs to repositories that publish an API through re-exporting
package files, not to Python: `requests`, `starlette` and `httpie` refuse
nothing and gain nothing. pydantic re-exports lazily through a module
`__getattr__`, and 2,872 of its refusals have no import statement for any chase
to follow — the fix takes 366 of them and cannot reach the rest.

Four new tests, and the two that pin the fix fail on the base commit.
