### PR TITLE
fix(mcp): stop four tools answering a bad argument with a reassuring negative

### DIFF
--- a/docs/agent/MCP_TOOLS.md
+++ b/docs/agent/MCP_TOOLS.md
@@ -43,7 +43,7 @@ repowise mcp --transport sse --port 7338 # legacy SSE transport
 [generate_refactoring_code](#generate_refactoring_code) &middot;
 [get_conformance](#get_conformance)
 
-Also see [Configuring the tool surface](#configuring-the-tool-surface) and [Reversible truncation](#reversible-truncation-_metaomitted).
+Also see [Configuring the tool surface](#configuring-the-tool-surface), [Reversible truncation](#reversible-truncation-_metaomitted) and [Unrecognised arguments](#unrecognised-arguments-ignored_arguments).
 
 ---
 
@@ -150,6 +150,38 @@ Resolve refs with `repowise expand <ref>` from a shell, or
 | `embedder`, `embedder_warning` | Only when the embedder fell back to a mock/degraded mode |
 
 Silence on `stale_warning` means the index is current; don't infer staleness from its absence. `list_repos`, `get_architecture`, `get_blast_radius`, and `get_conformance` don't carry a freshness envelope at all.
+
+---
+
+## Unrecognised arguments: `ignored_arguments`
+
+A tool never answers a bad argument with a filter that matches nothing. A value
+outside a closed vocabulary is **dropped, not applied** — so the response is the
+one you would have got without it — and the tool names what it dropped, at the
+top level:
+
+```jsonc
+"ignored_arguments": [
+  { "argument": "kind",
+    "values": ["unused_exports"],
+    "valid": ["unreachable_file", "unused_export", "unused_internal", "zombie_package"] }
+]
+```
+
+The key is absent when every argument was understood, so its presence is the
+whole signal. One entry per argument, however many of its values missed.
+
+This exists because the alternative is a lie: `get_dead_code(kind="unused_exports")`
+used to filter on the plural, match nothing, and recommend *"No dead code found
+matching your filters."* beside a summary counting hundreds of unused exports
+([#1496](https://github.com/repowise-dev/repowise/issues/1496)). It covers
+`get_dead_code` (`kind`, `tier`, `min_confidence`), `get_context` (`include`)
+and `search_codebase` (`kind`).
+
+`get_dead_code`'s `min_confidence` additionally accepts the tier names the
+response is organised by — `"high"` (0.8), `"medium"` (0.5), `"low"` (0.0) — as
+well as a float. `get_health` reports the same thing under its own older name,
+`unknown_only_keys`, for the `only` projection.
 
 ---
 

--- a/packages/server/src/repowise/server/mcp_server/_helpers.py
+++ b/packages/server/src/repowise/server/mcp_server/_helpers.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import os
 import os.path
+from collections.abc import Collection
 from pathlib import Path
 from typing import Any
 
@@ -205,6 +206,46 @@ def _unsupported_repo_all(tool_name: str) -> dict:
             f"Specify a repo alias instead. Available: {available}"
         ),
     }
+
+
+# ---------------------------------------------------------------------------
+# Closed-vocabulary arguments (used by get_dead_code, get_context, search_codebase)
+# ---------------------------------------------------------------------------
+
+
+def resolve_enum_argument(
+    value: str | None,
+    valid: Collection[str],
+    *,
+    argument: str,
+    ignored: list[dict[str, Any]],
+) -> str | None:
+    """Return *value* if it is in *valid*, else drop it and record it in *ignored*.
+
+    Same rule as ``get_health``'s ``unknown_only_keys``: an argument the tool
+    does not recognise is named rather than applied. Applying it is what makes
+    a typo indistinguishable from a real negative — a misspelled filter matches
+    nothing and the tool reports the empty result as an answer (issue #1496).
+    Dropping it and saying so is recoverable; raising is not, because the caller
+    loses the answer it could still have had.
+
+    Repeated calls for one *argument* (``include`` takes a list) collect into a
+    single entry, so the vocabulary is spelled out once however many values miss.
+    """
+    if value is None or value in valid:
+        return value
+    for entry in ignored:
+        if entry["argument"] == argument:
+            entry["values"].append(value)
+            return None
+    ignored.append({"argument": argument, "values": [value], "valid": sorted(valid)})
+    return None
+
+
+def attach_ignored_arguments(result: dict[str, Any], ignored: list[dict[str, Any]]) -> None:
+    """Name the arguments the tool dropped, at the top level, or add nothing."""
+    if ignored:
+        result["ignored_arguments"] = ignored
 
 
 # ---------------------------------------------------------------------------

--- a/packages/server/src/repowise/server/mcp_server/tool_context/context.py
+++ b/packages/server/src/repowise/server/mcp_server/tool_context/context.py
@@ -19,6 +19,11 @@ Optional ``include`` parameter widens the response:
   - include=["community"] → community membership + neighbors
   - include=["decisions"] → full decision records (default returns titles only)
   - include=["skeleton"]  → body-elided file rendering (signatures + top-PageRank bodies)
+  - include=["health"]    → code-health scores and biomarkers for the target
+
+An unrecognised key is dropped and named in ``ignored_arguments`` rather than
+silently ignored: an unknown key otherwise produces exactly the response the
+caller would have got without it, so a typo reads as a real answer (#1496).
 
 This module is the orchestrator; single-target resolution lives in
 ``targets`` and the budget cap in ``truncation``.
@@ -40,12 +45,36 @@ from repowise.server.mcp_server._helpers import (
     _get_repo,
     _resolve_repo_context,
     _unsupported_repo_all,
+    attach_ignored_arguments,
+    resolve_enum_argument,
 )
 from repowise.server.mcp_server._meta import build_meta as _build_meta
 from repowise.server.mcp_server._meta import context_hint as _context_hint
 from repowise.server.mcp_server.tool_context.targets import _resolve_one_target
 
 _log = logging.getLogger("repowise.mcp.context")
+
+# Every value ``include_set`` is tested against downstream, in ``targets.py``.
+# ``docs`` and ``freshness`` are always on but remain legal to pass explicitly.
+# ``source`` is tested in ``_meta.context_hint`` and left out deliberately: both
+# branches there return None, so accepting it would promise a block that does
+# nothing.
+_INCLUDE_BLOCKS = frozenset(
+    {
+        "docs",
+        "freshness",
+        "full_doc",
+        "callers",
+        "callees",
+        "ownership",
+        "last_change",
+        "metrics",
+        "community",
+        "decisions",
+        "skeleton",
+        "health",
+    }
+)
 
 
 @mcp.tool()
@@ -71,7 +100,8 @@ async def get_context(
     Args:
         targets: file paths, module paths, or "path::Symbol" ids.
         include: opt-in blocks: full_doc | ownership | last_change | callers
-            | callees | metrics | community | decisions | skeleton.
+            | callees | metrics | community | decisions | skeleton | health.
+            An unrecognised key is named in ignored_arguments.
         compact: default True; False adds structure+imports+docstrings.
         repo: usually omitted.
     """
@@ -87,7 +117,16 @@ async def get_context(
     # want them must pass include explicitly. Building the set this way
     # also fixes include=["skeleton"] silently dropping the file summary
     # and freshness card that every other call shape carries.
-    include_set = {"docs", "freshness"} | (set(include) if include else set())
+    # An unknown key adds no block, so without this the response is identical
+    # to one that never asked — and for callers/callees a genuine empty list is
+    # a *present* key, which makes the typo the quieter of the two (#1496).
+    ignored: list[dict[str, Any]] = []
+    known = [
+        k
+        for k in (include or [])
+        if resolve_enum_argument(k, _INCLUDE_BLOCKS, argument="include", ignored=ignored)
+    ]
+    include_set = {"docs", "freshness"} | set(known)
 
     exclude_spec = _get_exclude_spec(ctx.path)
 
@@ -199,4 +238,8 @@ async def get_context(
     # collector so a truncated response always carries expandable
     # ``[repowise#<ref>]`` markers instead of silently losing content.
     collector = OmissionCollector("get_context", repo_root=ctx.path)
-    return truncate_to_budget(response, collector=collector)
+    truncated = truncate_to_budget(response, collector=collector)
+    # After the cap, never before: a note about a dropped argument that the
+    # budget can itself drop is no note at all.
+    attach_ignored_arguments(truncated, ignored)
+    return truncated

--- a/packages/server/src/repowise/server/mcp_server/tool_dead_code.py
+++ b/packages/server/src/repowise/server/mcp_server/tool_dead_code.py
@@ -9,6 +9,7 @@ from typing import Any
 
 from sqlalchemy import select
 
+from repowise.core.analysis.dead_code.models import DeadCodeKind
 from repowise.core.analysis.dead_code.risk_factors import (
     RISK_CAP_CONFIDENCE,
     effective_safe_to_delete,
@@ -28,7 +29,9 @@ from repowise.server.mcp_server._helpers import (
     _is_workspace_mode,
     _resolve_all_contexts,
     _resolve_repo_context,
+    attach_ignored_arguments,
     filter_rows_by_attr,
+    resolve_enum_argument,
 )
 from repowise.server.mcp_server._meta import build_meta as _build_meta
 
@@ -157,13 +160,27 @@ async def _get_dead_code_all_repos(
     return result_ws
 
 
+# The bands this tool tiers by, in one place: the tier descriptions quote them
+# and ``min_confidence="high"`` resolves to them, so the vocabulary the response
+# is organised by and the one it accepts cannot drift apart (#1496). Deliberately
+# this tool's own numbers — the web and CLI tier at 0.7/0.4
+# (``DEAD_CODE_CONFIDENCE`` in packages/types/src/dead-code.ts); reconciling the
+# two changes output and is not this change.
+_TIER_FLOORS: dict[str, float] = {"high": 0.8, "medium": 0.5, "low": 0.0}
+
+# The four kinds the analyzer writes, taken from the enum it writes them with
+# rather than re-listed here, so a fifth kind never reads as a caller's typo.
+_DEAD_CODE_KINDS = frozenset(k.value for k in DeadCodeKind)
+
+
 def _build_tiers_from_dicts(
     merged_findings: list[dict], limit: int, tier: str | None
 ) -> dict[str, Any]:
     """Build the high/medium/low tier structure from pre-serialized dicts."""
-    high = [f for f in merged_findings if f["confidence"] >= 0.8]
-    medium = [f for f in merged_findings if 0.5 <= f["confidence"] < 0.8]
-    low = [f for f in merged_findings if f["confidence"] < 0.5]
+    hi, med = _TIER_FLOORS["high"], _TIER_FLOORS["medium"]
+    high = [f for f in merged_findings if f["confidence"] >= hi]
+    medium = [f for f in merged_findings if med <= f["confidence"] < hi]
+    low = [f for f in merged_findings if f["confidence"] < med]
 
     def _tier_from_dicts(items: list[dict], desc: str) -> dict:
         return {
@@ -212,11 +229,32 @@ _TIER_DESC_LOW = (
 )
 
 
+def _resolve_min_confidence(value: float | str, ignored: list[dict[str, Any]]) -> float:
+    """Resolve ``min_confidence`` to a float, accepting this tool's tier names.
+
+    The response is organised by ``high`` / ``medium`` / ``low`` and each tier
+    description states its band, so those are the words a caller reaches for;
+    the parameter used to reject them outright (#1496). A numeric string is
+    accepted too, because widening the annotation to ``float | str`` is what
+    lets one through in the first place.
+    """
+    if isinstance(value, bool) or not isinstance(value, str):
+        return float(value)
+    name = value.strip()
+    if name in _TIER_FLOORS:
+        return _TIER_FLOORS[name]
+    try:
+        return float(name)
+    except ValueError:
+        resolve_enum_argument(name, _TIER_FLOORS, argument="min_confidence", ignored=ignored)
+        return RISK_CAP_CONFIDENCE
+
+
 @mcp.tool()
 async def get_dead_code(
     repo: str | None = None,
     kind: str | None = None,
-    min_confidence: float = RISK_CAP_CONFIDENCE,
+    min_confidence: float | str = RISK_CAP_CONFIDENCE,
     safe_only: bool = False,
     limit: int = 20,
     tier: str | None = None,
@@ -237,7 +275,10 @@ async def get_dead_code(
     Args:
         repo: usually omitted.
         kind: unreachable_file | unused_export | unused_internal | zombie_package.
-        min_confidence: floor, default 0.4 (0.7 = cleanup-ready only).
+            An unrecognised value is dropped and named in ignored_arguments,
+            never applied as a filter that matches nothing.
+        min_confidence: floor, default 0.4 (0.7 = cleanup-ready only). Also
+            accepts a tier name: "high" (0.8) | "medium" (0.5) | "low" (0.0).
         safe_only: deletion-ready findings only (no runtime-load risk).
         limit: max findings per tier (clamped to 25).
         tier: "high" (>=0.8) | "medium" | "low".
@@ -257,10 +298,18 @@ async def get_dead_code(
     limit = min(max(limit, 1), max_per_tier)
     limit_clamped = requested_limit > max_per_tier
 
+    # Validated before anything is fetched: an unrecognised kind or tier is
+    # dropped rather than filtered on, so the answer is the unfiltered one plus
+    # a note, not "No dead code found matching your filters" over 445 findings.
+    ignored: list[dict[str, Any]] = []
+    kind = resolve_enum_argument(kind, _DEAD_CODE_KINDS, argument="kind", ignored=ignored)
+    tier = resolve_enum_argument(tier, _TIER_FLOORS, argument="tier", ignored=ignored)
+    confidence_floor = _resolve_min_confidence(min_confidence, ignored)
+
     filters = _FindingFilters(
         kind=kind,
         safe_only=safe_only,
-        min_confidence=min_confidence,
+        min_confidence=confidence_floor,
         directory=directory,
         owner=owner,
         excluded_kinds=_compute_excluded_kinds(
@@ -281,7 +330,9 @@ async def get_dead_code(
 
     # --- repo="all": aggregate dead code across all repos ---
     if repo == "all":
-        return await _get_dead_code_all_repos(filters, limit, tier, _maybe_limit_note)
+        result_ws = await _get_dead_code_all_repos(filters, limit, tier, _maybe_limit_note)
+        attach_ignored_arguments(result_ws, ignored)
+        return result_ws
 
     # --- Single repo path ---
     ctx = await _resolve_repo_context(repo)
@@ -338,6 +389,7 @@ async def get_dead_code(
     _maybe_limit_note(result)
 
     result["_meta"] = _build_meta(repository=repository)
+    attach_ignored_arguments(result, ignored)
     collector.attach(result)
     return result
 
@@ -449,16 +501,17 @@ def _build_tiers(
     With a *collector*, findings beyond the per-tier limit are captured for
     the omission store instead of being silently truncated.
     """
+    hi, med = _TIER_FLOORS["high"], _TIER_FLOORS["medium"]
     high = sorted(
-        [f for f in findings if f.confidence >= 0.8],
+        [f for f in findings if f.confidence >= hi],
         key=lambda f: (-f.confidence, -f.lines),
     )
     medium = sorted(
-        [f for f in findings if 0.5 <= f.confidence < 0.8],
+        [f for f in findings if med <= f.confidence < hi],
         key=lambda f: (-f.confidence, -f.lines),
     )
     low = sorted(
-        [f for f in findings if f.confidence < 0.5],
+        [f for f in findings if f.confidence < med],
         key=lambda f: (-f.confidence, -f.lines),
     )
 

--- a/packages/server/src/repowise/server/mcp_server/tool_search.py
+++ b/packages/server/src/repowise/server/mcp_server/tool_search.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import re
+from typing import Any
 
 from sqlalchemy import select
 
@@ -23,7 +24,9 @@ from repowise.server.mcp_server._helpers import (
     _is_path,
     _resolve_all_contexts,
     _resolve_repo_context,
+    attach_ignored_arguments,
     filter_dicts_by_key,
+    resolve_enum_argument,
 )
 from repowise.server.mcp_server._meta import build_meta as _build_meta
 from repowise.server.mcp_server._page_paths import file_candidates, hit_file_path
@@ -447,6 +450,11 @@ def _classify_hit_kind(target_path: str, page_type: str) -> str:
     if is_test_related_path(target_path):
         return "test"
     return "implementation"
+
+
+# Every value :func:`_classify_hit_kind` can return; anything else can only ever
+# match nothing, which is why an unknown kind is dropped rather than filtered on.
+_VALID_KINDS = frozenset({"implementation", "test", "config", "doc"})
 
 
 def _filter_by_kind(output: list[dict], kind: str | None) -> list[dict]:
@@ -995,10 +1003,17 @@ async def search_codebase(
     grep_hint = _grep_hint_for(query)
     resolved_mode = _resolve_mode(query, mode)
 
+    # An unknown kind used to take the same ``return False`` as a kind that is
+    # simply inapplicable, so a typo and a real empty result looked identical.
+    ignored: list[dict[str, Any]] = []
+    kind = resolve_enum_argument(kind, _VALID_KINDS, argument="kind", ignored=ignored)
+
     if resolved_mode in ("symbol", "path", "hybrid"):
-        return await _structured_search(
+        structured = await _structured_search(
             query, limit, page_type, kind, symbol_kind, repo, resolved_mode, grep_hint
         )
+        attach_ignored_arguments(structured, ignored)
+        return structured
 
     if repo == "all":
         # kind is filtered per-repo inside _search_single_repo, before each
@@ -1006,6 +1021,7 @@ async def search_codebase(
         federated = await _federated_search(query, limit, page_type, kind)
         if grep_hint and not federated.get("results"):
             federated["grep_hint"] = grep_hint
+        attach_ignored_arguments(federated, ignored)
         return federated
 
     ctx = await _resolve_repo_context(repo)
@@ -1075,6 +1091,7 @@ async def search_codebase(
         response["candidates"] = candidates
     if grep_hint and not output:
         response["grep_hint"] = grep_hint
+    attach_ignored_arguments(response, ignored)
     # Last, so nothing above has to know the field is on its way out.
     _drop_derivable_page_ids(output)
     return response

--- a/tests/unit/server/mcp/test_argument_validation.py
+++ b/tests/unit/server/mcp/test_argument_validation.py
@@ -1,0 +1,221 @@
+"""A bad argument is named, not answered with a reassuring negative (#1496).
+
+Every test calls the real tool entry point. The bugs these cover survived
+because a misspelled filter is a *successful* call: it matches nothing, and an
+empty result reads as an answer.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+def _entry(result: dict, argument: str) -> dict:
+    """The ignored_arguments entry for *argument*, or fail saying what is there."""
+    entries = result.get("ignored_arguments", [])
+    for e in entries:
+        if e["argument"] == argument:
+            return e
+    pytest.fail(f"no ignored_arguments entry for {argument!r}; got {entries!r}")
+
+
+class TestDeadCodeKind:
+    @pytest.mark.asyncio
+    async def test_unknown_kind_is_named_and_not_filtered_on(self, setup_mcp):
+        # Issue #1496's own call: the plural is not a kind, and filtering on it
+        # reported "No dead code found matching your filters" over 3 findings.
+        from repowise.server.mcp_server import get_dead_code
+
+        result = await get_dead_code(kind="unused_exports")
+
+        assert result["summary"]["filtered_findings"] == 3
+        assert "No dead code found" not in result["impact"]["recommendation"]
+        entry = _entry(result, "kind")
+        assert entry["values"] == ["unused_exports"]
+        assert "unused_export" in entry["valid"]
+
+    @pytest.mark.asyncio
+    async def test_known_kind_still_filters(self, setup_mcp):
+        from repowise.server.mcp_server import get_dead_code
+
+        result = await get_dead_code(kind="unused_export")
+
+        assert result["summary"]["filtered_findings"] == 2
+        assert "ignored_arguments" not in result
+
+    @pytest.mark.asyncio
+    async def test_valid_kinds_are_the_analyzer_vocabulary(self, setup_mcp):
+        # Pinned to the enum the analyzer writes, not to a hand-copied twin:
+        # a fifth kind added there must not read as a typo here.
+        from repowise.core.analysis.dead_code.models import DeadCodeKind
+        from repowise.server.mcp_server import get_dead_code
+
+        result = await get_dead_code(kind="nonsense")
+
+        assert _entry(result, "kind")["valid"] == sorted(k.value for k in DeadCodeKind)
+
+
+class TestDeadCodeMinConfidence:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [("high", 1), ("medium", 3), ("low", 3)],
+    )
+    async def test_tier_names_resolve_to_their_own_bands(self, setup_mcp, value, expected):
+        # The response is organised by these words and each tier description
+        # states its band; passing one back used to be a float_parsing error.
+        from repowise.server.mcp_server import get_dead_code
+
+        result = await get_dead_code(min_confidence=value)
+
+        assert result["summary"]["filtered_findings"] == expected
+        assert "ignored_arguments" not in result
+
+    @pytest.mark.asyncio
+    async def test_tier_name_agrees_with_the_tier_it_names(self, setup_mcp):
+        # min_confidence="high" must return exactly what tiers.high holds,
+        # or the input and output vocabularies mean different things again.
+        from repowise.server.mcp_server import get_dead_code
+
+        floored = await get_dead_code(min_confidence="high")
+        full = await get_dead_code()
+
+        assert floored["summary"]["filtered_findings"] == full["tiers"]["high"]["count"]
+
+    @pytest.mark.asyncio
+    async def test_numeric_string_is_still_a_number(self, setup_mcp):
+        # Widening the annotation to float | str is what lets "0.8" through.
+        from repowise.server.mcp_server import get_dead_code
+
+        result = await get_dead_code(min_confidence="0.8")
+
+        assert result["summary"]["filtered_findings"] == 1
+        assert "ignored_arguments" not in result
+
+    @pytest.mark.asyncio
+    async def test_float_is_unchanged(self, setup_mcp):
+        from repowise.server.mcp_server import get_dead_code
+
+        result = await get_dead_code(min_confidence=0.8)
+
+        assert result["summary"]["filtered_findings"] == 1
+        assert "ignored_arguments" not in result
+
+    @pytest.mark.asyncio
+    async def test_unrecognised_string_falls_back_and_is_named(self, setup_mcp):
+        from repowise.server.mcp_server import get_dead_code
+
+        result = await get_dead_code(min_confidence="hgih")
+
+        assert result["summary"]["filtered_findings"] == 3
+        assert _entry(result, "min_confidence")["values"] == ["hgih"]
+
+
+class TestDeadCodeTier:
+    @pytest.mark.asyncio
+    async def test_unknown_tier_returns_every_tier_and_is_named(self, setup_mcp):
+        # The worst of the three: a wrong tier emptied the whole tiers object,
+        # so the response carried no structure to read the miss off.
+        from repowise.server.mcp_server import get_dead_code
+
+        result = await get_dead_code(tier="High")
+
+        assert sorted(result["tiers"]) == ["high", "low", "medium"]
+        assert _entry(result, "tier")["values"] == ["High"]
+
+    @pytest.mark.asyncio
+    async def test_known_tier_still_scopes(self, setup_mcp):
+        from repowise.server.mcp_server import get_dead_code
+
+        result = await get_dead_code(tier="high")
+
+        assert sorted(result["tiers"]) == ["high"]
+        assert "ignored_arguments" not in result
+
+
+class TestContextInclude:
+    @pytest.mark.asyncio
+    async def test_unknown_include_key_is_named(self, setup_mcp):
+        from repowise.server.mcp_server import get_context
+
+        result = await get_context(["src/auth/service.py"], include=["ownersip"])
+
+        entry = _entry(result, "include")
+        assert entry["values"] == ["ownersip"]
+        assert "ownership" in entry["valid"]
+
+    @pytest.mark.asyncio
+    async def test_several_unknown_keys_share_one_entry(self, setup_mcp):
+        # One vocabulary listing however many values miss it — the note ships
+        # on the agent surface, where a repeated 12-item list is real budget.
+        from repowise.server.mcp_server import get_context
+
+        result = await get_context(["src/auth/service.py"], include=["ownersip", "caller"])
+
+        assert len(result["ignored_arguments"]) == 1
+        assert _entry(result, "include")["values"] == ["ownersip", "caller"]
+
+    @pytest.mark.asyncio
+    async def test_a_known_key_alongside_a_typo_still_resolves(self, setup_mcp):
+        from repowise.server.mcp_server import get_context
+
+        result = await get_context(["src/auth/service.py"], include=["ownership", "ownersip"])
+
+        assert "ownership" in result["targets"]["src/auth/service.py"]
+        assert _entry(result, "include")["values"] == ["ownersip"]
+
+    @pytest.mark.asyncio
+    async def test_health_is_a_real_block_not_a_typo(self, setup_mcp):
+        # Tested in targets.py but missing from both docstrings, so it was the
+        # one live key a hand-written allow-list would have rejected.
+        from repowise.server.mcp_server import get_context
+
+        result = await get_context(["src/auth/service.py"], include=["health"])
+
+        assert "ignored_arguments" not in result
+
+    @pytest.mark.asyncio
+    async def test_always_on_defaults_are_legal_to_pass(self, setup_mcp):
+        from repowise.server.mcp_server import get_context
+
+        result = await get_context(["src/auth/service.py"], include=["docs", "freshness"])
+
+        assert "ignored_arguments" not in result
+
+    @pytest.mark.asyncio
+    async def test_clean_call_adds_nothing(self, setup_mcp):
+        from repowise.server.mcp_server import get_context
+
+        result = await get_context(["src/auth/service.py"])
+
+        assert "ignored_arguments" not in result
+
+
+class TestSearchKind:
+    @pytest.mark.asyncio
+    async def test_unknown_kind_is_named(self, setup_mcp):
+        from repowise.server.mcp_server import search_codebase
+
+        result = await search_codebase("authentication service", kind="tests")
+
+        entry = _entry(result, "kind")
+        assert entry["values"] == ["tests"]
+        assert entry["valid"] == ["config", "doc", "implementation", "test"]
+
+    @pytest.mark.asyncio
+    async def test_known_kind_adds_nothing(self, setup_mcp):
+        from repowise.server.mcp_server import search_codebase
+
+        result = await search_codebase("authentication service", kind="implementation")
+
+        assert "ignored_arguments" not in result
+
+    @pytest.mark.asyncio
+    async def test_symbol_mode_carries_the_note_too(self, setup_mcp):
+        # search_codebase has three return paths and they are easy to fix one
+        # at a time; an identifier-shaped query routes past the concept path.
+        from repowise.server.mcp_server import search_codebase
+
+        result = await search_codebase("AuthService", kind="tests")
+
+        assert _entry(result, "kind")["values"] == ["tests"]


### PR DESCRIPTION
Closes #1496.

## The bug

```
get_dead_code({ kind: "unused_exports", min_confidence: 0.8 })
```

The plural is not a kind. The filter matched nothing, and the response
recommended **"No dead code found matching your filters."** beside a summary
counting 445 findings. A typo produced a confident all-clear.

The issue's second half is the mirror image: `min_confidence` rejected `"high"`
with a `float_parsing` error, even though the response is organised by that
exact word and each tier description states its band. The output vocabulary and
the input vocabulary disagreed.

## The fix

A value outside a closed vocabulary is **dropped, not applied**. The caller gets
the answer it would have had without the argument, and the response names what
was dropped:

```jsonc
"ignored_arguments": [
  { "argument": "kind",
    "values": ["unused_exports"],
    "valid": ["unreachable_file", "unused_export", "unused_internal", "zombie_package"] }
]
```

The shape is copied from `get_health`'s `unknown_only_keys`, not designed.
`resolve_enum_argument` / `attach_ignored_arguments` in `_helpers.py` are the one
implementation for `get_dead_code` (`kind`, `tier`, `min_confidence`),
`get_context` (`include`) and `search_codebase` (`kind`). Raising was the wrong
answer: it costs the caller an answer it could still have had.

`min_confidence` now also takes `"high"` / `"medium"` / `"low"`, resolving to the
floors its own tier descriptions quote. Floats and numeric strings still work.

## Measured before it was written, and it corrected the audit twice

In-process against this repo's own index, through the real tool entry points.

| call | before | after |
|---|---|---|
| `get_dead_code(kind="unused_exports")` | 0 findings, "No dead code found", beside `total_findings: 445` | 10 findings + note |
| `get_dead_code(tier="High")` | **`tiers: {}`** | all three tiers + note |
| `get_dead_code(min_confidence="high")` | `float_parsing` error | 10 findings, equal to `tiers.high.count` |
| `get_context(include=["caller"])` | no key, no signal | no block + note |
| `search_codebase(kind="tests")` | 0 results, same shape as a real miss | results + note |

**`tier` was the worst of the four, not the joint second.** A wrong `kind` at
least leaves the `tiers` scaffolding and the `by_kind` summary to read the miss
off. A wrong `tier` returns an empty `tiers` object, and there is nothing left in
the response to notice.

**`include=["health"]` is a live block that neither docstring lists.** It is
tested in `targets.py` and returns real data. An allow-list written from the
documentation would have reported the one working key as a typo, so the
vocabulary is traced from every membership test instead. `include=["source"]` is
the reverse case and stays out: both branches of the only test for it return
`None`, so accepting it would promise a block that does nothing.

**A genuine empty and a typo were not equally quiet, and not in the expected
direction.** For `callers`, a real "nothing calls this" returns `callers: []` —
the key is *present* — while a misspelled key returns no key at all. The typo was
the quieter of the two.

## Also in here

Two hand-kept twins removed on the way through: the tier bands were written out
in two functions of one file and are now one constant, and the kind vocabulary
comes from the analyzer's own `DeadCodeKind` enum rather than a fifth hand-copy
(pinned by a test, so a fifth kind added there cannot read as a caller's typo).

`search_codebase` gets no docstring line for this. It was already at 1573 of its
tested 1600-char schema budget, so the convention is documented once in
`docs/agent/MCP_TOOLS.md`, which is where that test points when it fails.

## Not fixed here, deliberately

- **The tier bands disagree with the rest of the product.** This tool tiers at
  0.8 / 0.5; `analyzer.py`, the dead-code crud and `packages/types` all tier at
  0.7 / 0.4 — and the TS constant's own comment records that it exists because
  three surfaces used to disagree. `min_confidence="high"` aliases to *this
  tool's* 0.8 so its own input and output agree, which is right locally and
  leaves the wider divergence alone; reconciling it changes output and is a
  product decision.
- **`search_codebase(mode=)`** falls back to `auto` for an unrecognised value
  inside `_resolve_mode`, which lowercases first. Validating it needs
  case-folding that none of the sites here use, and mixing two rules in one
  change was the worse trade.

## Gates

- `ruff check` on every changed Python file.
- `tests/unit/server/mcp`: **1,339 passed**, including 21 new ones.
- Every new test calls the real tool entry point. The before-column above was
  measured through the same entry points against a live index, not a fixture.
