### PR TITLE
feat(graph): resolve a namespace member through the re-export chain

### DIFF
--- a/packages/core/src/repowise/core/ingestion/call_resolver.py
+++ b/packages/core/src/repowise/core/ingestion/call_resolver.py
@@ -286,6 +286,7 @@ class CallResolver:
         # "*" name (it is not a binding), so without this pass the barrel chain
         # dead-ends one hop short of the real definition and a call through the
         # barrel resolves to nothing.
+        wildcard_sources: dict[str, list[str]] = defaultdict(list)
         for path, parsed in self._parsed_files.items():
             file_syms = self._file_symbols.get(path, {})
             for imp in parsed.imports:
@@ -294,11 +295,55 @@ class CallResolver:
                     continue
                 if imp.resolved_file.startswith("external:"):
                     continue
+                # ``export * as ns from "x"`` forwards the module under ``ns``,
+                # so x's names are reachable as ``ns.name`` and are NOT this
+                # file's own exports. Flattening them makes a bare ``name``
+                # resolve into a nested namespace it was never in.
+                if any(
+                    b.local_name == "*" and b.exported_name for b in imp.bindings
+                ):
+                    continue
                 resolved = imp.resolved_file
+                if resolved != path:
+                    wildcard_sources[path].append(resolved)
                 source_syms = self._file_symbols.get(resolved, {})
                 for sym_name in source_syms:
                     if sym_name not in file_syms:
                         self._barrel_origins[path][sym_name] = resolved
+
+        # The pass above forwards only what the source file DECLARES, so a
+        # barrel over a barrel forwards nothing and the chain breaks at its
+        # first link rather than its last. Forward what the source file
+        # re-exports too, to a fixpoint. The multi-hop pass below cannot do
+        # this job — it deepens entries that exist, and here none do.
+        #
+        # Sorted so that a name two of this file's barrels both forward lands on
+        # the same origin whatever order the repository was walked in.
+        for _ in range(4):
+            changed = False
+            for path, sources in sorted(wildcard_sources.items()):
+                file_syms = self._file_symbols.get(path, {})
+                origins = self._barrel_origins[path]
+                for source in sorted(sources):
+                    source_bindings = self._import_bindings.get(source, {})
+                    for name, declaring in sorted(self._barrel_origins.get(source, {}).items()):
+                        if name in file_syms or name in origins or declaring == path:
+                            continue
+                        # The map keys a name as the source file spells it and
+                        # records only the declaring file, never the name the
+                        # symbol has there. A hop that renames therefore hands
+                        # on a key the declaring file may coincidentally
+                        # declare as something unrelated, and the receiving
+                        # file carries no binding to undo it with. Refuse those
+                        # rather than forward a name that means something else
+                        # at the far end; it costs reach, never correctness.
+                        binding = source_bindings.get(name)
+                        if binding is not None and (binding.exported_name or name) != name:
+                            continue
+                        origins[name] = declaring
+                        changed = True
+            if not changed:
+                break
 
         # Multi-hop: follow chains up to 5 hops
         for _ in range(4):
@@ -888,6 +933,24 @@ class CallResolver:
                 return ResolvedCall(
                     caller_id, source_syms[method_name], 0.88, call.line, "module_alias"
                 )
+            # A namespace over a barrel names a file that declares nothing of
+            # its own, so the lookup above can only ever miss. Chase the
+            # re-export map, as free calls and typed receivers already do.
+            #
+            # Keyed on the name the declaring file uses, not the one written
+            # here: a member access cannot rename, but the re-export it arrives
+            # through can, and the map records only the file. Without this an
+            # ``export { foo as bar }`` binds any unrelated ``bar`` the
+            # declaring file happens to hold.
+            origin = self._barrel_origins.get(module_file, {}).get(method_name)
+            if origin is not None and origin != module_file:
+                binding = self._import_bindings.get(module_file, {}).get(method_name)
+                declared_name = (binding.exported_name if binding else None) or method_name
+                origin_syms = self._file_symbols.get(origin, {})
+                if declared_name in origin_syms:
+                    return ResolvedCall(
+                        caller_id, origin_syms[declared_name], 0.88, call.line, "module_alias"
+                    )
 
         # Strategy 1b: receiver in import names (non-alias fallback for backward compat)
         name_to_file = self._import_names.get(file_path, {})

--- a/packages/core/src/repowise/core/ingestion/extractors/bindings/ts_js.py
+++ b/packages/core/src/repowise/core/ingestion/extractors/bindings/ts_js.py
@@ -108,10 +108,19 @@ def extract_ts_js_bindings(stmt_node: Node, src: str) -> tuple[list[str], list[N
                             )
                         )
             elif child.type == "namespace_export":
-                # ``export * as ns from "x"`` — forwards the whole module.
+                # ``export * as ns from "x"`` — forwards the whole module, but
+                # under ``ns`` rather than flattened into this file's own
+                # namespace. The name rides on the wildcard binding so a
+                # consumer can tell the two shapes apart; the import-name maps
+                # drop a ``"*"`` binding before reading either field, so no
+                # lookup changes and ``imported_names`` stays as it was.
+                ns_name = next(
+                    (node_text(c, src) for c in child.children if c.type == "identifier"),
+                    None,
+                )
                 names.append("*")
                 bindings.append(
-                    NamedBinding(local_name="*", exported_name=None, source_file=None)
+                    NamedBinding(local_name="*", exported_name=ns_name, source_file=None)
                 )
             continue
 

--- a/tests/unit/ingestion/test_star_import_barrel.py
+++ b/tests/unit/ingestion/test_star_import_barrel.py
@@ -54,6 +54,107 @@ def test_call_through_star_import_barrel_resolves(tmp_path: Path) -> None:
     assert ("caller.py::run", "other.py::Thing::helper") not in edges, edges
 
 
+def test_namespace_member_resolves_through_a_barrel(tmp_path: Path) -> None:
+    """``import * as ns`` binds the barrel, which declares nothing itself.
+
+    The member lookup can only ever miss there, so the re-export map has to be
+    chased for the member name too.
+    """
+    files = {
+        "leaf.ts": "export function helper(x: number) {\n  return x;\n}\n",
+        "barrel.ts": 'export * from "./leaf.js";\n',
+        # a second `helper` defeats the global-unique tier
+        "other.ts": "export class Thing {\n  helper(x: number) {\n    return x;\n  }\n}\n",
+        "caller.ts": (
+            'import * as ns from "./barrel.js";\n\nexport function run() {\n  return ns.helper(1);\n}\n'
+        ),
+    }
+    edges = _build_calls(tmp_path, files)
+    assert ("caller.ts::run", "leaf.ts::helper") in edges, edges
+    assert ("caller.ts::run", "other.ts::Thing::helper") not in edges, edges
+
+
+def test_namespace_member_resolves_through_a_barrel_over_a_barrel(tmp_path: Path) -> None:
+    """Each hop forwards only what its source declares, so a chain of
+    re-exporting files breaks at its first link unless what a source itself
+    re-exports is forwarded too."""
+    files = {
+        "leaf.ts": "export function helper(x: number) {\n  return x;\n}\n",
+        "inner.ts": 'export * from "./leaf.js";\n',
+        "outer.ts": 'export * from "./inner.js";\n',
+        "other.ts": "export class Thing {\n  helper(x: number) {\n    return x;\n  }\n}\n",
+        "caller.ts": (
+            'import * as ns from "./outer.js";\n\nexport function run() {\n  return ns.helper(1);\n}\n'
+        ),
+    }
+    edges = _build_calls(tmp_path, files)
+    assert ("caller.ts::run", "leaf.ts::helper") in edges, edges
+    assert ("caller.ts::run", "other.ts::Thing::helper") not in edges, edges
+
+
+def test_a_nested_namespace_reexport_is_not_flattened(tmp_path: Path) -> None:
+    """``export * as coerce from "./coerce.js"`` puts coerce's names under
+    ``coerce``, not at top level, so a bare ``ns.string()`` must take the
+    top-level declaration and never the nested one."""
+    files = {
+        "coerce.ts": "export function string(x: unknown) {\n  return String(x);\n}\n",
+        "schemas.ts": "export function string(y: number) {\n  return y;\n}\n",
+        "external.ts": (
+            'export * as coerce from "./coerce.js";\nexport * from "./schemas.js";\n'
+        ),
+        "caller.ts": (
+            'import * as z from "./external.js";\n\nexport function run() {\n  return z.string(1);\n}\n'
+        ),
+    }
+    edges = _build_calls(tmp_path, files)
+    assert ("caller.ts::run", "coerce.ts::string") not in edges, edges
+    assert ("caller.ts::run", "schemas.ts::string") in edges, edges
+
+
+def test_namespace_member_through_a_renaming_reexport_takes_the_renamed_symbol(
+    tmp_path: Path,
+) -> None:
+    """``export { foo as bar }`` must bind ``foo``, not a same-named stranger.
+
+    The re-export map records only the declaring file, so the name written at
+    the call site is not the name that file declares.
+    """
+    files = {
+        "leaf.ts": (
+            "export function foo(x: number) {\n  return x;\n}\n"
+            "export function bar(y: string) {\n  return y;\n}\n"
+        ),
+        "mid.ts": 'export { foo as bar } from "./leaf.js";\n',
+        "caller.ts": (
+            'import * as ns from "./mid.js";\n\nexport function run() {\n  return ns.bar(1);\n}\n'
+        ),
+    }
+    edges = _build_calls(tmp_path, files)
+    assert ("caller.ts::run", "leaf.ts::bar") not in edges, edges
+    assert ("caller.ts::run", "leaf.ts::foo") in edges, edges
+
+
+def test_namespace_member_refuses_a_rename_forwarded_across_a_wildcard(
+    tmp_path: Path,
+) -> None:
+    """A wildcard hop hands on the renamed spelling and no binding to undo it
+    with, so the name is refused rather than bound to whatever the declaring
+    file happens to call ``bar``."""
+    files = {
+        "leaf.ts": (
+            "export function foo(x: number) {\n  return x;\n}\n"
+            "export function bar(y: string) {\n  return y;\n}\n"
+        ),
+        "mid1.ts": 'export { foo as bar } from "./leaf.js";\n',
+        "mid2.ts": 'export * from "./mid1.js";\n',
+        "caller.ts": (
+            'import * as ns from "./mid2.js";\n\nexport function run() {\n  return ns.bar(1);\n}\n'
+        ),
+    }
+    edges = _build_calls(tmp_path, files)
+    assert ("caller.ts::run", "leaf.ts::bar") not in edges, edges
+
+
 def test_star_barrel_edge_survives_global_name_shadow(tmp_path: Path) -> None:
     """A same-named method elsewhere makes the name globally non-unique, so the
     Tier-3 fallback cannot resolve the call: only following the star re-export


### PR DESCRIPTION
A module namespace bound to a barrel file resolved nothing.

```ts
import * as z from "zod/v4";
z.object({ ... });
```

`packages/zod/src/v4/index.ts` declares nothing of its own. It forwards to
`classic/index.ts`, which forwards to `classic/external.ts`, which forwards to
`classic/schemas.ts`, where `object` is actually declared. The member lookup
stopped at the first file, so 6,693 calls on one name went unresolved, over half
of everything we failed to resolve in that repository.

Two separate faults kept the existing machinery from firing, and fixing either
alone wins almost nothing.

**The namespace strategy never consulted the re-export map.** It looked the
method up in the file the import named and stopped, although the map was already
built and free calls and typed receivers have chased it for months.

**The map only ever went one hop.** The wildcard pass forwarded, for each
`export * from "./x"`, only the names `x` declares, never the names `x` itself
re-exports, so a chain of forwarding files broke at its first link rather than
its last. The multi-hop pass below it deepens entries that already exist, and
here none did. Forwarding is now iterated to a fixpoint, sorted so the result
does not depend on the order the repository was walked in.

Two wrong-edge shapes had to be refused before any of that was safe to read.
Both are pre-existing, and neither produced wrong edges before, because nothing
consulted this map for a member call.

**A renaming re-export could bind a same-named stranger.** The map records the
declaring file and never the name the symbol has there, so
`export { foo as bar } from "./leaf"` keys `bar` to `leaf`, and asking whether
`leaf` declares `bar` can be answered by an unrelated `bar`. The direct hop now
chases the exported name where a binding supplies one, which is the indirection
the typed-receiver path already performs, and a renamed name is refused across a
wildcard hop, where the receiving file holds no binding to undo the rename with.

**A nested namespace re-export was being flattened.**
`export * as coerce from "./coerce.js"` forwards a module under `coerce`, so its
names are reachable as `z.coerce.string()` and are not top-level exports. The
binding extractor recorded that statement and a plain `export * from`
identically, so the pass consuming them could not tell the two apart, and a bare
`z.string()` bound into the nested namespace. The namespace name now rides on the
wildcard binding, which the import-name maps drop before reading either field, so
no lookup changes and `imported_names` is untouched.

## Result

Measured over 15 repositories, before and after taken inside one checkout with
tsconfig path aliases wired on both sides.

| repo | resolved calls | gained | lost |
|---|---|---:|---:|
| zod | 2,677 to 7,992 | 5,315 | 0 |
| svelte | 11,712 to 13,674 | 1,962 | 0 |
| vue | 16,766 to 17,653 | 887 | 0 |
| solid | 2,300 to 2,478 | 178 | 0 |
| react | 28,290 to 28,407 | 117 | 0 |
| pydantic | 13,838 to 13,859 | 21 | 0 |
| scrapy | 7,556 to 7,576 | 20 | 0 |
| preact | 3,279 to 3,286 | 7 | 0 |
| hono, vitepress, taxonomy, caffeine, celery, gitleaks, leveldb | unchanged | 0 | 0 |

**Zero calls lost on all 15.** Symbol ids identical, heritage edges
byte-identical, file and symbol node counts pinned, and dead-code findings
unmoved on 14 repositories with the framework and dynamic passes enabled.

The spread is the honest reading rather than a mean. Seven repositories do not
move at all, including one that was measured as a true zero beforehand and kept
as a control precisely so that movement there would signal the mechanism firing
where it should not.

Two figures that must not be added to the gain. Eleven edges changed target, and
each was read by hand against the caller's own import: nine svelte `get` calls
move to the store module the file actually imports from, one `tick` moves off a
test helper onto the export the file imports, and one vue `computed` moves onto
the wrapper the importing package declares. Separately, several thousand existing
edges change tier rather than target, from a global-name guess at 0.50 to an
import-scoped match at 0.90, which is a confidence improvement on edges that
already existed.

The wildcard half is not TypeScript-only. It fires for `from x import *`, which
is where the pydantic and scrapy rows come from.

## Checks

Precision was hand-audited over 200 gained edges, one auditor per repository,
each told that repository's own hazard to hunt: zod 30/30, svelte 30/30, react
30/30, vue 30/30, solid 29/30 with the single failure belonging to a known
pre-existing shape, and pydantic 21/21 and scrapy 20/20 read as whole
populations. The eleven retargeted edges audited 11/11.

The first zod audit failed at 18/30 and is what surfaced the flattening described
above. It was fixed rather than shipped around, and the re-audit is 30/30.

Call-edge determinism is unchanged: zero differing edges between walk order and
shuffled ingestion on three repositories. Cost sits under the noise floor and
does not come out ordered, so it is reported as no measurable change rather than
as a speedup: graph build moves +5.07% on zod against a 0.14 second denominator,
-0.67% on svelte and -2.57% on react.

Five guard tests are added, four of which fail without the fix. The fifth guards
against a regression this change could introduce and passes on the base commit,
which is stated rather than counted as evidence.
