### PR TITLE
feat(graph): type a Go receiver from its declaration

### DIFF
--- a/packages/core/src/repowise/core/ingestion/call_resolver.py
+++ b/packages/core/src/repowise/core/ingestion/call_resolver.py
@@ -113,9 +113,14 @@ _CPP_STRATEGIES = _LanguageCallStrategies(free=("_resolve_cpp_same_target",))
 # Rust's crate-root strategy is deliberately absent: it runs for every language
 # today, and gating it here would drop crate-name receivers in mixed repos.
 _LANGUAGE_CALL_STRATEGIES: dict[str, _LanguageCallStrategies] = {
+    # Go's package tier runs first and claims ``pkg.Func()`` outright, so a
+    # package qualifier never reaches the typed fallback — 41% of gitleaks'
+    # lowercase-receiver misses are package names, and this is what keeps them
+    # out of it.
     "go": _LanguageCallStrategies(
         free=("_resolve_go_same_package",),
         member=("_resolve_go_package_call",),
+        member_fallback=_TYPED_RECEIVER,
     ),
     # Kotlin shares the JVM tiers but not the typed-receiver fallback: it has
     # no declaration shapes yet, so registering it would promise a resolution

--- a/packages/core/src/repowise/core/ingestion/languages/receiver_types.py
+++ b/packages/core/src/repowise/core/ingestion/languages/receiver_types.py
@@ -3,8 +3,11 @@
 ``user.save()`` names no type, so member resolution has nothing to look up.
 The declaration that gives ``user`` its type is either inside the same function
 — a parameter, a local, a catch or loop binding — or, when the receiver is a
-field, at the enclosing class's own scope. Both are written ``T name``, so one
-scan finds both and only the span they are read back over differs.
+field, at the enclosing class's own scope. In the C family both are written
+``T name``, so one scan finds both and only the span they are read back over
+differs. A language may order them the other way round: Go writes ``name T``
+and declares a method's receiver in the signature, which the body span already
+covers.
 
 The scan is allowed to be wrong. Nothing it returns becomes an edge until the
 resolver has checked that the type actually declares the method, so a
@@ -88,10 +91,68 @@ _PY_CONSTRUCTED = re.compile(
     r"(?m)^[ \t]*(?P<name>[a-z_]\w*)\s*=\s*(?P<type>[A-Z]\w*)\s*\("
 )
 
+# Go writes the name before the type, so none of the C-family shapes above
+# match a line of it. Two further differences decide these patterns.
+#
+# A type name may be lowercase, because that is how Go spells an unexported
+# one, and a private method hangs off exactly those. Admitting lowercase is
+# only safe because the language spec carries every predeclared identifier in
+# ``builtin_types``, so ``string`` and ``error`` are refused downstream rather
+# than looked up.
+#
+# The receiver a method is declared on — ``func (s *Server) handle()`` — is
+# written in the signature rather than the body, and it is the largest shape
+# by some way: 50.2% of the reachable population over five Go repos, against
+# 24.1% for parameters and 21.5% for composite literals. It needs no scope of
+# its own, because a function symbol's span starts at its ``func`` line, so
+# the body scan already reads it.
+_GO_NAME = r"[a-z_]\w*"
+_GO_TYPE = r"[A-Za-z_]\w*(?:\.[A-Za-z_]\w*)?"
+
+# A parameter, a named return, or a method's own receiver: ``name Type``
+# juxtaposed before a comma or the end of the list. Juxtaposition is a
+# declaration nearly everywhere it is legal in Go, which is why this needs
+# less guarding than the C family's did.
+#
+# ``func (s *Server) handle()`` needs no pattern of its own — the receiver
+# group presents as ``s *Server)`` and is matched here. A separate anchored
+# pattern for it was measured and removed: it added a whole-file scan and
+# changed no edge on any of the five Go repos.
+#
+# ``a * b`` is not matched because gofmt spaces a binary operator on both
+# sides while a pointer type binds tight, and Go source is gofmt'd.
+_GO_PARAM = re.compile(
+    rf"(?<![\w.])(?P<name>{_GO_NAME})\s+\*?(?P<type>{_GO_TYPE})\s*(?=[,)])"
+)
+
+# ``x := Foo{}``, ``x := &Foo{}``, ``x := y.(Foo)`` and ``x, ok := y.(Foo)``.
+# One scan rather than two: both shapes are a short declaration whose type is
+# written outright, and they differ only in what brackets it. The closing
+# ``{`` or ``)`` is what tells them from ``x := f()``, whose type is a return
+# value this phase deliberately does not chase.
+#
+# ``x := []Foo{}`` and ``x := map[k]Foo{}`` match nothing on purpose: the
+# value is a slice or a map, and typing ``x`` as ``Foo`` would be wrong rather
+# than merely unhelpful.
+_GO_SHORT_DECL = re.compile(
+    rf"(?<![\w.])(?P<name>{_GO_NAME})\s*(?:,\s*{_GO_NAME}\s*)?:="
+    rf"\s*(?:&|[\w.]+\.\(\*?)?(?P<type>{_GO_TYPE})\s*(?:\{{|\))"
+)
+
+# ``var x Foo`` / ``var x *Foo``. The smallest shape in every Go repo
+# measured — 2.5% of the reachable population — and kept only because it is
+# the one shape neither pattern above reaches.
+_GO_VAR_DECL = re.compile(rf"(?<![\w.])var\s+(?P<name>{_GO_NAME})\s+\*?(?P<type>{_GO_TYPE})")
+
 _C_FAMILY = (_TYPED_DECLARATION, _INFERRED_FROM_NEW)
+# No Go shape captures a closer, so every Go declaration carries ``""`` and
+# class scope would drop all of them. That is the intended reading: Go is not
+# in IMPLICIT_FIELD_LANGUAGES and must not be.
+_GO_FAMILY = (_GO_PARAM, _GO_SHORT_DECL, _GO_VAR_DECL)
 
 _LANGUAGE_PATTERNS: dict[str, tuple[re.Pattern[str], ...]] = {
     "csharp": _C_FAMILY,
+    "go": _GO_FAMILY,
     "java": _C_FAMILY,
     "python": (_PY_ANNOTATED, _PY_CONSTRUCTED),
 }
@@ -107,6 +168,7 @@ IMPLICIT_FIELD_LANGUAGES = frozenset({"csharp", "java"})
 
 _LANGUAGE_COMMENTS: dict[str, re.Pattern[str]] = {
     "csharp": _LINE_COMMENT,
+    "go": _LINE_COMMENT,
     "java": _LINE_COMMENT,
     "python": _HASH_COMMENT,
 }

--- a/tests/unit/ingestion/test_receiver_types.py
+++ b/tests/unit/ingestion/test_receiver_types.py
@@ -224,8 +224,83 @@ class TestRefusals:
         assert declared_types("void run() { // a Node node; once lived here\n }", "java") == {}
 
     def test_an_unregistered_language_yields_nothing(self) -> None:
-        body = "func run(w *TimerWheel) { }"
-        assert declared_types(body, "go") == {}
+        # Kotlin rather than Go: Go registered its shapes and now types this
+        # exact line. Kotlin is still one of the languages P8 left unattempted.
+        body = "fun run(w: TimerWheel) { }"
+        assert declared_types(body, "kotlin") == {}
+
+
+class TestGoShapes:
+    """Go writes ``name T``, which is the reverse of every other shape here.
+
+    The receiver a method is declared on is the largest share of the reachable
+    population — 56.5% over five Go repos — and it needs no scope of its own,
+    because a function symbol's span starts at its ``func`` line.
+    """
+
+    def test_a_methods_own_receiver(self) -> None:
+        body = "func (s *Server) handle() { s.route() }"
+        assert declared_types(body, "go")["s"] == "Server"
+
+    def test_a_value_receiver(self) -> None:
+        body = "func (c Config) apply() { c.merge() }"
+        assert declared_types(body, "go")["c"] == "Config"
+
+    def test_a_parameter(self) -> None:
+        body = "func run(d *Detector, n int) { d.Detect() }"
+        assert declared_types(body, "go")["d"] == "Detector"
+
+    def test_a_named_return(self) -> None:
+        body = "func build() (out *Report, err error) { out.Write() }"
+        assert declared_types(body, "go")["out"] == "Report"
+
+    def test_a_composite_literal(self) -> None:
+        assert declared_types("func f() { r := Rule{} ; r.Match() }", "go")["r"] == "Rule"
+
+    def test_an_addressed_composite_literal(self) -> None:
+        assert declared_types("func f() { r := &Rule{} }", "go")["r"] == "Rule"
+
+    def test_a_qualified_composite_literal_keeps_the_bare_name(self) -> None:
+        assert declared_types("func f() { a := config.Allowlist{} }", "go")["a"] == "Allowlist"
+
+    def test_a_type_assertion(self) -> None:
+        assert declared_types("func f() { w, ok := r.(*Writer) }", "go")["w"] == "Writer"
+
+    def test_a_var_declaration(self) -> None:
+        assert declared_types("func f() { var vc ViperConfig }", "go")["vc"] == "ViperConfig"
+
+    def test_an_unexported_type_is_admitted(self) -> None:
+        """A private method hangs off an unexported type, so refusing one on
+        case would refuse most of what this mechanism exists to reach."""
+        assert declared_types("func (s *startEnd) add() { }", "go")["s"] == "startEnd"
+
+    def test_a_predeclared_type_is_refused(self) -> None:
+        """Admitting a lowercase type is only safe because these are dropped."""
+        assert declared_types("func f(name string, n int) { }", "go") == {}
+
+    def test_a_constructor_call_names_no_type(self) -> None:
+        """``x := NewFoo()`` types ``x`` only via the callee's return type,
+        which is a second lookup this mechanism does not do."""
+        assert declared_types("func f() { d := NewDetector() }", "go") == {}
+
+    def test_a_slice_literal_does_not_type_its_element(self) -> None:
+        """``x`` is a slice of Rule, not a Rule, so typing it would be wrong."""
+        assert declared_types("func f() { rs := []Rule{} }", "go") == {}
+
+    def test_a_map_literal_does_not_type_its_value(self) -> None:
+        assert declared_types("func f() { m := map[string]Rule{} }", "go") == {}
+
+    def test_a_multiplication_is_not_a_pointer_declaration(self) -> None:
+        """gofmt spaces a binary operator on both sides and binds a pointer
+        type tight, which is the whole of what separates these two."""
+        assert declared_types("func f() { n := total(count * size) }", "go") == {}
+
+    def test_a_declaration_in_a_line_comment_is_ignored(self) -> None:
+        assert declared_types("func f() { // a *Rule rule once lived here\n }", "go") == {}
+
+    def test_two_types_for_one_name_yields_neither(self) -> None:
+        body = "func f(r *Rule) { r := Config{} }"
+        assert declared_types(body, "go")["r"] is None
 
 
 class TestClassScope:
@@ -282,9 +357,19 @@ class TestClassScope:
 
 def test_the_language_set_is_what_the_patterns_declare() -> None:
     """Excluding a language means removing its shapes, not gating a caller."""
-    assert set(RECEIVER_TYPE_LANGUAGES) == {"csharp", "java", "python"}
+    assert set(RECEIVER_TYPE_LANGUAGES) == {"csharp", "go", "java", "python"}
 
 
-@pytest.mark.parametrize("language", ["java", "csharp", "python"])
+def test_go_is_not_a_field_language() -> None:
+    """Go declares no field this mechanism can read, and must not claim to.
+
+    Its shapes capture no closer, so class scope would drop every one of them
+    anyway — but the set is the contract, and a package-level ``var`` is a
+    wider scope than a field rather than the same one.
+    """
+    assert "go" not in IMPLICIT_FIELD_LANGUAGES
+
+
+@pytest.mark.parametrize("language", ["java", "csharp", "python", "go"])
 def test_an_empty_body_is_not_an_error(language: str) -> None:
     assert declared_types("", language) == {}


### PR DESCRIPTION
## What

Go call resolution could not tell what type a receiver had, so `s.handle()` went unresolved. Java, C# and Python already carry receiver typing; Go had the registration slot for it and no declaration shapes, so the language gate refused it before anything ran.

This registers three Go shapes and fills the slot.

| shape | example |
|---|---|
| parameter, named return, and a method's own receiver | `func (s *Server) handle(x *Foo)` |
| short declaration with the type written out | `x := Foo{}`, `x := &Foo{}`, `x := y.(Foo)` |
| var declaration | `var x Foo` |

## Why the method receiver matters

Half the reachable population is a method's own receiver, the `(s *Server)` in the signature. It needs no new scope machinery: a function symbol's span starts at its `func` line, so the existing body scan already reads the signature. Go is deliberately left out of `IMPLICIT_FIELD_LANGUAGES`, since a package-level var is a wider scope than a field and is 0.2% of what is reachable.

Two Go specifics drove the patterns. Type names may be lowercase, because that is how Go spells an unexported type and a private method hangs off exactly those; that is only safe because the language spec already carries every predeclared identifier, so `string` and `error` are dropped before any lookup. And `a * b` is not read as a pointer declaration because gofmt spaces a binary operator on both sides while a pointer type binds tight.

Five patterns were written and three shipped. A separate anchored pattern for `func (s *T)` turned out to be redundant with the parameter shape, and the composite literal and type assertion differ only in what brackets the type. Merging them left the gained edge set byte identical on all five repos, so this removed a whole file scan without trading anything away.

## Results

Measured on gitleaks, tld, osv-scanner, syft and hugo.

| repo | calls before | after | gained | lost |
|---|---:|---:|---:|---:|
| gitleaks | 2,208 | 2,294 | +86 | 0 |
| tld | 13,297 | 14,193 | +896 | 0 |
| osv-scanner | 3,176 | 3,367 | +190 | 0 |
| syft | 12,609 | 13,451 | +842 | 0 |
| hugo | 9,403 | 11,664 | +2,258 | 0 |

Symbols, heritage edges, import edges and node counts are identical on every repo. Four repos with no Go (caffeine, celery, zod, eShopOnWeb) are byte identical.

Nothing is lost by construction, since the strategy sits in a slot that runs after every other tier and only ever sees a call nothing else claimed. The check is still run, because "cannot" and "did not" are different claims.

Precision was hand audited at 60/60 across two repos on the first round, 30 on gitleaks and 30 on hugo. The hugo sample deliberately covered the shapes most likely to break it: `Open` on seven different filesystem wrappers, `Environment` on four types, a method value reference, and a cross package receiver. All resolved to the correct owner.

## Known limits, recorded rather than hidden

Build cost rises past the 15% bar on the two largest repos, tld at 38% and hugo at 36 to 41%, and is marginal on gitleaks. As a share of parse plus build it is 3.5% to 14%. This is shipped with the failure recorded, matching how the Java and Python rounds were handled.

Two ceilings are sized and left for follow ups:

1. An unexported Go receiver type is refused on case when methods are filed under their type, so 39% to 59% of types in four of these repos hold no methods in the index at all. Fixing it raises the reachable population by about 1.5x, but it changes symbol parenting and so needs its own before and after run rather than riding on this one.
2. Go composite literals still produce no call site. On invocations alone this change puts us ahead of the comparison index; the whole remaining deficit is construction, which is a modelling question rather than a resolution bug.

## Tests

17 new cases covering each shape and, more importantly, the refusals: a predeclared type, a constructor call whose type would need a return type lookup, a slice literal, a map literal, a multiplication, a comment, and a name declared twice with two types. Two existing guards updated, since both asserted Go was unregistered. Full ingestion suite passes at 2,399.
