### PR TITLE
fix(graph): type a Go method whose receiver is unexported

### DIFF
--- a/packages/core/src/repowise/core/ingestion/extractors/helpers.py
+++ b/packages/core/src/repowise/core/ingestion/extractors/helpers.py
@@ -15,14 +15,20 @@ def node_text(node: Node | None, src: str) -> str:
 
 
 def extract_go_receiver_type(receiver_text: str) -> str | None:
-    """Extract 'Calculator' from '(c *Calculator)' or '(c Calculator)'."""
+    """Extract 'Calculator' from '(c *Calculator)' or '(c Calculator)'.
+
+    A Go receiver is ``name Type`` or a bare ``Type``, so the type is always
+    the last part. Selecting it by position rather than by an uppercase first
+    letter is what lets an unexported receiver — ``func (s *startEnd) add()`` —
+    carry a parent at all; the export convention says nothing about whether a
+    name is a type.
+    """
     text = receiver_text.strip("() ")
     parts = text.split()
-    for part in reversed(parts):
-        clean = part.lstrip("*")
-        if clean and clean[0].isupper():
-            return clean
-    return None
+    if not parts:
+        return None
+    clean = parts[-1].lstrip("*")
+    return clean or None
 
 
 def refine_go_type_kind(type_spec_node: Node, src: str) -> str:

--- a/tests/unit/ingestion/test_go_extractors.py
+++ b/tests/unit/ingestion/test_go_extractors.py
@@ -63,3 +63,20 @@ class TestGoMethodReceiver:
         greet = [s for s in result.symbols if s.name == "Greet"]
         assert greet
         assert greet[0].parent_name == "User"
+
+    def test_unexported_receiver_type_still_parents_the_method(
+        self, parser: ASTParser
+    ) -> None:
+        """Export status says nothing about whether a name is a type."""
+        src = b"package x\n\ntype startEnd struct{}\n\nfunc (s *startEnd) add() {}\n"
+        result = parser.parse_file(_file(), src)
+        add = [s for s in result.symbols if s.name == "add"]
+        assert add
+        assert add[0].parent_name == "startEnd"
+
+    def test_unnamed_receiver(self, parser: ASTParser) -> None:
+        src = b"package x\n\ntype cache struct{}\n\nfunc (*cache) reset() {}\n"
+        result = parser.parse_file(_file(), src)
+        reset = [s for s in result.symbols if s.name == "reset"]
+        assert reset
+        assert reset[0].parent_name == "cache"


### PR DESCRIPTION
`extract_go_receiver_type` picked the receiver type by looking for an uppercase
first letter, using Go's export convention as a stand-in for "is a type name".
`func (s *startEnd) add()` therefore parsed with no parent, never entered
`_global_methods`, and was unreachable by receiver typing or dispatch.

Types holding methods in the index, against types declared in source:

| repo | indexed | declared | missing |
|---|---:|---:|---:|
| gitleaks | 19 | 24 | 21% |
| tld | 57 | 126 | 55% |
| osv-scanner | 47 | 77 | 39% |
| syft | 133 | 327 | 59% |
| hugo | 304 | 681 | 55% |

A Go receiver is `name Type` or a bare `Type`, so the type is the last part.
Selecting it by position covers the unexported case and the unnamed receiver
`func (*cache) reset()` alike. `go_visibility` uses the same case test
correctly, to set a symbol's own visibility, and is unchanged.

## Measurement

This renames symbol ids, since a method's id gains its parent, so a plain
before/after diff of call rows is not a usable gate: on hugo it reports 1,343
lost and 2,591 gained. The gate instead keys symbols on
`(path, name, kind, start_line)` and call sites on
`(file, line, callee file, callee name)`, both invariant under renaming, and
runs both sides in one process.

| gate | result |
|---|---|
| Symbols | 0 unclassified, 0 vanished on 5 repos; every changed id is a Go method gaining a parent |
| Orphaned Go methods | 0 on all 5 |
| Call sites lost | 0 on gitleaks, osv-scanner, tld; 2 on syft; 2 on hugo |
| Heritage / imports | identical on 5 |
| Precision | 56/60 hand-read |
| Cost | worst +5.67% parse and build (syft) |
| Controls | caffeine, zod, celery, eShopOnWeb byte-identical |

2,333 edges gained, 2,219 of them new. An independent probe written before the
change predicted 2,052.

The fix also splits ids that had been merged: two unexported types in one file
declaring the same method name were a single symbol and a single graph node
(hugo 121, syft 19, tld 15, osv-scanner 5). That accounts for the node-count
rise and for 114 of the gained edges, which are the same call re-attributed
from a merged caller to the correct one.

All four lost call sites were read from source. Each is a guess at interface
dispatch moving between implementers, not a correct edge withdrawn; hugo's two
lines simultaneously gain the `sample()` edge they had been missing.

## Known follow-ups

Splitting a merged id lets a method shadow a same-named package-level func in
its own file, so `dbrepo.Open(ctx, opts)` can bind to `shallowMigrationFS.Open`.
Measured against source at 6 of 2,333 gained edges (0.3%), with one downstream
effect: `dbrepo.go::Open` is reported as an unused export at confidence 0.4,
the only dead-code movement across three repos checked. Excluding methods when
the call carries a package qualifier is a resolver-tier change and is filed
separately.

A census of methods parsed without a parent, run across nine languages to see
whether any other language drops methods the same way, found Go at 14.8% and
everything else at 0 except C# at 0.5% (22 of 4,404, two files, caused by an
`#if`/`#else` between a method's return type and its name). Also filed
separately.
