### PR TITLE
feat(graph): type a C# call on a freshly constructed receiver

### DIFF
--- a/packages/core/src/repowise/core/ingestion/queries/csharp.scm
+++ b/packages/core/src/repowise/core/ingestion/queries/csharp.scm
@@ -205,6 +205,27 @@
   arguments: (argument_list) @call.arguments
 ) @call.site
 
+; Fluent construction: new Builder().Method(args).
+; The receiver is captured from the constructed type rather than from a
+; variable, because here the type is written at the call site. That keeps the
+; site on the resolver's receiver-names-a-class path, which only binds when
+; that class declares the method, instead of the bare-name pool.
+(invocation_expression
+  function: (member_access_expression
+    expression: (object_creation_expression
+      type: [
+        (identifier) @call.receiver
+        (generic_name (identifier) @call.receiver)
+      ]
+    )
+    name: [
+      (identifier) @call.target
+      (generic_name (identifier) @call.target)
+    ]
+  )
+  arguments: (argument_list) @call.arguments
+) @call.site
+
 ; Constructor: new ClassName(args) and new ClassName<T>(args)
 (object_creation_expression
   type: [


### PR DESCRIPTION
`new Builder().Method(args)` matched none of `csharp.scm`'s three call patterns, so it produced no call site at all — **312 of Ocelot's 22,582 invocation nodes**.

It is the one uncaptured C# shape whose receiver type is written at the call site, so the pattern captures the constructed type as the receiver. That puts the site on the resolver's receiver-names-a-class tier (`call_resolver.py:984`), which binds only on a validated `(class, method)` pair — there is no bare-name fallback reachable from it. That property is the whole reason this shape was built and the larger ones were not.

## Measurement

Both sides run in one process behind a toggle of the query text, so the halves cannot drift on grammar version, corpus walk or resolver state.

| repo | call sites | resolved before | after | gained | lost |
|---|---:|---:|---:|---:|---:|
| Ocelot | 18,169 → 18,481 | 8,063 | 8,324 | 261 | 0 |
| PowerToys | 57,863 → 57,975 | 24,625 | 24,695 | 70 | 0 |
| eShopOnWeb | 1,539 → 1,557 | 340 | 351 | 11 | 0 |
| CleanArchitecture | 1,844 → 1,856 | 328 | 332 | 4 | 0 |

**+346 resolved calls, 0 lost, 0 retargeted.** Symbols, heritage and imports identical on all four repos.

**Precision 95/95.** Every sampled gained edge across the four repos, checked against the constructed type on the site's own source line. Three rows flagged by the mechanical check were read by hand and are also correct — at `eShopOnWeb/tests/UnitTests/Builders/OrderBuilder.cs:32,38,44` the line reads `new Order(TestBuyerId, new AddressBuilder().WithDefaultValues(), ...)` and the resolver bound the inner constructor's class, which is right; the check was wrong, not the edge.

**Recall rises on both denominators** on Ocelot, which is worth stating because a capture change usually moves them the other way:

| denominator | before | after |
|---|---:|---:|
| resolved / captured sites | 8,063 / 18,169 = 44.38% | 8,324 / 18,481 = 45.04% |
| resolved / AST invocations | 8,063 / 22,582 = 35.71% | 8,324 / 22,582 = 36.86% |

It rises because the gained sites resolve at **83.7%** against Ocelot's 45% baseline — the receiver is exact, so almost all of them land.

**Dead code** unmoved (0 findings change on Ocelot and eShopOnWeb). **Cost** +2.26% on Ocelot, −2.53% on PowerToys, against a 15% bar. **Controls** byte-identical on gitleaks (go), zod (typescript), celery (python) and caffeine (java).

Full unit suite green: 13,678 passed, 4 skipped, 2 xfailed.

## What is deliberately not captured

C#'s chained (3,756) and dotted (1,708) receiver shapes, and the equivalents in Python (4,696) and TypeScript (1,111). All are expressible as one more query alternative — that is measured, not assumed. All would mint sites whose receiver cannot be typed, which then resolve by bare name to a plausible stranger, a mechanism already measured at ~60% precise and refused. They need chained-receiver typing first, not another pattern.

## Re-index

Yes — C# call sites change.
