### PR TITLE
feat(graph): resolve a call through the name a module publishes

### DIFF
--- a/packages/core/src/repowise/core/ingestion/call_resolver.py
+++ b/packages/core/src/repowise/core/ingestion/call_resolver.py
@@ -312,7 +312,13 @@ class CallResolver:
                 if resolved != path:
                     wildcard_sources[path].append(resolved)
                 source_syms = self._file_symbols.get(resolved, {})
-                for sym_name in source_syms:
+                source_parsed = self._parsed_files.get(resolved)
+                published = (
+                    (*source_syms, *source_parsed.export_aliases)
+                    if source_parsed
+                    else tuple(source_syms)
+                )
+                for sym_name in published:
                     if sym_name not in file_syms:
                         self._barrel_origins[path][sym_name] = resolved
 
@@ -700,6 +706,23 @@ class CallResolver:
             resolved.origin,
         )
 
+    def _published(self, file_path: str, name: str) -> str | None:
+        """The symbol *file_path* publishes under *name*, or None.
+
+        A module may declare a symbol under one name and export it under
+        another — ``export { stringType as string }`` — and every lookup that
+        arrives through a namespace, a barrel or an import asks for the
+        published name while the symbol table holds the local one. The table
+        answers first, so the alias can only ever add a hit.
+        """
+        symbols = self._file_symbols.get(file_path, {})
+        found = symbols.get(name)
+        if found is not None:
+            return found
+        parsed = self._parsed_files.get(file_path)
+        local = parsed.export_aliases.get(name) if parsed else None
+        return symbols.get(local) if local else None
+
     def _merged_symbols_for(self, file_path: str) -> dict[str, str]:
         """Merged ``{name → symbol_id}`` across every file *file_path* imports.
 
@@ -849,11 +872,9 @@ class CallResolver:
             lookup_name = binding.exported_name or target_name
             if lookup_name in barrel:
                 source_file = barrel[lookup_name]
-            source_syms = self._file_symbols.get(source_file, {})
-            if lookup_name in source_syms:
-                return ResolvedCall(
-                    caller_id, source_syms[lookup_name], 0.90, call.line, "import_scoped"
-                )
+            published = self._published(source_file, lookup_name)
+            if published is not None:
+                return ResolvedCall(caller_id, published, 0.90, call.line, "import_scoped")
 
         if not declared:
             return None
@@ -865,11 +886,9 @@ class CallResolver:
             barrel = self._barrel_origins.get(source_file, {})
             if target_name in barrel:
                 source_file = barrel[target_name]
-            source_syms = self._file_symbols.get(source_file, {})
-            if target_name in source_syms:
-                return ResolvedCall(
-                    caller_id, source_syms[target_name], 0.90, call.line, "import_scoped"
-                )
+            published = self._published(source_file, target_name)
+            if published is not None:
+                return ResolvedCall(caller_id, published, 0.90, call.line, "import_scoped")
 
         # 2b: Check all imported files for the symbol (pre-merged lookup)
         merged_syms = self._merged_symbols_for(file_path)
@@ -933,11 +952,9 @@ class CallResolver:
         # Strategy 1: receiver is a module alias (e.g. "import models" → "models.User()")
         module_file = self._module_aliases.get(file_path, {}).get(receiver_name)
         if module_file:
-            source_syms = self._file_symbols.get(module_file, {})
-            if method_name in source_syms:
-                return ResolvedCall(
-                    caller_id, source_syms[method_name], 0.88, call.line, "module_alias"
-                )
+            published = self._published(module_file, method_name)
+            if published is not None:
+                return ResolvedCall(caller_id, published, 0.88, call.line, "module_alias")
             # A namespace over a barrel names a file that declares nothing of
             # its own, so the lookup above can only ever miss. Chase the
             # re-export map, as free calls and typed receivers already do.
@@ -951,21 +968,17 @@ class CallResolver:
             if origin is not None and origin != module_file:
                 binding = self._import_bindings.get(module_file, {}).get(method_name)
                 declared_name = (binding.exported_name if binding else None) or method_name
-                origin_syms = self._file_symbols.get(origin, {})
-                if declared_name in origin_syms:
-                    return ResolvedCall(
-                        caller_id, origin_syms[declared_name], 0.88, call.line, "module_alias"
-                    )
+                published = self._published(origin, declared_name)
+                if published is not None:
+                    return ResolvedCall(caller_id, published, 0.88, call.line, "module_alias")
 
         # Strategy 1b: receiver in import names (non-alias fallback for backward compat)
         name_to_file = self._import_names.get(file_path, {})
         if receiver_name in name_to_file and not module_file:
             source_file = name_to_file[receiver_name]
-            source_syms = self._file_symbols.get(source_file, {})
-            if method_name in source_syms:
-                return ResolvedCall(
-                    caller_id, source_syms[method_name], 0.88, call.line, "module_alias"
-                )
+            published = self._published(source_file, method_name)
+            if published is not None:
+                return ResolvedCall(caller_id, published, 0.88, call.line, "module_alias")
 
         # Strategy 1c: Rust crate-scoped reference (e.g. typst_html::module)
         # The receiver is a crate name, the target is a symbol in that crate's lib.rs

--- a/packages/core/src/repowise/core/ingestion/extractors/visibility.py
+++ b/packages/core/src/repowise/core/ingestion/extractors/visibility.py
@@ -146,6 +146,18 @@ _TS_EXPORT_DEFAULT_RE = re.compile(r"\bexport\s+default\s+([A-Za-z_$][\w$]*)")
 _TS_EXPORT_ASSIGN_RE = re.compile(r"\bexport\s*=\s*([A-Za-z_$][\w$]*)")
 _TS_CJS_EXPORTS_RE = re.compile(r"\bmodule\.exports\b|\bexports\s*[.\[]")
 
+# The same list form, plus whatever follows the closing brace, so a clause with
+# a ``from`` source can be told from one without. Only the source-less form
+# publishes a name for a symbol the file declares itself; the other is a
+# re-export the import pipeline already carries.
+_TS_EXPORT_LIST_SOURCE_RE = re.compile(r"\bexport\s*\{([^}]*)\}\s*(from\b)?")
+
+# Dropped outright rather than blanked: nothing downstream of the alias scan
+# reads a line number, and collapsing a comment between a clause and its
+# ``from`` is what lets the two be told apart at all.
+_TS_BLOCK_COMMENT = re.compile(r"/\*(?:.|\n)*?\*/")
+_TS_LINE_COMMENT = re.compile(r"//.*")
+
 _TS_CLASSLIKE_ANCESTORS = frozenset(
     {
         "class_declaration",
@@ -178,6 +190,45 @@ def ts_deferred_export_names(src: str) -> frozenset[str] | None:
         for m in regex.finditer(src):
             names.add(m.group(1))
     return frozenset(names)
+
+
+def ts_export_aliases(src: str) -> dict[str, str]:
+    """``{exported name: local name}`` for renaming, source-less export clauses.
+
+    ``export { stringType as string }`` is the only place a module states that
+    the symbol it declares as ``stringType`` is published as ``string``. It
+    carries no ``from`` clause, so it is not an import and nothing in the
+    import pipeline records it; the file's symbol table keeps the local name,
+    and every namespace, barrel and member lookup downstream asks for the
+    published one.
+
+    Clauses that do not rename are omitted: the two names agree, so the symbol
+    table already answers and an entry would only duplicate it.
+    """
+    # Every alias is written ``local as exported``, so a file without that
+    # token cannot hold one and need not be scanned. Most files do not, and
+    # the scan is over the whole source.
+    if " as " not in src:
+        return {}
+
+    # Comments are stripped first, and this map is the reason it is worth the
+    # pass. ``ts_deferred_export_names`` reads the same clause unstripped and a
+    # commented-out one only ever mislabels a symbol public; here it would name
+    # a local symbol as some module's published API and mint a call edge to it.
+    cleaned = _TS_LINE_COMMENT.sub("", _TS_BLOCK_COMMENT.sub("", src))
+
+    aliases: dict[str, str] = {}
+    for m in _TS_EXPORT_LIST_SOURCE_RE.finditer(cleaned):
+        if m.group(2):  # ``export { a as b } from "./x"`` — a re-export
+            continue
+        for part in m.group(1).split(","):
+            local, separator, exported = (p.strip() for p in part.partition(" as "))
+            if not separator or not local.isidentifier() or not exported.isidentifier():
+                continue
+            # A name published twice under one spelling has no single answer,
+            # and guessing costs a wrong edge where refusing costs none.
+            aliases[exported] = local if aliases.get(exported, local) == local else ""
+    return {exported: local for exported, local in aliases.items() if local}
 
 
 def refine_ts_visibility(

--- a/packages/core/src/repowise/core/ingestion/models.py
+++ b/packages/core/src/repowise/core/ingestion/models.py
@@ -540,6 +540,11 @@ class ParsedFile:
     symbols: list[Symbol]
     imports: list[Import]
     exports: list[str]  # names exported by this file
+    # ``{exported name: local name}`` where a TS/JS module publishes a symbol
+    # it declares under a different name (``export { stringType as string }``).
+    # Empty for every other language and for the far commoner clause that does
+    # not rename, where the symbol table already answers.
+    export_aliases: dict[str, str] = field(default_factory=dict)
     calls: list[CallSite] = field(default_factory=list)
     heritage: list[HeritageRelation] = field(default_factory=list)
     docstring: str | None = None  # module/file-level docstring

--- a/packages/core/src/repowise/core/ingestion/parser.py
+++ b/packages/core/src/repowise/core/ingestion/parser.py
@@ -54,6 +54,7 @@ from .extractors.visibility import (
     refine_csharp_visibility,
     refine_ts_visibility,
     ts_deferred_export_names,
+    ts_export_aliases,
 )
 from .language_configs import LANGUAGE_CONFIGS, LanguageConfig
 from .languages.registry import REGISTRY as _LANG_REGISTRY
@@ -447,6 +448,7 @@ class ASTParser:
         )
         heritage = extract_heritage(matches, config, file_info, src)
         exports = self._derive_exports(symbols, config, src)
+        export_aliases = ts_export_aliases(src) if lang in _TS_JS_LANGUAGES else {}
         docstring = extract_module_docstring(root, src, lang)
         type_refs = self._extract_type_refs(matches, src, lang)
 
@@ -474,6 +476,7 @@ class ASTParser:
             symbols=symbols,
             imports=imports,
             exports=exports,
+            export_aliases=export_aliases,
             calls=calls,
             heritage=heritage,
             docstring=docstring,

--- a/tests/unit/ingestion/test_star_import_barrel.py
+++ b/tests/unit/ingestion/test_star_import_barrel.py
@@ -174,3 +174,71 @@ def test_star_barrel_edge_survives_global_name_shadow(tmp_path: Path) -> None:
     assert ("caller.py::run", "pkg/leaf.py::helper") in edges, edges
     # and it did NOT mis-resolve to the shadowing method
     assert ("caller.py::run", "other.py::Thing::helper") not in edges, edges
+
+
+def test_namespace_member_resolves_through_a_local_export_alias(tmp_path: Path) -> None:
+    """``export { stringType as string }`` publishes a symbol under a new name.
+
+    The clause carries no ``from``, so it is not an import and the barrel map
+    never sees it; the file's symbol table keeps ``stringType`` while every
+    lookup through the namespace asks for ``string``. A second ``string``
+    elsewhere defeats the global-unique tier, so the edge exists only if the
+    published name is read.
+    """
+    files = {
+        "leaf.ts": (
+            "function stringType(x: number) {\n  return x;\n}\n\n"
+            "export { stringType as string };\n"
+        ),
+        "barrel.ts": 'export * from "./leaf.js";\n',
+        "other.ts": "export class Thing {\n  string(x: number) {\n    return x;\n  }\n}\n",
+        "caller.ts": (
+            'import * as ns from "./barrel.js";\n\n'
+            "export function run() {\n  return ns.string(1);\n}\n"
+        ),
+    }
+    edges = _build_calls(tmp_path, files)
+    assert ("caller.ts::run", "leaf.ts::stringType") in edges, edges
+    assert ("caller.ts::run", "other.ts::Thing::string") not in edges, edges
+
+
+def test_default_export_alias_beats_a_same_named_stranger(tmp_path: Path) -> None:
+    """``export { _set as default }`` against a default import of that module.
+
+    The importer's local name is its own choice, so the only link between the
+    call and the declaration is the alias. Without it the call falls to a
+    weaker tier and binds a same-named symbol in an unrelated file.
+    """
+    files = {
+        "set.ts": "function _set(x: number) {\n  return x;\n}\n\nexport { _set as default };\n",
+        "stranger.ts": "export function set(x: number) {\n  return x;\n}\n",
+        "caller.ts": (
+            'import set from "./set.js";\n\nexport function run() {\n  return set(1);\n}\n'
+        ),
+    }
+    edges = _build_calls(tmp_path, files)
+    assert ("caller.ts::run", "set.ts::_set") in edges, edges
+    assert ("caller.ts::run", "stranger.ts::set") not in edges, edges
+
+
+def test_a_commented_out_export_alias_publishes_nothing(tmp_path: Path) -> None:
+    """A clause inside a comment names no published symbol.
+
+    The alias map decides which local symbol a module's public name reaches, so
+    reading one out of a comment does not mislabel a symbol -- it mints a call
+    edge to a local the module never exported.
+    """
+    files = {
+        "leaf.ts": (
+            "function real(x: number) {\n  return x;\n}\n\n"
+            "// export { real as helper };\n"
+            "/* export { real as helper }; */\n"
+        ),
+        "barrel.ts": 'export * from "./leaf.js";\n',
+        "caller.ts": (
+            'import * as ns from "./barrel.js";\n\n'
+            "export function run() {\n  return ns.helper(1);\n}\n"
+        ),
+    }
+    edges = _build_calls(tmp_path, files)
+    assert ("caller.ts::run", "leaf.ts::real") not in edges, edges


### PR DESCRIPTION
## The defect

A TypeScript or JavaScript module can declare a symbol under one name and export it under another. zod's v3 factory table is the shape:

```ts
const stringType = ZodString.create;

export {
  numberType as number,
  stringType as string,
  // ...40 more
};
```

The clause carries no `from`, so it is not an import and `typescript.scm` captures it as nothing — that query captures an export statement only when it has a `source`, because that is the shape the import pipeline turns into an edge. So the file's symbol table holds `stringType`, and every namespace, barrel and import lookup downstream asks for `string`. **The name a module publishes is recorded nowhere**, and a call through the module's public API reaches no symbol at all.

On zod that is 1,177 call sites behind one `import * as z from "zod/v3"`, three wildcard hops above the file that declares them.

It is also why a call could bind the *wrong* symbol. In next.js's vendored babel helpers, `callSuper.js` does `import isNativeReflectConstruct from "./isNativeReflectConstruct.js"`, and that file exports `_isNativeReflectConstruct as default`. With the published name invisible the call fell through to the global-unique tier and bound `compiled/assert/assert.js::isNativeReflectConstruct` — an unrelated function in a different vendored package.

## The change

- `ts_export_aliases` reads `{exported: local}` per TS/JS file, next to the existing helper that reads the same clause for visibility.
- It rides on `ParsedFile.export_aliases`, empty for every other language.
- `CallResolver._published(file, name)` asks the symbol table first and the alias only on a miss. Five lookups now go through it, so the namespace strategy, its re-export chase and both import-scoped tiers agree.
- The barrel wildcard pass forwards published names as well as declared ones, so a rename survives a hop.

**Additive by construction.** The alias is consulted only where the symbol table already missed, and it is a mapping between two names the module itself writes down — there is no candidate set to choose from and no bare-name pool to fall into.

Comments are stripped before the scan. The neighbouring visibility helper reads the same clause unstripped and does not need to: there a commented-out clause only mislabels a symbol public. Here it would name a local symbol as some module's published API and mint a call edge to it, so the strip is load-bearing and has a test.

## Measurement

Both sides run in one process behind a toggle of the extractor, so the two halves cannot drift on grammar version, corpus walk or resolver state.

| repo | lang | resolved before | after | gained | lost | retargeted |
|---|---|---:|---:|---:|---:|---:|
| zod | ts | 7,981 | **9,175** | 1,194 | 0 | 0 |
| next.js | js | 80,295 | 80,369 | 74 | 0 | 6 |
| vue | ts | 17,532 | 17,552 | 20 | 0 | 0 |
| svelte | js | 10,286 | 10,297 | 11 | 0 | 0 |
| react | js | 16,947 | 16,948 | 1 | 0 | 0 |
| dub, react/ts, hono, svelte/ts, solid, preact, vitepress, taxonomy, express, vue/js | — | — | — | **0** | 0 | 0 |

**+1,300 across fifteen repository/language pairs, nothing lost anywhere, no call site lost, and symbols, heritage and imports byte-identical on every one.** Four repositories in untouched languages — python, C#, Go and Java — are byte-identical.

zod's recall rises on every denominator: 24.81% → 28.53% of captured sites, 23.68% → 27.22% of AST invocation nodes, 23.04% → 26.48% of invocations plus constructions. Capture is untouched, so all three move by the same edges.

**Precision: 42 gained edges hand-read at both ends of the chain — the call as written, the statement that binds the name, the export clause at the far end — across four repositories, and all 42 are correct.** The 6 retargets were read from source too and all 6 are corrections: each replaces a wrong edge into an unrelated vendored package with the right one.

Cost is within measurement noise on parse and build. No dead-code finding moves on zod, vue or svelte.

## Scope

The shape is small in every repository and consumed heavily in one: 58 clauses in zod, 197 in next.js, between zero and twenty everywhere else. That is why eight of the corpus repositories gain nothing — expected, and sized before the code was written rather than discovered after.

Two guard tests for the resolution, one for the comment strip; each fails without the change. `tests/unit/ingestion` passes, 2,408 tests.

## Follow-up, not in this PR

`analysis/dead_code/analyzer.py` already carries a near-identical regex over the same clause in the opposite direction. Consolidating the two belongs in `extractors/visibility.py` and in a PR that owns that directory.
