### PR TITLE
feat(graph): capture three call receivers a bare-name match was guessing

### DIFF
--- a/packages/core/src/repowise/core/ingestion/call_resolver.py
+++ b/packages/core/src/repowise/core/ingestion/call_resolver.py
@@ -951,6 +951,17 @@ class CallResolver:
         if method_name not in self._global_symbols:
             return None
 
+        # The caller's own file first. Every other tier is ordered narrow-first
+        # and this one was not: the language strategies below run before
+        # ``_receiver_pair_match``, so ``_resolve_jvm_receiver_same_package``
+        # claimed ``new Builder<>(...).build()`` for any same-package class of
+        # that name — a test-source-set one included — while the caller's own
+        # file declared a private inner ``Builder`` on the same page. The
+        # narrowest scope that can answer is the one the call actually means.
+        own_file = self._file_methods.get(file_path, {}).get((receiver_name, method_name))
+        if own_file is not None and own_file != caller_id:
+            return ResolvedCall(caller_id, own_file, 0.93, call.line, "receiver_same_file")
+
         # A language may reach a receiver no import statement mentions: a Go
         # package alias spanning several files, a JVM class in the same package.
         for strategy in self._strategies_for(file_path).member:

--- a/packages/core/src/repowise/core/ingestion/queries/java.scm
+++ b/packages/core/src/repowise/core/ingestion/queries/java.scm
@@ -103,6 +103,51 @@
   arguments: (argument_list) @call.arguments
 ) @call.site
 
+; Self-dispatch: this.method(args). The pattern above claims ``this.field.m()``
+; and the bare pattern claims everything, so without this a plain ``this.m()``
+; arrives receiver-less and is read as an implicit receiver — which resolves by
+; bare name through the flat same-file index instead of against the caller's own
+; class.
+;
+; ``super`` is deliberately NOT in this alternation, and the reason is narrower
+; than "super is unsafe". Capturing any receiver makes the bare twin
+; member-shaped, which suppresses ``_enclosing_class_method``'s recursion
+; refusal — the guard that emits no edge when the flat index hands a method its
+; own name. The call then falls through to the same-file tier, and THAT is only
+; wrong when the file declares the target name on MORE THAN ONE class: the flat
+; index is last-wins, so it answers with a sibling's method.
+;
+; So the hazard is a property of the file, not of the keyword, and ``this`` is
+; not immune to it — it is merely far less likely to sit in such a file.
+; Measured on caffeine: ``super`` costs 2 wrong edges (``DelegationBenchmark``
+; declares ``get`` on both ``InheritMap`` and ``DelegateMap``), while all 3
+; self-recursive ``this.add()`` sites are safe because ``IntegerSum`` is the only
+; class in its file declaring ``add`` and the ``callee != caller`` guard then
+; refuses. ``super`` is excluded because its population sits in override-heavy
+; files where sibling classes share names; that costs recall only, which is the
+; right direction to err in. If a future session adds ``super``, the fix it
+; needs first is a same-file index keyed by class, not a wider capture.
+(method_invocation
+  object: (this) @call.receiver
+  name: (identifier) @call.target
+  arguments: (argument_list) @call.arguments
+) @call.site
+
+; Fluent construction: new Foo().bar(args). The receiver type is written at the
+; call site, so this lands on the receiver-names-a-class tier — which only binds
+; when that class declares the method — instead of the bare-name pool. Same
+; shape as csharp.scm's ``new Builder().Method()`` (#1680).
+(method_invocation
+  object: (object_creation_expression
+    type: [
+      (type_identifier) @call.receiver
+      (generic_type (type_identifier) @call.receiver)
+    ]
+  )
+  name: (identifier) @call.target
+  arguments: (argument_list) @call.arguments
+) @call.site
+
 ; Chained method call: obj.method1().method2(args)
 (method_invocation
   object: (method_invocation)

--- a/packages/core/src/repowise/core/ingestion/queries/ruby.scm
+++ b/packages/core/src/repowise/core/ingestion/queries/ruby.scm
@@ -55,3 +55,20 @@
   receiver: (identifier) @call.receiver
   method: (identifier) @call.target
 ) @call.site
+
+; Namespaced class/module method call: Foo::Bar.baz(args).
+;
+; The pattern above constrains the receiver to a bare ``constant``, and the
+; simple-call pattern constrains nothing, so a namespaced receiver arrives with
+; no receiver at all and resolves by bare name.
+;
+; The TRAILING constant is captured rather than the whole path, because that is
+; the name the class index holds — so no receiver normalizer is needed (contrast
+; ``_normalize_php_receiver``). The collapse is lossy and its cost is known and
+; stated: ``A::Foo`` and ``B::Foo`` both offer ``Foo``, so a short class name
+; reused across sibling gems in one repo can bind to the wrong namespace. Fixing
+; that needs Ruby module nesting in the index, which this does not build.
+(call
+  receiver: (scope_resolution name: (constant) @call.receiver)
+  method: (identifier) @call.target
+) @call.site


### PR DESCRIPTION
When a tree-sitter query matches a method call but doesn't capture its receiver, the call reaches the resolver as a bare name — and a bare name matches whatever symbol of that name the index happens to hold, which is often the wrong one.

Three call shapes were being dropped that way. This captures their receivers so each lands on a tier that only binds when the named class actually declares the method.

## What ships

| | Java (`java.scm`) | Ruby (`ruby.scm`) |
|---|---|---|
| shapes | `this.m(x)`, `new Foo().bar(x)` | `Foo::Bar.baz(x)` |
| resolved calls | **+96** (4 repos) | **+136** (2 repos) |
| lost | **0** | **0** |
| retargeted | 10 (all from the resolver fix below) | 0 |

| repo | resolved | delta | lost | gained | retargeted |
|---|---|---|---|---|---|
| caffeine | 65,640 -> 65,674 | +34 | 3 | 37 | 3 |
| jhipster-sample-app | 3,190 -> 3,248 | +58 | 0 | 58 | 0 |
| javalin | 3,766 -> 3,769 | +3 | 7 | 10 | 7 |
| spring-petclinic | 412 -> 413 | +1 | 0 | 1 | 0 |
| jekyll | 2,601 -> 2,703 | +102 | 0 | 102 | 0 |
| sinatra | 2,350 -> 2,384 | +34 | 0 | 34 | 0 |

No new bare-name resolution anywhere — every added edge comes from a validated `(class, method)` pair.

**Call site counts rise, and that is a cost rather than a result.** The parser deduplicates on `(line, target, receiver)`, so adding a receiver-bearing pattern mints a *second* site for the same call and the receiver-less one survives alongside it. 696 new sites buy 232 edges. The number that matters is the 0 lost.

## Precision

Every added edge was read against the source by hand. On the smaller repo of each language the whole population was read; the larger was sampled.

| population | read | correct | precision |
|---|---|---|---|
| Java caffeine (whole population) | 34 | 34 | **100%** |
| Java jhipster (sampled) | 40 | 40 | **100%** |
| **Java pooled** | **74** | **74** | **100%** |
| Ruby jekyll (sampled) | 52 | 52 | **100%** |
| Ruby sinatra (whole population) | 34 | 27 | **79.4%** |
| **Ruby pooled** | **86** | **79** | **91.9%** |

Split by mechanism, since the two Java captures ship together: `this.m()` is 33/33 and `new Foo().bar()` is 41/41.

## Second commit: resolver tier ordering

`_resolve_member_call` ran the language-specific `member` strategies before `_receiver_pair_match`. For the JVM that meant `_resolve_jvm_receiver_same_package` claimed `new Builder<>(...).build()` for *any* same-package class of that name — including one from the test source set — while the calling file declared a private inner `Builder` on the same page. Every other tier in the resolver is ordered narrowest-scope-first; this one was not.

caffeine's `MultiQueuePolicy` and `S4LruPolicy` were bound to **each other's** `Node::sentinel`, in both directions.

Pure retarget: 10 edges across 4 Java repos, 0 net change, and the whole 10-row population was hand-read at **10/10 correct**. It is what takes Java from 73/74 to 74/74.

The tier itself is not new — `_receiver_pair_match` already consulted `_file_methods` on this key at this confidence. This only moves it above the strategy loop, so it cannot bind a pair that was not already bindable.

## Shapes that were built and refused

| shape | population | measured | verdict |
|---|---|---|---|
| Java `super.m(x)` | 64 sites | **2 wrong edges on caffeine** | refused |
| Java `a.b.m(x)` | 1,105 sites | 224 receiver sites, **+0 resolved** | refused |
| Ruby `@ivar.m(x)` | 626 sites | 396 receiver sites, **+0 resolved** | refused |
| Ruby `self.m(x)` | 28 sites | **+0 resolved** | refused |
| Ruby class-name ambiguity guard | — | **-252 net edges on jekyll** | refused |
| chained `a.m().n(x)` | 22,321 java + 1,566 ruby | out of scope here | not attempted |

`super` is the one worth reading, because the reason is not "super is unsafe".

Capturing *any* receiver makes the receiver-less twin member-shaped, which suppresses `_enclosing_class_method`'s recursion refusal — the guard that emits no edge when the flat index hands a method its own name. The call then falls through to the same-file tier, and that is only wrong when **the file declares the target name on more than one class**, because the flat index is last-wins and answers with a sibling's method.

So the hazard is a property of the file, not of the keyword, and `this` is **not** immune to it — merely far less likely to meet it. Measured on caffeine: all 3 self-recursive `this.add()` sites are safe because `IntegerSum` is the only class in its file declaring `add`, while `DelegationBenchmark` declares `get` on two sibling classes and that is exactly where `super` produces the wrong edge. `super` is excluded because its population lives in override-heavy files where sibling classes share names; that costs recall only. The prerequisite for ever adding it is a same-file index keyed by class, not a wider capture.

**This regression appears as a gained wrong edge, never as a lost one**, so a gate that only compares edge counts would have passed it.

The three `+0 resolved` refusals share one structural cause: Ruby is in neither implicit-receiver language set and registers no call strategies, so a captured Ruby receiver reaches no tier that can type it.

## Known defect, shipped deliberately

Ruby's 79.4% on sinatra is a single systematic failure. The pattern captures the trailing constant of the scope resolution, because that is the name the class index holds — which collapses `Rack::Protection::Base` and `Sinatra::Base` onto `Base`. Only Sinatra's declares `new`, so all 7 wrong edges are `Rack::Protection::Base.new` binding into Sinatra.

Two guards were built and both refused: a pair-ambiguity guard has **zero effect** (the `(Base, new)` pair really is unique — the namespace is what is ambiguous), and a class-name-ambiguity guard kills all 7 but costs **345 existing jekyll edges**. The sound fix needs Ruby module nesting in the index, which this does not build; it is filed separately.

Shipped because refusing would cost 136 edges to avoid 7. But **91.9% should not be quoted as "Ruby precision"** — it is two repos, one of which contains the adversarial shape and one of which does not, and a Ruby monorepo vendoring gems in-tree could read below 79%.

## Verification

- Symbols, heritage and imports **byte-identical** on every repo measured, hashed rather than counted
- Controls **byte-identical**: gitleaks (go), zod (ts), celery (python), Ocelot (csharp)
- Resolver reorder unmoved on **10 repos**, including exposed and ktor (kotlin) and hugo and gin-vue-admin (go). go, java and kotlin are the only languages registering a `member` strategy; csharp and python register only `member_fallback`, which already ran later, so they cannot be reached by the change
- **Dead code findings 0 moved** on 6 repos
- Cost -0.91% to +2.96% of parse plus build
- 2,754 tests pass, 1 skipped; ruff clean

Both sides of every measurement ran in a single process behind a toggle of the query text, rather than across two checkouts, so no result carries a machine-state difference.
