### PR TITLE
feat(graph): type a Kotlin call receiver from its declaration

### DIFF
--- a/packages/core/src/repowise/core/ingestion/call_resolver.py
+++ b/packages/core/src/repowise/core/ingestion/call_resolver.py
@@ -126,11 +126,12 @@ _LANGUAGE_CALL_STRATEGIES: dict[str, _LanguageCallStrategies] = {
         member=("_resolve_go_package_call",),
         member_fallback=_TYPED_RECEIVER,
     ),
-    # Kotlin shares the JVM tiers but not the typed-receiver fallback: it has
-    # no declaration shapes yet, so registering it would promise a resolution
-    # the language gate immediately declines.
+    # Kotlin shares the JVM tiers and, since its declaration shapes landed,
+    # the typed-receiver fallback too. One `name: Type` shape reaches its
+    # typed vals, vars and parameters alike, so the language gate no longer
+    # declines the moment the fallback asks.
     "java": replace(_JVM_STRATEGIES, member_fallback=_TYPED_RECEIVER),
-    "kotlin": _JVM_STRATEGIES,
+    "kotlin": replace(_JVM_STRATEGIES, member_fallback=_TYPED_RECEIVER),
     "csharp": _LanguageCallStrategies(member_fallback=_TYPED_RECEIVER),
     "python": _LanguageCallStrategies(member_fallback=_TYPED_RECEIVER),
     "cpp": _CPP_STRATEGIES,

--- a/packages/core/src/repowise/core/ingestion/languages/receiver_types.py
+++ b/packages/core/src/repowise/core/ingestion/languages/receiver_types.py
@@ -23,7 +23,7 @@ Adding a language means adding its shapes to ``_LANGUAGE_PATTERNS``; a
 language absent from it is excluded by construction. Two smaller tables sit
 beside it: ``_FRAMEWORK_DECORATOR_TYPES``, for a decorator that changes what
 the symbol it wraps is, and ``_PY_BINDINGS``, which says only that a name is
-taken -- a refusal rather than a type.
+taken — a refusal rather than a type.
 """
 
 from __future__ import annotations
@@ -70,6 +70,20 @@ _HASH_COMMENT = re.compile(r"#.*")
 # so triple-quoted runs are blanked, keeping their newlines so line numbers
 # survive.
 _DOCSTRING = re.compile(r"(\"\"\"|''')(?:.|\n)*?\1")
+
+# A block comment, blanked to its newlines so line numbers survive. Kotlin
+# needs this where Java and C# do not, and the asymmetry is in the shapes
+# rather than in the languages: KDoc writes `@param connection: Store`, which
+# is exactly Kotlin's `name: Type`, while javadoc's `@param connection the
+# Store` is not the C family's `Type name`. Measured on the same text — the
+# Kotlin scan fabricated `connection: Store` from prose and the Java scan
+# returned nothing.
+#
+# Run before the line strip, not after: truncating at `//` first would eat the
+# `*/` out of `/* see http://x */` and leave the opener unterminated. As with
+# `//`, a `/*` inside a string literal is over-matched, which can only ever
+# lose a declaration and never invent one.
+_BLOCK_COMMENT = re.compile(r"/\*(?:.|\n)*?\*/")
 
 _NEWLINE = re.compile(r"\n")
 
@@ -147,16 +161,80 @@ _GO_SHORT_DECL = re.compile(
 # the one shape neither pattern above reaches.
 _GO_VAR_DECL = re.compile(rf"(?<![\w.])var\s+(?P<name>{_GO_NAME})\s+\*?(?P<type>{_GO_TYPE})")
 
+# Kotlin annotates after the name, as Python does, and one shape reaches every
+# declaration that matters: `val x: Foo`, `var x: Foo`, `fun f(x: Foo)` and a
+# primary constructor's `class A(val x: Foo)` are all `name: Type`. Measured
+# over ktor and exposed, that one shape is 6,291 typed `val`s, 1,242 `var`s and
+# ~8,800 parameters, against 1,183 for the constructor shape below.
+#
+# The type reuses the C family's `_TYPE`, so a generic is matched and reduced to
+# its bare name. That is right in Kotlin and wrong in Python for the same
+# reason spelled backwards: `List<Foo>` bares to `List`, a builtin the language
+# spec refuses downstream, while `Column<T>` bares to `Column`, which is the
+# type the value actually has. Python's `Optional[T]` had no such reading, which
+# is why `_PY_ANNOTATED` refuses a generic outright.
+#
+# A trailing `?` is consumed rather than refused: `Foo?` is still a `Foo` at the
+# call site, and it is 15% of ktor's typed declarations.
+#
+# `by` closes a declaration as well as the punctuation does. `val x: Foo by
+# lazy { ... }` is a delegated property, `x` is a `Foo`, and without this the
+# whole idiom types nothing. It is a word rather than a symbol, so it is an
+# alternation and not another character in the class — and it can never be a
+# field closer, which is the conservative reading: a delegated property at
+# class scope stays untyped rather than being guessed at.
+#
+# The `val`/`var` keyword is captured, optional, and read by nothing except
+# field classification. A parameter is `name: Type` with no keyword, and a
+# primary constructor's `class C(timeout: Duration = 5.seconds)` therefore
+# closes on `=` at class scope exactly as a real property does — so without
+# this group `timeout` is registered as a field it is not, since a parameter
+# with no `val`/`var` is not a property and no method body can name it.
+# Blanking the closer is what refuses it; body typing is unaffected either
+# way, because only `types_by_class` reads a closer at all.
+#
+# `(` is deliberately not a closer. It is what keeps the pattern off an
+# annotation use-site target — `@get:JvmName("x")` reads as `get: JvmName`.
+#
+# A function type's own parameters are reached incidentally: `statement:
+# Transaction.(dest: Dest) -> Unit` presents `dest: Dest` to the same pattern.
+# That is kept rather than excluded — the hand-read found 3 such rows and all
+# 3 were right, and the validator makes a wrong one cost an edge, not an error.
+_KT_ANNOTATED = re.compile(
+    rf"(?<![\w.])(?:(?P<keyword>va[lr])\s+)?(?P<name>[a-z_]\w*)\s*:\s*"
+    rf"(?P<type>{_TYPE})\??\s*(?=(?P<closer>[=,)\n]|by\b))"
+)
+
+# `val x = Foo(...)`, the shape an inferred Kotlin declaration takes. Anchored
+# to `val`/`var` rather than to the start of a statement, which is what Python's
+# equivalent needed: Kotlin spells a named argument with `=` too, so
+# `dispatch(logger = Emitter())` is otherwise read as declaring `logger`.
+# Bare-named on purpose — `val x = Foo.bar()` is a call on a class, and typing
+# `x` as `Foo` from it would simply be wrong.
+#
+# The lookahead refuses a chain: `val x = Builder().build()` makes `x` whatever
+# `build()` returns, not a `Builder`, and typing it as one is a wrong answer
+# rather than a missing one. `_PY_CONSTRUCTED` has the same shape and does not
+# refuse it; moving Python is its own measured change and is not made here.
+# `[^()]*` cannot cross a nested call, so `Foo(bar(1)).baz()` is still typed --
+# a stated ceiling, and the same direction of error as today rather than a new
+# one.
+_KT_CONSTRUCTED = re.compile(
+    r"(?<![\w.])va[lr]\s+(?P<name>[a-z_]\w*)\s*=\s*(?P<type>[A-Z]\w*)\s*\((?![^()]*\)\s*\.)"
+)
+
 _C_FAMILY = (_TYPED_DECLARATION, _INFERRED_FROM_NEW)
 # No Go shape captures a closer, so every Go declaration carries ``""`` and
 # class scope would drop all of them. That is the intended reading: Go is not
 # in IMPLICIT_FIELD_LANGUAGES and must not be.
 _GO_FAMILY = (_GO_PARAM, _GO_SHORT_DECL, _GO_VAR_DECL)
+_KT_FAMILY = (_KT_ANNOTATED, _KT_CONSTRUCTED)
 
 _LANGUAGE_PATTERNS: dict[str, tuple[re.Pattern[str], ...]] = {
     "csharp": _C_FAMILY,
     "go": _GO_FAMILY,
     "java": _C_FAMILY,
+    "kotlin": _KT_FAMILY,
     "python": (_PY_ANNOTATED, _PY_CONSTRUCTED),
 }
 
@@ -167,7 +245,18 @@ RECEIVER_TYPE_LANGUAGES = frozenset(_LANGUAGE_PATTERNS)
 # writes ``self.foo.bar()``, whose receiver is dotted and which our grammar
 # queries mint no call site for at all — so class scope has nothing there to
 # answer, and consulting it could only bind a bare local name to a field.
-IMPLICIT_FIELD_LANGUAGES = frozenset({"csharp", "java"})
+#
+# Kotlin is here on a count rather than on its semantics, which is the lesson
+# bug 63 cost: Python has implicit field access too, and registering it would
+# have promised nothing, because only 1.8% of its field receivers are typed
+# where this scan looks. Kotlin declares a property at class scope in its own
+# idiom, and the scan does find them — 56 of ktor's 1,349 gained edges and 100
+# of exposed's 320, hand-read 10/10 correct. Small, and measured.
+#
+# Only a `val`/`var` reaches class scope. A primary-constructor parameter with
+# a default closes on `=` there too and is not a property at all, which is why
+# `_KT_ANNOTATED` captures the keyword.
+IMPLICIT_FIELD_LANGUAGES = frozenset({"csharp", "java", "kotlin"})
 
 # A decorator that changes what the symbol it wraps *is*: `@shared_task` leaves
 # no function behind, so `add.s(...)` is a method call and `(Task, s)` a
@@ -267,10 +356,15 @@ def framework_decorated_type(decorators: Iterable[str], language: str) -> str | 
                 return type_name
     return None
 
+_LANGUAGE_BLOCK_COMMENTS: dict[str, re.Pattern[str]] = {
+    "kotlin": _BLOCK_COMMENT,
+}
+
 _LANGUAGE_COMMENTS: dict[str, re.Pattern[str]] = {
     "csharp": _LINE_COMMENT,
     "go": _LINE_COMMENT,
     "java": _LINE_COMMENT,
+    "kotlin": _LINE_COMMENT,
     "python": _HASH_COMMENT,
 }
 
@@ -324,6 +418,9 @@ def scan_declarations(text: str, language: str) -> tuple[Declaration, ...]:
     cleaned = text
     if language == "python":
         cleaned = _DOCSTRING.sub(lambda m: "\n" * m.group(0).count("\n"), cleaned)
+    block = _LANGUAGE_BLOCK_COMMENTS.get(language)
+    if block is not None:
+        cleaned = block.sub(lambda m: "\n" * m.group(0).count("\n"), cleaned)
     comment = _LANGUAGE_COMMENTS.get(language)
     if comment is not None:
         cleaned = comment.sub("", cleaned)
@@ -343,12 +440,19 @@ def scan_declarations(text: str, language: str) -> tuple[Declaration, ...]:
             type_name = resolved[raw]
             if type_name is None:
                 continue
+            groups = match.groupdict()
+            # A shape that names a declaration keyword and did not match one
+            # is not a declaration that can own a field — see `_KT_ANNOTATED`.
+            # Shapes with no `keyword` group are unaffected.
+            closer = groups.get("closer") or ""
+            if "keyword" in groups and not groups["keyword"]:
+                closer = ""
             found.append(
                 Declaration(
                     bisect_right(starts, match.start()),
                     match.group("name"),
                     type_name,
-                    match.groupdict().get("closer") or "",
+                    closer,
                 )
             )
 

--- a/tests/unit/ingestion/test_receiver_types.py
+++ b/tests/unit/ingestion/test_receiver_types.py
@@ -224,10 +224,179 @@ class TestRefusals:
         assert declared_types("void run() { // a Node node; once lived here\n }", "java") == {}
 
     def test_an_unregistered_language_yields_nothing(self) -> None:
-        # Kotlin rather than Go: Go registered its shapes and now types this
-        # exact line. Kotlin is still one of the languages P8 left unattempted.
-        body = "fun run(w: TimerWheel) { }"
+        # Ruby rather than Kotlin: Kotlin registered its shapes and now types
+        # `w: TimerWheel`. Ruby is one of the languages P8 left unattempted,
+        # and it annotates nothing to begin with.
+        body = "def run(w)\n  w.tick\nend"
+        assert declared_types(body, "ruby") == {}
+
+
+class TestKotlinShapes:
+    """Kotlin annotates after the name, and one shape reaches almost all of it.
+
+    A typed `val`, a typed `var`, a function parameter and a primary
+    constructor's property are all `name: Type`, which is why there is one
+    annotation pattern here rather than four. Measured over ktor and exposed,
+    it is 6,291 typed `val`s, 1,242 `var`s and roughly 8,800 parameters,
+    against 1,183 for the construction shape.
+    """
+
+    def test_a_typed_val(self) -> None:
+        body = "fun run() {\n    val ctx: PipelineContext = call.context\n}"
+        assert declared_types(body, "kotlin")["ctx"] == "PipelineContext"
+
+    def test_a_typed_var(self) -> None:
+        body = "fun run() {\n    var engine: HttpEngine = make()\n}"
+        assert declared_types(body, "kotlin")["engine"] == "HttpEngine"
+
+    def test_a_parameter(self) -> None:
+        body = "fun handle(call: ApplicationCall, n: Int) { call.respond() }"
+        assert declared_types(body, "kotlin")["call"] == "ApplicationCall"
+
+    def test_a_parameter_in_a_multi_line_signature(self) -> None:
+        body = "fun handle(\n    request: HttpRequest,\n    n: Int,\n) { }"
+        assert declared_types(body, "kotlin")["request"] == "HttpRequest"
+
+    def test_a_primary_constructor_property(self) -> None:
+        body = "class Server(private val config: ServerConfig) { }"
+        assert declared_types(body, "kotlin")["config"] == "ServerConfig"
+
+    def test_a_construction(self) -> None:
+        body = "fun run() {\n    val registry = PluginRegistry()\n}"
+        assert declared_types(body, "kotlin")["registry"] == "PluginRegistry"
+
+    def test_a_nullable_type_keeps_its_type(self) -> None:
+        """``Foo?`` is still a ``Foo`` at the call site, and it is 15% of
+        ktor's typed declarations. Refusing it refuses a correct answer."""
+        body = "fun run() {\n    val timeout: Duration? = null\n}"
+        assert declared_types(body, "kotlin")["timeout"] == "Duration"
+
+    def test_a_generic_keeps_its_outer_type(self) -> None:
+        """The reverse of Python's rule, for the same reason spelled
+        backwards: Kotlin's ``Column<T>`` *is* a ``Column``, where Python's
+        ``Optional[T]`` is not a ``T``."""
+        body = "fun run(column: Column<String>) { }"
+        assert declared_types(body, "kotlin")["column"] == "Column"
+
+
+class TestKotlinRefusals:
+    def test_a_builtin_generic_is_refused(self) -> None:
+        """``List<Header>`` bares to ``List``, which the language spec refuses
+        — and must, because the value is a List and not a Header."""
+        body = "fun run() {\n    val items: List<Header> = call.headers\n}"
+        assert "items" not in declared_types(body, "kotlin")
+
+    def test_a_named_argument_is_not_a_declaration(self) -> None:
+        """Kotlin spells a named argument with ``=``, which is why the
+        construction shape is anchored to ``val``/``var`` rather than to the
+        start of a statement as Python's is."""
+        body = "fun run() {\n    dispatch(logger = Emitter())\n}"
         assert declared_types(body, "kotlin") == {}
+
+    def test_a_factory_call_is_not_a_construction(self) -> None:
+        """``Store.of(call)`` is a call on a class. Reading the qualifier's
+        last segment types ``cache`` as ``of``, which it briefly did."""
+        body = "fun run() {\n    val cache = Store.of(call)\n}"
+        assert "cache" not in declared_types(body, "kotlin")
+
+    def test_an_annotation_use_site_target_is_not_a_declaration(self) -> None:
+        """``@get:JvmName("x")`` reads as ``get: JvmName``. ``(`` is kept out
+        of the closer set precisely to refuse it."""
+        body = 'class C {\n    @get:JvmName("x")\n    fun f() { }\n}'
+        assert declared_types(body, "kotlin") == {}
+
+    def test_a_builtin_type_is_refused(self) -> None:
+        assert declared_types("fun run(name: String, n: Int) { }", "kotlin") == {}
+
+    def test_a_declaration_in_a_line_comment_is_ignored(self) -> None:
+        body = "fun run() { // a val node: Node once lived here\n }"
+        assert declared_types(body, "kotlin") == {}
+
+    def test_a_supertype_clause_is_not_a_declaration(self) -> None:
+        """Kotlin spells inheritance with the same colon. The name group being
+        lowercase-anchored is all that separates the two."""
+        assert declared_types("class Server : BaseServer() { }", "kotlin") == {}
+
+    def test_kotlin_reaches_class_scope(self) -> None:
+        """Unlike Python's, a Kotlin property is named with no qualifier, so a
+        class-scope declaration can answer for a bare receiver. It earned 56 of
+        ktor's 1,349 gained edges — small, and measured rather than assumed."""
+        assert "kotlin" in IMPLICIT_FIELD_LANGUAGES
+
+    def test_a_class_scope_property_is_a_field(self) -> None:
+        source = (
+            "class C {\n    private val logger: Logger = make()\n"
+            "    fun f() {\n        logger.debug()\n    }\n}"
+        )
+        assert fields(source, "kotlin", [(3, 5)])["logger"] == "Logger"
+
+    def test_a_local_is_not_a_field(self) -> None:
+        source = "class C {\n    fun f() {\n        val local: Logger = make()\n    }\n}"
+        assert "local" not in fields(source, "kotlin", [(2, 4)])
+
+
+    def test_a_chained_construction_types_nothing(self) -> None:
+        """``val x = Builder().build()`` makes ``x`` whatever ``build()``
+        returns, so typing it as a ``Builder`` is a wrong answer rather than a
+        missing one. ``_PY_CONSTRUCTED`` still has this shape; moving Python is
+        its own measured change."""
+        body = "fun f() {\n    val x = Builder().build()\n}"
+        assert declared_types(body, "kotlin") == {}
+
+    def test_a_nested_argument_chain_is_a_stated_ceiling(self) -> None:
+        """``[^()]*`` cannot cross a nested call, so this one is still typed.
+        The same direction of error as before the guard, not a new one."""
+        body = "fun f() {\n    val x = Builder(g(1)).build()\n}"
+        assert declared_types(body, "kotlin")["x"] == "Builder"
+
+    def test_a_kdoc_block_comment_is_not_a_declaration(self) -> None:
+        """KDoc writes ``@param connection: Store``, which is exactly Kotlin's
+        declaration shape -- unlike javadoc's ``@param connection the Store``,
+        which is not the C family's. Kotlin needs a block strip where Java does
+        not, and this fabricated a type from prose before it had one."""
+        body = "/**\n * @param connection: Store\n */\nfun run() { }"
+        assert declared_types(body, "kotlin") == {}
+
+    def test_the_java_scan_does_not_need_the_block_strip(self) -> None:
+        """The asymmetry is in the shapes, not the languages. Measured on the
+        same text, so the Kotlin-only table is a decision rather than an
+        oversight."""
+        body = "/**\n * @param connection the Store connection\n */\nvoid run() { }"
+        assert declared_types(body, "java") == {}
+
+
+class TestKotlinDelegation:
+    def test_a_delegated_property_is_typed(self) -> None:
+        """``by`` closes a declaration as well as punctuation does, and without
+        it the whole ``by lazy`` idiom types nothing."""
+        body = "fun f() {\n    val cache: Store by lazy { make() }\n}"
+        assert declared_types(body, "kotlin")["cache"] == "Store"
+
+
+class TestKotlinFieldScope:
+    def test_a_constructor_parameter_with_a_default_is_not_a_field(self) -> None:
+        """It closes on ``=`` at class scope exactly as a property does, and it
+        is not a property at all -- no ``val``/``var``, so no method body can
+        name it. The captured keyword is what tells the two apart."""
+        source = (
+            "class C(port: Int, timeout: Duration = Duration.seconds(5)) {\n"
+            "    fun run() { timeout.toString() }\n}"
+        )
+        assert "timeout" not in fields(source, "kotlin", [(2, 2)])
+
+    def test_a_constructor_property_with_a_default_is_still_read(self) -> None:
+        """The guard must not take the real property beside it."""
+        source = (
+            "class C {\n    private var timeout: Duration = Duration.seconds(5)\n"
+            "    fun run() { timeout.toString() }\n}"
+        )
+        assert fields(source, "kotlin", [(3, 3)])["timeout"] == "Duration"
+
+    def test_a_parameter_is_never_a_field(self) -> None:
+        """A `fun` parameter carries no keyword either, so class scope drops it
+        whatever punctuation follows."""
+        source = "class C {\n    fun run(timeout: Duration = d) { }\n}"
+        assert fields(source, "kotlin", []) == {}
 
 
 class TestGoShapes:
@@ -357,7 +526,7 @@ class TestClassScope:
 
 def test_the_language_set_is_what_the_patterns_declare() -> None:
     """Excluding a language means removing its shapes, not gating a caller."""
-    assert set(RECEIVER_TYPE_LANGUAGES) == {"csharp", "go", "java", "python"}
+    assert set(RECEIVER_TYPE_LANGUAGES) == {"csharp", "go", "java", "kotlin", "python"}
 
 
 def test_go_is_not_a_field_language() -> None:


### PR DESCRIPTION
`_resolve_typed_receiver` works out what `x` is from its declaration and emits `x.foo()` only where that type declares `foo`, so a mis-inference costs a missing edge and never a wrong one. It was registered for csharp, go, java and python. Kotlin was not one of them, because it had no declaration shapes and registering it would have promised a resolution the language gate immediately declined.

## What it took

Counting the shapes over ktor and exposed before writing any pattern found that Kotlin spells nearly all of them one way. A typed `val`, a typed `var`, a function parameter and a primary constructor's property are all `name: Type`:

| shape | ktor | exposed |
|---|---:|---:|
| `fun f(x: Foo)` parameters | 5,939 | 2,850 |
| `val x: Foo` | 5,011 | 1,280 |
| `var x: Foo` | 1,048 | 194 |
| `val x = Foo(...)` | 1,006 | 177 |
| `var x = Foo(...)` | 4 | 0 |

So this is two patterns rather than the four or five it looked like, and `var x = Foo()` was refused on a count of 4 across both repos.

## Results

Both sides run in one process behind a toggle of `_LANGUAGE_PATTERNS`, never two checkouts, so the halves cannot drift on grammar version, corpus walk or resolver state.

| repo | distinct sites | resolved before to after | gained | lost | recall |
|---|---:|---:|---:|---:|---|
| ktor | 63,020 | 24,742 to 26,055 | **+1,314** | **0** | 39.3% to **41.3%** |
| exposed | 33,073 | 12,444 to 12,760 | **+316** | **0** | 37.6% to **38.6%** |
| javalin | 10,375 | 2,426 to 2,629 | **+203** | **0** | 23.4% to **25.3%** |

No query changed, so call sites are byte-identical either side and recall rises on an unchanged denominator.

| gate | result |
|---|---|
| Symbols, heritage, imports, node counts | byte-identical on all three repos |
| Controls | flask, gitleaks, caffeine, eShopOnWeb all byte-identical, 0 gained, 0 lost |
| Cost | +0.50% to +5.19% of parse and build, against a 15% bar |
| Dead code | 0 moved, per kind and in total, on exposed (355) and javalin (19) |
| Precision | **61 of 62** rows hand-read from source, 98.4%. Body scope 50/51, field scope 11/11 |

caffeine is the control that matters: java shares `_C_FAMILY` and `IMPLICIT_FIELD_LANGUAGES`, both of which this touches, and its 65,674 resolved calls do not move by one.

## Kotlin also joins `IMPLICIT_FIELD_LANGUAGES`

On a count rather than on the language's semantics. Kotlin, Swift and C++ all have implicit `this`, so registering them looks obviously right, and that reasoning is what bug 63 cost the last time it was applied to Python for a 1.8% payoff. Kotlin qualifies because it declares a property at class scope in its own idiom rather than in an initialiser body. Class scope earns 163 of the edges above, 4.3% of ktor's gain and 31.6% of exposed's, and it carries its own origin literals so it can be dropped without touching the body-scope half.

Two ceilings, stated rather than left to be discovered. `_FIELD_CLOSERS` admits `=` and `;`, so `abstract val`, `lateinit var` and a `by`-delegated property close on something else and never answer as fields; widening that set would move java and csharp too, so it is its own change. And a primary constructor's `class C(val x: Foo)` closes on `)`, so it types bodies but not fields.

## Four refusals that are load-bearing

Each has a test. Three came out of a review of the first build, which had passed every count-based gate.

- **A parameter is not a property.** `class C(timeout: Duration = d)` closes on `=` at class scope exactly as a real property does, but with no `val`/`var` it is not a property and no method body can name it. The keyword is now captured, and a match without one cannot own a field. Body typing is unaffected either way, since only `types_by_class` reads a closer.
- **KDoc is stripped.** `@param connection: Store` is exactly Kotlin's declaration shape, so prose was fabricating declarations. The asymmetry with java is in the shapes rather than the languages and was measured both ways on the same text: javadoc's `@param connection the Store` is not the C family's `Type name`, and the java scan returns nothing on it. Both directions are pinned by a test.
- **A chained construction types nothing.** `val x = Builder().build()` makes `x` whatever `build()` returns. `_PY_CONSTRUCTED` has the identical shape and is deliberately left alone, since moving python is its own measured change. `[^()]*` cannot cross a nested call, so `Foo(bar(1)).baz()` is still typed; that is the same direction of error as before the guard rather than a new one, and it has a test saying so.
- **`Store.of(call)` is not a construction.** Reading the qualifier's last segment typed `cache` as `of`. The type group is bare-named, as python's is.

Also refused, with tests: `dispatch(logger = Emitter())` (kotlin spells a named argument with `=`, so the construction shape is anchored to `val`/`var`), `@get:JvmName("x")` (reads as `get: JvmName`, which is why `(` is not a closer), `class Server : BaseServer()` (inheritance uses the same colon), and `List<Header>` (bares to `List`, a builtin, and the value is a List rather than a Header).

Kept on purpose: a generic, because Kotlin's `Column<T>` is a `Column` where python's `Optional[T]` is not a `T`; a trailing `?`, which is 15% of ktor's typed declarations; and `by`, so the `by lazy` idiom types its property rather than nothing.

## The one wrong precision row is not a receiver-typing error

`ServerPipeline.kt:148` calls `response.close(cause)` where `val response = ByteChannel()`. The type is right and `ByteChannel` does declare `close`, but it declares it with no arguments, and the declaration this one-argument call actually binds is the top-level extension `ByteWriteChannel.close(cause: Throwable?)`. The resolver checks that the inferred type declares a method of the call's name, not of its arity.

That check is shared by csharp, go, java and python, and `CallSite.argument_count` already exists, so the mechanism for a fix is there. It is not made here: narrowing the check would move four other languages' numbers inside a Kotlin registration and needs its own gate, and overloads of one name share a symbol id so an arity filter has to not discard them. Kotlin surfaces the shape because an extension function is how the language adds an overload from outside the class. Filed, unsized, fix named.

## Notes

- javalin was picked as a java control and turned out to be 303 kotlin files to 64 java, so it is reported as a third corpus repo.
- The correction pass cost 41 resolved calls, +1,874 to +1,833, and all 41 came out of the body-typed half. Field-scope edges are 163 before and after, so the parameter-as-field defect produced no edges on this corpus and that fix removes a latent wrongness rather than a measured one.
- Harnesses are in `local-stash/structural-debt/harnesses/`; the full write-up is `GRAPH_FOUNDATION_MEASUREMENTS.md` M39.
