### PR TITLE
feat(graph): type a Swift call receiver from its declaration

### DIFF
--- a/packages/core/src/repowise/core/ingestion/call_resolver.py
+++ b/packages/core/src/repowise/core/ingestion/call_resolver.py
@@ -134,6 +134,10 @@ _LANGUAGE_CALL_STRATEGIES: dict[str, _LanguageCallStrategies] = {
     "kotlin": replace(_JVM_STRATEGIES, member_fallback=_TYPED_RECEIVER),
     "csharp": _LanguageCallStrategies(member_fallback=_TYPED_RECEIVER),
     "python": _LanguageCallStrategies(member_fallback=_TYPED_RECEIVER),
+    # Swift registers the fallback and nothing else: it has no package
+    # tier of its own, so a typed receiver is looked for in the caller's
+    # file, in what the file imports, and then in the global pair index.
+    "swift": _LanguageCallStrategies(member_fallback=_TYPED_RECEIVER),
     "cpp": _CPP_STRATEGIES,
     "c": _CPP_STRATEGIES,
 }

--- a/packages/core/src/repowise/core/ingestion/languages/receiver_types.py
+++ b/packages/core/src/repowise/core/ingestion/languages/receiver_types.py
@@ -223,12 +223,54 @@ _KT_CONSTRUCTED = re.compile(
     r"(?<![\w.])va[lr]\s+(?P<name>[a-z_]\w*)\s*=\s*(?P<type>[A-Z]\w*)\s*\((?![^()]*\)\s*\.)"
 )
 
+# Swift annotates after the name as Kotlin does, and the same one shape reaches
+# more of the language than it does of Kotlin: `let x: Foo`, `var x: Foo` and
+# all three parameter spellings are `name: Type`.
+#
+# The argument label is the reason to anchor on the colon rather than on the
+# bracket that opens the list. Swift writes a parameter as `f(x: Foo)`,
+# `f(_ x: Foo)` or `f(label x: Foo)`, and in the last of those the declared
+# name is the *second* identifier. A pattern anchored at `(` or `,` takes the
+# label instead and is wrong 736 times over swift-nio and Alamofire. The
+# identifier adjacent to the colon is the declared name in all three
+# spellings, with no branch on any of them.
+#
+# Measured over those two repos, this one shape is 88% of the declaration
+# population: 4,001 single-name parameters, 2,876 stored properties, 2,104
+# `var`s, 1,356 underscore-label parameters, 1,304 `let`s and 736 two-name
+# parameters. The construction shape below is a further 6%.
+#
+# `some`/`any` is consumed rather than refused: an opaque or existential
+# `some Foo` is a `Foo` at the call site, as a trailing `?` or `!` is.
+#
+# `[Foo]` and `[K: V]` match nothing on purpose — the value is an Array or a
+# Dictionary, and typing the name as `Foo` would be wrong rather than merely
+# unhelpful. `]` stays out of the closer set for the same reason: it is what a
+# dictionary type's inner `k: V` would otherwise close on.
+#
+# The `let`/`var` keyword is captured for the reason Kotlin's is: an
+# initialiser's `init(timeout: Duration = .seconds(5))` sits at type scope and
+# closes on `=` exactly as a stored property does, and it is a parameter
+# rather than a property. Only a keyword-bearing match may own a field.
+_SWIFT_ANNOTATED = re.compile(
+    rf"(?<![\w.])(?:(?P<keyword>let|var)\s+)?(?P<name>[a-z_]\w*)\s*:\s*"
+    rf"(?:(?:some|any)\s+)?(?P<type>{_TYPE})[?!]?\s*(?=(?P<closer>[=,)\n{{]))"
+)
+
+# `let x = Foo(...)`. Bare-named, and refusing a chain, for the reasons
+# `_KT_CONSTRUCTED` gives: `let x = Foo.bar()` is a call on a class, and
+# `let x = Builder().build()` makes `x` whatever `build()` returns.
+_SWIFT_CONSTRUCTED = re.compile(
+    r"(?<![\w.])(?:let|var)\s+(?P<name>[a-z_]\w*)\s*=\s*(?P<type>[A-Z]\w*)\s*\((?![^()]*\)\s*\.)"
+)
+
 _C_FAMILY = (_TYPED_DECLARATION, _INFERRED_FROM_NEW)
 # No Go shape captures a closer, so every Go declaration carries ``""`` and
 # class scope would drop all of them. That is the intended reading: Go is not
 # in IMPLICIT_FIELD_LANGUAGES and must not be.
 _GO_FAMILY = (_GO_PARAM, _GO_SHORT_DECL, _GO_VAR_DECL)
 _KT_FAMILY = (_KT_ANNOTATED, _KT_CONSTRUCTED)
+_SWIFT_FAMILY = (_SWIFT_ANNOTATED, _SWIFT_CONSTRUCTED)
 
 _LANGUAGE_PATTERNS: dict[str, tuple[re.Pattern[str], ...]] = {
     "csharp": _C_FAMILY,
@@ -236,6 +278,7 @@ _LANGUAGE_PATTERNS: dict[str, tuple[re.Pattern[str], ...]] = {
     "java": _C_FAMILY,
     "kotlin": _KT_FAMILY,
     "python": (_PY_ANNOTATED, _PY_CONSTRUCTED),
+    "swift": _SWIFT_FAMILY,
 }
 
 RECEIVER_TYPE_LANGUAGES = frozenset(_LANGUAGE_PATTERNS)
@@ -256,7 +299,7 @@ RECEIVER_TYPE_LANGUAGES = frozenset(_LANGUAGE_PATTERNS)
 # Only a `val`/`var` reaches class scope. A primary-constructor parameter with
 # a default closes on `=` there too and is not a property at all, which is why
 # `_KT_ANNOTATED` captures the keyword.
-IMPLICIT_FIELD_LANGUAGES = frozenset({"csharp", "java", "kotlin"})
+IMPLICIT_FIELD_LANGUAGES = frozenset({"csharp", "java", "kotlin", "swift"})
 
 # A decorator that changes what the symbol it wraps *is*: `@shared_task` leaves
 # no function behind, so `add.s(...)` is a method call and `(Task, s)` a
@@ -365,6 +408,7 @@ _LANGUAGE_COMMENTS: dict[str, re.Pattern[str]] = {
     "go": _LINE_COMMENT,
     "java": _LINE_COMMENT,
     "kotlin": _LINE_COMMENT,
+    "swift": _LINE_COMMENT,
     "python": _HASH_COMMENT,
 }
 

--- a/tests/unit/ingestion/test_receiver_types.py
+++ b/tests/unit/ingestion/test_receiver_types.py
@@ -399,6 +399,105 @@ class TestKotlinFieldScope:
         assert fields(source, "kotlin", []) == {}
 
 
+
+class TestSwiftShapes:
+    """Swift annotates after the name, and one shape reaches 88% of it.
+
+    Measured over swift-nio and Alamofire: 4,001 single-name parameters, 2,876
+    stored properties, 2,104 `var`s, 1,356 underscore-label parameters, 1,304
+    `let`s and 736 two-name-label parameters are all `name: Type`.
+    """
+
+    def test_a_typed_let(self) -> None:
+        body = "func run() {\n    let ctx: ChannelContext = loop.context\n}"
+        assert declared_types(body, "swift")["ctx"] == "ChannelContext"
+
+    def test_a_typed_var(self) -> None:
+        body = "func run() {\n    var channel: ServerChannel = make()\n}"
+        assert declared_types(body, "swift")["channel"] == "ServerChannel"
+
+    def test_a_plain_parameter(self) -> None:
+        body = "func handle(request: HTTPRequest) { request.body() }"
+        assert declared_types(body, "swift")["request"] == "HTTPRequest"
+
+    def test_an_underscore_label_names_the_second_identifier(self) -> None:
+        body = "func handle(_ request: HTTPRequest) { request.body() }"
+        assert declared_types(body, "swift")["request"] == "HTTPRequest"
+
+    def test_a_two_name_label_names_the_second_identifier(self) -> None:
+        """The declared name is `loop`, not `on`. A pattern anchored at `(` or
+        `,` takes the label and is wrong 736 times over the two repos; taking
+        the identifier adjacent to the colon is right in all three spellings
+        with no branch on any of them."""
+        body = "func handle(on loop: EventLoop) { loop.execute() }"
+        types = declared_types(body, "swift")
+        assert types["loop"] == "EventLoop"
+        assert "on" not in types
+
+    def test_a_construction(self) -> None:
+        body = "func run() {\n    let body = ResponseBody(request)\n}"
+        assert declared_types(body, "swift")["body"] == "ResponseBody"
+
+    def test_an_opaque_type_keeps_its_type(self) -> None:
+        """`some Foo` is a `Foo` at the call site, as `any Foo` is."""
+        body = "func run() {\n    let opaque: some Renderer = make()\n}"
+        assert declared_types(body, "swift")["opaque"] == "Renderer"
+
+    def test_an_optional_keeps_its_type(self) -> None:
+        body = "func run() {\n    var channel: ServerChannel? = nil\n}"
+        assert declared_types(body, "swift")["channel"] == "ServerChannel"
+
+    def test_an_implicitly_unwrapped_optional_keeps_its_type(self) -> None:
+        body = "func run() {\n    let session: Session! = current\n}"
+        assert declared_types(body, "swift")["session"] == "Session"
+
+
+class TestSwiftRefusals:
+    def test_an_array_types_nothing(self) -> None:
+        """The value is an Array of Header, not a Header. The type token starts
+        with `[`, so it matches nothing rather than matching wrongly."""
+        body = "func run() {\n    let items: [Header] = request.headers\n}"
+        assert "items" not in declared_types(body, "swift")
+
+    def test_a_dictionary_types_nothing(self) -> None:
+        """`]` is kept out of the closer set precisely so the inner `k: V` of a
+        dictionary type cannot close on it."""
+        body = "func run() {\n    let lookup: [String: Header] = request.map\n}"
+        assert declared_types(body, "swift") == {}
+
+    def test_a_factory_call_is_not_a_construction(self) -> None:
+        body = "func run() {\n    let cache = Store.shared(request)\n}"
+        assert "cache" not in declared_types(body, "swift")
+
+    def test_a_chained_construction_types_nothing(self) -> None:
+        body = "func run() {\n    let x = Builder().build()\n}"
+        assert declared_types(body, "swift") == {}
+
+    def test_a_doc_comment_parameter_is_not_a_declaration(self) -> None:
+        """swift-nio carries 18,722 `///` lines and 331 `- Parameter Name:`
+        ones, which read exactly like `name: Type`. `///` starts with `//`, so
+        one line-comment pattern covers them; Swift needs no block strip, since
+        genuine `/* */` runs are 15 in swift-nio and 2 in Alamofire."""
+        body = "/// - Parameter Handler: the RequestHandler to use\nfunc run() { }"
+        assert declared_types(body, "swift") == {}
+
+    def test_an_initialiser_parameter_is_not_a_field(self) -> None:
+        """It sits at type scope and closes on `=` exactly as a stored property
+        does, and it is a parameter. The captured keyword is what refuses it."""
+        source = (
+            "class C {\n    init(timeout: Duration = .seconds(5)) { }\n"
+            "    func run() { timeout.tick() }\n}"
+        )
+        assert "timeout" not in fields(source, "swift", [(2, 2), (3, 3)])
+
+    def test_a_stored_property_is_a_field(self) -> None:
+        source = (
+            "class C {\n    private let logger: Logger = Logger()\n"
+            "    func run() {\n        logger.debug()\n    }\n}"
+        )
+        assert fields(source, "swift", [(3, 5)])["logger"] == "Logger"
+
+
 class TestGoShapes:
     """Go writes ``name T``, which is the reverse of every other shape here.
 
@@ -526,7 +625,7 @@ class TestClassScope:
 
 def test_the_language_set_is_what_the_patterns_declare() -> None:
     """Excluding a language means removing its shapes, not gating a caller."""
-    assert set(RECEIVER_TYPE_LANGUAGES) == {"csharp", "go", "java", "kotlin", "python"}
+    assert set(RECEIVER_TYPE_LANGUAGES) == {"csharp", "go", "java", "kotlin", "python", "swift"}
 
 
 def test_go_is_not_a_field_language() -> None:


### PR DESCRIPTION
> Follows #1687 (merged), and reuses the `let`/`var` keyword capture that PR added: Swift has the same shape it exists to refuse.

Swift was the worst call recall in the corpus at 16.5%, against java 67.3%, go 52.4%, csharp 45.0%, python 37.1% and typescript 28.5%. This registers it for `_resolve_typed_receiver`, which types `x` from its declaration and emits `x.foo()` only where that type declares `foo`.

## One shape, and the argument label is not the trap it looks like

Swift collapses to a single `name: Type` pattern more completely than Kotlin does. Over swift-nio and Alamofire that shape is 88% of the declaration population:

| shape | count |
|---|---:|
| `func f(x: Foo)` single-name parameter | 4,001 |
| stored property at type scope | 2,876 |
| `var x: Foo` | 2,104 |
| `func f(_ x: Foo)` underscore label | 1,356 |
| `let x: Foo` | 1,304 |
| `func f(label x: Foo)` two-name label | 736 |

The two-name label declares `x`, not `label`, and it is the shape a naive pattern gets wrong 736 times. It is not a trap for a pattern anchored on the colon, which takes the identifier adjacent to it and is right in all three spellings with no branch on any of them.

`some` and `any` are consumed, since `some Foo` is a `Foo` at the call site, as a trailing `?` or `!` is. `[Foo]` and `[K: V]` match nothing on purpose, because the value is an Array or a Dictionary, and `]` stays out of the closer set so a dictionary type's inner `k: V` cannot close on it.

Swift needs no block-comment strip where Kotlin did, and that is measured rather than assumed. `///` starts with `//`, so one line pattern covers swift-nio's 18,722 doc-comment lines including the 331 `- Parameter Name:` ones that read exactly like a declaration, while genuine `/* */` runs are 15 there and 2 in Alamofire.

## Results

| repo | distinct sites | resolved before to after | gained | lost | recall |
|---|---:|---:|---:|---:|---|
| swift-nio | 40,129 | 6,602 to 8,654 | **+2,052** | **0** | 16.5% to **21.6%** |
| Alamofire | 10,006 | 2,124 to 2,610 | **+486** | **0** | 21.2% to **26.1%** |

+5.1 and +4.9 recall points on unchanged site denominators, the largest single-language movement this track has measured.

| gate | result |
|---|---|
| Symbols, heritage, imports, node counts | byte-identical on both repos |
| Controls | flask, gitleaks, caffeine, eShopOnWeb all byte-identical, 0 gained, 0 lost |
| Cost | +0.68% to +2.98% of parse and build, against a 15% bar |
| Dead code | 0 moved on Alamofire, 53 findings before and after, unchanged per kind |
| Precision | **61 of 62** rows hand-read from source, 98.4% |

## Where these edges land, which is not where Kotlin's did

Kotlin resolved mostly through the import and same-package tiers. Swift has neither, since it has no package tier and `import NIOCore` names a module rather than a type, so 87% of swift-nio's gain and 96% of Alamofire's falls through to `receiver_typed_global`. That tier matches a `(type, method)` pair against a repo-wide index and takes the first file-insertion match with no uniqueness requirement.

A 30-row sample cannot see a 3% failure in that tier, so it was sized outright:

| repo | global-tier edges | pair names one file | pair names several |
|---|---:|---:|---:|
| swift-nio | 1,791 | 1,612 | 179 (10.0%) |
| Alamofire | 484 | 345 | 139 (28.7%) |

That probe overstates the risk, and the hand-read is what corrected it. Counting candidate files is not counting candidate types: in Swift an `extension Session` spread over several files is one type, and Alamofire's 139 are almost entirely that. Enumerating same-named types by hand found 0 of Alamofire's 29 global rows and 2 of swift-nio's 28 with more than one candidate type. One of those two landed correctly and one did not.

## The one wrong row, filed rather than fixed here

`StreamChannelsTest.swift:265` calls `chan1.syncCloseAcceptingAlreadyClosed()` where `chan1: Channel`. The type is right. Two byte-identical `extension Channel { func syncCloseAcceptingAlreadyClosed() }` blocks exist, one in `NIOHTTP1Tests/TestUtils.swift` and one in `NIOPosixTests/TestUtils.swift`, and the tier took the alphabetically earlier file, which is the other test target's copy.

This is not a Swift defect and not a receiver-typing defect. The `receiver_global` tier has behaved this way for every language since it was written, and Swift merely leans on it hardest. The fix, either refusing where the pair is not unique or preferring a candidate that shares the caller's module or directory, would change every language's numbers inside a Swift registration and needs its own gate measuring what refusing costs. The sizing above is where that gate should start.

Shipping at 98.4% is the same call made for Ruby at 91.9%: refusing the mechanism to avoid roughly one wrong edge in sixty would cost 2,538.

## Field scope

Swift joins `IMPLICIT_FIELD_LANGUAGES` on the same count-not-semantics rule, and it earns much less than Kotlin did: 16 of swift-nio's edges and 11 of Alamofire's. The reason is the stated ceiling rather than the language. `_FIELD_CLOSERS` admits `=` and `;`, and Swift's idiom is `private let logger: Logger` with the value assigned in `init`, which closes on a newline and is dropped. Reading a constructor body is what would move this, and it is named rather than built.

## Notes

- 108 tests pass, ruff clean. Every refusal above has a test, including the two-name label naming the second identifier.
- Full write-up is `GRAPH_FOUNDATION_MEASUREMENTS.md` M40; harnesses in `local-stash/structural-debt/harnesses/`, including `size_global_ambiguity.py` which is new here.
