### PR TITLE
fix(graph): file Rust type positions as type_use, not calls

### DIFF
--- a/packages/core/src/repowise/core/ingestion/graph/builder.py
+++ b/packages/core/src/repowise/core/ingestion/graph/builder.py
@@ -446,7 +446,19 @@ class GraphBuilder(MetricsMixin, ResolveMixin, EdgesMixin, SerializeMixin, Rehyd
                 # only contribute to file-reachability — not to
                 # ``import_targets`` which gates cross-file call /
                 # heritage lookups.
-                if data.get("edge_type") in ("imports", "type_use"):
+                # ``no_scope_widening`` marks a type-use edge whose target was
+                # inferred (the repo declares that type name in exactly one
+                # file) rather than read off an import the file actually
+                # writes. Such an edge is real evidence the target is used, so
+                # it still counts for file reachability and the unused-export
+                # pass, but it is not evidence that this file's bare names
+                # resolve into the target — feeding it to ``import_targets``
+                # let unrelated same-named symbols match and minted false call
+                # edges (measured on goose: 25% precision on the edges it
+                # gained).
+                if data.get("edge_type") in ("imports", "type_use") and not data.get(
+                    "no_scope_widening"
+                ):
                     import_targets.setdefault(path, set()).add(target)
         if progress:
             _phase_done = getattr(progress, "on_phase_done", None)

--- a/packages/core/src/repowise/core/ingestion/parser_helpers.py
+++ b/packages/core/src/repowise/core/ingestion/parser_helpers.py
@@ -810,6 +810,75 @@ def _kotlin_head_type_identifier(type_node: Node, src: str) -> str | None:
     return text if is_resolvable_type_name(text, "kotlin") else None
 
 
+# ---------------------------------------------------------------------------
+# Rust type-reference head extraction
+# ---------------------------------------------------------------------------
+
+def _rust_head_type_identifier(type_node: Node, src: str) -> str | None:
+    """Return the head identifier of a Rust type expression, or None.
+
+    Rust needs its own extractor because the C#-shaped default spells a type
+    name ``identifier`` while tree-sitter-rust spells it ``type_identifier``.
+    The default therefore returned None for every bare Rust type, and for
+    ``std::io::Error`` returned the leftmost segment ``io`` — a crate name,
+    not the type.
+
+    Examples:
+        ``MyType``              -> "MyType"
+        ``&Other`` / ``&mut T`` -> "Other"  (reference_type unwrapped)
+        ``dyn MyTrait``         -> "MyTrait"
+        ``impl Shape``          -> "Shape"
+        ``Box<Inner>``          -> "Box"    -> filtered (builtin)
+        ``std::io::Error``      -> "Error"  (rightmost component)
+        ``u32`` / ``String``    -> None     (builtin)
+        ``T``                   -> None     (single-letter generic param)
+
+    Generic arguments are not recursed into: ``Vec<Foo>`` yields the head
+    ``Vec`` only. Foo reaches the resolver through its own capture, matching
+    the Go and Kotlin extractors.
+    """
+    node: Node | None = type_node
+    text = ""
+    for _ in range(8):
+        if node is None:
+            return None
+        kind = node.type
+        if kind == "type_identifier":
+            text = _node_text(node, src)
+            break
+        if kind == "scoped_type_identifier":
+            # ``std::io::Error`` — the type is the rightmost component.
+            name = node.child_by_field_name("name")
+            if name is None:
+                return None
+            node = name
+            continue
+        if kind in ("reference_type", "pointer_type"):
+            # ``&T`` / ``&mut T`` / ``*const T`` — the type field is the
+            # referent; ``mut`` and ``const`` are unnamed children.
+            node = node.child_by_field_name("type")
+            continue
+        if kind == "generic_type":
+            # ``Box<Inner>`` — head is the constructor, args are captured
+            # separately.
+            node = node.child_by_field_name("type")
+            continue
+        if kind in ("dynamic_type", "abstract_type"):
+            # ``dyn Trait`` / ``impl Trait`` — sole named child is the trait.
+            node = node.child_by_field_name("trait") or next(
+                iter(node.named_children), None
+            )
+            continue
+        if kind in ("primitive_type", "tuple_type", "unit_type", "array_type",
+                    "function_type", "never_type", "empty_type"):
+            # Builtin, or no single head name to resolve.
+            return None
+        # Unknown shape - descend into the first named child and re-classify.
+        node = next(iter(node.named_children), None)
+
+    return text if is_resolvable_type_name(text, "rust") else None
+
+
 # Per-language head-identifier extractor for ``@param.type`` captures.
 # Defaults to the C#-shaped extractor; languages with a differently-shaped
 # type grammar register their own here.
@@ -821,6 +890,7 @@ TYPE_HEAD_EXTRACTORS: dict[str, Callable[[Node, str], str | None]] = {
     "javascript": _ts_head_type_identifier,
     "java": _java_head_type_identifier,
     "kotlin": _kotlin_head_type_identifier,
+    "rust": _rust_head_type_identifier,
 }
 
 

--- a/packages/core/src/repowise/core/ingestion/queries/rust.scm
+++ b/packages/core/src/repowise/core/ingestion/queries/rust.scm
@@ -294,14 +294,6 @@
   )
 )
 
-; Type argument in turbofish: func::<MyType>(...), Channel::<MyType>::new()
-; Creates a reference edge so MyType is not flagged as unused.
-(generic_function
-  type_arguments: (type_arguments
-    (type_identifier) @call.target
-  )
-) @call.site
-
 ; Scoped identifier in struct field initializer: Foo { field: module::func }
 ; Captures the final identifier as a reference to prevent false dead code flags.
 (field_initializer
@@ -317,47 +309,68 @@
 )
 
 ; ---------------------------------------------------------------------------
-; Type references — track types used in signatures to prevent false dead code
+; Type references — drive file-level ``type_use`` edges
 ; ---------------------------------------------------------------------------
+; These positions previously carried ``@call.target``/``@call.site``, which
+; recorded the enclosing function as *calling* the type: ``fn take(x: MyType)``
+; became take -> MyType in the call graph. A type is not callable, so every one
+; of those edges was wrong. The nodes captured are unchanged — only the
+; capture name moves to the cross-language ``@param.type``, which
+; parser._extract_type_refs turns into TypeReference records and
+; type_ref_resolution._resolve_rust_type_refs resolves into ``type_use``
+; edges. The dead-code reference the old captures existed to provide is
+; preserved, because type_use is a file-level use edge.
+;
+; Each pattern captures the bare ``type_identifier`` rather than the enclosing
+; type node, keeping this a 1:1 move; the Rust head extractor in
+; parser_helpers.py unwraps ``&T`` / ``Box<T>`` / ``dyn T`` / ``std::io::Error``
+; for the day a capture widens, and filters the 55 rust builtins.
 
 ; Type reference in function parameter: fn foo(x: MyType)
 (parameter
-  type: (type_identifier) @call.target
-) @call.site
+  type: (type_identifier) @param.type
+)
 
 ; Type reference via &dyn: fn foo(x: &dyn MyTrait)
 (parameter
   type: (reference_type
     type: (dynamic_type
-      (type_identifier) @call.target
+      (type_identifier) @param.type
     )
   )
-) @call.site
+)
 
 ; Type reference via impl Trait: fn foo(x: impl MyTrait)
 (parameter
   type: (abstract_type
-    (type_identifier) @call.target
+    (type_identifier) @param.type
   )
-) @call.site
+)
 
 ; Trait bound in generic parameter: fn foo<T: MyTrait>()
 ; Also matches where clauses: where T: MyTrait + OtherTrait
 (trait_bounds
-  (type_identifier) @call.target
-) @call.site
+  (type_identifier) @param.type
+)
 
 ; Return type reference: fn foo() -> MyType
 (function_item
-  return_type: (type_identifier) @call.target
-) @call.site
+  return_type: (type_identifier) @param.type
+)
 
 ; dyn Trait in type arguments: Box<dyn MyTrait>, Arc<dyn MyTrait>
 (type_arguments
   (dynamic_type
-    (type_identifier) @call.target
+    (type_identifier) @param.type
   )
-) @call.site
+)
+
+; Type argument in turbofish: func::<MyType>(...), Channel::<MyType>::new()
+(generic_function
+  type_arguments: (type_arguments
+    (type_identifier) @param.type
+  )
+)
 
 ; ---------------------------------------------------------------------------
 ; Fields

--- a/packages/core/src/repowise/core/ingestion/type_ref_resolution.py
+++ b/packages/core/src/repowise/core/ingestion/type_ref_resolution.py
@@ -192,15 +192,54 @@ def _resolve_rust_type_refs(
         if bare in rust_builtin_types:
             continue
 
-        target = _find_rust_type_file(
+        target, inferred = _find_rust_type_file(
             bare, from_path, sorted_imports, ctx, graph, defined_names
         )
         if target is None:
             continue
         _add_or_merge_type_use_edge(graph, src=from_path, dst=target,
-                                    type_name=bare, origin=ref.origin)
+                                    type_name=bare, origin=ref.origin,
+                                    widens_scope=not inferred)
         emitted += 1
     return emitted
+
+
+def _rust_unique_owner_index(
+    graph: nx.DiGraph,
+    defined_names: dict[str, set[str]],
+) -> dict[str, str]:
+    """Map each type name declared in exactly one Rust file to that file.
+
+    Rust reaches most sibling-crate types through a ``use`` path that import
+    resolution cannot always land on a file, and its type names almost never
+    match a file stem, so the import and stem lookups in
+    :func:`_find_rust_type_file` both miss. Without a third lookup the vast
+    majority of Rust type references resolve to nothing, and a type used only
+    in a parameter or return position reads as an unused export.
+
+    Only names with a single Rust definition are kept: a name defined twice is
+    ambiguous and gets no edge, the same rule the stem lookup applies. The
+    index is restricted to Rust files so a name shared with a class in another
+    language cannot mint a cross-language edge.
+
+    Cached on the graph and keyed by the identity of *defined_names*, which is
+    rebuilt once per :func:`resolve_type_refs` pass; holding the reference
+    keeps that identity valid for the life of the cache.
+    """
+    cached = graph.graph.get("_rust_type_owner_cache")
+    if cached is not None and cached[0] is defined_names:
+        return cached[1]
+
+    owners: dict[str, str | None] = {}
+    for file_path, names in defined_names.items():
+        node = graph.nodes.get(file_path)
+        if node is None or node.get("language") != "rust":
+            continue
+        for name in names:
+            owners[name] = file_path if name not in owners else None
+    index = {name: f for name, f in owners.items() if f is not None}
+    graph.graph["_rust_type_owner_cache"] = (defined_names, index)
+    return index
 
 
 def _find_rust_type_file(
@@ -210,17 +249,31 @@ def _find_rust_type_file(
     ctx: ResolverContext,
     graph: nx.DiGraph,
     defined_names: dict[str, set[str]],
-) -> str | None:
-    """Find the file defining *type_name*, preferring imported files."""
+) -> tuple[str | None, bool]:
+    """Find the file defining *type_name*, preferring imported files.
+
+    Returns ``(target, inferred)``. *inferred* is True when the answer came
+    from a name-shaped guess — the file stem matching the type name, or the
+    repo-wide unique-owner index — rather than from an import the file actually
+    writes. That distinction matters downstream: an inferred edge is good
+    evidence the target file is *used* (so it counts for reachability and the
+    unused-export pass) but it is not evidence that the caller's bare names
+    resolve into that file, so it must not widen call-resolution scope. Both
+    guesses were measured minting false call edges on goose when they did.
+    """
     for imp_file in sorted_imports:
         if type_name in defined_names.get(imp_file, _EMPTY_NAMES):
-            return imp_file
+            return imp_file, False
 
     candidates = ctx.stem_map.get(type_name.lower(), [])
     if len(candidates) == 1 and candidates[0] != from_path and graph.has_node(candidates[0]):
-        return candidates[0]
+        return candidates[0], True
 
-    return None
+    owner = _rust_unique_owner_index(graph, defined_names).get(type_name)
+    if owner is not None and owner != from_path:
+        return owner, True
+
+    return None, False
 
 
 # ---------------------------------------------------------------------------
@@ -740,6 +793,7 @@ def _add_or_merge_type_use_edge(
     type_name: str,
     origin: str,
     hint_source: str | None = None,
+    widens_scope: bool = True,
 ) -> None:
     """Add a ``type_use`` edge between two files, merging on conflict.
 
@@ -775,6 +829,10 @@ def _add_or_merge_type_use_edge(
         names = data.setdefault("imported_names", [])
         if type_name not in names:
             names.append(type_name)
+        # One directly-evidenced reference upgrades the whole edge: the files
+        # are genuinely import-linked however the earlier references were found.
+        if widens_scope:
+            data.pop("no_scope_widening", None)
         return
     attrs: dict[str, Any] = {
         "edge_type": "type_use",
@@ -783,6 +841,8 @@ def _add_or_merge_type_use_edge(
         "type_uses": [type_name],
         "imported_names": [type_name],
     }
+    if not widens_scope:
+        attrs["no_scope_widening"] = True
     if hint_source is not None:
         attrs["hint_source"] = hint_source
     graph.add_edge(src, dst, **attrs)

--- a/tests/unit/ingestion/test_rust_type_use.py
+++ b/tests/unit/ingestion/test_rust_type_use.py
@@ -1,0 +1,308 @@
+"""Rust type positions produce ``type_use`` edges, never ``calls`` edges.
+
+``rust.scm`` used to capture parameter types, return types, trait bounds,
+``dyn``/``impl`` Trait and turbofish type arguments as ``@call.target`` /
+``@call.site``, so ``fn take(x: MyType)`` recorded the enclosing function as
+*calling* ``MyType``. A type is not callable, so every such edge was wrong
+(bug 46). The captures now carry ``@param.type`` and resolve to ``type_use``.
+
+Covers:
+
+* the Rust head extractor, which the C#-shaped default could not serve
+  (tree-sitter-rust spells a type name ``type_identifier``, not
+  ``identifier``, and its qualified form is ``scoped_type_identifier``);
+* ``@param.type`` capture -> ``TypeReference`` extraction for each of the
+  seven type positions the query matches;
+* ``_resolve_rust_type_refs`` -> ``type_use`` edges, and the dead-code
+  outcome they exist to protect: a type used only as a parameter type in
+  another file is not flagged as an unused export;
+* the guard that keeps this safe -- an *inferred* target (name-shaped guess
+  rather than a written import) must not widen call-resolution scope, or
+  unrelated same-named symbols resolve into it and mint false call edges.
+
+All tests drive the real parser and GraphBuilder -- no mocking.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from typing import ClassVar
+
+import networkx as nx
+
+from repowise.core.analysis.dead_code import DeadCodeAnalyzer, DeadCodeKind
+from repowise.core.ingestion.graph import GraphBuilder
+from repowise.core.ingestion.models import FileInfo
+from repowise.core.ingestion.parser import ASTParser
+
+_PARSER = ASTParser()
+
+
+def _file_info(path: str, abs_path: str) -> FileInfo:
+    return FileInfo(
+        path=path,
+        abs_path=abs_path,
+        language="rust",
+        size_bytes=100,
+        git_hash="",
+        last_modified=datetime.now(),
+        is_test=False,
+        is_config=False,
+        is_api_contract=False,
+        is_entry_point=False,
+    )
+
+
+def _parse(body: str, path: str = "src/lib.rs"):
+    return _PARSER.parse_file(_file_info(path, f"/repo/{path}"), body.encode("utf-8"))
+
+
+def _type_names(body: str) -> set[str]:
+    return {r.type_name for r in _parse(body).type_refs}
+
+
+def _call_targets(body: str) -> set[str]:
+    return {c.target_name for c in _parse(body).calls}
+
+
+# ---------------------------------------------------------------------------
+# Capture: each type position becomes a TypeReference, not a call
+# ---------------------------------------------------------------------------
+
+
+class TestRustTypePositionsAreNotCalls:
+    def test_parameter_type(self) -> None:
+        body = "fn take(x: MyType) {}\n"
+        assert "MyType" in _type_names(body)
+        assert "MyType" not in _call_targets(body)
+
+    def test_return_type(self) -> None:
+        body = "fn make() -> Other { todo!() }\n"
+        assert "Other" in _type_names(body)
+        assert "Other" not in _call_targets(body)
+
+    def test_dyn_trait_parameter(self) -> None:
+        body = "fn take(x: &dyn MyTrait) {}\n"
+        assert "MyTrait" in _type_names(body)
+        assert "MyTrait" not in _call_targets(body)
+
+    def test_impl_trait_parameter(self) -> None:
+        body = "fn take(x: impl Shape) {}\n"
+        assert "Shape" in _type_names(body)
+        assert "Shape" not in _call_targets(body)
+
+    def test_trait_bound(self) -> None:
+        body = "fn take<T: Bound>(x: T) {}\n"
+        assert "Bound" in _type_names(body)
+        assert "Bound" not in _call_targets(body)
+
+    def test_dyn_in_type_arguments(self) -> None:
+        body = "fn take(x: Box<dyn Handler>) {}\n"
+        assert "Handler" in _type_names(body)
+        assert "Handler" not in _call_targets(body)
+
+    def test_turbofish_type_argument(self) -> None:
+        body = "fn go() { make::<Widget>(); }\n"
+        assert "Widget" in _type_names(body)
+        assert "Widget" not in _call_targets(body)
+
+    def test_real_calls_are_still_captured(self) -> None:
+        """The honesty guard: moving type captures must not cost real calls."""
+        body = (
+            "fn go(cfg: Config) -> Report {\n"
+            "    helper(1);\n"
+            "    cfg.refresh();\n"
+            "    Report::new()\n"
+            "}\n"
+        )
+        targets = _call_targets(body)
+        assert "helper" in targets
+        assert "refresh" in targets
+        # ...while neither type position leaked back in as a call.
+        assert "Config" not in targets
+        assert "Report" not in targets
+
+
+# ---------------------------------------------------------------------------
+# Head extractor: shapes the C#-shaped default could not read
+# ---------------------------------------------------------------------------
+
+
+class TestRustHeadTypeIdentifier:
+    """The extractor is exercised directly.
+
+    The query deliberately captures the bare ``type_identifier`` at each type
+    position, so wrapped forms (``&Widget``, ``Box<T>``, ``std::io::Error``)
+    do not reach it through the current patterns -- they are the shapes a
+    widened capture would hand it. Pinning the unwrapping here means widening
+    the query later is a query-only change.
+    """
+
+    def _head(self, type_src: str) -> str | None:
+        import tree_sitter
+        import tree_sitter_rust
+
+        from repowise.core.ingestion.parser_helpers import _rust_head_type_identifier
+
+        src = f"fn f(a: {type_src}) {{}}\n"
+        lang = tree_sitter.Language(tree_sitter_rust.language())
+        tree = tree_sitter.Parser(lang).parse(src.encode())
+
+        def walk(node):
+            yield node
+            for child in node.named_children:
+                yield from walk(child)
+
+        param = next(n for n in walk(tree.root_node) if n.type == "parameter")
+        return _rust_head_type_identifier(param.child_by_field_name("type"), src)
+
+    def test_reference_and_mut_are_unwrapped(self) -> None:
+        assert self._head("&Widget") == "Widget"
+        assert self._head("&mut Gadget") == "Gadget"
+
+    def test_scoped_type_takes_rightmost_component(self) -> None:
+        """The default extractor returned the leading crate segment instead."""
+        assert self._head("std::io::Error") == "Error"
+
+    def test_dyn_and_impl_are_unwrapped(self) -> None:
+        assert self._head("&dyn Handler") == "Handler"
+        assert self._head("impl Shape") == "Shape"
+
+    def test_generic_head_is_the_constructor(self) -> None:
+        # ``Box`` is a builtin so the head filters out; the inner ``Inner``
+        # arrives through the type_arguments capture instead.
+        assert self._head("Box<Inner>") is None
+        assert self._head("Wrapper<Inner>") == "Wrapper"
+
+    def test_builtin_heads_are_filtered(self) -> None:
+        assert self._head("u32") is None
+        assert self._head("String") is None
+
+    def test_builtins_are_filtered(self) -> None:
+        names = _type_names("fn f(a: u32, b: String, c: bool) -> Vec<u8> { todo!() }\n")
+        assert names & {"u32", "String", "bool", "Vec", "u8"} == set()
+
+    def test_single_letter_generic_param_is_filtered(self) -> None:
+        assert "T" not in _type_names("fn f<T>(x: T) {}\n")
+
+
+# ---------------------------------------------------------------------------
+# Resolution: type_use edges and the dead-code outcome they protect
+# ---------------------------------------------------------------------------
+
+
+_SOURCES: dict[str, str] = {
+    "src/lib.rs": "pub mod types;\npub mod api;\n",
+    "src/types.rs": (
+        "pub struct RequestPayload {\n"
+        "    pub id: u32,\n"
+        "}\n"
+    ),
+    # Uses RequestPayload only as a parameter type: no call, no method use.
+    # This is exactly the shape the old bogus `calls` edge used to rescue.
+    "src/api.rs": (
+        "use crate::types::RequestPayload;\n\n"
+        "pub fn handle(req: RequestPayload) -> u32 {\n"
+        "    req.id\n"
+        "}\n"
+    ),
+}
+
+
+def _build_graph(repo: Path) -> nx.DiGraph:
+    for rel, body in _SOURCES.items():
+        p = repo / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(body, encoding="utf-8")
+
+    builder = GraphBuilder(repo_path=repo)
+    for rel in _SOURCES:
+        abs_path = str((repo / rel).resolve())
+        parsed = _PARSER.parse_file(_file_info(rel, abs_path), (repo / rel).read_bytes())
+        builder.add_file(parsed)
+    return builder.build()
+
+
+class TestRustTypeUseResolution:
+    def test_parameter_type_emits_a_type_use_edge(self, tmp_path: Path) -> None:
+        graph = _build_graph(tmp_path)
+        data = graph.get_edge_data("src/api.rs", "src/types.rs") or {}
+        assert data, "expected an edge from the consumer to the defining file"
+        assert "RequestPayload" in data.get("type_uses", []) or "RequestPayload" in data.get(
+            "imported_names", []
+        )
+
+    def test_no_calls_edge_from_the_type_position(self, tmp_path: Path) -> None:
+        graph = _build_graph(tmp_path)
+        bogus = [
+            (u, v)
+            for u, v, d in graph.edges(data=True)
+            if d.get("edge_type") == "calls" and str(v).endswith("::RequestPayload")
+        ]
+        assert bogus == [], f"a type was recorded as callable: {bogus}"
+
+    def test_type_only_use_is_not_an_unused_export(self, tmp_path: Path) -> None:
+        """The protection the old captures existed to provide, preserved."""
+        graph = _build_graph(tmp_path)
+        analyzer = DeadCodeAnalyzer(graph, repo_root=tmp_path)
+        flagged = {
+            f.symbol_name
+            for f in analyzer.analyze().findings
+            if f.kind == DeadCodeKind.UNUSED_EXPORT
+        }
+        assert "RequestPayload" not in flagged
+
+
+class TestInferredTargetsDoNotWidenCallScope:
+    """An inferred type target must not let bare names resolve into it.
+
+    ``consumer.rs`` writes no import for ``Registry``; the target is found
+    only because the repo declares that name once. That is good enough to
+    call ``registry.rs`` used, but not good enough to claim the unrelated
+    ``spec()`` call lands on ``registry.rs::spec``. Measured on goose, letting
+    it do so scored 25% precision on the edges it gained.
+    """
+
+    _SRC: ClassVar[dict[str, str]] = {
+        "src/lib.rs": "pub mod registry;\npub mod consumer;\n",
+        "src/registry.rs": (
+            "pub struct Registry;\n\n"
+            "pub fn spec() -> u32 { 1 }\n"
+        ),
+        "src/consumer.rs": (
+            "pub fn run(reg: Registry) -> u32 {\n"
+            "    let other = make();\n"
+            "    other.spec()\n"
+            "}\n"
+        ),
+    }
+
+    def _build(self, repo: Path) -> nx.DiGraph:
+        for rel, body in self._SRC.items():
+            p = repo / rel
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text(body, encoding="utf-8")
+        builder = GraphBuilder(repo_path=repo)
+        for rel in self._SRC:
+            abs_path = str((repo / rel).resolve())
+            parsed = _PARSER.parse_file(
+                _file_info(rel, abs_path), (repo / rel).read_bytes()
+            )
+            builder.add_file(parsed)
+        return builder.build()
+
+    def test_inferred_edge_is_marked_and_reaches_the_file(self, tmp_path: Path) -> None:
+        graph = self._build(tmp_path)
+        data = graph.get_edge_data("src/consumer.rs", "src/registry.rs") or {}
+        assert data.get("edge_type") == "type_use"
+        assert data.get("no_scope_widening") is True
+
+    def test_inferred_edge_does_not_mint_a_bare_name_call(self, tmp_path: Path) -> None:
+        graph = self._build(tmp_path)
+        leaked = [
+            (u, v)
+            for u, v, d in graph.edges(data=True)
+            if d.get("edge_type") == "calls" and str(v) == "src/registry.rs::spec"
+        ]
+        assert leaked == [], f"bare-name call resolved through an inferred edge: {leaked}"


### PR DESCRIPTION
`rust.scm` captured parameter types, return types, trait bounds, `dyn`/`impl` Trait and turbofish type arguments as `@call.target`/`@call.site`. So

```rust
fn take(x: MyType) -> Other
```

recorded the enclosing function as *calling* `MyType` and `Other`. A type is not callable, so every one of those that survived resolution was a wrong edge.

This was sized at capture time (~3,634 sites on goose) but never at edge. Measured at edge here for the first time.

## What changed

A strict 1:1 capture move. The same seven patterns match the same nodes and fields; only the capture name changes to the cross-language `@param.type`, which resolves into `type_use` edges. The dead-code protection the old captures existed to provide is preserved, because `type_use` is a file-level use edge.

Two prerequisites turned up by probing rather than reading, and neither was optional:

**A Rust head extractor was mandatory.** `TYPE_HEAD_EXTRACTORS` had no `rust` entry, so Rust fell back to the C#-shaped `_head_type_identifier`. That extractor returns `None` for *every* Rust type node, because C# spells a type name `identifier` and tree-sitter-rust spells it `type_identifier`, and it returned `io` for `std::io::Error`. Without the new extractor this change would have removed 16k edges and replaced them with nothing.

**The targets had to be findable.** `_find_rust_type_file` consulted only written imports and the file-stem map. Rust type names almost never match a file stem, so nearly every reference resolved to nothing and a type used only as a parameter read as an unused export. Added a repo-wide unique-owner lookup, restricted to Rust files so a name shared with another language cannot mint a cross-language edge.

## The trap, and the guard

`builder.py` folds every `type_use` edge into `import_targets`, which gates cross-file call lookup. The unique-owner and stem lookups are name-shaped guesses, not written imports, so the first working version gained **+468 resolved calls on goose that hand-read at 25% precision**. The dominant failure was not a mistyped receiver: most pointed at lines containing no call at all (parameter names, destructuring bindings, match-arm bindings) that matched a same-named symbol in a newly reachable file.

Inferred targets now stamp `no_scope_widening` and are kept out of `import_targets`. They still count for file reachability and the unused-export pass, which is the whole point of the edge, but cannot widen call scope. One directly-evidenced reference upgrades the edge. Gained calls fall to 0 on all three repos, so this became a pure removal with no precision risk on calls.

## Numbers

Both sides in one process behind a query toggle, so the halves cannot drift on grammar version, corpus walk or resolver state.

| repo | capture sites | resolved calls | removed | gained | type refs | type_use |
|---|---|---|---:|---:|---:|---|
| bevy | 193,468 → 169,947 | 57,868 → 47,764 | **10,104** | **0** | 16,302 | 0 → 1,830 |
| nextjs | | 30,042 → 25,483 | **4,559** | **0** | 6,361 | 5 → 883 |
| goose | 91,673 → 88,039 | 22,636 → 21,177 | **1,459** | **0** | 2,286 | 0 → 166 |

goose's capture-site drop is exactly the 3,634 originally sized, which validates the toggle. Of those, 1,459 (40%) had been surviving into real edges.

`type_use` cannot rise "by roughly what calls lost" in edge counts, because calls are symbol to symbol while `type_use` is file to file and merges. The like-for-like comparison is 24,949 type references against 16,122 removed call edges.

## Gate

| gate | result |
|---|---|
| Removed edges are function to type | **40/40 hand-read, 100%.** Parameter types, return types, turbofish args, trait bounds, `dyn`. Zero real calls |
| Real calls lost | **0** |
| Symbols / heritage / imports | byte-identical, all 3 repos, whole repo not just Rust |
| Other languages | byte-identical, every edge touching no Rust file |
| Tests | 2,816 pass in ingestion + dead_code, plus 20 new covering all seven positions and the scope guard |

## Dead code

The old `.scm` comment said these captures existed "to prevent false dead code", so this was measured rather than argued. On goose: `unreachable_file` 40 → 35, `unused_export` 62 → 65, total 102 → **100**. The 5 dropped unreachable files are the exact files whose types were being referenced; the 3 new unused exports are all inside one of them, a reclassification from "this whole file is dead" to "this file is live, 3 exports are unused". bevy 21 → 20. nextjs unchanged.

## Notes for reviewers

- A Rust repo indexed before this ships keeps the old bogus `calls` edges until a full reindex.
- Fan-in / fan-out and centrality over `calls` edges will drop for Rust-heavy repos after reindex. That is the intended correction, not a regression.
- Left deliberately for a follow-up: the query still matches only a bare `type_identifier`, so `&Foo`, `Box<Foo>` and `std::io::Error` are real type uses it misses. The head extractor already unwraps all three and is unit-tested on them, so widening is a query-only change. Not taken here because it would have invalidated the three measured runs.
