### PR TITLE
fix(graph): a struct field is not callable, so the bare-name tier must not offer one

### DIFF
--- a/packages/core/src/repowise/core/ingestion/call_resolver.py
+++ b/packages/core/src/repowise/core/ingestion/call_resolver.py
@@ -941,19 +941,28 @@ class CallResolver:
         # that mints an edge (bug 90). Filtered here rather than at index build
         # so the `declared` gate above and the member gate in
         # ``_resolve_member_call`` keep seeing the whole repo.
+        # Uniqueness is judged on the unfiltered list on purpose. Filtering the
+        # pool *before* the length test would re-uniquify a name that a field
+        # and a method both declare, firing the tier where it used to refuse —
+        # measured at +916 new 0.50-confidence edges on goose, on the one tier
+        # hand-read at 28.6% precision.
         candidates = self._global_symbols.get(target_name, [])
-        if (
-            len(candidates) == 1
-            and candidates[0] != caller_id
-            # Uniqueness is judged on the unfiltered list on purpose: this asks
-            # only whether the single answer is callable, so the tier can lose
-            # an edge but never gain one. Filtering the pool *before* the
-            # length test instead would re-uniquify a name that a field and a
-            # method both declare, firing the tier where it used to refuse —
-            # measured at +916 new 0.50-confidence edges on goose, on the one
-            # tier hand-read at 28.6% precision.
-            and candidates[0] not in self._non_callable_ids
-        ):
+        if len(candidates) == 1 and candidates[0] != caller_id:
+            if candidates[0] in self._non_callable_ids:
+                # Refused here rather than by falling through, so "this tier
+                # can lose an edge but never gain one" is true of the control
+                # flow and not only of the corpus. Falling through would reach
+                # the implicit-receiver tier below, which the old code could
+                # not reach on this input.
+                #
+                # That tier is provably empty here anyway: it ends in
+                # ``_inherited_method``, which reads ``_file_methods`` — filled
+                # by the same loop that unconditionally fills
+                # ``_global_symbols``. So any method it could return would be a
+                # second entry under this name, and ``len(candidates)`` would
+                # not be 1. Returning is what stops that argument having to be
+                # re-derived if either index changes.
+                return None
             caller_lang = symbol_id_language(self._parsed_files, caller_id)
             callee_lang = symbol_id_language(self._parsed_files, candidates[0])
             if caller_lang and callee_lang and caller_lang != callee_lang:

--- a/packages/core/src/repowise/core/ingestion/call_resolver.py
+++ b/packages/core/src/repowise/core/ingestion/call_resolver.py
@@ -107,6 +107,24 @@ _TYPED_RECEIVER = ("_resolve_typed_receiver",)
 _TYPE_KINDS = frozenset({"class", "struct", "interface", "enum", "trait", "impl"})
 _FUNCTION_KINDS = frozenset({"function", "method"})
 
+# Kinds that can never be the callee of a call, used to keep the bare-name
+# Tier 3 index from offering a data member as a function (bug 90).
+#
+# This is deliberately NOT the complement of ``_FUNCTION_KINDS``. Measured over
+# the corpus, plenty of non-function kinds are legitimately called: ``class``
+# is a constructor in python/java/c#/typescript; ``variable`` is both a rust
+# tuple ``enum_variant`` (309 grounded call edges on goose) and a typescript
+# const whose initialiser is not syntactically a function, such as a factory
+# result or a ``.bind()`` handle (2,173 on zod); ``type_alias`` is a Go
+# conversion. Denying by function-ness would delete thousands of real edges.
+#
+# ``property`` is the one kind in the whole of ``language_configs.py`` that
+# means "data member" and nothing else: it is emitted by exactly one mapping,
+# rust's ``field_declaration``. Every other language spells its fields
+# ``variable``, which is why this fix cannot be extended to them — there a
+# field is indistinguishable from a callable value by kind alone.
+_NON_CALLABLE_KINDS = frozenset({"property"})
+
 _JVM_STRATEGIES = _LanguageCallStrategies(
     free=("_resolve_jvm_same_package",),
     member=("_resolve_jvm_receiver_same_package",),
@@ -197,6 +215,11 @@ class CallResolver:
 
         # Global symbol index: {name: [symbol_ids]} — for Tier 3
         self._global_symbols: dict[str, list[str]] = defaultdict(list)
+
+        # Symbols in the index above that are data members, not callables
+        # (bug 90). Held as an id set rather than a full id→kind map because
+        # it is the only kind question asked of it and the set is small.
+        self._non_callable_ids: set[str] = set()
 
         # C/C++ forward declaration → the definition it declares. Populated by
         # ``_build_indices``; applied to every resolved call so the edge lands
@@ -643,6 +666,8 @@ class CallResolver:
                     self._global_methods[key].append((path, sym.id))
 
                 # Global indices
+                if sym.kind in _NON_CALLABLE_KINDS:
+                    self._non_callable_ids.add(sym.id)
                 self._global_symbols[sym.name].append(sym.id)
 
             self._file_symbols[path] = file_syms
@@ -911,9 +936,24 @@ class CallResolver:
                 caller_id, merged_syms[target_name], 0.85, call.line, "import_merged"
             )
 
-        # Tier 3: global unique match — only within the same language
+        # Tier 3: global unique match — only within the same language.
+        # A data member is not callable, so it must not be the unique answer
+        # that mints an edge (bug 90). Filtered here rather than at index build
+        # so the `declared` gate above and the member gate in
+        # ``_resolve_member_call`` keep seeing the whole repo.
         candidates = self._global_symbols.get(target_name, [])
-        if len(candidates) == 1 and candidates[0] != caller_id:
+        if (
+            len(candidates) == 1
+            and candidates[0] != caller_id
+            # Uniqueness is judged on the unfiltered list on purpose: this asks
+            # only whether the single answer is callable, so the tier can lose
+            # an edge but never gain one. Filtering the pool *before* the
+            # length test instead would re-uniquify a name that a field and a
+            # method both declare, firing the tier where it used to refuse —
+            # measured at +916 new 0.50-confidence edges on goose, on the one
+            # tier hand-read at 28.6% precision.
+            and candidates[0] not in self._non_callable_ids
+        ):
             caller_lang = symbol_id_language(self._parsed_files, caller_id)
             callee_lang = symbol_id_language(self._parsed_files, candidates[0])
             if caller_lang and callee_lang and caller_lang != callee_lang:

--- a/packages/core/src/repowise/core/ingestion/language_configs.py
+++ b/packages/core/src/repowise/core/ingestion/language_configs.py
@@ -364,7 +364,10 @@ LANGUAGE_CONFIGS: dict[str, LanguageConfig] = {
             "declProc": "function",  # signature only (interface decl / forward decl)
             "defProc": "function",   # full definition with body
             # Matches C#'s choice for the same concept (property_declaration ->
-            # "variable"); "property" is not a valid SymbolKind literal.
+            # "variable"). Rust is the one language that keeps fields under a
+            # distinct "property" kind; everywhere else a field and a callable
+            # value share "variable", which is what stops the call resolver's
+            # non-callable refusal from extending beyond Rust.
             "declProp": "variable",
         },
         import_node_types=["declUses"],

--- a/packages/core/src/repowise/core/ingestion/models.py
+++ b/packages/core/src/repowise/core/ingestion/models.py
@@ -118,6 +118,13 @@ SymbolKind = Literal[
     "module",
     "macro",
     "variable",
+    # Rust's ``field_declaration`` only. Every other language maps its fields
+    # and properties to ``variable``; Rust keeps them separate, and the call
+    # resolver relies on that to refuse a field as a bare-name call target
+    # (``_NON_CALLABLE_KINDS``). Normalising this to ``variable`` would make
+    # Rust fields indistinguishable from callable values and silently undo
+    # that refusal, so it is declared here rather than mapped away.
+    "property",
 ]
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/ingestion/test_bare_name_index_kinds.py
+++ b/tests/unit/ingestion/test_bare_name_index_kinds.py
@@ -1,0 +1,172 @@
+"""Tier 3 must not offer a data member as a function (bug 90).
+
+``_resolve_free_call``'s global-unique tier answers a bare name with any
+repo symbol carrying that name. The index it consults holds every symbol,
+kinds included that cannot be called, so ``x.ok()`` on a ``Result`` resolved
+to a struct field ``ok: bool`` declared in an unrelated file. A field is not
+callable, so every such edge was wrong.
+
+The two negative tests below are the ones that matter: the predicate is
+deliberately narrower than "not a function", because ``class`` is a
+constructor and ``variable`` is both a TypeScript arrow function and a Rust
+tuple enum variant. Denying by function-ness would delete real edges.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+
+from repowise.core.ingestion.call_resolver import _NON_CALLABLE_KINDS, CallResolver
+from repowise.core.ingestion.models import FileInfo, ParsedFile
+from repowise.core.ingestion.parser import parse_file
+
+
+def _file_info(rel: str, abs_: Path, lang: str) -> FileInfo:
+    return FileInfo(
+        path=rel,
+        abs_path=str(abs_),
+        language=lang,  # type: ignore[arg-type]
+        size_bytes=abs_.stat().st_size,
+        git_hash="",
+        last_modified=datetime.now(),
+        is_test=False,
+        is_config=False,
+        is_api_contract=False,
+        is_entry_point=False,
+    )
+
+
+def _parse_all(tmp_path: Path, files: dict[str, tuple[str, str]]) -> dict[str, ParsedFile]:
+    out: dict[str, ParsedFile] = {}
+    for rel, (lang, content) in files.items():
+        abs_ = tmp_path / rel
+        abs_.parent.mkdir(parents=True, exist_ok=True)
+        abs_.write_text(content)
+        out[rel] = parse_file(_file_info(rel, abs_, lang), content.encode("utf-8"))
+    return out
+
+
+def _edges(parsed: dict[str, ParsedFile], tmp_path: Path) -> list[tuple[str, str, str]]:
+    resolver = CallResolver(
+        parsed, {p: set() for p in parsed}, repo_path=str(tmp_path)
+    )
+    return [
+        (rc.caller_id, rc.callee_id, rc.origin)
+        for path, pf in parsed.items()
+        for rc in resolver.resolve_file(path, pf.calls)
+    ]
+
+
+def _kinds(parsed: dict[str, ParsedFile], name: str) -> set[str]:
+    return {s.kind for pf in parsed.values() for s in pf.symbols if s.name == name}
+
+
+class TestFieldsAreNotCallable:
+    def test_a_struct_field_does_not_answer_a_bare_name(self, tmp_path: Path) -> None:
+        """``.ok()`` on a Result must not bind to a field named ``ok``."""
+        parsed = _parse_all(
+            tmp_path,
+            {
+                "model.rs": ("rust", "pub struct Reply {\n    pub ok: bool,\n}\n"),
+                "caller.rs": (
+                    "rust",
+                    "pub fn run(v: &str) -> Option<u64> {\n"
+                    "    v.parse::<u64>().ok()\n"
+                    "}\n",
+                ),
+            },
+        )
+        # Guard the premise: `ok` is indexed, and only as a field.
+        assert _kinds(parsed, "ok") == {"property"}
+        assert not [
+            e for e in _edges(parsed, tmp_path) if e[1] == "model.rs::ok"
+        ]
+
+    def test_a_real_function_still_answers_the_same_bare_name(
+        self, tmp_path: Path
+    ) -> None:
+        """The tier itself is untouched -- only non-callable answers are refused."""
+        parsed = _parse_all(
+            tmp_path,
+            {
+                "util.rs": ("rust", "pub fn only_one_of_these() -> u8 {\n    1\n}\n"),
+                "caller.rs": (
+                    "rust",
+                    "pub fn run() -> u8 {\n    only_one_of_these()\n}\n",
+                ),
+            },
+        )
+        assert (
+            "caller.rs::run",
+            "util.rs::only_one_of_these",
+            "global_unique",
+        ) in _edges(parsed, tmp_path)
+
+    def test_a_field_never_makes_a_shadowed_name_unique(self, tmp_path: Path) -> None:
+        """Uniqueness is judged before the callability test, never after.
+
+        A name declared by both a field and a function is ambiguous, and must
+        stay refused. Filtering the candidate pool first would make the field
+        vanish, leave one answer and fire the tier -- measured at +916 new
+        0.50-confidence edges on goose, on a tier hand-read at 28.6%.
+        """
+        parsed = _parse_all(
+            tmp_path,
+            {
+                "model.rs": ("rust", "pub struct Reply {\n    pub emit: bool,\n}\n"),
+                "util.rs": ("rust", "pub fn emit() -> u8 {\n    1\n}\n"),
+                "caller.rs": ("rust", "pub fn run() -> u8 {\n    emit()\n}\n"),
+            },
+        )
+        assert _kinds(parsed, "emit") == {"property", "function"}
+        assert not [
+            e for e in _edges(parsed, tmp_path) if e[0] == "caller.rs::run"
+        ]
+
+
+class TestThePredicateStaysNarrow:
+    """Kinds that look non-callable but are not. Regression guards."""
+
+    def test_only_property_is_denied(self) -> None:
+        assert frozenset({"property"}) == _NON_CALLABLE_KINDS
+
+    def test_a_rust_tuple_enum_variant_stays_callable(self, tmp_path: Path) -> None:
+        """``enum_variant`` maps to ``variable``; ``Shape::Circle(1.0)`` is a call."""
+        parsed = _parse_all(
+            tmp_path,
+            {
+                "shape.rs": ("rust", "pub enum Shape {\n    Circle(f64),\n}\n"),
+                "caller.rs": (
+                    "rust",
+                    "pub fn run() -> Shape {\n    Circle(1.0)\n}\n",
+                ),
+            },
+        )
+        assert "variable" in _kinds(parsed, "Circle")
+        assert "variable" not in _NON_CALLABLE_KINDS
+
+    def test_a_typescript_callable_const_stays_callable(self, tmp_path: Path) -> None:
+        """A const whose initialiser is not syntactically a function is a
+        ``variable`` -- and is still called.
+
+        An arrow or function expression is already classified ``function``, so
+        ``variable`` is precisely the bucket holding factory results and
+        ``.bind()`` handles. zod alone has 2,173 grounded call edges landing on
+        one, which is why this kind cannot join the deny set.
+        """
+        parsed = _parse_all(
+            tmp_path,
+            {
+                "util.ts": (
+                    "typescript",
+                    "import { base } from './base';\nexport const doThing = base.bind(null);\n",
+                ),
+                "caller.ts": (
+                    "typescript",
+                    "export function run() {\n  return doThing();\n}\n",
+                ),
+            },
+        )
+        assert _kinds(parsed, "doThing") == {"variable"}
+        assert [e for e in _edges(parsed, tmp_path) if e[1] == "util.ts::doThing"]


### PR DESCRIPTION
Tier 3 of `_resolve_free_call` answers a bare name with any repo symbol carrying that name, and the index it consults holds every symbol regardless of kind. So `v.parse::<u64>().ok()` resolved to a struct field `ok: bool` declared in an unrelated file, and `.map(..)` to a `map: HashMap<..>` field. A field is not callable, so every one of those edges was wrong.

This is the second change in this track where the usual gate is inverted: resolved calls fall, and the bar is that every removed edge is wrong.

## Result

**1,399 edges removed, 0 gained, 0 retargeted. 45 of 45 removed edges hand-read as wrong, 0 real.**

| gate | result |
|---|---|
| Removed edges name a non-callable | 45/45 hand-read across goose and bevy, 3 independent readers |
| Real calls lost | 0 |
| Calls gained | 0 on both Rust repos |
| Retargeted | 0 |
| Non-call edges | byte-identical on all 13 repos (symbols, heritage, imports, type_use) |
| Dead code | unchanged on goose: 131 unreachable_file, 152 unused_export, 370 unused_internal, 5 zombie_package |
| Cost | 2.0% of parse + build (goose: 9.78s parse, 2.00s to 2.24s build) |
| Unit suite | 3,432 passed, 0 failed, including 6 new |

Every removal was a stdlib `Result::ok` / `Option::map` / `Iterator::map` / `Path::parent`, a builder method, a closure parameter, or a local `fn`, bound to an unrelated struct field.

## Per language, whole corpus

13 repos, 14 languages. The zeroes are the control and are reported for that reason.

| language | repos | before | after | delta |
|---|---|---:|---:|---:|
| java | bevy, caffeine | 52,058 | 52,058 | +0 |
| **rust** | **bevy, goose** | **48,674** | **47,275** | **-1,399** |
| typescript | bevy, goose, zod | 13,453 | 13,453 | +0 |
| python | caffeine, celery, fmt, gitleaks, goose | 9,943 | 9,943 | +0 |
| cpp | fmt | 9,058 | 9,058 | +0 |
| csharp | Ocelot | 8,324 | 8,324 | +0 |
| ruby | jekyll, sinatra | 4,794 | 4,794 | +0 |
| swift | Alamofire | 2,610 | 2,610 | +0 |
| go | gitleaks | 2,279 | 2,279 | +0 |
| php | slim | 606 | 606 | +0 |
| javascript | Alamofire, goose, jekyll, zod | 287 | 287 | +0 |
| shell | 7 repos | 249 | 249 | +0 |
| kotlin | caffeine, goose | 135 | 135 | +0 |
| c | caffeine, fmt | 72 | 72 | +0 |

Measured in one process behind a toggle, with the parse shared between both sides, so a difference cannot come from a different checkout or a different parse.

The two Rust repos differ enormously: goose 1,369 of 15,599 (8.8%), bevy 30 of 33,075 (0.09%). That is 46x by raw count and 97x by rate, so this is a per-repo hazard and there is no corpus rate worth quoting.

## Two alternatives were built and lost on numbers

**Filtering at index build ("wide")** removes 391 more edges across the two Rust repos and mints **1,726 unvetted ones** doing it, because dropping fields out of `_global_symbols` flips the `declared` gate and lets weaker tiers fire on names that used to refuse.

| variant | goose removed | goose gained | bevy removed | bevy gained |
|---|---:|---:|---:|---:|
| shipped | 1,369 | **0** | 30 | **0** |
| wide | 1,757 | 918 | 33 | 808 |

**Filtering the candidate pool before the length test** gains **+916 on goose**. A name that both a field and a method declare has two candidates today and correctly refuses; drop the field and it becomes "unique" and fires, minting brand new 0.50-confidence edges on the one tier hand-read at 28.6% precision. Uniqueness is therefore judged on the unfiltered list, and only the single surviving answer is kind-checked. A unit test pins this.

## The predicate is `{"property"}` and it cannot be extended

Not the complement of `_FUNCTION_KINDS`. Measured over the corpus, plenty of non-function kinds are legitimately called:

| language | kind | grounded call edges | what it is |
|---|---|---:|---|
| typescript | `variable` | 2,173 (zod) | const holding a factory result or a `.bind()` handle |
| python | `class` | 2,449 (celery) | constructor |
| rust | `variable` | 309 (goose) | tuple `enum_variant` |
| java | `class` | 131 (caffeine) | constructor |
| go | `type_alias` | 9 (gitleaks) | conversion |

Denying by function-ness would have deleted thousands of real edges.

`property` is the one kind in the whole of `language_configs.py` that means "data member" and nothing else. It is emitted by exactly one mapping, Rust's `field_declaration`. Every other language maps fields and properties to `variable`, the same kind as the callables above, so their equivalent wrong edges (C# 39, TS 15, java 7) are out of reach of a kind predicate and need a different mechanism.

Ruby gains nothing despite having the corpus's highest bare-name share (jekyll 36.4%, sinatra 31.3%). Every one of its bare-name callees is a `method` or `function`, because Ruby's extractor emits no field symbols at all.

## Commits

1. **The fix.** Kind-check Tier 3's single candidate.
2. **`property` declared in `SymbolKind`.** It was emitted by the Rust config but absent from the Literal, and a comment asserted it was "not a valid SymbolKind literal". That mismatch is now load-bearing: normalising Rust to `variable` for consistency with every other language would make Rust fields indistinguishable from callable values and silently undo the fix. Annotation only; the TypeScript mirror already admits `(string & {})`.
3. **Explicit refusal instead of fallthrough.** Behaviour-identical, found by review. Letting the condition go False fell through to the implicit-receiver tier, a path the old code could not reach on that input, which made "can lose but never gain" a claim about the corpus rather than the control flow. The fallthrough is provably empty (`_inherited_method` reads `_file_methods`, filled by the same loop that unconditionally fills `_global_symbols`, so any method it could return would be a second candidate and `len(candidates)` would not be 1), and re-measuring confirms goose 1,369/0 and bevy 30/0 unchanged. goose is the case that would expose a difference, being rust + kotlin where kotlin is in both language sets.

## Follow-ups, filed not fixed

- Three hand-read rows show the old resolver preferring a spurious global field over a **local `fn` in the same file**. Post-fix those sites resolve to nothing rather than to the local function. Removing the wrong edge is still right, but the missed local edge is a Tier 1 recall gap for functions nested inside test modules, and it needs its own measurement.
- The roughly 60 non-Rust edges of this same shape, which a kind predicate cannot reach.
