### PR TITLE
fix(graph): register .hh as C++ and reassign .inc from Pascal

### DIFF
--- a/packages/core/src/repowise/core/ingestion/dynamic_hints/cpp.py
+++ b/packages/core/src/repowise/core/ingestion/dynamic_hints/cpp.py
@@ -24,7 +24,7 @@ _SKIP_DIRS = {
 # .inl is exactly where function-pointer and designated-initialiser wiring
 # tends to live, which is the wiring this extractor exists to find.
 _CPP_EXTS: tuple[str, ...] = (
-    ".cc", ".cpp", ".cxx", ".c++", ".hpp", ".hxx", ".h",
+    ".cc", ".cpp", ".cxx", ".c++", ".hh", ".hpp", ".hxx", ".h",
     *sorted(INCLUDE_FRAGMENT_EXTENSIONS),
 )
 

--- a/packages/core/src/repowise/core/ingestion/dynamic_hints/cpp.py
+++ b/packages/core/src/repowise/core/ingestion/dynamic_hints/cpp.py
@@ -1,8 +1,8 @@
 """Dynamic-hint extractor for C++ function pointers, dlopen/dlsym, and Qt
 ``QObject::connect`` signal/slot wiring.
 
-Mirrors :mod:`.c` but on C++ extensions (``.cc``/``.cpp``/``.cxx``/``.hpp``/
-``.hxx``) and adds the Qt connect-string idiom — ``QObject::connect(s,
+Mirrors :mod:`.c` but on the C++ extensions in ``_CPP_EXTS`` below, and adds
+the Qt connect-string idiom — ``QObject::connect(s,
 SIGNAL(sig()), r, SLOT(slot()))`` — which wires a method into a runtime
 dispatch table that the static call graph never sees.
 """

--- a/packages/core/src/repowise/core/ingestion/languages/specs/cpp.py
+++ b/packages/core/src/repowise/core/ingestion/languages/specs/cpp.py
@@ -11,7 +11,16 @@ from .c import BUILTIN_TYPES as _C_BUILTIN_TYPES
 #: each keep their own list: which extensions are C++ at all, which behave like
 #: a header for include resolution and reachability, and which are a fragment
 #: rather than a module. See ``traverser`` for the last of those.
-INCLUDE_FRAGMENT_EXTENSIONS: frozenset[str] = frozenset({".inl", ".ipp", ".tpp"})
+#:
+#: ``.inc`` was claimed exclusively by the Pascal spec, which routed abseil's
+#: 24 template-implementation fragments to a grammar that cannot parse them —
+#: no symbols, no edges, no error. Reassigned here on the corpus count: 24 of
+#: the 25 code-bearing ``.inc`` files are C++ and none are Pascal, on a corpus
+#: that does contain Pascal. The one PHP ``.inc`` (a Drush plugin) is the known
+#: cost; ``.inc`` is shared by C++, PHP and Pascal in the wild, and a
+#: content- or sibling-aware router is the real answer if a second language's
+#: usage ever shows up in the corpus.
+INCLUDE_FRAGMENT_EXTENSIONS: frozenset[str] = frozenset({".inl", ".ipp", ".tpp", ".inc"})
 
 SPEC = LanguageSpec(
     tag="cpp",
@@ -24,7 +33,7 @@ SPEC = LanguageSpec(
     # its API surface (fmt, leveldb, boost layouts). Root-anchored: a
     # vendored include/ deep in another tree must not mint the layer.
     layer_dir_hints=(("/include", "API"),),
-    extensions=frozenset({".cpp", ".cc", ".cxx", ".h", ".hpp", ".hxx"})
+    extensions=frozenset({".cpp", ".cc", ".cxx", ".h", ".hh", ".hpp", ".hxx"})
     | INCLUDE_FRAGMENT_EXTENSIONS,
     grammar_package="tree_sitter_cpp",
     scm_file="cpp.scm",

--- a/packages/core/src/repowise/core/ingestion/languages/specs/pascal.py
+++ b/packages/core/src/repowise/core/ingestion/languages/specs/pascal.py
@@ -22,7 +22,13 @@ from ..spec import LanguageSpec
 SPEC = LanguageSpec(
     tag="pascal",
     display_name="Object Pascal",
-    extensions=frozenset({".pas", ".pp", ".dpr", ".dpk", ".lpr", ".inc"}),
+    # ``.inc`` is a Delphi include convention, but it is also C++'s and PHP's,
+    # and this spec held it exclusively. The corpus has 24 C++ ``.inc`` files
+    # and zero Pascal ones, so it now belongs to cpp — see the note on
+    # ``specs/cpp.INCLUDE_FRAGMENT_EXTENSIONS``. Dropped rather than left to
+    # first-spec-wins ordering so the routing survives a reordering of
+    # ``ALL_SPECS``.
+    extensions=frozenset({".pas", ".pp", ".dpr", ".dpk", ".lpr"}),
     grammar_package="tree_sitter_pascal",
     scm_file="pascal.scm",
     heritage_node_types=frozenset({"declType"}),


### PR DESCRIPTION
## What

Two extension-registration defects in the C++ language spec.

`.hh` was not a registered C++ extension. `REGISTRY.from_extension(".hh")`
returned `unknown`, so a repository using the GNU/Google header convention never
had its headers parsed: no symbols, no edges, no participation in the graph at
all. seastar is 283 `.hh` files against 244 `.cc`, so its entire public API was
invisible.

`.inc` was claimed exclusively by the Pascal spec. Files were routed to a
grammar that cannot parse C++ and failed silently, producing no symbols and no
error. abseil-cpp uses `.inc` for template implementations and has 24 of them.

The rest of the codebase already treated both as C++ headers. `cmake.py`,
`graph_warmups.py`, `graph/_resolvers.py`, `resolvers/cpp.py` and
`cpp_reachability.py` all list `.hh` and `.inc`, so include resolution and
reachability believed one thing while the parser believed another.

## How

`.hh` joins the C++ extension set. `.inc` joins `INCLUDE_FRAGMENT_EXTENSIONS`,
which is the exported set those five consumers already read, and is removed from
the Pascal spec.

`.inc` is the first extension in this codebase claimed by more than one
language, so the choice is recorded rather than assumed. The extension map is
built first-spec-wins and cpp already sits ahead of pascal in `ALL_SPECS`, but
relying on that would leave the routing to declaration order, where a later
reshuffle could flip it back without any test noticing. Removing it from Pascal
makes the assignment explicit.

Which extensions to add was decided by counting files, not by matching the
language standard. `.tcc`, `.h++` and `.c++` are the obvious symmetry additions
and have no files anywhere in the test corpus, so they are not registered.
`.cppm` has two and is also left out.

`dynamic_hints/cpp.py` carried the same `.hh` omission and is fixed with it. Its
module docstring separately enumerated a subset of the extensions the module
actually scans, and now points at the tuple instead.

## Behavior

Files that previously produced nothing now parse, so symbols, nodes and edges
rise on repositories using either convention:

| | seastar (`.hh`) | abseil-cpp (`.inc`) |
|---|---:|---:|
| files parsed | 326 to 609 | 930 to 930 |
| symbols declared | 6,880 to 14,197 | 12,121 to 12,435 |
| graph nodes | 5,822 to 11,647 | 8,824 to 9,021 |
| resolved calls | 7,319 to 12,457 | 19,581 to 19,862 |
| cross-file coverage | 0.9221 to 0.9714 | unchanged |

abseil's file count does not move because those 24 files were already being
walked, just as Pascal and yielding nothing. That is why the defect did not show
up in any file-count check.

Some existing call edges change target. On seastar 1,355 edges move, and 1,008
of them are the same call site binding somewhere new: 884 go from `src` to
`include`. A call whose declaration was missing had been binding to a same-named
symbol elsewhere in the repository, and the real declaration now takes it. Of
the 347 sites that resolve to nothing afterwards, 239 had been pointing into
`tests/` from production source. The resolver declines those rather than
guessing, because the added files push a previously unique bare name into
ambiguity.

New edges inherit an existing limitation: a call on an untyped receiver, such as
`f(...).get()` on a future, can bind to any same-named member in the repository.
That behavior is unchanged by this PR, but it applies to more files now, and it
is the main source of incorrect edges among the new ones. Registering the
extension is correct independently of it; the files carried no edges at all
before.

Dead-code findings rise on seastar, from 47 to 694, almost entirely
`unused_export` on public API headers whose callers are downstream consumers
rather than seastar itself. The file-level reachability pass already handles the
header-as-API case and is unaffected (`unreachable_file` moves 12 to 11); the
symbol-level export detector does not consult it. abseil moves 51 to 56.

## Verification

Measured with one process per repository and the extension routing toggled in
memory, so both arms come from a single checkout.

Fourteen repositories, four arms. The two defects are attributable apart: the
`.hh` arm moves seastar and nothing else, the `.inc` arm moves abseil and
nothing else.

Twelve of the fourteen are byte-identical on the resolved-call set, including
every non-C++ control (C#, Java, Python, Go, Kotlin, TypeScript) and every C++
repository carrying neither extension (Crow, aria2, fmt, leveldb, nlohmann-json,
pybind11). osv-scanner holds one `.inc` and is unmoved, because the file is
vendored test data the traverser already excludes.

Cross-file coverage is flat on every C++ repository except seastar. Only seastar
uses `.hh`, so this is a gain for repositories of that convention rather than a
language-wide coverage change.

Parse and build cost rises 2.6% on abseil. On seastar it rises 50.7% while
parsing 87% more files; per-file cost falls from 12.4ms to 10.0ms.

`tests/unit/ingestion` and `tests/unit/analysis` pass, 3,086 tests. The existing
`TestSharedExtensionSet` guard already pins every consumer against the shared
fragment set, so the five downstream lists pick `.inc` up without edits.
