### PR TITLE
fix(dead-code): keep a stored commit time comparable to a fresh one

### DIFF
--- a/packages/core/src/repowise/core/persistence/crud/git.py
+++ b/packages/core/src/repowise/core/persistence/crud/git.py
@@ -7,7 +7,7 @@ every public name, so existing imports are unaffected.
 from __future__ import annotations
 
 from collections.abc import Sequence
-from datetime import datetime
+from datetime import UTC, datetime
 
 from sqlalchemy import delete, func, or_, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -134,6 +134,13 @@ _DEAD_CODE_GIT_FIELDS = (
 )
 
 
+def _as_aware_utc(value: datetime | None) -> datetime | None:
+    """Treat a naive stored timestamp as the UTC it was written as."""
+    if value is None or value.tzinfo is not None:
+        return value
+    return value.replace(tzinfo=UTC)
+
+
 async def get_dead_code_git_fields(session: AsyncSession, repository_id: str) -> dict[str, dict]:
     """Return ``{file_path: {field: value}}`` for the dead-code scoring fields.
 
@@ -151,6 +158,15 @@ async def get_dead_code_git_fields(session: AsyncSession, repository_id: str) ->
     The values are one update-interval stale for idle files, whose time-decayed
     windows are rewritten later in the same run, after analysis. That is
     strictly closer to the truth than the empty dict it replaces.
+
+    ``last_commit_at`` comes back tz-aware. SQLite drops the offset from
+    ``DateTime(timezone=True)``, and the analyzer merges these rows with freshly
+    read git metadata, which *is* aware — so a naive value here meets an aware
+    one in ``datetime.now(UTC) - last_commit`` and in the ``>`` that picks a
+    package's newest commit, and raises ``TypeError``. The dead-code phase
+    catches broadly, so the whole analysis was skipped for a one-line warning
+    and every finding kept its previous verdict. Normalizing at the read is what
+    keeps that from reaching either site.
     """
     rows = (
         await session.execute(
@@ -160,7 +176,13 @@ async def get_dead_code_git_fields(session: AsyncSession, repository_id: str) ->
             ).where(GitMetadata.repository_id == repository_id)
         )
     ).all()
-    return {r[0]: dict(zip(_DEAD_CODE_GIT_FIELDS, r[1:], strict=True)) for r in rows}
+    return {
+        r[0]: {
+            f: _as_aware_utc(v) if f == "last_commit_at" else v
+            for f, v in zip(_DEAD_CODE_GIT_FIELDS, r[1:], strict=True)
+        }
+        for r in rows
+    }
 
 
 # Repo-wide-walk signals (co-change pairs, Hassan entropy). A pass that did

--- a/tests/unit/persistence/test_dead_code_crud.py
+++ b/tests/unit/persistence/test_dead_code_crud.py
@@ -386,3 +386,39 @@ async def test_summary_uses_shared_confidence_thresholds(async_session, monkeypa
         "medium": 2,
         "low": 1,
     }
+
+
+async def test_get_dead_code_git_fields_returns_last_commit_at_aware(async_session):
+    """A stored timestamp must come back comparable to fresh git metadata.
+
+    SQLite drops the offset from ``DateTime(timezone=True)``, so this read used
+    to hand the analyzer a naive value. It merges those rows with freshly read
+    git metadata, which is aware, and then does ``datetime.now(UTC) - value``
+    when ageing a zombie package and ``>`` when picking the package's newest
+    commit. Either raises ``TypeError: can't subtract offset-naive and
+    offset-aware datetimes``, which the dead-code phase catches broadly — the
+    whole analysis is skipped and every finding silently keeps its previous
+    verdict on every incremental update.
+    """
+    from datetime import UTC, datetime
+
+    from repowise.core.persistence.crud import get_dead_code_git_fields
+    from repowise.core.persistence.models import GitMetadata
+
+    repo = await insert_repo(async_session)
+    async_session.add(
+        GitMetadata(
+            repository_id=repo.id,
+            file_path="a.py",
+            last_commit_at=datetime(2025, 12, 21, 0, 6, 49, tzinfo=UTC),
+        )
+    )
+    await async_session.commit()
+
+    stored = (await get_dead_code_git_fields(async_session, repo.id))["a.py"]["last_commit_at"]
+
+    assert stored.tzinfo is not None, "a naive value here skips the whole dead-code analysis"
+    # The two operations that raised, exactly as the analyzer performs them.
+    assert (datetime.now(UTC) - stored).days >= 0
+    assert stored > datetime(2020, 1, 1, tzinfo=UTC)
+    assert stored == datetime(2025, 12, 21, 0, 6, 49, tzinfo=UTC), "must not shift the instant"


### PR DESCRIPTION
## The bug

Every `repowise update` on a repo with a zombie-package candidate silently skipped **the entire dead-code analysis**:

```
Dead code analysis skipped: can't subtract offset-naive and offset-aware datetimes
```

Findings then keep their previous verdict, which is precisely the staleness #1389 widened this path to fix.

## Why

The update path reads the dead-code scoring columns back out of `git_metadata` for every file it did not re-index. SQLite drops the offset from `DateTime(timezone=True)`, so `last_commit_at` came back **naive**, and the analyzer merges those rows with freshly read git metadata, which is **aware**. Two sites then mix them:

- `datetime.now(UTC) - pkg_last_commit` when ageing a zombie package
- the `>` that picks the package's newest commit

Either raises `TypeError`, and the phase's broad `except Exception` turns it into one yellow line.

## The fix

Normalize at the read — where the naive value enters, and the one place covering both sites. The analyzer is unchanged. Repowise writes these as UTC, so attaching UTC restores the value as stored rather than shifting it; `_as_aware_utc` in `decisions/extractor.py` and `_aware` in `pipeline/fix_rollups.py` already do this for the same reason.

## Scope

Present since #1389 shipped in **v0.40.0** — four releases. Not a regression from the current cycle, but worth landing before the next release, which carries a stack of dead-code fixes that update users would otherwise never see.

## Test plan

- [x] New regression test asserts the value is aware and performs both operations the analyzer does. Verified it **fails** on `main` (`assert None is not None`) and passes with the fix.
- [x] `tests/unit/persistence` + `tests/unit/dead_code` — 956 passed
- [x] `tests/unit/pipeline` — 118 passed
- [x] `ruff check .` — clean
- [x] End-to-end on `test-repos/microdot` indexed at 0.43.0: before, update skipped the analysis and left 94 stale rows; after, the same update reports `Dead code findings: 94` and exits 0.
