### PR TITLE
fix(graph): a template forward declaration is a declaration too

### DIFF
--- a/packages/core/src/repowise/core/ingestion/parser.py
+++ b/packages/core/src/repowise/core/ingestion/parser.py
@@ -138,6 +138,15 @@ def _is_bodiless_cpp_type(language: str, node_type: str, def_node: Node) -> bool
     """
     if language not in ("cpp", "c"):
         return False
+    if node_type == "template_declaration":
+        # ``template <typename T> class Foo;``. The wrapper carries no ``body``
+        # field of its own — the inner specifier does — so asking the wrapper
+        # would call every template a declaration. Ask the type it wraps.
+        inner = next(
+            (c for c in def_node.children if c.type in _CPP_TYPE_SPECIFIER_NODES),
+            None,
+        )
+        return inner is not None and inner.child_by_field_name("body") is None
     if node_type not in _CPP_TYPE_SPECIFIER_NODES:
         return False
     if def_node.child_by_field_name("body") is not None:

--- a/tests/unit/ingestion/test_cpp_decl_def.py
+++ b/tests/unit/ingestion/test_cpp_decl_def.py
@@ -177,3 +177,19 @@ class TestTypeDeclarationFlag:
         assert graph.get_edge_data("def_first.h", "def_first.h::Shape") == {
             "edge_type": "defines"
         }
+
+    def test_bodiless_template_type_is_marked(self, tmp_path: Path) -> None:
+        # ``template <typename T> class Foo;`` — the wrapper node carries no
+        # ``body`` field of its own, so the check has to ask the type it wraps
+        # or every template reads as a declaration.
+        (tmp_path / "t.hh").write_text(
+            "template <typename T> class Foo;\n"
+            "template <typename T> class Bar { int x; };\n"
+            "template <typename... T>\nclass Multi;\n"
+            "template <typename T> T fn() { return T(); }\n"
+        )
+        graph = _build(tmp_path)
+        assert graph.nodes["t.hh::Foo"]["is_declaration"] is True
+        assert graph.nodes["t.hh::Multi"]["is_declaration"] is True
+        assert graph.nodes["t.hh::Bar"]["is_declaration"] is False
+        assert graph.nodes["t.hh::fn"]["is_declaration"] is False


### PR DESCRIPTION
Follow-up to #1700, closing a gap it left.

`template <typename T> class Foo;` reaches the parser as a `template_declaration`
wrapping a bodiless `class_specifier`. The wrapper carries no `body` field of its
own, so asking it would call every template a declaration, and not asking it left
templates unmarked.

#1700 suppressed them anyway — by accident. The parser emits both nodes under one
symbol id, and last-wins made the bodiless specifier the node. Its second commit
stopped a declaration displacing a definition (a real defect, seastar's `smp.hh`)
and incidentally blocked that second emission, so template forward declarations
became reportable again on main:

```cpp
// include/seastar/core/future.hh:154
template <typename... T>
class shared_future;          // node 154-155, is_declaration=False
```

`_is_bodiless_cpp_type` now asks the wrapper's inner specifier for its body.
Verified across six shapes — bodiless template class and struct, the multi-line
form, a bodied template class, and function templates with and without a body —
only the bodiless types are marked.

### Measured

Same six repos, same in-process arm toggle, one process.

| repo | main | this PR | removed | added |
|---|---:|---:|---:|---:|
| seastar | 590 | **582** | 108 | 0 |
| nlohmann-json | 280 | **278** | 3 | 0 |
| abseil-cpp | 55 | **54** | 2 | 0 |
| leveldb | 67 | 67 | 43 | 0 |
| fmt | 16 | 16 | 0 | 0 |
| Crow | 8 | 8 | 0 | 0 |

156 removed and **0 added**, against 148 removed / 3 added on main.

### The 3 that stop being added are the correct outcome

Not a re-hiding — all three are the same shape, a bodiless primary template
declaration followed by partial specializations that carry the bodies and are
what the code actually uses:

- `coroutine/all.hh:143` `struct generate_aligned_union;`, specialization at 145,
  consumed as `continuation_storage` at 149
- `rpc/rpc_impl.hh:748`, specializations at 750/754, consumed as `drop_smart_ptr`
  at 758
- abseil `str_format/arg.h:501`, specializations at 504/515/528

Reporting the primary declaration is a false positive that main still emits.

Tests: 2,842 pass, ruff clean.
