### PR TITLE
release: v0.44.0 - receiver typing across eight languages, and an update that delivers it

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "name": "repowise",
       "source": "./plugins/claude-code",
       "description": "Codebase intelligence for Claude Code. Indexes your repo into five layers (Graph, Git, Docs, Decisions, Code Health) and gives Claude deep understanding of architecture, ownership, hotspots, decisions, and defect risk — fewer greps, fewer file reads, lower cost per query.",
-      "version": "0.43.0",
+      "version": "0.44.0",
       "category": "productivity",
       "keywords": [
         "codebase",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,55 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.44.0] — 2026-08-18
+
+The theme this cycle is the call graph knowing who the receiver is. A call written `user.save()` only becomes an edge if something can say what `user` is, and for most languages nothing could: the resolver matched the bare name against every symbol in the repo and guessed. Receiver typing now runs for Go, Kotlin, Swift, C#, Java, Python, PHP and Luau, and resolution follows re-export chains. On microdot, a small pure-Python repo with none of the languages that gained most, call edges went from 876 to 1,371. Dead code got the matching precision pass, and updates now carry both onto an index built by an older version, which they previously did not. Expect the first `repowise update` after upgrading to run long, once.
+
+### Added
+
+- **Receiver typing across eight languages.** A call's receiver is typed from its declaration in Go (#1674), Kotlin (#1687), Swift (#1688) and C# (#1680), from the enclosing class for a bare call plus PHP and Luau receivers (#1630), from a field's declaring class (#1642), from a local's declaration (#1639), from assignments in a Python function body (#1643), from a Java call on its own field (#1658), and from a framework decorator that retyped it (#1684). Three more receiver shapes a bare-name match had been guessing at are now captured directly (#1686).
+- **Resolution follows re-exports.** A call resolves through the name a module publishes (#1682), a method on a type imported through a re-export (#1664), and a namespace member through the whole re-export chain (#1672).
+- **`dispatches_to` edges** link a base method to the implementations that answer for it (#1649), and a framework-wired symbol to the symbol it is wired to (#1654).
+- **Every call edge records the strategy that resolved it** (#1628), and the web UI says how each edge got into the graph (#1652). An execution flow now says why it stopped instead of just stopping (#1650).
+- **Security findings carry a verified line and a commit date** (#1668).
+- **Pascal is registered in the complexity, duplication and dataflow dialects**, so health scores it like the other 18 languages (#1629).
+
+### Changed
+
+- **The file detail page is ported onto the design language** (#1621) and gained inbound and outbound navigation (#1622).
+- **The workspace System Map moves its chrome off the canvas**, and the per-repo view works (#1616).
+- **Dead code surfaces staleness on the web** and drops the package column (#1669).
+- **`this.method()` self-dispatch is recorded in six languages** (#1617).
+- **Export aliases are read from the parser** rather than a second scan of the file (#1683).
+
+### Fixed
+
+- **An extraction change now reaches unchanged files.** An incremental update rewrote only the git-changed files' rows in `graph_edges`, which is right for a content change and wrong for a parser change: the latter alters every file's edges at once. The build that wrote a repo's edges is now recorded, and a mismatch widens the reconcile to the whole parsed set once before re-stamping. Without this, none of this release's graph work would reach an existing index short of a full re-index. (#1619)
+- **Dead-code analysis no longer skips itself on update.** Stored commit timestamps came back without a timezone while freshly read ones carried one, so ageing a package raised `TypeError`, a broad catch turned it into a one-line warning, and every finding silently kept its previous verdict. Present since 0.40.0. (#1702)
+- **Symbols reached by a framework or a container** (#1673), **wired in by a registration decorator** (#1681), or **named by a docs build or an API dump** (#1677) are no longer reported as dead.
+- **Every use of a private symbol counts**, not only a call (#1662). Only genuinely narrow scopes stay in the uncalled-symbol pool (#1646), and a top-tier confidence means the checks behind it ran (#1666).
+- **C and C++**: a forward-declared type is not an unused export (#1700), nor is a template forward declaration (#1703); a call edge attaches to the definition rather than the header declaration (#1626); a function named but never called counts as a use (#1627); `.inl` / `.ipp` / `.tpp` (#1625) and `.hh` are recognised as C++, and `.inc` is reassigned from Pascal (#1693).
+- **Every language gives one answer for a type's bare name** (#1634). A struct field is not callable, so the bare-name tier no longer offers one (#1692), and Rust type positions are filed as `type_use` rather than calls (#1690).
+- **Inheritance is emitted for JavaScript classes** (#1636) and Go interface embedding (#1641). C# resolves inherited calls again (#1651), captures generic method calls (#1637), and records the visibility a declaration actually has (#1644).
+- **A third-party JVM import no longer takes a same-named repo class** (#1659). A Go method whose receiver is unexported is typed (#1676). A workspace package that publishes only from a build directory binds correctly (#1670).
+- **A method passed as a value is separated from a method called** (#1661).
+- **MCP**: four tools answered a bad argument with a reassuring negative instead of an error (#1671); `get_context` counted a subclass and a fixture as callers (#1663); raw doubles and two different scales shipped under one key (#1631). The symbol page made the same subclass mistake (#1660).
+- **A failed framework pass is reported** rather than swallowed (#1645).
+- **`repowise update --full` runs under the single-flight lock** (#1529), and the incremental hotspot gate reuses the persisted function-modification p80 (#1532).
+- **ADR discovery no longer mines paths git cannot see** (#1614), the security history scanner actually scans (#1667), and fix history ignores the shallow-clone boundary (#1633).
+
+### Performance
+
+- **Graph build stops re-reading the repository** (#1648), and each language gets a call-strategy seam that rejects unresolvable names first (#1632).
+- **The file page stops reading the whole repo to render one file** (#1618).
+- **Workspace `.csproj` scanning walks each repo once** (#1615).
+
+### Documentation
+
+- The language-support pages are rewritten, a graph layer page is added, and the claims that pointed at them are corrected (#1689).
+
+---
+
 ## [0.43.0] — 2026-08-15
 
 The through-line this cycle is a number meaning what it says. Change risk scored the size of the diff and presented it as danger. `get_answer` could return `confidence: high` beside `retrieval_quality: weak`, with a note that asserted dominance and denied it in the same sentence. `get_why` answered every question, including the ones its store knew nothing about. The dashboard summed dead exports across a side project and a monorepo. Six surfaces each computed hotspot health their own way and none of them agreed. Each of those is fixed by giving the answer one owner and reporting the reason alongside it. `repowise risk` now leads with the bug-fix history of the files a change touches, an answer's confidence note quotes the test that earned it, and a question the decision store cannot answer gets a redirect instead of the three closest records.

--- a/packages/cli/src/repowise/cli/__init__.py
+++ b/packages/cli/src/repowise/cli/__init__.py
@@ -16,4 +16,4 @@ from repowise.cli._stdio import _ensure_utf8_stdio
 # is already UTF-8.
 _ensure_utf8_stdio()
 
-__version__ = "0.43.0"
+__version__ = "0.44.0"

--- a/packages/core/src/repowise/core/__init__.py
+++ b/packages/core/src/repowise/core/__init__.py
@@ -6,4 +6,4 @@ generation engine. This is the heart of repowise — all other packages depend o
 Namespace package: repowise.core is part of the repowise namespace.
 """
 
-__version__ = "0.43.0"
+__version__ = "0.44.0"

--- a/packages/core/src/repowise/core/upgrade/_data/CHANGELOG.md
+++ b/packages/core/src/repowise/core/upgrade/_data/CHANGELOG.md
@@ -13,6 +13,55 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.44.0] — 2026-08-18
+
+The theme this cycle is the call graph knowing who the receiver is. A call written `user.save()` only becomes an edge if something can say what `user` is, and for most languages nothing could: the resolver matched the bare name against every symbol in the repo and guessed. Receiver typing now runs for Go, Kotlin, Swift, C#, Java, Python, PHP and Luau, and resolution follows re-export chains. On microdot, a small pure-Python repo with none of the languages that gained most, call edges went from 876 to 1,371. Dead code got the matching precision pass, and updates now carry both onto an index built by an older version, which they previously did not. Expect the first `repowise update` after upgrading to run long, once.
+
+### Added
+
+- **Receiver typing across eight languages.** A call's receiver is typed from its declaration in Go (#1674), Kotlin (#1687), Swift (#1688) and C# (#1680), from the enclosing class for a bare call plus PHP and Luau receivers (#1630), from a field's declaring class (#1642), from a local's declaration (#1639), from assignments in a Python function body (#1643), from a Java call on its own field (#1658), and from a framework decorator that retyped it (#1684). Three more receiver shapes a bare-name match had been guessing at are now captured directly (#1686).
+- **Resolution follows re-exports.** A call resolves through the name a module publishes (#1682), a method on a type imported through a re-export (#1664), and a namespace member through the whole re-export chain (#1672).
+- **`dispatches_to` edges** link a base method to the implementations that answer for it (#1649), and a framework-wired symbol to the symbol it is wired to (#1654).
+- **Every call edge records the strategy that resolved it** (#1628), and the web UI says how each edge got into the graph (#1652). An execution flow now says why it stopped instead of just stopping (#1650).
+- **Security findings carry a verified line and a commit date** (#1668).
+- **Pascal is registered in the complexity, duplication and dataflow dialects**, so health scores it like the other 18 languages (#1629).
+
+### Changed
+
+- **The file detail page is ported onto the design language** (#1621) and gained inbound and outbound navigation (#1622).
+- **The workspace System Map moves its chrome off the canvas**, and the per-repo view works (#1616).
+- **Dead code surfaces staleness on the web** and drops the package column (#1669).
+- **`this.method()` self-dispatch is recorded in six languages** (#1617).
+- **Export aliases are read from the parser** rather than a second scan of the file (#1683).
+
+### Fixed
+
+- **An extraction change now reaches unchanged files.** An incremental update rewrote only the git-changed files' rows in `graph_edges`, which is right for a content change and wrong for a parser change: the latter alters every file's edges at once. The build that wrote a repo's edges is now recorded, and a mismatch widens the reconcile to the whole parsed set once before re-stamping. Without this, none of this release's graph work would reach an existing index short of a full re-index. (#1619)
+- **Dead-code analysis no longer skips itself on update.** Stored commit timestamps came back without a timezone while freshly read ones carried one, so ageing a package raised `TypeError`, a broad catch turned it into a one-line warning, and every finding silently kept its previous verdict. Present since 0.40.0. (#1702)
+- **Symbols reached by a framework or a container** (#1673), **wired in by a registration decorator** (#1681), or **named by a docs build or an API dump** (#1677) are no longer reported as dead.
+- **Every use of a private symbol counts**, not only a call (#1662). Only genuinely narrow scopes stay in the uncalled-symbol pool (#1646), and a top-tier confidence means the checks behind it ran (#1666).
+- **C and C++**: a forward-declared type is not an unused export (#1700), nor is a template forward declaration (#1703); a call edge attaches to the definition rather than the header declaration (#1626); a function named but never called counts as a use (#1627); `.inl` / `.ipp` / `.tpp` (#1625) and `.hh` are recognised as C++, and `.inc` is reassigned from Pascal (#1693).
+- **Every language gives one answer for a type's bare name** (#1634). A struct field is not callable, so the bare-name tier no longer offers one (#1692), and Rust type positions are filed as `type_use` rather than calls (#1690).
+- **Inheritance is emitted for JavaScript classes** (#1636) and Go interface embedding (#1641). C# resolves inherited calls again (#1651), captures generic method calls (#1637), and records the visibility a declaration actually has (#1644).
+- **A third-party JVM import no longer takes a same-named repo class** (#1659). A Go method whose receiver is unexported is typed (#1676). A workspace package that publishes only from a build directory binds correctly (#1670).
+- **A method passed as a value is separated from a method called** (#1661).
+- **MCP**: four tools answered a bad argument with a reassuring negative instead of an error (#1671); `get_context` counted a subclass and a fixture as callers (#1663); raw doubles and two different scales shipped under one key (#1631). The symbol page made the same subclass mistake (#1660).
+- **A failed framework pass is reported** rather than swallowed (#1645).
+- **`repowise update --full` runs under the single-flight lock** (#1529), and the incremental hotspot gate reuses the persisted function-modification p80 (#1532).
+- **ADR discovery no longer mines paths git cannot see** (#1614), the security history scanner actually scans (#1667), and fix history ignores the shallow-clone boundary (#1633).
+
+### Performance
+
+- **Graph build stops re-reading the repository** (#1648), and each language gets a call-strategy seam that rejects unresolvable names first (#1632).
+- **The file page stops reading the whole repo to render one file** (#1618).
+- **Workspace `.csproj` scanning walks each repo once** (#1615).
+
+### Documentation
+
+- The language-support pages are rewritten, a graph layer page is added, and the claims that pointed at them are corrected (#1689).
+
+---
+
 ## [0.43.0] — 2026-08-15
 
 The through-line this cycle is a number meaning what it says. Change risk scored the size of the diff and presented it as danger. `get_answer` could return `confidence: high` beside `retrieval_quality: weak`, with a note that asserted dominance and denied it in the same sentence. `get_why` answered every question, including the ones its store knew nothing about. The dashboard summed dead exports across a side project and a monorepo. Six surfaces each computed hotspot health their own way and none of them agreed. Each of those is fixed by giving the answer one owner and reporting the reason alongside it. `repowise risk` now leads with the bug-fix history of the files a change touches, an answer's confidence note quotes the test that earned it, and a question the decision store cannot answer gets a redirect instead of the three closest records.

--- a/packages/server/src/repowise/server/__init__.py
+++ b/packages/server/src/repowise/server/__init__.py
@@ -7,4 +7,4 @@ Provides:
     - Background job scheduler (APScheduler)
 """
 
-__version__ = "0.43.0"
+__version__ = "0.44.0"

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "repowise",
   "description": "Codebase intelligence for Claude Code. Indexes your codebase into five layers (Graph, Git, Docs, Decisions, Code Health) and exposes them through eleven task-shaped MCP tools — so Claude understands architecture, ownership, hotspots, why code is built the way it is, and where the defect risk lives.",
-  "version": "0.43.0",
+  "version": "0.44.0",
   "author": {
     "name": "Repowise",
     "email": "hello@repowise.dev",

--- a/plugins/claude-code/CHANGELOG.md
+++ b/plugins/claude-code/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the Repowise Claude Code plugin are documented here.
 
+## 0.44.0
+
+### Changed
+- Version bump to track the 0.44.0 release. No command, skill, hook or MCP tool
+  surface changed this cycle: the live `list_tools()` set is unchanged, no
+  `@click.option` moved on any documented command, and `hooks.json` still
+  mirrors `claude_config.py`.
+
 ## 0.43.0
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "repowise"
-version = "0.43.0"
+version = "0.44.0"
 description = "The codebase intelligence layer for your AI coding agent — dependency graph, git history, dead code, decisions, and code health, exposed over MCP"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/server.json
+++ b/server.json
@@ -8,12 +8,12 @@
     "source": "github"
   },
   "websiteUrl": "https://www.repowise.dev",
-  "version": "0.43.0",
+  "version": "0.44.0",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "repowise",
-      "version": "0.43.0",
+      "version": "0.44.0",
       "transport": {
         "type": "stdio"
       },

--- a/uv.lock
+++ b/uv.lock
@@ -3051,7 +3051,7 @@ wheels = [
 
 [[package]]
 name = "repowise"
-version = "0.43.0"
+version = "0.44.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Version bump + changelog for 0.44.0. Bump-only, per the runbook.

## What's in the release

The call graph learned who the receiver is. Receiver typing now runs for Go, Kotlin, Swift, C#, Java, Python, PHP and Luau; resolution follows re-export chains; dead code got the matching precision pass. Indexing microdot, a small pure-Python repo with none of the languages that gained most, call edges went from **876 to 1,371**.

## Store format: no bump, and that is deliberate

A graph-heavy cycle looks like it should want `STORE_FORMAT_VERSION` and a `REINDEX_RECOMMENDED` notice. It does not, and I verified that rather than reasoning about it:

- `parser_fingerprint()` already moves on its own, twice over: 13 `.scm` query files changed, and `models.py` gained `is_declaration`, `export_aliases` and `references`, both of which the fingerprint hashes. The parse cache self-invalidates.
- #1619 (unreleased until now) then widens the incremental edge write from "git-changed files" to the whole parsed set and re-stamps. It is a delete-then-insert, so it clears the old build's wrong edges rather than layering over them.
- **Measured:** restored a 0.43.0-written microdot store, ran `update` on the 0.44.0 code. `calls` went 876 → 1,371, matching a full re-index exactly, and the fingerprint stamp was written.

Bumping the store format would push every user toward a full rebuild for something one update already does.

One caveat worth knowing: a **no-op** update does not do it. With no git change, `update` prints `Already up to date` and short-circuits before the pipeline, so the widen never runs. It takes one real commit to trigger, which is the normal case. The changelog notes the first update after upgrading runs long, once.

## Version bump

`pyproject.toml`, the three package `__init__.py` files, `uv.lock` (via an explicit `uv lock`), `.claude-plugin/marketplace.json`, `plugins/claude-code/.claude-plugin/plugin.json`, `server.json` (×2). Drift grep clean for `0.43.0`. `plugins/codex/` stays on its own line (0.6.0), unchanged this cycle.

## Test plan

- [x] `tests/unit/test_release_manifests.py` — 8 passed
- [x] `tests/unit/upgrade/test_bundled_changelog_sync.py` — passed (bundled copy resynced)
- [x] Drift grep: no `0.43.0` in any tracked manifest
- [x] `ruff check .` — clean
- [x] `uv build --wheel` — `repowise-0.44.0-py3-none-any.whl`, 94 command files, `serve_cmd.py` present, 19 `.scm` + 36 `.j2` package-data files, bundled changelog included
- [x] `npm ci && npm run build --workspace packages/web` — **hard gate, green**. Standalone `server.js` emitted, workspace-package code compiled into the route bundles
- [x] Plugin parity: live `list_tools()` unchanged; only `get_architecture_diagram` mention is the historical one in the plugin CHANGELOG documenting its removal, which the runbook allows; no `@click.option` moved; `hooks.json` still mirrors `claude_config.py`
- [x] README: `mcp-name` registry marker intact on line 1; the 19-language claim is still correct
- [ ] Tag `v0.44.0` on `main` after squash-merge, push to trigger `publish.yml`
- [ ] Publish `server.json` to the MCP registry once PyPI serves the wheel
- [ ] Final gate: install the published wheel into a throwaway venv and cold-index `test-repos/microdot`

## Needs a decision, not a blocker

**The VS Code extension's bundled UI has drifted.** `packages/ui/src/` has 9 commits since `vscode-v0.8.0`, and the changed subpaths include `docs`, `graph`, `health`, `shared` and `wiki` — all of which the webviews import. Extension users are on whatever `packages/ui` looked like at the 0.8.0 tag. Cutting an extension release means bumping `packages/vscode/package.json`, running the `packages/vscode/RELEASING.md` build + clean-profile VSIX smoke test, and pushing a `vscode-v*` tag; it is independent of this PR's tag namespace, so it can land any time.
