### PR TITLE
fix(persistence): store symbol names as Text, not VARCHAR(255)

### DIFF
--- a/packages/core/alembic/versions/0062_widen_symbol_name_columns.py
+++ b/packages/core/alembic/versions/0062_widen_symbol_name_columns.py
@@ -1,0 +1,78 @@
+"""Widen the symbol-name columns to ``Text`` (PostgreSQL only).
+
+Six columns store a symbol name, or a label built from one, under
+``VARCHAR(255)``. A symbol name has no length bound — generated code
+(protobuf/OpenAPI bindings, minified bundles) routinely emits identifiers past
+255 characters — and PostgreSQL enforces the declared length where SQLite
+ignores it. So the narrow type is invisible on the default backend and aborts
+the run on the one the architecture docs recommend for production, in the
+persistence phase, after the entire index has been computed (issue #1565).
+
+Reproduced on a repository with one 365-character function name:
+``StringDataRightTruncationError`` on ``INSERT INTO graph_nodes``.
+
+Only PostgreSQL is altered. SQLite does not enforce ``VARCHAR`` length — the
+columns already behave as ``TEXT`` there — and local SQLite stores never run
+Alembic anyway (``init_db``'s reconciler is additive-only), so a
+``batch_alter_table`` would rebuild six tables to change nothing.
+
+Revision ID: 0062
+Revises: 0061
+Create Date: 2026-08-18
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers
+revision: str = "0062"
+down_revision: str | None = "0061"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+# (table, column, nullable) — nullability is preserved, only the type changes.
+_COLUMNS: tuple[tuple[str, str, bool], ...] = (
+    ("graph_nodes", "name", True),
+    ("wiki_symbols", "name", False),
+    ("wiki_symbols", "parent_name", True),
+    ("dead_code_findings", "symbol_name", True),
+    ("health_findings", "function_name", True),
+    ("refactoring_suggestions", "target_symbol", False),
+)
+
+
+def upgrade() -> None:
+    if op.get_bind().dialect.name != "postgresql":
+        return
+    for table, column, nullable in _COLUMNS:
+        op.alter_column(
+            table,
+            column,
+            existing_type=sa.String(length=255),
+            type_=sa.Text(),
+            existing_nullable=nullable,
+        )
+
+
+def downgrade() -> None:
+    """Narrow the columns back.
+
+    This fails on a database that already stores a value longer than 255
+    characters, which is the correct outcome: casting with ``left(col, 255)``
+    would silently destroy the name the row is about in order to make the
+    downgrade look clean.
+    """
+    if op.get_bind().dialect.name != "postgresql":
+        return
+    for table, column, nullable in _COLUMNS:
+        op.alter_column(
+            table,
+            column,
+            existing_type=sa.Text(),
+            type_=sa.String(length=255),
+            existing_nullable=nullable,
+        )

--- a/packages/core/src/repowise/core/persistence/models.py
+++ b/packages/core/src/repowise/core/persistence/models.py
@@ -237,7 +237,7 @@ class GraphNode(Base):
     community_meta_json: Mapped[str] = mapped_column(Text, nullable=False, default="{}")
     # Symbol-level fields (null for file nodes)
     kind: Mapped[str | None] = mapped_column(String(32), nullable=True)
-    name: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    name: Mapped[str | None] = mapped_column(Text, nullable=True)
     qualified_name: Mapped[str | None] = mapped_column(Text, nullable=True)
     file_path: Mapped[str | None] = mapped_column(Text, nullable=True)
     start_line: Mapped[int | None] = mapped_column(Integer, nullable=True)
@@ -456,7 +456,7 @@ class WikiSymbol(Base):
     file_path: Mapped[str] = mapped_column(Text, nullable=False)
     # "{path}::{name}" — the ingestion Symbol.id field
     symbol_id: Mapped[str] = mapped_column(Text, nullable=False)
-    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    name: Mapped[str] = mapped_column(Text, nullable=False)
     qualified_name: Mapped[str] = mapped_column(Text, nullable=False)
     kind: Mapped[str] = mapped_column(String(32), nullable=False)
     signature: Mapped[str] = mapped_column(Text, nullable=False, default="")
@@ -467,7 +467,7 @@ class WikiSymbol(Base):
     is_async: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
     complexity_estimate: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
     language: Mapped[str] = mapped_column(String(32), nullable=False, default="")
-    parent_name: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    parent_name: Mapped[str | None] = mapped_column(Text, nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, default=_now_utc
     )
@@ -1152,7 +1152,7 @@ class DeadCodeFinding(Base):
         String(32), nullable=False
     )  # unreachable_file, unused_export, etc.
     file_path: Mapped[str] = mapped_column(Text, nullable=False)
-    symbol_name: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    symbol_name: Mapped[str | None] = mapped_column(Text, nullable=True)
     symbol_kind: Mapped[str | None] = mapped_column(String(32), nullable=True)
     confidence: Mapped[float] = mapped_column(Float, nullable=False, default=0.0)
     reason: Mapped[str] = mapped_column(Text, nullable=False, default="")
@@ -1196,7 +1196,7 @@ class HealthFinding(Base):
     file_path: Mapped[str] = mapped_column(Text, nullable=False)
     biomarker_type: Mapped[str] = mapped_column(String(64), nullable=False)
     severity: Mapped[str] = mapped_column(String(16), nullable=False)
-    function_name: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    function_name: Mapped[str | None] = mapped_column(Text, nullable=True)
     line_start: Mapped[int | None] = mapped_column(Integer, nullable=True)
     line_end: Mapped[int | None] = mapped_column(Integer, nullable=True)
     details_json: Mapped[str] = mapped_column(Text, nullable=False, default="{}")
@@ -1263,7 +1263,7 @@ class RefactoringSuggestion(Base):
     )
     refactoring_type: Mapped[str] = mapped_column(String(32), nullable=False)
     file_path: Mapped[str] = mapped_column(Text, nullable=False)
-    target_symbol: Mapped[str] = mapped_column(String(255), nullable=False, default="")
+    target_symbol: Mapped[str] = mapped_column(Text, nullable=False, default="")
     line_start: Mapped[int | None] = mapped_column(Integer, nullable=True)
     line_end: Mapped[int | None] = mapped_column(Integer, nullable=True)
     plan_json: Mapped[str] = mapped_column(Text, nullable=False, default="{}")

--- a/tests/integration/test_postgres_symbol_lengths.py
+++ b/tests/integration/test_postgres_symbol_lengths.py
@@ -1,0 +1,124 @@
+"""PostgreSQL regression for issue #1565 — long symbol names must persist.
+
+SQLite ignores ``VARCHAR`` length, so every SQLite test in this suite passes
+whatever the declared width is. Only PostgreSQL enforces it, and that is where
+a generated identifier past 255 characters aborted the persistence phase after
+the whole index had been computed.
+
+Skipped unless a PostgreSQL URL is configured, so a local ``pytest`` run is
+unchanged::
+
+    REPOWISE_TEST_PG_URL=postgresql+asyncpg://user@localhost:5432/repowise_test \\
+        uv run pytest tests/integration/test_postgres_symbol_lengths.py
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from repowise.core.persistence.database import init_db
+from repowise.core.persistence.models import (
+    Base,
+    DeadCodeFinding,
+    GraphNode,
+    HealthFinding,
+    RefactoringSuggestion,
+    Repository,
+    WikiSymbol,
+    _new_uuid,
+)
+
+PG_URL = os.environ.get("REPOWISE_TEST_PG_URL")
+
+pytestmark = pytest.mark.skipif(
+    not PG_URL, reason="REPOWISE_TEST_PG_URL not set — PostgreSQL-only regression"
+)
+
+# Longer than the 255 the columns used to declare, and shorter than anything a
+# btree index limit would care about. Real generated bindings reach this.
+LONG_NAME = "process_" + "generated_protobuf_message_field_descriptor_" * 8 + "value"
+
+
+@pytest.fixture
+async def pg_session():
+    # The fixture drops every table, so it refuses a database that is not
+    # named like a scratch one. Pointing the env var at a real index and
+    # losing it should take more than a typo.
+    database = (PG_URL or "").rsplit("/", 1)[-1].split("?")[0]
+    if "test" not in database and "scratch" not in database:
+        pytest.skip(f"refusing to drop tables in {database!r}: name it *test* or *scratch*")
+
+    engine = create_async_engine(PG_URL or "", poolclass=None)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+    await init_db(engine)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as session:
+        yield session
+    await engine.dispose()
+
+
+async def test_long_symbol_names_round_trip(pg_session: AsyncSession) -> None:
+    """Every column that stores a symbol name accepts one 365 characters long."""
+    assert len(LONG_NAME) > 255
+
+    now = datetime.now(UTC)
+    repo = Repository(id=_new_uuid(), name="repro", local_path="/tmp/repro", url="")
+    pg_session.add(repo)
+    await pg_session.flush()
+
+    pg_session.add_all(
+        [
+            GraphNode(
+                id=_new_uuid(),
+                repository_id=repo.id,
+                node_id=f"generated.py::{LONG_NAME}",
+                node_type="symbol",
+                name=LONG_NAME,
+                qualified_name=LONG_NAME,
+                file_path="generated.py",
+                created_at=now,
+            ),
+            WikiSymbol(
+                id=_new_uuid(),
+                repository_id=repo.id,
+                symbol_id=f"generated.py::{LONG_NAME}",
+                name=LONG_NAME,
+                qualified_name=LONG_NAME,
+                kind="function",
+                parent_name=LONG_NAME,
+                file_path="generated.py",
+            ),
+            DeadCodeFinding(
+                id=_new_uuid(),
+                repository_id=repo.id,
+                kind="unused_export",
+                file_path="generated.py",
+                symbol_name=LONG_NAME,
+            ),
+            HealthFinding(
+                id=_new_uuid(),
+                repository_id=repo.id,
+                file_path="generated.py",
+                biomarker_type="brain_method",
+                severity="high",
+                function_name=LONG_NAME,
+            ),
+            RefactoringSuggestion(
+                id=_new_uuid(),
+                repository_id=repo.id,
+                refactoring_type="extract_method",
+                file_path="generated.py",
+                target_symbol=LONG_NAME,
+            ),
+        ]
+    )
+    await pg_session.commit()
+
+    stored = await pg_session.scalar(select(WikiSymbol.name).where(WikiSymbol.repository_id == repo.id))
+    assert stored == LONG_NAME, "the name came back truncated"

--- a/tests/unit/persistence/test_models.py
+++ b/tests/unit/persistence/test_models.py
@@ -334,3 +334,34 @@ def test_base_includes_all_models():
         "kg_node_meta",
     }
     assert expected == table_names
+
+
+# ---------------------------------------------------------------------------
+# Column widths — the values that have no natural bound
+# ---------------------------------------------------------------------------
+
+# Columns that store a symbol name, or a label built from one. SQLite ignores
+# VARCHAR length, so a narrow type here is invisible on the default backend and
+# aborts the run on PostgreSQL (issue #1565: a 365-character generated symbol
+# name kills `INSERT INTO graph_nodes` in the persistence phase, after the whole
+# index has been computed). Bounded vocabularies — severity, confidence, kind,
+# status — are deliberately absent: String(n) is the right type for those.
+_UNBOUNDED_TEXT_COLUMNS = [
+    ("graph_nodes", "name"),
+    ("wiki_symbols", "name"),
+    ("wiki_symbols", "parent_name"),
+    ("dead_code_findings", "symbol_name"),
+    ("health_findings", "function_name"),
+    ("refactoring_suggestions", "target_symbol"),
+]
+
+
+@pytest.mark.parametrize(("table_name", "column_name"), _UNBOUNDED_TEXT_COLUMNS)
+def test_symbol_columns_are_unbounded_text(table_name: str, column_name: str) -> None:
+    column = Base.metadata.tables[table_name].columns[column_name]
+    length = getattr(column.type, "length", None)
+    assert length is None, (
+        f"{table_name}.{column_name} is {column.type!r}; it holds a symbol name, "
+        "which has no length bound — a long one aborts the PostgreSQL insert. "
+        "Use Text."
+    )


### PR DESCRIPTION
## Summary

- Six columns hold a symbol name under `VARCHAR(255)`. SQLite ignores the width, Postgres enforces it, so the run dies in the persistence phase after the whole index is computed. A one-file repo with a 365-character function name reproduces it on `main`: `StringDataRightTruncationError` on `INSERT INTO graph_nodes`, which is a different table than the one reported, so widening only the reported columns moves the crash.
- Columns widened: `graph_nodes.name`, `wiki_symbols.name`, `wiki_symbols.parent_name`, `dead_code_findings.symbol_name`, `health_findings.function_name`, `refactoring_suggestions.target_symbol`. With them as `Text` the same run completes and the stored values measure 365 to 372.
- Left narrow on measurement: `health_file_metrics.module` (holds a package path, longest producible is 142 on an 18-component tree) and `git_function_blame.symbol_id` at 512 (max 114 across a real 4.5k-row index). Bounded vocabularies keep `String(n)`.
- Migration 0055 is Postgres-only. SQLite does not enforce the width and local stores never run Alembic per 0054, so a batch rebuild of six tables would change nothing.

## Related Issues

Fixes #1565

## Test Plan

Verified against PostgreSQL 16:

- the init that died in Phase 4 now exits 0
- `alembic upgrade head` flips all six columns to `text`; `downgrade -1` returns them to `varchar(255)`
- downgrade with a 400-character row present fails with `StringDataRightTruncationError` and leaves the row intact, rather than truncating it clean
- `alembic upgrade head` then `downgrade -1` on a fresh SQLite file is a no-op that does not error

Two new tests, both confirmed to fail when a column is reverted:

- `tests/unit/persistence/test_models.py` asserts the six columns are unbounded, so the next one cannot ship narrow
- `tests/integration/test_postgres_symbol_lengths.py` round-trips a 365-character name through all six. It skips unless `REPOWISE_TEST_PG_URL` is set, and refuses a database whose name does not look like a scratch one, since it drops tables

- [x] Tests pass (`pytest tests/unit/persistence tests/unit/analysis tests/unit/pipeline tests/integration/test_persistence.py`, 1360 passed)
- [x] Lint passes (`ruff check`)
- [ ] Web build passes (no frontend changes)

Nothing in CI runs Postgres, so this class is invisible there. Happy to open that separately rather than widen this PR.

## Checklist

- [x] My code follows the project's code style
- [x] I have added tests for new functionality
- [x] All existing tests still pass
- [ ] I have updated documentation if needed (no user-facing change)
