### PR TITLE
fix(graph): the bare-name tier must not answer for the standard library

### DIFF
--- a/packages/core/src/repowise/core/ingestion/call_resolver.py
+++ b/packages/core/src/repowise/core/ingestion/call_resolver.py
@@ -31,6 +31,7 @@ from typing import Any
 
 import structlog
 
+from .language_data import get_builtin_methods
 from .languages.receiver_types import (
     FRAMEWORK_DECORATOR_LANGUAGES,
     IMPLICIT_FIELD_LANGUAGES,
@@ -946,8 +947,15 @@ class CallResolver:
         # and a method both declare, firing the tier where it used to refuse —
         # measured at +916 new 0.50-confidence edges on goose, on the one tier
         # hand-read at 28.6% precision.
+        #
+        # A std-library name is refused the same way, and for the same reason
+        # one rung up: the name is in scope in every file without an import,
+        # so the repo symbol that happens to share it is not what the call
+        # site named. `Ok(())` and a chained `.unwrap()` are the shape.
         candidates = self._global_symbols.get(target_name, [])
         if len(candidates) == 1 and candidates[0] != caller_id:
+            if target_name in get_builtin_methods(self._language_of(file_path) or ""):
+                return None
             if candidates[0] in self._non_callable_ids:
                 # Refused here rather than by falling through, so "this tier
                 # can lose an edge but never gain one" is true of the control

--- a/packages/core/src/repowise/core/ingestion/language_data.py
+++ b/packages/core/src/repowise/core/ingestion/language_data.py
@@ -49,6 +49,12 @@ def get_builtin_parents(language: str) -> frozenset[str]:
     return spec.builtin_parents if spec else frozenset()
 
 
+def get_builtin_methods(language: str) -> frozenset[str]:
+    """Return the std-library method names the bare-name tier must not answer."""
+    spec = REGISTRY.get(language)
+    return spec.builtin_methods if spec else frozenset()
+
+
 def get_builtin_types(language: str) -> frozenset[str]:
     """Return the type names that never resolve to a repo-declared symbol."""
     spec = REGISTRY.get(language)

--- a/packages/core/src/repowise/core/ingestion/languages/spec.py
+++ b/packages/core/src/repowise/core/ingestion/languages/spec.py
@@ -147,6 +147,13 @@ class LanguageSpec:
     # clause; a type may be ubiquitous in parameter position without ever
     # being inherited from.
     builtin_types: frozenset[str] = field(default_factory=frozenset)
+    # Method and constructor names the language's own standard library owns.
+    # Read *only* by the bare-name fallback in ``CallResolver``, to stop it
+    # answering ``Ok(..)`` or ``.unwrap()`` with whatever same-named symbol the
+    # repository happens to declare once. Deliberately not ``builtin_calls``:
+    # that set is matched receiver-blind in the parser and drops the call site
+    # outright, which would also delete a real ``obj.unwrap()`` edge.
+    builtin_methods: frozenset[str] = field(default_factory=frozenset)
 
     # -- Display ---------------------------------------------------------
     color_hex: str = "#8b5cf6"  # fallback purple ("other")

--- a/packages/core/src/repowise/core/ingestion/languages/specs/rust.py
+++ b/packages/core/src/repowise/core/ingestion/languages/specs/rust.py
@@ -111,5 +111,34 @@ SPEC = LanguageSpec(
             "Self", "self",
         }
     ),
+    # Prelude constructors and std trait methods. Every one is in scope in
+    # every file without an import, so a bare-name guess that answers one with
+    # a repo symbol is answering for the standard library — `Ok(())` bound to
+    # the single repo symbol spelled `Ok`, `.unwrap()` on a chained receiver
+    # bound to an unrelated private helper. Names a repository plausibly
+    # declares and calls in its own right (`new`, `from`, `get`, `len`, `map`,
+    # `next`, `insert`, `push`, `parse`) are deliberately absent: the tier this
+    # feeds is a guess, but it is not always a wrong one, and the gate is that
+    # every edge it loses was wrong.
+    builtin_methods=frozenset(
+        {
+            # Prelude constructors and variants
+            "Ok", "Err", "Some", "None",
+            # Option / Result
+            "unwrap", "unwrap_or", "unwrap_or_else", "unwrap_or_default",
+            "unwrap_err", "expect", "expect_err",
+            "is_some", "is_none", "is_ok", "is_err",
+            "ok_or", "ok_or_else", "map_err", "and_then", "or_else",
+            # Iterator
+            "collect", "filter_map", "flat_map", "enumerate", "rev",
+            "cloned", "copied", "into_iter", "peekable", "zip",
+            # Conversion and ownership
+            "to_owned", "to_string", "to_vec", "as_ref", "as_mut",
+            "as_str", "as_bytes", "as_slice", "borrow_mut",
+            # str / slice / Path methods with no plausible repo twin
+            "starts_with", "ends_with", "to_lowercase", "to_uppercase",
+            "canonicalize", "is_file", "is_dir",
+        }
+    ),
     color_hex="#DEA584",
 )


### PR DESCRIPTION
## What

`_resolve_free_call`'s last tier answers a bare name with the only symbol in the repository carrying it, at 0.50 confidence. `models.py` already describes it honestly as a guess. When the name belongs to the language's own standard library, that guess is always wrong.

Two shapes reach it in Rust:

- **Prelude constructors.** `Ok(())` and `Some(flag)` bind to whatever single symbol happens to be spelled `Ok` or `Some` — on ripgrep, `crates/core/flags/parse.rs::Ok`.
- **Methods on a receiver no query can name.** The chained-call pattern captures `@call.target` and no receiver, so `parse_low_raw(..).unwrap()` arrives at the resolver looking exactly like a free call and binds to `crates/index/src/literal.rs::GramQuery::unwrap`, a private helper never in scope at the call site.

This adds `LanguageSpec.builtin_methods`, a per-language frozenset read at exactly one site. **Rust only** — every other language's set is empty, so the change is a no-op there by construction.

## Why it is shaped this way

**Not `builtin_calls`.** That set is matched receiver-blind in the parser and drops the call site outright, so putting `unwrap` there would also delete a real `obj.unwrap()` edge.

**Not a rule about chained call sites.** That was the first hypothesis and the measurement refuted it. A volume-weighted sample of chained rows read 20/20 wrong, but that sample was 89% `unwrap` — it was measuring one name. Sampling one row per *distinct* name shows roughly half of them resolve correctly: `Error::with_path`, `InnerLiterals::one_regex`, `BinaryDetection::quit_byte`, `CounterWriter::reset_count` are all chained and all right. The shape is not the discriminator; the name is.

For the same reason the list leaves out names a repository plausibly declares and calls in its own right — `new`, `from`, `get`, `len`, `map`, `next`, `insert`, `push`, `parse`.

**The refusal sits after the uniqueness test and returns rather than falling through**, so the tier can lose an edge and can never gain one. Filtering the candidate pool *before* the length test would do the opposite: it re-uniquifies a name two kinds declare and fires the tier where it previously refused. That variant was measured at +916 new 0.50-confidence edges and rejected.

## Numbers

Predicted before measuring, from an instrument that reads the source line as text and shares no code with the change:

| repo | before | after | removed | predicted |
|---|---:|---:|---:|---:|
| ripgrep | 2,162 | 444 | 1,718 | 1,718 |
| serde | 533 | 282 | 251 | 251 |
| bevy | 5,238 | 2,668 | 2,570 | 2,570 |
| **total** | **7,933** | **3,394** | **4,539** | **4,539** |

**0 edges gained on any repo** — asserted, not assumed.

**Every removed edge was wrong.** The 4,539 removals carry only 21 distinct names, so the name surface was read exhaustively rather than sampled: **21/21 wrong**, plus **20/20** on a volume-weighted draw, with **no correct removal found**. The five largest are `Ok` 1,732, `unwrap` 1,006, `collect` 771, `Some` 291, `Err` 215.

**Precision, hand read from source** (30 rows, 10 each from ripgrep/serde/bevy): **20/30 → 22/30**. At n=30 on a fresh draw that point estimate is inside noise; the firmer result is that the residual changed composition and is now dominated by macro invocations.

**Controls byte-identical.** Alamofire 973 → 973, ktor 860 → 860, celery 338 → 338, zod 453 → 453, gitleaks 0 → 0. On the Rust repos every edge type other than `calls` is unchanged and both node counts are pinned.

**Cost, both sides in one process behind a toggle, measured per file:** ripgrep 9.57 → 9.38 ms/file (the change removes work), bevy 17.00 → 17.02 ms/file.

**Dead-code findings: 0 moved** on ripgrep and serde, nothing gone and nothing new.

## What is deliberately not in here

**Macro invocations.** They reach the same tier — 645 rows across the three repos — and an audit grades them wrong. They are left alone because **the target is correct**: every row read binds to the repository's own `macro_rules!` definition of that name. Deleting them would delete a real dependency in order to raise a precision number. What is wrong is the type, a macro is not a function, and the fix for that is a reclassification off `calls` with its own gate (the precedent is #1690). It is now the largest residual class in the Rust cell.

**Swift and Kotlin.** They ship nothing here and the zero is measured, not assumed: neither language's queries produce a chained or macro shape at all (Alamofire 973 rows and ktor 860 rows are 100% bare), and their standard-name populations are dominated by *external* libraries rather than the language prelude — AssertJ and JUnit on caffeine, coroutines on ktor, Foundation on Alamofire. That is a larger and differently shaped list problem.

## Test plan

- `tests/unit/ingestion/` resolver, language-capability, edge-type-vocabulary and unparseable-language suites: 73 passed
- `ruff check` clean on all four changed files
