### PR TITLE
fix: preserve Java and C# method return types

### DIFF
--- a/packages/core/src/repowise/core/ingestion/extractors/signatures.py
+++ b/packages/core/src/repowise/core/ingestion/extractors/signatures.py
@@ -43,8 +43,14 @@ def build_signature(node_type: str, name: str, params_text: str, def_node: Node,
         # TypeScript/JavaScript class method
         return f"{name}{params_text}{_ret(('return_type',))}"
     if node_type == "method_declaration":
-        # Go method: include receiver text and result type
         recv_node = def_node.child_by_field_name("receiver")
+        declared_type_fields = ("type", "returns")
+        if recv_node is None and any(
+            def_node.child_by_field_name(field) is not None for field in declared_type_fields
+        ):
+            # Java/C#: the declared type is the return type; there is no method keyword.
+            return f"{name}{params_text}{_ret(declared_type_fields)}"
+        # Go method: include receiver text and result type.
         recv_text = node_text(recv_node, src) if recv_node else ""
         recv_prefix = f"{recv_text} " if recv_text else ""
         return f"func {recv_prefix}{name}{params_text}{_ret(('result',))}"

--- a/tests/unit/ingestion/parser/test_method_signatures.py
+++ b/tests/unit/ingestion/parser/test_method_signatures.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import pytest
+
+from repowise.core.ingestion.parser import ASTParser
+from tests.unit.ingestion.parser._helpers import _make_file_info
+
+
+@pytest.mark.parametrize(
+    ("path", "language", "source", "name", "expected"),
+    [
+        (
+            "Example.java",
+            "java",
+            b"class Example { V get(K key) { return null; } }",
+            "get",
+            "get(K key) -> V",
+        ),
+        (
+            "Example.cs",
+            "csharp",
+            b"class Example { V Get(K key) { return default; } }",
+            "Get",
+            "Get(K key) -> V",
+        ),
+        (
+            "example.go",
+            "go",
+            b'package example\ntype Example struct{}\nfunc (e *Example) Get(key string) (string, error) { return "", nil }',
+            "Get",
+            "func (e *Example) Get(key string) -> (string, error)",
+        ),
+    ],
+)
+def test_method_signature_uses_language_syntax(
+    parser: ASTParser, path: str, language: str, source: bytes, name: str, expected: str
+) -> None:
+    result = parser.parse_file(_make_file_info(path, language), source)
+    method = next(symbol for symbol in result.symbols if symbol.name == name)
+    assert method.signature == expected


### PR DESCRIPTION
## Summary

- Preserve Java and C# method return types without adding Go's `func` prefix.
- Keep Go receiver and result signatures unchanged.
- Add regression coverage for Java, C#, and Go method signatures.

## Related Issues

Fixes #1696

## Test Plan

- [x] Tests pass (`uv run pytest -q tests/unit/ingestion/parser/test_method_signatures.py tests/unit/ingestion/parser/test_java.py tests/unit/ingestion/parser/test_csharp.py tests/unit/ingestion/parser/test_go.py`) — 36 passed
- [x] Lint passes (`uv run ruff check` on both changed files)
- [x] Format check passes (`uv run ruff format --check` on both changed files)
- [x] Type check passes (`uv run mypy --follow-imports=skip packages/core/src/repowise/core/ingestion/extractors/signatures.py`)
- [ ] Web build passes (`npm run build`) *(N/A — no frontend changes)*

## Checklist

- [x] My code follows the project's code style
- [x] I have added tests for new functionality
- [ ] All existing tests still pass *(full suite not run; all relevant parser tests pass)*
- [x] I have updated documentation if needed *(N/A — behavior fix covered by tests)*
