### PR TITLE
fix(mcp): honor configured reasoning in get_answer

### DIFF
--- a/packages/server/src/repowise/server/mcp_server/tool_answer/answer.py
+++ b/packages/server/src/repowise/server/mcp_server/tool_answer/answer.py
@@ -179,6 +179,7 @@ from repowise.server.mcp_server.tool_answer.symbols import (
 from repowise.server.mcp_server.tool_answer.synthesis import (
     _hash_question,
     _resolve_provider_for_answer,
+    _resolve_reasoning_for_answer,
     synthesize,
 )
 
@@ -669,6 +670,7 @@ async def get_answer(
         provider,
         _SYSTEM_PROMPT,
         user_prompt,
+        reasoning=_resolve_reasoning_for_answer(getattr(ctx, "path", None)),
         session_factory=getattr(ctx, "session_factory", None),
         repo_id=repo_id,
     )

--- a/packages/server/src/repowise/server/mcp_server/tool_answer/synthesis.py
+++ b/packages/server/src/repowise/server/mcp_server/tool_answer/synthesis.py
@@ -15,6 +15,8 @@ import math
 import os
 from pathlib import Path
 
+from repowise.core.reasoning import ReasoningMode, resolve_reasoning
+from repowise.core.repo_config import load_repo_config
 from repowise.server.mcp_server.tool_answer.config import (
     _SYNTHESIS_MAX_TOKENS,
     _SYNTHESIS_TEMPERATURE,
@@ -44,6 +46,12 @@ def _hash_question(question: str) -> str:
     """Stable SHA-256 of the normalized question. Lowercase + strip + collapse ws."""
     norm = " ".join(question.lower().strip().split())
     return hashlib.sha256(norm.encode("utf-8")).hexdigest()
+
+
+def _resolve_reasoning_for_answer(repo_path: Path | None) -> ReasoningMode:
+    """Resolve the synthesis reasoning mode from env and repo config."""
+    config = load_repo_config(repo_path) if repo_path is not None else None
+    return resolve_reasoning(config=config)
 
 
 def _load_repo_provider_config(
@@ -392,6 +400,7 @@ async def synthesize(
     system_prompt: str,
     user_prompt: str,
     *,
+    reasoning: ReasoningMode = "auto",
     session_factory=None,
     repo_id: str | None = None,
 ) -> tuple[str, str | None]:
@@ -424,6 +433,7 @@ async def synthesize(
                     user_prompt=user_prompt,
                     max_tokens=_SYNTHESIS_MAX_TOKENS,
                     temperature=_SYNTHESIS_TEMPERATURE,
+                    reasoning=reasoning,
                 ),
                 None,
             )

--- a/tests/unit/server/mcp/test_answer_always_synthesize.py
+++ b/tests/unit/server/mcp/test_answer_always_synthesize.py
@@ -83,6 +83,50 @@ async def test_non_dominant_returns_prose_at_medium_with_evidence(setup_mcp, mon
 
 
 @pytest.mark.asyncio
+async def test_configured_reasoning_reaches_synthesis(setup_mcp, monkeypatch):
+    import repowise.server.mcp_server.tool_answer.answer as answer_mod
+    from repowise.server.mcp_server import get_answer
+
+    _patch_pipeline(monkeypatch, answer_mod, scores=(2.0, 1.9))
+    _patch_provider(monkeypatch, answer_mod, "The go() function drives it (pkg/alpha/one.py).")
+    monkeypatch.setenv("REPOWISE_REASONING", "off")
+    seen: dict = {}
+
+    async def _capture_synthesis(provider, system_prompt, user_prompt, **kwargs):
+        seen.update(kwargs)
+        return "The go() function drives it (pkg/alpha/one.py).", None
+
+    monkeypatch.setattr(answer_mod, "synthesize", _capture_synthesis)
+
+    await get_answer("how does the alpha module go function work")
+
+    assert seen["reasoning"] == "off"
+
+
+@pytest.mark.asyncio
+async def test_repo_reasoning_resolution_reaches_synthesis(setup_mcp, monkeypatch):
+    import repowise.server.mcp_server.tool_answer.answer as answer_mod
+    from repowise.server.mcp_server import get_answer
+
+    _patch_pipeline(monkeypatch, answer_mod, scores=(2.0, 1.9))
+    _patch_provider(monkeypatch, answer_mod, "The go() function drives it (pkg/alpha/one.py).")
+    monkeypatch.setattr(
+        answer_mod, "_resolve_reasoning_for_answer", lambda _path: "low", raising=False
+    )
+    seen: dict = {}
+
+    async def _capture_synthesis(provider, system_prompt, user_prompt, **kwargs):
+        seen.update(kwargs)
+        return "The go() function drives it (pkg/alpha/one.py).", None
+
+    monkeypatch.setattr(answer_mod, "synthesize", _capture_synthesis)
+
+    await get_answer("how does the alpha module go function work")
+
+    assert seen["reasoning"] == "low"
+
+
+@pytest.mark.asyncio
 async def test_hedged_non_dominant_demotes_low_but_keeps_prose(setup_mcp, monkeypatch):
     """(b) A hedged synthesis on non-dominant retrieval still demotes to low,
     but now carries the prose + best_guesses instead of an empty answer."""

--- a/tests/unit/server/mcp/test_answer_synthesis_timeout.py
+++ b/tests/unit/server/mcp/test_answer_synthesis_timeout.py
@@ -305,7 +305,16 @@ async def test_prompts_and_sampling_are_passed_through_unchanged():
         "user_prompt": "the user prompt",
         "max_tokens": _SYNTHESIS_MAX_TOKENS,
         "temperature": _SYNTHESIS_TEMPERATURE,
+        "reasoning": "auto",
     }
+
+
+async def test_reasoning_mode_is_passed_to_the_provider():
+    provider = _SlowProvider(duration=0, budget=30.0)
+
+    await synthesize(provider, "system", "user", reasoning="off")
+
+    assert provider.calls[0]["reasoning"] == "off"
 
 
 async def test_a_non_timeout_failure_is_not_reported_as_a_budget_overrun():

--- a/tests/unit/server/mcp/test_provider_resolution.py
+++ b/tests/unit/server/mcp/test_provider_resolution.py
@@ -13,6 +13,7 @@ import json as _json
 
 import pytest
 
+from repowise.server.mcp_server.tool_answer import synthesis as synthesis_module
 from repowise.server.mcp_server.tool_answer.synthesis import (
     _load_repo_provider_config,
     _resolve_provider_for_answer,
@@ -25,6 +26,7 @@ def _clean_env(monkeypatch):
         "REPOWISE_PROVIDER",
         "REPOWISE_DOC_MODEL",
         "REPOWISE_MODEL",
+        "REPOWISE_REASONING",
         "OPENAI_API_KEY",
         "ANTHROPIC_API_KEY",
         "GEMINI_API_KEY",
@@ -70,6 +72,12 @@ def test_state_json_still_used_when_config_lacks_provider(tmp_path):
     name, model, _ = _load_repo_provider_config(repo)
     assert name == "openai"
     assert model == "gpt-5.4-nano"
+
+
+def test_reasoning_is_loaded_from_repo_config(tmp_path):
+    repo = _write_repo(tmp_path, config={"reasoning": "low"})
+
+    assert synthesis_module._resolve_reasoning_for_answer(repo) == "low"
 
 
 def test_keyless_persisted_provider_falls_back_to_available_key(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

- resolve the MCP answer synthesis reasoning mode through the shared `resolve_reasoning` helper
- thread the resolved mode through `get_answer` and `synthesize` into `provider.generate`
- add focused regression coverage for environment, repo-config, orchestration, and provider-call propagation

## Root cause

`get_answer` resolved the configured provider, but it never resolved the reasoning mode. `synthesize` also omitted the `reasoning` argument when calling `provider.generate`, so the provider's default `"auto"` applied on every synthesis call. As a result, `REPOWISE_REASONING=off` and the repo-local reasoning setting had no effect on MCP answer synthesis.

## Impact

Users can now disable or select reasoning for `get_answer` through the same environment and `.repowise/config.yaml` settings used by other generation paths. This prevents reasoning-capable models from silently ignoring `off` during the 1024-token answer synthesis budget.

## Validation

- `python -m pytest tests/unit/server/mcp/test_provider_resolution.py tests/unit/server/mcp/test_answer_synthesis_timeout.py tests/unit/server/mcp/test_answer_always_synthesize.py -q` — 73 passed
- `ruff check` on the five changed files
- `ruff format --check` on the five changed files

Closes #1560
