### PR TITLE
fix(ingestion): strip leading colon from TS return type in signatures

### DIFF
--- a/packages/core/src/repowise/core/ingestion/extractors/signatures.py
+++ b/packages/core/src/repowise/core/ingestion/extractors/signatures.py
@@ -15,7 +15,14 @@ def build_signature(node_type: str, name: str, params_text: str, def_node: Node,
         for f in fields:
             n = def_node.child_by_field_name(f)
             if n is not None:
-                return f" -> {node_text(n, src)}"
+                text = node_text(n, src)
+                # TypeScript/JavaScript's return_type is a type_annotation
+                # node whose text already carries a leading colon (": string"),
+                # unlike Python ("int"), Rust ("i32"), or Go ("string"). Strip
+                # it so we never emit a doubled " -> : type".
+                if text.startswith(":"):
+                    text = text[1:].lstrip()
+                return f" -> {text}"
         return ""
 
     if node_type == "function_definition":

--- a/tests/unit/ingestion/test_ts_signature_colon.py
+++ b/tests/unit/ingestion/test_ts_signature_colon.py
@@ -1,0 +1,56 @@
+"""Tests for TypeScript/JavaScript signature building (stray colon fix)."""
+
+from __future__ import annotations
+
+import pytest
+from tree_sitter import Language, Parser
+
+import tree_sitter_typescript
+
+from repowise.core.ingestion.extractors.signatures import build_signature
+
+
+def _sig(code: bytes, node_type: str) -> str:
+    parser = Parser(Language(tree_sitter_typescript.language_typescript()))
+    tree = parser.parse(code)
+
+    def find(node):
+        if node.type == node_type:
+            return node
+        for child in node.children:
+            found = find(child)
+            if found is not None:
+                return found
+        return None
+
+    def_node = find(tree.root_node)
+    assert def_node is not None
+    name = ""
+    for child in def_node.children:
+        if child.type in ("identifier", "property_identifier"):
+            name = child.text.decode()
+            break
+    return build_signature(node_type, name, "()", def_node, code.decode())
+
+
+def test_ts_function_signature_no_doubled_colon() -> None:
+    sig = _sig(
+        b'function foo(a: number): string { return "x"; }',
+        "function_declaration",
+    )
+    assert sig == "function foo() -> string"
+    assert "-> :" not in sig
+
+
+def test_ts_method_signature_no_doubled_colon() -> None:
+    sig = _sig(
+        b"class C { bar(): number { return 1 } }",
+        "method_definition",
+    )
+    assert sig == "bar() -> number"
+    assert "-> :" not in sig
+
+
+def test_ts_function_no_return_type() -> None:
+    sig = _sig(b"function baz() { return; }", "function_declaration")
+    assert sig == "function baz()"

--- a/tests/unit/ingestion/test_ts_signature_colon.py
+++ b/tests/unit/ingestion/test_ts_signature_colon.py
@@ -2,10 +2,8 @@
 
 from __future__ import annotations
 
-import pytest
-from tree_sitter import Language, Parser
-
 import tree_sitter_typescript
+from tree_sitter import Language, Parser
 
 from repowise.core.ingestion.extractors.signatures import build_signature
 


### PR DESCRIPTION
Fixes #1695

## Problem
TypeScript/JavaScript function signatures rendered with a stray colon: `function foo() -> : string` instead of `function foo() -> string`.

## Root cause
In `signatures.py`, `_ret` prepends ` -> ` to the return-type node's text. For TypeScript/JavaScript, the `return_type` field is a `type_annotation` node whose text **already includes a leading colon** (`: string`). Python (`int`), Rust (`i32`), and Go (`string`) return-type nodes don't include the colon, so only TS/JS were affected.

## Fix
Strip a leading colon (and any following space) from the return-type text in `_ret`, so signatures render as `-> string`. Other languages are unaffected since their return-type text doesn't start with a colon.

## Tests
Added `test_ts_signature_colon.py` covering:
- TS function with return type → `function foo() -> string` (no `-> :`)
- TS method with return type → `bar() -> number`
- TS function with no return type → `function baz()`

All pass.