### PR TITLE
fix(cli): warn when cascade budget truncates regeneration

### DIFF
--- a/packages/cli/src/repowise/cli/commands/update_cmd/command.py
+++ b/packages/cli/src/repowise/cli/commands/update_cmd/command.py
@@ -1203,9 +1203,9 @@ def run_update(
         affected.regenerate = list(dict.fromkeys([*affected.regenerate, *stale_renderer_paths]))
         console.print(f"Pages from an older renderer: [cyan]{len(stale_renderer_paths)}[/cyan]")
 
-    if cascade_budget_is_auto and cascade_budget == 50 and getattr(affected, "stale_due_to_budget", 0) > 0:
+    if affected.stale_due_to_budget > 0:
         console.print(
-            f"\n[yellow]⚠ Cascade budget capped at 50 pages. "
+            f"\n[yellow]⚠ Cascade budget of {cascade_budget} pages was reached. "
             f"{affected.stale_due_to_budget} dependent pages were skipped and marked stale.[/yellow]"
         )
         console.print(

--- a/packages/cli/src/repowise/cli/commands/update_cmd/command.py
+++ b/packages/cli/src/repowise/cli/commands/update_cmd/command.py
@@ -1177,7 +1177,8 @@ def run_update(
         emitter.stage("plan_pages")
 
     # Determine affected pages (auto-scale budget if not explicitly set)
-    if cascade_budget is None:
+    cascade_budget_is_auto = cascade_budget is None
+    if cascade_budget_is_auto:
         from repowise.core.ingestion.change_detector import compute_adaptive_budget
 
         cascade_budget = compute_adaptive_budget(file_diffs, file_count)
@@ -1201,6 +1202,16 @@ def run_update(
     if stale_renderer_paths:
         affected.regenerate = list(dict.fromkeys([*affected.regenerate, *stale_renderer_paths]))
         console.print(f"Pages from an older renderer: [cyan]{len(stale_renderer_paths)}[/cyan]")
+
+    if cascade_budget_is_auto and cascade_budget == 50 and getattr(affected, "stale_due_to_budget", 0) > 0:
+        console.print(
+            f"\n[yellow]⚠ Cascade budget capped at 50 pages. "
+            f"{affected.stale_due_to_budget} dependent pages were skipped and marked stale.[/yellow]"
+        )
+        console.print(
+            f"[yellow]  Pass `--cascade-budget {cascade_budget + affected.stale_due_to_budget}` "
+            f"to regenerate them all.[/yellow]\n"
+        )
 
     console.print(f"Pages to regenerate: [cyan]{len(affected.regenerate)}[/cyan]")
     if affected.decay_only:

--- a/packages/core/src/repowise/core/ingestion/change_detector.py
+++ b/packages/core/src/repowise/core/ingestion/change_detector.py
@@ -76,6 +76,7 @@ class AffectedPages:
     regenerate: list[str]  # page IDs to fully regenerate
     rename_patch: list[str]  # pages that only need a symbol rename text patch
     decay_only: list[str]  # pages to mark stale without immediate regeneration
+    stale_due_to_budget: int = 0  # pages skipped due to cascade budget cap
 
 
 def compute_adaptive_budget(file_diffs: list[FileDiff], total_files: int) -> int:
@@ -464,12 +465,14 @@ class ChangeDetector:
         decay_only = (
             all_pages_needing_regen[cascade_budget:] + sorted(two_hop) + sorted(co_change_decay)
         )
+        stale_due_to_budget = max(0, len(all_pages_needing_regen) - cascade_budget)
         rename_patch = [p for p in rename_candidates if p in regenerate]
 
         return AffectedPages(
             regenerate=regenerate,
             rename_patch=rename_patch,
             decay_only=decay_only,
+            stale_due_to_budget=stale_due_to_budget,
         )
 
     # ------------------------------------------------------------------

--- a/tests/unit/ingestion/test_change_detector.py
+++ b/tests/unit/ingestion/test_change_detector.py
@@ -236,6 +236,18 @@ class TestGetAffectedPages:
         assert len(result.regenerate) <= 3
         # Some go to decay_only
         assert len(result.decay_only) > 0
+        # Check that skipped pages are counted in stale_due_to_budget
+        assert result.stale_due_to_budget > 0
+        assert result.stale_due_to_budget == 10 - len(result.regenerate)
+
+    def test_stale_due_to_budget_is_zero_when_under_budget(self, tmp_path: Path) -> None:
+        """When under cascade budget, stale_due_to_budget should be 0."""
+        d = self._detector(tmp_path)
+        g = nx.DiGraph()
+        g.add_node("file0.py")
+        diff = self._simple_file_diff("file0.py")
+        result = d.get_affected_pages([diff], graph=g, cascade_budget=50)
+        assert result.stale_due_to_budget == 0
 
     def test_all_lists_are_disjoint(self, tmp_path: Path) -> None:
         """regenerate, rename_patch, and decay_only should be disjoint."""


### PR DESCRIPTION
Fixes #850

When the `--cascade-budget` is omitted, `repowise update` automatically sets a cascade budget of up to 50 pages to prevent runaway costs on large refactors. Previously, if this 50-page cap was reached, the regeneration would silently truncate, leaving the remaining dependent pages untouched but quietly marking them as stale (decayed) without notifying the user.

This PR adds a warning that fires **only** when the 50-page auto-cap is actively binding and truncation occurs.

### Changes
- Updated `AffectedPages` in `change_detector.py` to track `stale_due_to_budget`, which captures the exact number of pages skipped due to the cascade budget.
- Added a warning in the CLI (`update_cmd/command.py`) that informs the user how many dependent pages were left stale when the budget hits the cap.
- The warning explicitly provides the command needed to regenerate the skipped pages (`--cascade-budget N`).
- Added tests in `test_change_detector.py` to assert that `stale_due_to_budget` correctly tracks skipped pages.
