### PR TITLE
fix(ingestion): capture TypeScript #private class members and calls

### DIFF
--- a/packages/core/src/repowise/core/ingestion/queries/typescript.scm
+++ b/packages/core/src/repowise/core/ingestion/queries/typescript.scm
@@ -50,6 +50,12 @@
   parameters: (formal_parameters) @symbol.params
 ) @symbol.def
 
+; Private method inside class body (ECMAScript #private members)
+(method_definition
+  name: (private_property_identifier) @symbol.name
+  parameters: (formal_parameters) @symbol.params
+) @symbol.def
+
 ; Arrow function assigned to const/let: const foo = (...) => { }
 (lexical_declaration
   (variable_declarator
@@ -226,7 +232,7 @@
 (call_expression
   function: (member_expression
     object: [(identifier) (this)] @call.receiver
-    property: (property_identifier) @call.target
+    property: [(property_identifier) (private_property_identifier)] @call.target
   )
   arguments: (arguments) @call.arguments
 ) @call.site

--- a/tests/unit/ingestion/parser/test_typescript.py
+++ b/tests/unit/ingestion/parser/test_typescript.py
@@ -630,3 +630,36 @@ export const handler = onCall(async () => 1);
 
     def test_class_and_function_expression_bindings_are_indexed(self, parser: ASTParser) -> None:
         assert {"KlassExpr", "fnExpr"} <= self._names(parser)
+
+
+class TestTypeScriptPrivateMembers:
+    """ECMAScript #private class members should produce a symbol and a call site.
+
+    Regression for #1715: tree-sitter spells ``#foo`` as
+    ``private_property_identifier``, which the symbol and member-call query
+    patterns did not accept, so private methods were invisible at both ends.
+    """
+
+    def test_private_method_produces_symbol(self, parser: ASTParser) -> None:
+        fi = _make_file_info("src/counter.ts", "typescript")
+        src = b"""\
+class Counter {
+  #count = 0;
+  #increment() { this.#count++; }
+  inc() { this.#increment(); return this.#count; }
+}"""
+        result = parser.parse_file(fi, src)
+        method_names = [s.name for s in result.symbols if s.kind == "method"]
+        assert "#increment" in method_names
+
+    def test_private_method_call_produces_call_site(self, parser: ASTParser) -> None:
+        fi = _make_file_info("src/counter.ts", "typescript")
+        src = b"""\
+class Counter {
+  #count = 0;
+  #increment() { this.#count++; }
+  inc() { this.#increment(); return this.#count; }
+}"""
+        result = parser.parse_file(fi, src)
+        call_targets = [c.target_name for c in result.calls]
+        assert "#increment" in call_targets


### PR DESCRIPTION
Fixes #1715

## Problem
ECMAScript `#private` class members (`#foo`) produced **no symbol** and **no call site** — invisible at both ends.

## Root cause
tree-sitter-typescript spells `#foo` as `private_property_identifier`. The `method_definition` symbol pattern only accepts `property_identifier`, and the member-call pattern only accepts `property_identifier` for the property, so private methods were dropped entirely.

## Fix
In `queries/typescript.scm`:
- Add a `method_definition` symbol pattern that accepts `private_property_identifier`
- Widen the member-call `property:` alternation to include `private_property_identifier`

(`queries/tsx.scm` only contains JSX-specific additions and doesn't duplicate these patterns.)

## Tests
Added `TestTypeScriptPrivateMembers` to `test_typescript.py`:
- `#increment` appears as a method symbol
- `this.#increment()` produces a call site with target `#increment`

All 45 TS parser tests pass.