### PR TITLE
fix(ingestion): probe index.tsx and index.jsx for relative TS imports

### DIFF
--- a/packages/core/src/repowise/core/ingestion/resolvers/typescript.py
+++ b/packages/core/src/repowise/core/ingestion/resolvers/typescript.py
@@ -34,9 +34,11 @@ def resolve_ts_js_import(module_path: str, importer_path: str, ctx: ResolverCont
             ".js",
             ".jsx",
             "/index.ts",
+            "/index.tsx",
             "/index.mts",
             "/index.cts",
             "/index.js",
+            "/index.jsx",
         )
         if ctx.has_sfc_files:
             # Both the bare file (``./Foo`` -> ``Foo.vue``) and the directory

--- a/tests/unit/ingestion/test_typescript_resolver.py
+++ b/tests/unit/ingestion/test_typescript_resolver.py
@@ -79,6 +79,46 @@ class TestExplicitRelativeExtensions:
         assert result == "data/example.ts"
 
 
+class TestDirectoryIndexProbing:
+    """A relative import to a directory must probe its index files.
+
+    The resolver already probed ``/index.ts`` and ``/index.js`` but missed the
+    two React index forms (``/index.tsx``, ``/index.jsx``) that the bare
+    extension list and the tsconfig path resolver both accept — so a
+    directory-index React component resolved to nothing and read as an
+    unreachable external dep.
+    """
+
+    @pytest.mark.parametrize(
+        "index_file",
+        [
+            "src/components/TodoList/index.ts",
+            "src/components/TodoList/index.tsx",
+            "src/components/TodoList/index.mts",
+            "src/components/TodoList/index.cts",
+            "src/components/TodoList/index.js",
+            "src/components/TodoList/index.jsx",
+        ],
+    )
+    def test_directory_index_resolves(self, tmp_path: Path, index_file: str) -> None:
+        ctx = _ctx(tmp_path, [index_file, "src/main.ts"])
+        result = resolve_ts_js_import("./components/TodoList", "src/main.ts", ctx)
+        assert result == index_file
+
+    def test_tsx_index_wins_over_ts_when_both_present(self, tmp_path: Path) -> None:
+        # ``/index.ts`` is probed before ``/index.tsx``; when both exist the
+        # first match wins, matching the bare-extension ordering.
+        ctx = _ctx(
+            tmp_path,
+            [
+                "src/components/TodoList/index.ts",
+                "src/components/TodoList/index.tsx",
+            ],
+        )
+        result = resolve_ts_js_import("./components/TodoList", "src/main.ts", ctx)
+        assert result == "src/components/TodoList/index.ts"
+
+
 class TestWorkspaceMap:
     def test_workspaces_array_form(self, tmp_path: Path) -> None:
         (tmp_path / "package.json").write_text(json.dumps({"workspaces": ["packages/*"]}))


### PR DESCRIPTION
Fixes #1717

## Problem
A relative import to a directory probed `/index.ts` and `/index.js` but missed the two React index forms (`/index.tsx`, `/index.jsx`) that the bare-extension list and the tsconfig path resolver both accept. A directory-index React component therefore resolved to nothing and read as an unreachable external dep.

## Fix
Add `/index.tsx` and `/index.jsx` to the relative-import probe list, keeping the existing ordering (`/index.ts` before `/index.tsx`, matching the bare-extension order).

## Test
Parametrized test covering every index extension plus a ts-before-tsx ordering guard. `tests/unit/ingestion/test_typescript_resolver.py`: 70 passed.