### PR TITLE
fix(ingestion): keep package qualifier on Go embeds

### DIFF
--- a/packages/core/src/repowise/core/ingestion/extractors/heritage/go.py
+++ b/packages/core/src/repowise/core/ingestion/extractors/heritage/go.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from tree_sitter import Node
 
 from ...models import HeritageRelation
-from ...type_names import bare_type_name
+from ...type_names import strip_type_arguments
 from ..helpers import node_text
 
 
@@ -33,12 +33,16 @@ def _extract_go_heritage(
             type_child = field_decl.child_by_field_name("type")
             if name_node is None and type_child is not None:
                 parent = node_text(type_child, src).strip().lstrip("*")
-                bare = bare_type_name(parent)
-                if bare:
+                # Keep the package qualifier: ``io.Reader`` must stay
+                # ``io.Reader``, not ``Reader``, or an embed of a stdlib type
+                # binds to whatever repo-local type shares the short name (and
+                # can inherit from itself). Type arguments are still stripped.
+                parent = strip_type_arguments(parent)
+                if parent:
                     out.append(
                         HeritageRelation(
                             child_name=name,
-                            parent_name=bare,
+                            parent_name=parent,
                             kind="mixin",
                             line=line,
                         )
@@ -53,12 +57,13 @@ def _extract_go_heritage(
             # is a generic bound, carrying no methods to inherit.
             if "|" in text or "~" in text:
                 continue
-            bare = bare_type_name(text)
-            if bare:
+            # Keep the package qualifier (see the struct branch above).
+            parent = strip_type_arguments(text)
+            if parent:
                 out.append(
                     HeritageRelation(
                         child_name=name,
-                        parent_name=bare,
+                        parent_name=parent,
                         kind="extends",
                         line=line,
                     )

--- a/tests/unit/ingestion/test_go_extractors.py
+++ b/tests/unit/ingestion/test_go_extractors.py
@@ -46,6 +46,28 @@ class TestGoHeritage:
         parents = {r.parent_name for r in result.heritage}
         assert "Base" in parents
 
+    def test_qualified_embed_keeps_package_qualifier(self, parser: ASTParser) -> None:
+        """``io.Reader`` must stay ``io.Reader``, not ``Reader``.
+
+        Stripping the qualifier lets an embed of a stdlib type bind to whatever
+        repo-local type shares the short name — and when the enclosing type
+        has that same name, the type inherits from itself.
+        """
+        src = b"package x\n\ntype Reader struct{}\n\ntype Foo struct {\n  io.Reader\n}\n"
+        result = parser.parse_file(_file(), src)
+        parents = {r.parent_name for r in result.heritage}
+        assert "io.Reader" in parents
+        assert "Reader" not in parents
+
+    def test_qualified_interface_embed_keeps_package_qualifier(
+        self, parser: ASTParser
+    ) -> None:
+        src = b"package x\n\ntype Reader interface{}\n\ntype Foo interface {\n  io.Reader\n}\n"
+        result = parser.parse_file(_file(), src)
+        parents = {r.parent_name for r in result.heritage}
+        assert "io.Reader" in parents
+        assert "Reader" not in parents
+
 
 class TestGoBindings:
     def test_imports(self, parser: ASTParser) -> None:

--- a/tests/unit/ingestion/test_heritage_type_names.py
+++ b/tests/unit/ingestion/test_heritage_type_names.py
@@ -54,17 +54,39 @@ CASES: list[tuple[str, str, str, str, list[tuple[str, str]]]] = [
     ("cpp", "cpp", "class Child : public {p} {{}};\n", "ns::Qual", [("Qual", "extends")]),
     ("cpp", "cpp", "class Child : public {p} {{}};\n", "ns::Both<Arg>", [("Both", "extends")]),
     # --- go: struct embedding ----------------------------------------------
+    # Go keeps the package qualifier on an embed: ``io.Reader`` must stay
+    # ``io.Reader``, not ``Reader``, or an embed of a stdlib type binds to
+    # whatever repo-local type shares the short name (and can inherit from
+    # itself). Type arguments are still stripped.
     ("go", "go", "type Child struct {{\n\t{p}\n}}\n", "Bare", [("Bare", "mixin")]),
     ("go", "go", "type Child struct {{\n\t{p}\n}}\n", "Gen[Arg]", [("Gen", "mixin")]),
-    ("go", "go", "type Child struct {{\n\t{p}\n}}\n", "ns.Qual", [("Qual", "mixin")]),
-    ("go", "go", "type Child struct {{\n\t{p}\n}}\n", "ns.Both[Arg]", [("Both", "mixin")]),
+    ("go", "go", "type Child struct {{\n\t{p}\n}}\n", "ns.Qual", [("ns.Qual", "mixin")]),
+    (
+        "go",
+        "go",
+        "type Child struct {{\n\t{p}\n}}\n",
+        "ns.Both[Arg]",
+        [("ns.Both", "mixin")],
+    ),
     # --- go: interface embedding -------------------------------------------
     # The same relation through a different node — the grammar wraps each
     # embed in a `type_elem`.
     ("go", "go", "type Child interface {{\n\t{p}\n}}\n", "Bare", [("Bare", "extends")]),
     ("go", "go", "type Child interface {{\n\t{p}\n}}\n", "Gen[Arg]", [("Gen", "extends")]),
-    ("go", "go", "type Child interface {{\n\t{p}\n}}\n", "ns.Qual", [("Qual", "extends")]),
-    ("go", "go", "type Child interface {{\n\t{p}\n}}\n", "ns.Both[Arg]", [("Both", "extends")]),
+    (
+        "go",
+        "go",
+        "type Child interface {{\n\t{p}\n}}\n",
+        "ns.Qual",
+        [("ns.Qual", "extends")],
+    ),
+    (
+        "go",
+        "go",
+        "type Child interface {{\n\t{p}\n}}\n",
+        "ns.Both[Arg]",
+        [("ns.Both", "extends")],
+    ),
     # A type set is a generic bound, not an embed: it carries no methods.
     ("go", "go", "type Child interface {{\n\t{p}\n}}\n", "~int | string", []),
     # ...and skipping one must not cost the embed sitting beside it.


### PR DESCRIPTION
Fixes #1716

## Problem
Go heritage extraction stripped the package qualifier via `bare_type_name`, so an embed of `io.Reader` became `Reader` and bound to whatever repo-local type shared the short name — and when the enclosing type had that same name, the type inherited from itself.

## Fix
Keep the qualifier (strip only type arguments) on both the struct and interface embed branches of `extractors/heritage/go.py`.

## Test
Pinned the new behaviour in the heritage type-name table (`ns.Qual` → `ns.Qual`, `ns.Both[Arg]` → `ns.Both`) and added a self-inheritance regression test asserting `io.Reader` stays `io.Reader` and never binds to a local `Reader`. `test_go_extractors.py` + `test_heritage_type_names.py`: 64 passed.