### PR TITLE
fix(ingestion): capture Go method calls through a field

### DIFF
--- a/packages/core/src/repowise/core/ingestion/queries/go.scm
+++ b/packages/core/src/repowise/core/ingestion/queries/go.scm
@@ -64,6 +64,20 @@
   arguments: (argument_list) @call.arguments
 ) @call.site
 
+; Method call through a field: a.b.Method(args)
+; The operand is itself a selector_expression (``o.in`` in ``o.in.Do()``),
+; which the identifier-only pattern above does not match, so the call was
+; missing from the graph entirely. Capture the whole receiver expression so
+; the resolver has something to type; resolution is a separate, measured
+; change and must not route the composed text to the bare-name lookup.
+(call_expression
+  function: (selector_expression
+    operand: (selector_expression) @call.receiver
+    field: (field_identifier) @call.target
+  )
+  arguments: (argument_list) @call.arguments
+) @call.site
+
 ; Package-qualified call: pkg.Function(args)
 ; (same pattern as method call — receiver is the package alias)
 ; Captured by the selector_expression pattern above.

--- a/tests/unit/ingestion/test_go_extractors.py
+++ b/tests/unit/ingestion/test_go_extractors.py
@@ -80,3 +80,42 @@ class TestGoMethodReceiver:
         reset = [s for s in result.symbols if s.name == "reset"]
         assert reset
         assert reset[0].parent_name == "cache"
+
+
+class TestGoCallThroughField:
+    """A method call whose receiver is a field (``o.in.Do()``) must be captured.
+
+    The operand of the selector is itself a selector_expression, which the
+    identifier-only method-call pattern did not match — so the call was missing
+    from the graph entirely rather than present and unresolved. Capture the
+    whole receiver expression; resolution is a separate, measured change.
+    """
+
+    def test_field_receiver_call_site_is_captured(self, parser: ASTParser) -> None:
+        src = (
+            b"package p\n\n"
+            b"type inner struct{}\n\n"
+            b"func (i inner) Do() {}\n\n"
+            b"type outer struct{ in inner }\n\n"
+            b"func (o outer) Run() {\n"
+            b"\to.in.Do()\n"
+            b"}\n"
+        )
+        result = parser.parse_file(_file(), src)
+        do_calls = [c for c in result.calls if c.target_name == "Do"]
+        assert len(do_calls) == 1, f"expected one call site for Do, got {do_calls}"
+        assert do_calls[0].receiver_name == "o.in"
+
+    def test_plain_method_call_still_captured(self, parser: ASTParser) -> None:
+        src = (
+            b"package p\n\n"
+            b"type inner struct{}\n\n"
+            b"func (i inner) Do() {}\n\n"
+            b"func (o outer) Run() {\n"
+            b"\ti.Do()\n"
+            b"}\n"
+        )
+        result = parser.parse_file(_file(), src)
+        do_calls = [c for c in result.calls if c.target_name == "Do"]
+        assert len(do_calls) == 1, f"expected one call site for Do, got {do_calls}"
+        assert do_calls[0].receiver_name == "i"


### PR DESCRIPTION
Fixes #1718

## Problem
A call written `a.b.Method()` — receiver is a field, not a plain variable — matched no call pattern, so no call site was recorded at all. The call was missing from the graph rather than present and unresolved, which also meant it did not appear in any recall or coverage figure as a miss.

## Fix
Add a pattern accepting a `selector_expression` operand and capture the whole receiver expression so the resolver has something to type. This is the **capture half only**, per the issue's guidance: resolution is a separate, measured change and must not route the composed receiver to the bare-name lookup.

## Test
Parser test asserting `o.in.Do()` yields one call site with receiver `o.in`, plus a guard that a plain `i.Do()` still captures. `test_go_extractors.py`: 10 passed; broader Go suite: 83 passed.