### PR TITLE
fix(ingestion): resolve module.symbol() calls through submodule bindings

### DIFF
--- a/packages/core/src/repowise/core/ingestion/import_index.py
+++ b/packages/core/src/repowise/core/ingestion/import_index.py
@@ -52,11 +52,17 @@ def build_import_name_maps(parsed_files: dict[str, ParsedFile]) -> ImportNameMap
                 for binding in imp.bindings:
                     if binding.local_name == "*":
                         continue
-                    binding.source_file = resolved
-                    maps.import_names[path][binding.local_name] = resolved
+                    # A binding whose source_file was already pinned to a
+                    # submodule file (``from pkg import submodule`` fan-out,
+                    # #1193) must keep it: ``imp.resolved_file`` is the package
+                    # ``__init__.py``, which declares nothing the submodule
+                    # name resolves to. Only back-fill when unset.
+                    if binding.source_file is None:
+                        binding.source_file = resolved
+                    maps.import_names[path][binding.local_name] = binding.source_file
                     maps.import_bindings[path][binding.local_name] = binding
                     if binding.is_module_alias:
-                        maps.module_aliases[path][binding.local_name] = resolved
+                        maps.module_aliases[path][binding.local_name] = binding.source_file
             else:
                 # Fallback for imports without binding data
                 for name in imp.imported_names:

--- a/packages/core/src/repowise/core/ingestion/resolvers/python.py
+++ b/packages/core/src/repowise/core/ingestion/resolvers/python.py
@@ -114,4 +114,14 @@ def resolve_python_import_all(
                         break
             if hit and hit != base:
                 targets.append(hit)
+                # Point the binding for this name at the submodule file, not
+                # the package ``__init__.py``. ``from pkg import submodule``
+                # binds ``submodule`` to ``pkg/submodule.py``, so a later
+                # ``submodule.symbol()`` call must resolve against that file
+                # (#1193). Without this the binding's source_file stays the
+                # package init, which declares nothing, and the call is missed.
+                for binding in imp.bindings:
+                    if binding.local_name == name:
+                        binding.source_file = hit
+                        break
     return tuple(dict.fromkeys(targets))

--- a/tests/unit/ingestion/test_python_resolver_fanout.py
+++ b/tests/unit/ingestion/test_python_resolver_fanout.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import networkx as nx
 
-from repowise.core.ingestion.models import Import
+from repowise.core.ingestion.models import Import, NamedBinding
 from repowise.core.ingestion.resolvers.context import ResolverContext
 from repowise.core.ingestion.resolvers.python import resolve_python_import_all
 
@@ -19,13 +19,20 @@ def _ctx(path_set: set[str]) -> ResolverContext:
     return ResolverContext(path_set=path_set, stem_map={}, graph=nx.DiGraph())
 
 
-def _imp(module_path: str, names: list[str], *, relative: bool = False) -> Import:
+def _imp(
+    module_path: str,
+    names: list[str],
+    *,
+    relative: bool = False,
+    bindings: list | None = None,
+) -> Import:
     return Import(
         raw_statement="",
         module_path=module_path,
         imported_names=names,
         is_relative=relative,
         resolved_file=None,
+        bindings=bindings or [],
     )
 
 
@@ -97,3 +104,55 @@ def test_source_root_nested_package_fans_out() -> None:
     imp = _imp("myapp.routers", ["users"])
     targets = resolve_python_import_all(imp, "src/myapp/server.py", _ctx(paths))
     assert targets == ("src/myapp/routers/__init__.py", "src/myapp/routers/users.py")
+
+
+def test_submodule_binding_points_at_submodule_file() -> None:
+    """``from pkg import submodule`` binds ``submodule`` to the submodule file.
+
+    The binding's source_file must be ``pkg/submodule.py``, not the package
+    ``__init__.py``, so a later ``submodule.symbol()`` call resolves against
+    the file that actually declares the symbol (#1193).
+    """
+    paths = {
+        "sensors/__init__.py",
+        "sensors/foo.py",
+        "caller.py",
+    }
+    imp = _imp(
+        "sensors",
+        ["foo"],
+        bindings=[NamedBinding(local_name="foo", exported_name=None, source_file=None)],
+    )
+    targets = resolve_python_import_all(imp, "caller.py", _ctx(paths))
+    assert targets == ("sensors/__init__.py", "sensors/foo.py")
+    # The binding for ``foo`` must point at the submodule file.
+    assert len(imp.bindings) == 1
+    assert imp.bindings[0].local_name == "foo"
+    assert imp.bindings[0].source_file == "sensors/foo.py"
+
+
+def test_non_submodule_binding_keeps_package_init() -> None:
+    """A name that is not a submodule file keeps the package init as its source.
+
+    ``from pkg import some_function`` (a symbol re-exported by the package)
+    must not be repointed to a submodule file that does not exist.
+    """
+    paths = {
+        "sensors/__init__.py",
+        "sensors/foo.py",
+        "caller.py",
+    }
+    imp = _imp(
+        "sensors",
+        ["some_function"],
+        bindings=[
+            NamedBinding(
+                local_name="some_function", exported_name=None, source_file=None
+            )
+        ],
+    )
+    targets = resolve_python_import_all(imp, "caller.py", _ctx(paths))
+    assert targets == ("sensors/__init__.py",)
+    assert len(imp.bindings) == 1
+    assert imp.bindings[0].local_name == "some_function"
+    assert imp.bindings[0].source_file is None


### PR DESCRIPTION
Fixes #1193

## Problem
`from pkg import submodule` bound `submodule` to the package `__init__.py` (the fan-out's first target), so a later `submodule.symbol()` call resolved against a file that declares nothing and the call was missed. Dead-code then reported the symbol as safe-to-delete despite a real caller.

## Fix
Two-part:
- `resolve_python_import_all` now points each submodule binding's `source_file` at the submodule file it resolves to, not the package init.
- `build_import_name_maps` only back-fills a binding's `source_file` when it is unset, so the submodule pin survives.

Verified end-to-end: `from sensors import foo; foo.check()` now resolves to `sensors/foo.py::check` (0.88).

## Test
Adds regression tests for the submodule-binding pin and the non-submodule (package re-export) case. `test_python_resolver_fanout.py`: 9 passed; full `tests/unit/ingestion` + `tests/unit/dead_code`: 2855 passed (1 pre-existing env failure unrelated to this change).