### PR TITLE
fix(cpp): use byte-safe AST node text

### DIFF
--- a/packages/core/src/repowise/core/ingestion/extractors/visibility.py
+++ b/packages/core/src/repowise/core/ingestion/extractors/visibility.py
@@ -16,6 +16,8 @@ import re
 from collections.abc import Callable
 from typing import TYPE_CHECKING
 
+from .helpers import node_text
+
 if TYPE_CHECKING:
     from tree_sitter import Node
 
@@ -412,7 +414,7 @@ def _has_export_marker(def_node: Node, src: str) -> bool:
     sibling = def_node.prev_sibling
     seen = 0
     while sibling is not None and seen < 4:
-        text = src[sibling.start_byte : sibling.end_byte]
+        text = node_text(sibling, src)
         if any(marker in text for marker in _CPP_EXPORT_MARKERS):
             return True
         sibling = sibling.prev_sibling
@@ -420,7 +422,7 @@ def _has_export_marker(def_node: Node, src: str) -> bool:
     # Also check the def_node's own leading children — some grammars
     # nest the declspec inside the function_definition.
     for child in def_node.children[:3]:
-        text = src[child.start_byte : child.end_byte]
+        text = node_text(child, src)
         if any(marker in text for marker in _CPP_EXPORT_MARKERS):
             return True
     return False
@@ -430,7 +432,7 @@ def _has_file_scope_static(def_node: Node, src: str) -> bool:
     """Return True if a ``static`` storage-class specifier appears in the leading declarators."""
     for child in def_node.children[:4]:
         if child.type == "storage_class_specifier":
-            text = src[child.start_byte : child.end_byte]
+            text = node_text(child, src)
             if "static" in text:
                 return True
     return False

--- a/packages/core/src/repowise/core/ingestion/parser_helpers.py
+++ b/packages/core/src/repowise/core/ingestion/parser_helpers.py
@@ -113,7 +113,7 @@ def _qualified_cpp_parent(name_node: Node, src: str) -> str | None:
     scope = parent.child_by_field_name("scope")
     if scope is None:
         return None
-    text = src[scope.start_byte : scope.end_byte].strip()
+    text = node_text(scope, src).strip()
     # ``scope`` may itself be a qualified path (``NS::Foo``); take the
     # last component — that's the immediate enclosing type.
     return text.rsplit("::", 1)[-1] or None

--- a/tests/unit/ingestion/test_cpp_extractors.py
+++ b/tests/unit/ingestion/test_cpp_extractors.py
@@ -121,10 +121,32 @@ void Free() { }
         assert by_name["Free"].kind == "function"
         assert by_name["Free"].parent_name is None
 
+    def test_qualified_definition_after_multibyte_text_binds_to_class(
+        self, parser: ASTParser
+    ) -> None:
+        src = """\
+// Author: 李
+void Foo::DoWork() { }
+""".encode()
+        result = parser.parse_file(_file(), src)
+        sym = next(s for s in result.symbols if s.name == "DoWork")
+        assert sym.kind == "method"
+        assert sym.parent_name == "Foo"
+
     def test_dllexport_marks_exported_symbol(self, parser: ASTParser) -> None:
         src = b"""\
 extern "C" __declspec(dllexport) HRESULT DllRegisterServer(void) { return 0; }
 """
+        result = parser.parse_file(_file(), src)
+        sym = next(s for s in result.symbols if s.name == "DllRegisterServer")
+        assert sym.visibility == "public"
+        assert sym.is_exported_symbol is True
+
+    def test_dllexport_after_multibyte_text_marks_exported_symbol(self, parser: ASTParser) -> None:
+        src = """\
+// Author: 李
+extern "C" __declspec(dllexport) HRESULT DllRegisterServer(void) { return 0; }
+""".encode()
         result = parser.parse_file(_file(), src)
         sym = next(s for s in result.symbols if s.name == "DllRegisterServer")
         assert sym.visibility == "public"


### PR DESCRIPTION
## Summary

- Replace four C/C++ helpers' decoded-string byte-offset slices with the existing `node_text()` helper, so earlier multibyte UTF-8 text cannot shift AST node extraction.
- Add end-to-end regressions for both affected outcomes: preserving `__declspec(dllexport)` metadata and attaching a qualified `Foo::method()` definition to `Foo`.

The root cause was using tree-sitter byte offsets to slice a decoded Python `str`. When a non-ASCII character appeared earlier in the file, those byte offsets selected the wrong characters, silently dropping either the export flag or the method-parent graph edge.

## Related Issues

Fixes #1699

## Test Plan

- [x] Confirmed both new multibyte regression tests fail on unmodified `main`.
- [x] C++ ingestion and parser tests pass (`118 passed`).
- [x] Full Python lint passes (`ruff check .`).
- [x] Web build is not applicable; this change only touches Python ingestion code and tests.

## Checklist

- [x] My code follows the project's code style.
- [x] I have added tests for the bug fix.
- [x] Relevant existing tests pass.
- [x] Documentation changes are not needed for this internal parser correction.
