### PR TITLE
tests: drop the workspace ctx field that no longer exists

### DIFF
--- a/tests/unit/cli/test_workspace_init_dry_run.py
+++ b/tests/unit/cli/test_workspace_init_dry_run.py
@@ -57,7 +57,6 @@ def _ctx(repo: Path, *, dry_run: bool) -> _WorkspaceCtx:
         yes=True,
         resume=False,
         onboarding=False,
-        harvest_decisions=False,
         wiki_style="default",
         language="en",
         resolved_reasoning="auto",


### PR DESCRIPTION
Main is red on every Python job (3.11, 3.12, 3.13) with a single error:

```
TypeError: _WorkspaceCtx.__init__() got an unexpected keyword argument 'harvest_decisions'
FAILED tests/unit/cli/test_workspace_init_dry_run.py::test_workspace_dry_run_never_persists
FAILED tests/unit/cli/test_workspace_init_dry_run.py::test_workspace_dry_run_still_counts_files
```

Neither of the two pull requests involved was wrong on its own, and both were green when they ran.

#1610 removed the `harvest_decisions` plumbing from workspace init: the field on `_WorkspaceCtx`, the parameter on `_run_workspace_generation`, the parameter on `_workspace_init`, and the advanced-options read that fed it. #1526 added these dry-run regression tests from a branch cut before that removal, so its `_ctx()` helper still builds a `_WorkspaceCtx` with `harvest_decisions=False`. Neither branch's CI saw the other's tree, and main went red the moment the second one landed.

The kwarg is dropped rather than replaced. Nothing else in the tree references `harvest_decisions` in any language, so there is no surviving setting for the tests to pin, and what these two tests assert is that a dry run persists nothing, not anything about decision harvesting. Their coverage is unchanged.

Those two tests are the only failures in the run, so this takes main back to green on its own.

## Verification

Branch cut from a freshly fetched `origin/main` (dd41b02c).

- The two previously failing tests: 2 passed
- Full `tests/unit/cli/`: 2169 passed, 2 skipped, 2 xfailed, exit 0
- `ruff check .`: all checks passed