### PR TITLE
fix(mcp): widen transport_security to match --host

### DIFF
--- a/packages/server/src/repowise/server/mcp_server/_server.py
+++ b/packages/server/src/repowise/server/mcp_server/_server.py
@@ -9,6 +9,7 @@ from contextlib import asynccontextmanager
 from typing import Any
 
 from mcp.server.fastmcp import FastMCP
+from mcp.server.transport_security import TransportSecuritySettings
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from repowise.core.persistence.database import (
@@ -562,6 +563,46 @@ def create_mcp_server(
 #: two deep in practice; the cap only stops a pathological cycle from hanging.
 _MAX_GROUP_DEPTH = 10
 
+#: Host values FastMCP's own default construction already treats as local.
+_LOOPBACK_HOSTS = ("127.0.0.1", "localhost", "::1")
+
+#: ``allowed_hosts``/``allowed_origins`` patterns for the loopback callers a
+#: non-loopback bind should still accept (e.g. an SSH tunnel or a client
+#: running on the same box as the server).
+_LOOPBACK_ALLOWLIST_PATTERNS = ("127.0.0.1:*", "localhost:*", "[::1]:*")
+
+
+def _configure_transport_security(host: str) -> None:
+    """Widen the DNS-rebinding ``Host`` allowlist to match ``--host``.
+
+    ``FastMCP`` builds ``mcp.settings.transport_security`` at import time,
+    before any CLI ``--host`` is known, so it bakes in an allowlist scoped to
+    loopback only. ``run_mcp`` rebinds the socket via ``mcp.settings.host``
+    later, but nothing updated the allowlist to match — so every request to a
+    non-loopback ``--host`` failed ``Host`` header validation with
+    ``421 Misdirected Request`` no matter what host was actually given.
+
+    A loopback host needs no change (FastMCP's default already covers it). A
+    wildcard bind (``0.0.0.0``/``::``) can't be matched by any single ``Host``
+    value, so the check is disabled rather than left permanently failing.
+    Anything else gets an allowlist scoped to that host plus loopback.
+    """
+    if host in _LOOPBACK_HOSTS:
+        return
+    if host in ("0.0.0.0", "::"):
+        mcp.settings.transport_security = TransportSecuritySettings(
+            enable_dns_rebinding_protection=False,
+        )
+        return
+    mcp.settings.transport_security = TransportSecuritySettings(
+        enable_dns_rebinding_protection=True,
+        allowed_hosts=[f"{host}:*", *_LOOPBACK_ALLOWLIST_PATTERNS],
+        allowed_origins=[
+            f"http://{host}:*",
+            *(f"http://{p}" for p in _LOOPBACK_ALLOWLIST_PATTERNS),
+        ],
+    )
+
 
 def _run_transport(transport: str) -> None:
     """Run the server, raising the cause of a task-group failure rather than the group.
@@ -612,6 +653,7 @@ def run_mcp(
     if transport == "sse":
         mcp.settings.host = host
         mcp.settings.port = port
+        _configure_transport_security(host)
         if host in ("0.0.0.0", "::") and not os.environ.get("REPOWISE_API_KEY"):
             _log.warning(
                 "SECURITY WARNING: MCP server (sse) is binding to %s without "
@@ -623,6 +665,7 @@ def run_mcp(
     elif transport == "streamable-http":
         mcp.settings.host = host
         mcp.settings.port = port
+        _configure_transport_security(host)
         if host in ("0.0.0.0", "::") and not os.environ.get("REPOWISE_API_KEY"):
             _log.warning(
                 "SECURITY WARNING: MCP server (streamable-http) is binding to %s without "

--- a/packages/server/src/repowise/server/mcp_server/_server.py
+++ b/packages/server/src/repowise/server/mcp_server/_server.py
@@ -572,6 +572,21 @@ _LOOPBACK_HOSTS = ("127.0.0.1", "localhost", "::1")
 _LOOPBACK_ALLOWLIST_PATTERNS = ("127.0.0.1:*", "localhost:*", "[::1]:*")
 
 
+def _bracket_if_ipv6(host: str) -> str:
+    """Bracket a bare IPv6 literal to match the ``Host``/``Origin`` header shape a client sends.
+
+    ``TransportSecurityMiddleware`` matches by ``host.startswith(base + ":")``
+    (see ``mcp/server/transport_security.py``), so an allowlist entry has to
+    be shaped exactly like the wire value. A client connecting to an IPv6
+    literal sends a bracketed Host header (``[2001:db8::1]:7338``), which
+    never starts with a bare ``2001:db8::1:`` — hostnames and IPv4 addresses
+    never contain a colon, so any colon in ``host`` here means IPv6.
+    """
+    if ":" in host and not host.startswith("["):
+        return f"[{host}]"
+    return host
+
+
 def _configure_transport_security(host: str) -> None:
     """Widen the DNS-rebinding ``Host`` allowlist to match ``--host``.
 
@@ -582,10 +597,17 @@ def _configure_transport_security(host: str) -> None:
     non-loopback ``--host`` failed ``Host`` header validation with
     ``421 Misdirected Request`` no matter what host was actually given.
 
-    A loopback host needs no change (FastMCP's default already covers it). A
-    wildcard bind (``0.0.0.0``/``::``) can't be matched by any single ``Host``
-    value, so the check is disabled rather than left permanently failing.
-    Anything else gets an allowlist scoped to that host plus loopback.
+    A loopback host needs no change (FastMCP's default already covers it).
+    Anything else — including a concrete IPv6 literal, bracketed to match the
+    header shape — gets an allowlist scoped to that host plus loopback.
+
+    A wildcard bind (``0.0.0.0``/``::``) can't be matched by any single
+    ``Host`` value, so the check is disabled rather than left permanently
+    failing. That trades DNS-rebinding protection for reachability on a
+    wildcard bind; the startup security warning logged elsewhere in
+    ``run_mcp`` for an unauthenticated wide bind is, until #1400 lands, the
+    only remaining gate on that surface — this fix is what makes it live
+    traffic instead of traffic that already 421'd.
     """
     if host in _LOOPBACK_HOSTS:
         return
@@ -594,11 +616,18 @@ def _configure_transport_security(host: str) -> None:
             enable_dns_rebinding_protection=False,
         )
         return
+    base = _bracket_if_ipv6(host)
+    # allowed_origins inherits the SDK's same startswith(base + ":") prefix
+    # match as allowed_hosts (see _validate_origin), so e.g.
+    # "http://172.21.12.48:*" also technically accepts an Origin like
+    # "http://172.21.12.48:8080.evil.com". Pre-existing SDK behavior — the
+    # loopback defaults FastMCP bakes in have the identical looseness — not
+    # something introduced or worsened here.
     mcp.settings.transport_security = TransportSecuritySettings(
         enable_dns_rebinding_protection=True,
-        allowed_hosts=[f"{host}:*", *_LOOPBACK_ALLOWLIST_PATTERNS],
+        allowed_hosts=[f"{base}:*", *_LOOPBACK_ALLOWLIST_PATTERNS],
         allowed_origins=[
-            f"http://{host}:*",
+            f"http://{base}:*",
             *(f"http://{p}" for p in _LOOPBACK_ALLOWLIST_PATTERNS),
         ],
     )

--- a/tests/unit/server/test_mcp_transport_security.py
+++ b/tests/unit/server/test_mcp_transport_security.py
@@ -66,6 +66,32 @@ def test_hostname_bind_gets_widened_too() -> None:
     assert "http://my-machine.lan:*" in settings.allowed_origins
 
 
+def test_ipv6_host_gets_bracketed_in_the_allowlist() -> None:
+    """A bare IPv6 --host must be bracketed to match the Host header shape a
+    client actually sends (``[2001:db8::1]:7338``, not ``2001:db8::1:7338``).
+    """
+    _server._configure_transport_security("2001:db8::1")
+    settings = _server.mcp.settings.transport_security
+
+    assert settings.enable_dns_rebinding_protection is True
+    assert "[2001:db8::1]:*" in settings.allowed_hosts
+    assert "http://[2001:db8::1]:*" in settings.allowed_origins
+
+
+@pytest.mark.parametrize(
+    ("host", "expected"),
+    [
+        ("172.21.12.48", "172.21.12.48"),
+        ("my-machine.lan", "my-machine.lan"),
+        ("2001:db8::1", "[2001:db8::1]"),
+        ("[2001:db8::1]", "[2001:db8::1]"),  # already bracketed — left alone
+        ("::1", "[::1]"),
+    ],
+)
+def test_bracket_if_ipv6(host: str, expected: str) -> None:
+    assert _server._bracket_if_ipv6(host) == expected
+
+
 @pytest.mark.parametrize(
     ("header_host", "expected"),
     [
@@ -79,6 +105,25 @@ def test_hostname_bind_gets_widened_too() -> None:
 def test_real_middleware_validates_reported_host_header(header_host: str, expected: bool) -> None:
     """Exercise the actual SDK middleware, not just our settings object."""
     _server._configure_transport_security("172.21.12.48")
+    middleware = TransportSecurityMiddleware(_server.mcp.settings.transport_security)
+
+    assert middleware._validate_host(header_host) is expected
+
+
+@pytest.mark.parametrize(
+    ("header_host", "expected"),
+    [
+        ("[2001:db8::1]:7338", True),  # bracketed, as a real client sends it
+        ("2001:db8::1:7338", False),  # unbracketed — not the wire shape, must not match
+        ("[::1]:7338", True),  # loopback pattern still allowed alongside it
+        ("[2001:db8::2]:7338", False),  # a different IPv6 host
+    ],
+)
+def test_real_middleware_validates_ipv6_host_header(header_host: str, expected: bool) -> None:
+    """The gap a prior review caught: an unbracketed allowlist entry never
+    matches the bracketed Host header a client sends for an IPv6 literal.
+    """
+    _server._configure_transport_security("2001:db8::1")
     middleware = TransportSecurityMiddleware(_server.mcp.settings.transport_security)
 
     assert middleware._validate_host(header_host) is expected

--- a/tests/unit/server/test_mcp_transport_security.py
+++ b/tests/unit/server/test_mcp_transport_security.py
@@ -1,0 +1,119 @@
+"""Tests for the MCP HTTP/SSE transport_security host allowlist.
+
+``repowise mcp --transport streamable-http --host <non-loopback>`` failed
+every request with ``421 Misdirected Request`` / ``Invalid Host header``,
+regardless of the ``--host`` value given. ``FastMCP`` builds
+``mcp.settings.transport_security`` at import time, before any CLI ``--host``
+is known, so it bakes in a DNS-rebinding ``Host`` allowlist scoped to
+loopback only; ``run_mcp`` later rebinds the socket via ``mcp.settings.host``
+but never updated the allowlist to match.
+
+``_configure_transport_security`` rebuilds the allowlist around the actual
+bind host (or disables the now-unsatisfiable check for a wildcard bind).
+"""
+
+from __future__ import annotations
+
+import pytest
+from mcp.server.transport_security import TransportSecurityMiddleware
+
+from repowise.server.mcp_server import _server
+
+
+@pytest.fixture(autouse=True)
+def _restore_transport_security():
+    """Isolate mcp.settings.transport_security across tests."""
+    original = _server.mcp.settings.transport_security
+    yield
+    _server.mcp.settings.transport_security = original
+
+
+def test_loopback_host_is_left_alone() -> None:
+    """127.0.0.1/localhost/::1 already work under FastMCP's default — no-op."""
+    before = _server.mcp.settings.transport_security
+
+    for host in ("127.0.0.1", "localhost", "::1"):
+        _server.mcp.settings.transport_security = before
+        _server._configure_transport_security(host)
+        assert _server.mcp.settings.transport_security is before
+
+
+def test_wildcard_bind_disables_the_host_check() -> None:
+    """0.0.0.0/:: can't be matched by any single Host value, so it's disabled."""
+    for host in ("0.0.0.0", "::"):
+        _server._configure_transport_security(host)
+        settings = _server.mcp.settings.transport_security
+        assert settings.enable_dns_rebinding_protection is False
+
+
+def test_lan_host_gets_widened_to_that_host_plus_loopback() -> None:
+    _server._configure_transport_security("172.21.12.48")
+    settings = _server.mcp.settings.transport_security
+
+    assert settings.enable_dns_rebinding_protection is True
+    assert "172.21.12.48:*" in settings.allowed_hosts
+    assert "127.0.0.1:*" in settings.allowed_hosts
+    assert "localhost:*" in settings.allowed_hosts
+    assert "[::1]:*" in settings.allowed_hosts
+    assert "http://172.21.12.48:*" in settings.allowed_origins
+
+
+def test_hostname_bind_gets_widened_too() -> None:
+    _server._configure_transport_security("my-machine.lan")
+    settings = _server.mcp.settings.transport_security
+
+    assert "my-machine.lan:*" in settings.allowed_hosts
+    assert "http://my-machine.lan:*" in settings.allowed_origins
+
+
+@pytest.mark.parametrize(
+    ("header_host", "expected"),
+    [
+        ("172.21.12.48:7338", True),
+        ("localhost:7338", True),
+        ("127.0.0.1:7338", True),
+        ("172.21.12.48", False),  # bare host, no port — not in the allowlist
+        ("evil.com:7338", False),
+    ],
+)
+def test_real_middleware_validates_reported_host_header(header_host: str, expected: bool) -> None:
+    """Exercise the actual SDK middleware, not just our settings object."""
+    _server._configure_transport_security("172.21.12.48")
+    middleware = TransportSecurityMiddleware(_server.mcp.settings.transport_security)
+
+    assert middleware._validate_host(header_host) is expected
+
+
+def test_run_mcp_applies_transport_security_for_streamable_http(monkeypatch) -> None:
+    calls: list[dict] = []
+    monkeypatch.setattr(_server.mcp, "run", lambda **kw: calls.append(kw))
+    monkeypatch.delenv("REPOWISE_API_KEY", raising=False)
+
+    _server.run_mcp(transport="streamable-http", host="172.21.12.48", port=7338)
+
+    settings = _server.mcp.settings.transport_security
+    assert settings.enable_dns_rebinding_protection is True
+    assert "172.21.12.48:*" in settings.allowed_hosts
+
+
+def test_run_mcp_applies_transport_security_for_sse(monkeypatch) -> None:
+    calls: list[dict] = []
+    monkeypatch.setattr(_server.mcp, "run", lambda **kw: calls.append(kw))
+    monkeypatch.delenv("REPOWISE_API_KEY", raising=False)
+
+    _server.run_mcp(transport="sse", host="172.21.12.48", port=7338)
+
+    settings = _server.mcp.settings.transport_security
+    assert settings.enable_dns_rebinding_protection is True
+    assert "172.21.12.48:*" in settings.allowed_hosts
+
+
+def test_run_mcp_stdio_does_not_touch_transport_security(monkeypatch) -> None:
+    """stdio never binds a socket — there's nothing for the allowlist to gate."""
+    before = _server.mcp.settings.transport_security
+    monkeypatch.setattr(_server.mcp, "run", lambda **kw: None)
+    monkeypatch.setattr("repowise.server.mcp_server._watchdog.start_parent_watchdog", lambda: None)
+
+    _server.run_mcp(transport="stdio")
+
+    assert _server.mcp.settings.transport_security is before


### PR DESCRIPTION
FastMCP builds its module-level instance with no host= argument, at import time, before any CLI --host is known, so it auto-bakes a DNS-rebinding Host allowlist scoped to loopback only. run_mcp() later rebinds the socket via mcp.settings.host, but never updated the allowlist to match, so every request to a non-loopback --host failed Host validation with 421 Misdirected Request no matter what --host was given.

_configure_transport_security() rebuilds the allowlist around the actual bind host (or disables the now-unsatisfiable Host check for a wildcard bind, where nothing else currently gates access).

## Summary

<!-- What does this PR do? Keep it to 1-3 bullet points. -->

- Widen the MCP HTTP/SSE transport's DNS-rebinding `Host` allowlist to match `--host`, instead of leaving it frozen on loopback (fixes `421 Misdirected Request` on any non-default `--host`)

## Related Issues

<!-- Link any related issues: Fixes #123, Closes #456 -->

Fixes #1736
Related to #1400 (same function — `run_mcp` in `_server.py` — but a distinct concern: #1400 is about missing authentication on a wide-open bind, which this PR does not address)

## Test Plan

<!-- How did you verify this works? -->

- [x] Tests pass (`pytest`) — `uv run pytest tests/unit/server/test_mcp_transport_security.py tests/unit/cli/test_mcp_transport.py`, 28 passed
- [x] Lint passes (`ruff check .`)
- [ ] Web build passes (`npm run build`) *(if frontend changes)* — n/a, no frontend changes
- [x] Manual: `repowise mcp --transport streamable-http --host <non-loopback IP>`, then a request with a matching `Host` header — `200 OK` / clean `initialize` response, no `421`/`Invalid Host header` (verified against both a wildcard `0.0.0.0` bind and a concrete interface IP)

## Checklist

- [x] My code follows the project's code style
- [x] I have added tests for new functionality
- [x] All existing tests still pass
- [ ] I have updated documentation if needed