### PR TITLE
remove duplicate Python decorator collection

### DIFF
--- a/packages/core/src/repowise/core/ingestion/parser.py
+++ b/packages/core/src/repowise/core/ingestion/parser.py
@@ -569,11 +569,29 @@ class ASTParser:
         if file_info.language in _TS_JS_LANGUAGES:
             ts_deferred_exports = ts_deferred_export_names(src)
 
+        # Pre-group modifier nodes (e.g. decorators) by symbol (start_line, name)
+        modifiers_by_symbol: dict[tuple[int, str], list[Node]] = {}
+        for capture_dict in matches:
+            def_nodes = capture_dict.get("symbol.def", [])
+            name_nodes = capture_dict.get("symbol.name", [])
+            modifier_nodes = capture_dict.get("symbol.modifiers", [])
+            if def_nodes and name_nodes:
+                def_node = def_nodes[0]
+                name = _node_text(name_nodes[0], src)
+                if name:
+                    start_line = def_node.start_point[0] + 1
+                    key = (start_line, name)
+                    if key not in modifiers_by_symbol:
+                        modifiers_by_symbol[key] = []
+                    existing_ids = {id(n) for n in modifiers_by_symbol[key]}
+                    for m in modifier_nodes:
+                        if id(m) not in existing_ids:
+                            modifiers_by_symbol[key].append(m)
+
         for capture_dict in matches:
             def_nodes = capture_dict.get("symbol.def", [])
             name_nodes = capture_dict.get("symbol.name", [])
             params_nodes = capture_dict.get("symbol.params", [])
-            modifier_nodes = capture_dict.get("symbol.modifiers", [])
             receiver_nodes = capture_dict.get("symbol.receiver", [])
 
             if not def_nodes or not name_nodes:
@@ -589,6 +607,7 @@ class ASTParser:
             if dedup_key in seen:
                 continue
             seen.add(dedup_key)
+            modifier_nodes = modifiers_by_symbol.get(dedup_key, [])
 
             # Kind from node type
             node_type = def_node.type
@@ -688,10 +707,7 @@ class ASTParser:
 
             # Visibility
             modifier_texts = [_node_text(m, src) for m in modifier_nodes]
-            if def_node.parent and def_node.parent.type == "decorated_definition":
-                for sibling in def_node.parent.children:
-                    if sibling.type == "decorator":
-                        modifier_texts.append(_node_text(sibling, src))
+
 
             # Rust: outer attributes (#[...]) are preceding siblings of the item
             rust_attrs: list[str] = []

--- a/tests/unit/ingestion/parser/test_python.py
+++ b/tests/unit/ingestion/parser/test_python.py
@@ -233,6 +233,102 @@ class TestPythonParser:
         assert "add" in result.exports
         assert "Calculator" in result.exports
 
+    def test_single_decorator_on_function(self, parser: ASTParser) -> None:
+        """Test that a decorated function has exactly one decorator entry (no duplication)."""
+        source = b'''
+@pytest.fixture
+def setup_db():
+    """Setup test database."""
+    pass
+'''
+        fi = _make_file_info("test_db.py", "python")
+        result = parser.parse_file(fi, source)
+        setup = next(s for s in result.symbols if s.name == "setup_db")
+        assert setup.decorators == ["@pytest.fixture"], "Single decorator should not be duplicated"
+        assert len(setup.decorators) == 1, "Decorator list should have exactly one entry"
+
+    def test_multiple_decorators_on_function(self, parser: ASTParser) -> None:
+        """Test that multiple decorators are captured without duplication."""
+        source = b'''
+@app.get("/users")
+@validate_request
+@cache(ttl=300)
+def list_users():
+    """List all users."""
+    pass
+'''
+        fi = _make_file_info("api.py", "python")
+        result = parser.parse_file(fi, source)
+        list_users = next(s for s in result.symbols if s.name == "list_users")
+        assert len(list_users.decorators) == 3, "Should have exactly 3 decorators"
+        assert any("@app.get" in d for d in list_users.decorators), "Should contain @app.get"
+        assert any("@validate_request" in d for d in list_users.decorators), "Should contain @validate_request"
+        assert any("@cache" in d for d in list_users.decorators), "Should contain @cache"
+
+    def test_decorated_class(self, parser: ASTParser) -> None:
+        """Test that decorated classes are captured correctly."""
+        source = b'''
+@dataclass
+class User:
+    """User model."""
+    name: str
+'''
+        fi = _make_file_info("models.py", "python")
+        result = parser.parse_file(fi, source)
+        user = next(s for s in result.symbols if s.name == "User" and s.kind == "class")
+        assert user.decorators == ["@dataclass"], "Class decorator should be captured exactly once"
+
+    def test_undecorated_function_has_empty_decorators(self, parser: ASTParser) -> None:
+        """Test that functions without decorators have empty decorators list."""
+        source = b'''
+def plain_function():
+    """A function with no decorators."""
+    pass
+'''
+        fi = _make_file_info("utils.py", "python")
+        result = parser.parse_file(fi, source)
+        plain = next(s for s in result.symbols if s.name == "plain_function")
+        assert plain.decorators == [], "Undecorated function should have empty decorators list"
+
+    def test_decorator_with_complex_args(self, parser: ASTParser) -> None:
+        """Test that decorators with complex arguments are captured completely."""
+        source = b'''
+@pytest.mark.parametrize("input,expected", [(1, 2), (3, 4)])
+def test_add(input, expected):
+    """Parametrized test."""
+    pass
+'''
+        fi = _make_file_info("test_calc.py", "python")
+        result = parser.parse_file(fi, source)
+        test_add = next(s for s in result.symbols if s.name == "test_add")
+        assert len(test_add.decorators) == 1, "Should have exactly one decorator"
+        assert "parametrize" in test_add.decorators[0], "Decorator should contain parametrize"
+        assert "[(1" in test_add.decorators[0], "Should preserve arguments"
+
+    def test_method_decorator_not_duplicated(self, parser: ASTParser) -> None:
+        """Regression test: method decorators should not be duplicated."""
+        source = b'''
+class Calculator:
+    @staticmethod
+    def version() -> str:
+        """Return version string."""
+        return "1.0"
+    
+    @classmethod
+    def create(cls):
+        """Create instance."""
+        return cls()
+'''
+        fi = _make_file_info("calc.py", "python")
+        result = parser.parse_file(fi, source)
+        version = next(s for s in result.symbols if s.name == "version")
+        create = next(s for s in result.symbols if s.name == "create")
+        assert len(version.decorators) == 1, "@staticmethod should appear exactly once"
+        assert version.decorators == ["@staticmethod"]
+        assert len(create.decorators) == 1, "@classmethod should appear exactly once"
+        assert create.decorators == ["@classmethod"]
+
+
 
 PYTHON_CONSTANTS_SOURCE = b'''"""Module with constants."""
 


### PR DESCRIPTION
## Description
This PR resolves the Python decorator duplication bug (#1698). 

### Root Cause
Decorators were being collected twice on decorated Python functions and classes:
1. Declaratively via the `python.scm` tree-sitter query (captured as `symbol.modifiers`).
2. Redundantly through a manual parent/sibling AST traversal in `parser.py`.

Additionally, when multiple decorators were present, tree-sitter returned multiple query matches (one for each decorator). The parser's deduplication check discarded subsequent matches, resulting in only the first decorator being processed from the query.

### Solution
1. **Pre-grouped Modifiers**: In `parser.py`, we now pre-group all captured modifier nodes by their unique symbol key `(start_line, name)` and filter out duplicate modifier node instances by ID.
2. **Removed Redundancy**: Deleted the manual parent sibling traversal logic from `parser.py`.
3. **Tests Added**: Introduced 6 new unit tests in `test_python.py` covering single, multiple, nested, class-level, and complex argument decorators.

## Verification
- Ran ingestion parser unit tests:
  ```bash
  pytest tests/unit/ingestion/parser/