### PR TITLE
feat(health): answer "what tests this" from the graph when no coverage exists

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **A test-to-code map that needs no coverage report.** The per-test map only
+  ever existed if you ingested a coverage report with contexts, so on most
+  repositories `tests_to_run` was empty, `impacted_tests` said "run the full
+  suite", and `untested_hotspot` fell back to matching filenames. The dependency
+  graph already records which test files import which source files, and that
+  relation now answers when the measured one cannot. It is labelled `inferred`
+  everywhere, never blended with measured coverage, and never turned into a
+  percentage. Nothing is stored: it is a bounded walk over rows already indexed,
+  measured at 27 ms once per health run on a 3,700-file repository.
+
+  New fields: `tests_to_run_basis` on `get_risk`'s directive
+  (`measured` / `inferred` / `none`), `basis` and a `status: "inferred"` on
+  `get_change_risk`'s `impacted_tests`, and a `via` marker on every
+  `repowise impacted-tests` candidate.
+
+### Changed
+
+- **`untested_hotspot` stops accusing files that six tests import.** With no
+  coverage ingested it fired on any hotspot without a *paired test file*, which
+  is a filename convention, so a suite that names its tests for behaviour
+  satisfied nothing. A test reaching the file in the import graph now suppresses
+  it too. On this repository five of the six worst bug-magnet files had no test
+  named for them and read as untested; the sixth, `analysis/health/engine.py`,
+  was called tested because the convention matched `distill/test_engine.py` on
+  basename alone. The same floor now runs under `get_risk`'s `missing_tests`,
+  which had two separate filename heuristics that disagreed.
+
+  Measured on repowise's own index: 74 of its 110 standing `untested_hotspot`
+  findings are cleared, 18 of them graded critical. The persisted
+  `has_test_file` widens to match, so the file table stops labelling those same
+  files "untested" while the biomarker says nothing.
+
+  Both stored values are wrong on an index built before this, so
+  `HEALTH_ANALYZER_VERSION` moves to 2 and the next `repowise update` with
+  changed files re-scores health rather than waiting out the decay timer.
+
+- **`repowise impacted-tests --format json` renames `guessed_tests` to
+  `inferred_tests`.** The bucket no longer holds only filename guesses, so the
+  old name described the wrong thing; each entry carries `via`
+  (`import-graph` or `filename-pattern`) to say which tier answered.
+
 ---
 
 ## [0.44.0] — 2026-08-18

--- a/docs/agent/MCP_TOOLS.md
+++ b/docs/agent/MCP_TOOLS.md
@@ -431,7 +431,7 @@ Modification risk assessment for files or a set of changed files.
 
 > **Scales.** Ratios derived from ownership or percentile columns are 0-1 (`hotspot_score`, `owner_pct`, `recent_owner_pct`); coverage and gap fields are 0-100 (`coverage_pct`, `branch_coverage_pct`, `share_of_repo_gap_pct`, `change_entropy_pct`, `churn_percentile`). The `_pct` suffix alone does not tell you which — check this table. Every emitted float is rounded to 4 significant digits.
 
-When `changed_files` is passed, the response leads with a `directive` block. Its core lists are the local blast radius: `will_break` (production files that depend on the diff and are likely to break), `will_break_tests` (test files impacted the same way, kept separate so a burst of broken tests doesn't crowd production impact out of the capped list), `missing_cochanges` (historical co-changers absent from the diff), `missing_tests` (changed files without test coverage), and `tests_to_run` (the positive complement of `missing_tests`: the tests the per-test coverage map proves execute the changed files, as pytest-runnable ids to validate the change; empty until a coverage map is ingested with `repowise coverage add`). In workspace mode that directive also carries the cross-repo fallout of the changed repo:
+When `changed_files` is passed, the response leads with a `directive` block. Its core lists are the local blast radius: `will_break` (production files that depend on the diff and are likely to break), `will_break_tests` (test files impacted the same way, kept separate so a burst of broken tests doesn't crowd production impact out of the capped list), `missing_cochanges` (historical co-changers absent from the diff), `missing_tests` (changed files without test coverage), and `tests_to_run` (the positive complement of `missing_tests`: the tests that exercise the changed files, as pytest-runnable arguments). Read `tests_to_run_basis` beside it, because the ids alone do not say where they came from: `measured` means the per-test coverage map proves those tests execute the changed files; `inferred` means the import graph shows those test *files* reaching the change, which is a candidate list rather than proof and needs no coverage ingest; `none` means neither source knows of a test, which is unknown and not "untested". The two are never mixed in one list. In workspace mode that directive also carries the cross-repo fallout of the changed repo:
 
 - `will_break_consumers`: services in *other* repos that depend on this one (structural impact), each with `repo`, `service`, `distance`, `score`, and the edge kinds carrying the impact.
 - `missing_cross_repo_cochanges`: services in other repos that historically co-change with this one but aren't in the diff.
@@ -488,10 +488,14 @@ execute the change's changed *lines* (line-precise, so a narrower set than
 `truncated` reporting any overflow. Its `missing_tests` buckets flag
 `untested_changes` (covered file, uncovered change), `stale_test_candidates`
 (covered lines whose guarding test file is absent from the diff), `covered`, and
-`no_coverage_data` (files absent from the map). When no map is ingested,
-`status` is `no_map` and the change is reported as unknown ("run the full
-suite"), never as untested. Build the map with `coverage run --contexts=test`
-followed by `repowise coverage add`.
+`no_coverage_data` (files absent from the map). When no map is ingested the
+change is never reported as untested: `status` becomes `inferred` when the
+import graph can name test files reaching the change (candidates, file-level, no
+line attribution, and `missing_tests` stays empty because reaching cannot speak
+to lines), and `no_map` ("run the full suite") when it cannot. `basis` carries
+the same distinction in one word: `measured`, `inferred`, or absent. Build the
+measured map with `coverage run --contexts=test` followed by
+`repowise coverage add`.
 
 When the changed files carry counted bug fixes, the response also holds
 `prior_fixes`: per file, how many past bug-fix commits touched it

--- a/docs/layers/TEST_INTELLIGENCE.md
+++ b/docs/layers/TEST_INTELLIGENCE.md
@@ -5,6 +5,12 @@ which files are risky *and* untested, and which tests a given diff actually
 exercises. That second one turns a 4,000-test suite into the 40 tests that guard
 the change you just made.
 
+Without a coverage report there is still an answer, a weaker one. The dependency
+graph records which test files import which source files, so repowise can say
+*something reaches this* even where nothing measured it. That inferred tier needs
+no setup and is always labelled as inferred. See
+[The inferred tier](#the-inferred-tier-no-coverage-report-needed).
+
 Everything here is an index lookup: no LLM, no network.
 
 ## Quick start
@@ -50,10 +56,12 @@ for everything below.
 |-----------|-----------------|--------|
 | **Per-file aggregate** | This file is 71% covered, merged across every test. | `untested_hotspot`, `coverage_gap`, `coverage_gradient` in [code health](CODE_HEALTH.md), the coverage dashboard |
 | **Per-test map** | Test `tests/test_auth.py::test_login` covered lines 40-58 of `src/auth/service.py`. | `repowise impacted-tests`, `get_change_risk`'s `impacted_tests`, `get_risk`'s `tests_to_run` |
+| **Inferred map** (no ingest) | `tests/test_round_trips.py` imports `src/auth/service.py`, so it reaches it. | The fallback under every row above, always labelled `inferred` |
 
 The aggregate always gets stored. The map is only built when the report carries
 per-test contexts. A report without contexts still ingests fine, it just skips
-the map.
+the map. The inferred map is not stored at all: it is read off the graph when
+asked.
 
 Both are point-in-time: each ingest replaces the previous rows rather than
 appending history. Ingest at the same commit you intend to query, so line numbers
@@ -141,8 +149,10 @@ It always says which path fired, and it never lets a guess pass for evidence:
 | Situation | Reported as |
 |-----------|-------------|
 | Changed file has per-test coverage on the changed lines | The exact covering tests, `via: coverage` |
-| Changed file has no coverage rows | A filename-pattern **guess** at its paired test, labelled `via: filename-pattern-guess` and printed in its own "NOT coverage-backed" table |
-| Neither coverage nor a paired test | "unknown, run the full suite to be safe" |
+| The changed file is itself a test | Itself, `via: changed-test` |
+| Changed file has no coverage rows, but a test reaches it in the graph | Those test files, `via: import-graph`, in the "NOT coverage-backed" table |
+| No coverage and no graph edge, but a name-shaped match | That file, `via: filename-pattern`, in the same table |
+| None of the above | "unknown, run the full suite to be safe" |
 | No map ingested at all | A prompt to run `coverage add` on a report with contexts |
 
 Deletion-only files are dropped from the diff (there are no new lines to cover).
@@ -161,8 +171,12 @@ refactor" case. It fires only when a file is all three of:
 2. **Centrally depended on.** At least 4 dependents. Below that, a churning file
    is usually a leaf one author is iterating on, and flagging it is noise.
 3. **Under-tested.** Line coverage below 40%. When no coverage has been ingested
-   at all, it falls back to firing only when the file has no paired test file
-   either, which is the conservative reading.
+   at all, it falls back to firing only when *nothing* says a test touches the
+   file: no paired test file by name, and no test reaching it in the import
+   graph. Either signal suppresses the finding, because this is the one place
+   the layer asserts a negative and the bar for asserting it is no evidence at
+   all. The graph half is what fixed the long-standing false positive on suites
+   that name their tests for behaviour rather than for the file under test.
 
 Severity is `CRITICAL` at 15% coverage or less with 10+ dependents, `HIGH` at one
 of those two, `MEDIUM` otherwise. Its sibling `coverage_gap` handles the
@@ -175,9 +189,19 @@ proportion to how much of it is untested rather than only at a cliff.
 Two MCP tools carry test information, at two different granularities.
 
 **`get_risk(changed_files=[...])`** leads with a `directive` block whose
-`tests_to_run` names the tests the map proves exercise the changed *files*. It is
-file-level and scoped to the diff itself, capped at ten, and holds test node ids
-rather than paths.
+`tests_to_run` names the tests that exercise the changed *files*. It is
+file-level and scoped to the diff itself, and capped at ten.
+
+Read `tests_to_run_basis` beside it. The two sources are not interchangeable
+and the ids alone will not tell them apart:
+
+| `tests_to_run_basis` | `tests_to_run` holds | Means |
+|---|---|---|
+| `measured` | test node ids | the map proves these execute the changed files |
+| `inferred` | test *file* paths | the graph shows these reaching the change; candidates, run them first |
+| `none` | `[]` | neither source knows of a test. Unknown, not "untested" |
+
+Both forms are runnable arguments to pytest. They are never mixed in one list.
 
 **`get_change_risk(revspec=...)`** returns `impacted_tests`, computed from the
 changed *lines*, so it is a strictly narrower and more useful set:
@@ -209,6 +233,103 @@ map.
 cannot tell a guess from real coverage, and `no_coverage_data` already reports
 those files honestly.
 
+## The inferred tier: no coverage report needed
+
+Everything above needs an ingest. Most repositories never do one, and the layer
+used to have nothing to say to them: `tests_to_run` came back empty,
+`impacted_tests` said "run the full suite", and `untested_hotspot` fell back to
+matching filenames.
+
+Matching filenames fails both ways, and this repository is the proof. Of its six
+worst bug-magnet files, five have no file named for them anywhere under `tests/`
+and so read as untested, while the graph names the tests that import them:
+
+| File | Filename convention | Graph |
+|---|---|---|
+| `ingestion/call_resolver.py` | nothing | 7 test files |
+| `analysis/dead_code/analyzer.py` | nothing | 9 |
+| `pipeline/persist.py` | nothing | 23 |
+| `mcp_server/tool_answer/answer.py` | nothing | 18 |
+| `analysis/pr_blast.py` | nothing | 3 |
+| `analysis/health/engine.py` | `tests/unit/distill/test_engine.py` | 6, all under `tests/unit/health/` |
+
+The last row is the worse failure. The convention matches on basename alone, so
+it paired the health engine with the *distill* engine's tests (a different
+subsystem) and called the file tested on the strength of a name collision.
+
+Across the whole index the effect is large: 74 of repowise's 110 standing
+`untested_hotspot` findings are cleared once the graph is consulted, 18 of them
+graded critical.
+
+The dependency graph already holds a weaker version of the same relation. A test
+file that imports a source file **reaches** it. That is not proof it executes it,
+and the layer never claims otherwise, but it is a recorded edge rather than a
+name-shaped guess, and it needs no setup at all.
+
+### What it is allowed to claim
+
+| | Measured map | Inferred map |
+|---|---|---|
+| Comes from | a coverage report you ingested | the import graph, already indexed |
+| Granularity | lines | files |
+| Proves | this test executed these lines | this test imports this file |
+| Decays | yes, see the coverage age report | no |
+| May produce a percentage | yes | **never** |
+| Labelled | `basis: "measured"` | `basis: "inferred"` |
+
+The two are shown side by side and are never averaged into one number. Where
+both can answer, the measured one wins outright and the graph is not consulted;
+the inferred tier only fills silence. Its error is one-sided and known: importing
+a module pulls in every symbol it defines while the test body may touch one
+function, so it **over-claims**. That makes it sound as a floor ("something
+reaches this, do not call it untested") and unsound as a quantity.
+
+### How far it walks
+
+One hop by default: a test importing the file. That default was measured, not
+chosen, by dogfooding against a real `coverage run --contexts=test` on this
+repository over a slice where per-test attribution was complete and both sides
+saw the same test files:
+
+| `max_depth` | reach precision | reach recall | run-list precision | run-list hit rate |
+|---|---|---|---|---|
+| **1** (default) | **72.1%** | 30.4% | **93.1%** | 96.8% |
+| 2 | 40.7% | 45.1% | 73.8% | 97.9% |
+| 3 | 17.1% | 45.1% | n/a | n/a |
+
+Both uses want precision: a false "something reaches this" suppresses a real
+untested-hotspot finding, and a false entry in a run-list sends someone to run a
+test that cannot fail for their change. The extra recall a second hop buys is not
+worth halving either, and by depth 3 the closure has begun to blow up: 269
+claims for the same 46 confirmations.
+
+Depth 1's recall already beats the filename convention it sits beside (30.4%
+against 23.5% on the same set) while resting on an edge rather than a name, and
+the two are unioned rather than ranked, so the shipped floor is better than
+either alone. A repository whose tests import a package facade rather than the
+module under test will want a second hop; it is a keyword argument on both walks.
+
+### Nothing is stored
+
+The inferred map is read off `graph_edges` when asked and never written to
+`test_coverage`. Two reasons, and the first is the one that matters:
+
+1. **A consumer cannot mistake it for measured data.** Sharing the table behind
+   a marker column would make every existing reader work immediately and would
+   make every existing reader silently start returning inferred rows the day
+   someone forgot to check the marker. That exact ambiguity, "no data" read as
+   "not loaded", is the shape of [#1739](https://github.com/repowise-dev/repowise/issues/1739).
+2. **It would be a transitive closure.** On this repository tests reach 1,630 of
+   2,509 production files; materialising that is O(tests x sources) rows that go
+   stale the moment the graph moves, to answer a query that is a bounded
+   breadth-first search over rows already in the database.
+
+The cost of deriving it is what makes that affordable. Indexing gains nothing:
+the health pass computes the whole-repo answer in one multi-source walk, measured
+at **27 ms** on this 3,700-file repository, once per run and cached. The
+per-change walk is one `IN` query at depth 1, over the same edge table
+`pr_blast` already reads.
+
 ## Empty means unknown, not "no tests"
 
 This is the contract that makes the whole layer safe to act on, and it is worth
@@ -217,17 +338,21 @@ stating plainly: **an empty test list never means the change is untested.**
 Both tools carry an explicit discriminator alongside the list:
 
 - `get_change_risk` sets `status` to `"map_present"` only when a map exists.
-  With no map ingested it returns `status: "no_map"`, `map_present: false`, and a
-  summary that says "run the full suite" plus the two commands that build the
-  map. Other degraded statuses are `no_index` (nothing indexed yet), `unknown`
-  (the git read failed), and `no_source_line_changes`.
-- `get_risk` produces `tests_to_run` from a `guarding_tests` block whose
-  `map_present` flag is `false` when no map is ingested. Note that the
-  `directive` lifts `tests_to_run` but not `map_present`, so read
-  `pr_blast_radius.guarding_tests.map_present` to tell the two cases apart.
+  With no map ingested it returns `status: "inferred"` when the graph can name
+  candidate test files, and `status: "no_map"`, `map_present: false` and a
+  summary that says "run the full suite" when it cannot. Other degraded statuses
+  are `no_index` (nothing indexed yet), `unknown` (the git read failed), and
+  `no_source_line_changes`. `basis` carries the same distinction in one word.
+- `get_risk` produces `tests_to_run` from a `guarding_tests` block, and the
+  `directive` lifts `tests_to_run_basis` beside it, so the two cases are
+  distinguishable without reaching into `pr_blast_radius`. `map_present` remains
+  the measured-map flag and is still available at
+  `pr_blast_radius.guarding_tests.map_present`.
 
 Only `status: "map_present"` with an empty `tests` list means "the map exists and
-nothing in it covers this change". That is a real finding. Everything else is an
+nothing in it covers this change". That is a real finding. `status: "inferred"`
+is not: it is a candidate list from the import graph, and passing everything in
+it does not clear a change. Everything else is an
 absence of evidence, and repowise says so rather than implying a clean bill of
 health. The same rule runs through the CLI ("unknown, run the full suite"), the
 `no_coverage_data` bucket, and the coverage lookup helpers, which document

--- a/docs/reference/CLI_REFERENCE.md
+++ b/docs/reference/CLI_REFERENCE.md
@@ -834,9 +834,15 @@ index lookup.
 know, and always says which path fired:
 
 - a changed file with per-test coverage -> the exact covering tests (`via: coverage`);
-- a changed file with no coverage rows -> a filename-pattern **guess** at its paired test, labelled as a guess (never presented as coverage-backed);
-- a new file with neither coverage nor a paired test -> reported as "unknown, run the full suite" (never implied as "no tests needed");
-- no map ingested at all -> a prompt to run `repowise coverage add` on a report with contexts first.
+- a changed file that is itself a test -> itself (`via: changed-test`);
+- a changed file with no coverage rows, but a test reaching it in the import graph -> those test files (`via: import-graph`), in a table headed "NOT coverage-backed";
+- neither of those, but a name-shaped match -> that file (`via: filename-pattern`), in the same table;
+- none of the above -> reported as "unknown, run the full suite" (never implied as "no tests needed");
+- no map ingested at all -> a prompt to run `repowise coverage add` on a report with contexts first, alongside whatever the graph could infer.
+
+The `via` marker is not decoration. `coverage` is proof that a test executed the
+changed lines; the other two are candidates that over-claim, and passing them
+does not clear the change.
 
 The map only exists when coverage was ingested from a report that carries
 per-test contexts (a coverage.py `.coverage` written with dynamic contexts, or a

--- a/packages/cli/src/repowise/cli/agent_targets/_data/codex_prompts/repowise-impacted-tests.md
+++ b/packages/cli/src/repowise/cli/agent_targets/_data/codex_prompts/repowise-impacted-tests.md
@@ -33,13 +33,15 @@ repowise impacted-tests main..HEAD --format list | xargs pytest
 
 ## Notes
 
-- Requires a per-test map from `repowise coverage add` on a report with
-  contexts. If none is ingested, the command prompts to run
-  `/prompts:repowise-coverage` / `repowise coverage add` — it does **not** invent an
-  empty "no tests needed" result.
-- A changed file with no coverage rows may get a filename-pattern **guess**
-  labelled as a guess — never present guesses as coverage-backed.
-- A brand-new file with neither coverage nor a paired test is "unknown, run
-  the full suite".
+- Line-precise answers need a per-test map from `repowise coverage add` on a
+  report with contexts. If none is ingested, the command still prompts to run
+  `/prompts:repowise-coverage` / `repowise coverage add`. It does **not** invent an empty
+  "no tests needed" result.
+- A changed file with no coverage rows gets *candidates* instead, in a table
+  headed "NOT coverage-backed", each carrying a `via` marker: `changed-test`
+  (the changed file is itself a test), `import-graph` (a test file that reaches
+  it, no ingest needed), or `filename-pattern` (a name-shaped guess). Report
+  them as candidates. Only `via: coverage` proves a test executed the change.
+- A file none of those can speak to is "unknown, run the full suite".
 - For a whole-change defect-risk score, use `/prompts:repowise-risk`. For per-file
   blast radius / `tests_to_run`, use the `get_risk` MCP tool.

--- a/packages/cli/src/repowise/cli/commands/impacted_tests_cmd.py
+++ b/packages/cli/src/repowise/cli/commands/impacted_tests_cmd.py
@@ -7,8 +7,9 @@ the per-test test-to-code map built by ``repowise coverage add``. The output is
 
 Honest about what it knows:
   - a changed file with per-test coverage -> the exact covering tests;
-  - a changed file with no coverage rows -> a filename-pattern *guess* at its
-    paired test, clearly labelled as a guess;
+  - a changed file with no coverage rows -> candidate tests the import graph
+    shows reaching it, or failing that a filename-pattern guess, each labelled
+    with which one answered and none of them claimed as coverage;
   - a new file with neither -> "unknown, run the full suite" (never implied
     as "no tests needed").
 
@@ -132,8 +133,8 @@ def _empty_result(changed_files: int) -> dict:
         "map_empty": False,
         "changed_files": changed_files,
         "covered": {},  # test_id -> {test_file, source_files: [...]}
-        "guessed": [],  # {source_file, test_file}
-        "unknown": [],  # source_file (no coverage, no paired test)
+        "inferred": [],  # {source_file, test_file, via}
+        "unknown": [],  # source_file (nothing knows of a test for it)
     }
 
 
@@ -144,40 +145,96 @@ async def _resolve_impacted(
     repo_keys: set[str],
     out: dict,
 ) -> dict:
-    """Classify each changed file: covered tests, guessed test, or unknown.
+    """Classify each changed file: covered tests, inferred tests, or unknown.
 
     Mutates and returns *out*. Split from ``_collect`` (which owns the DB
     bootstrap) so the diff -> lines -> tests path is testable against a seeded
     ``test_coverage`` table.
+
+    Three tiers, and the output says which one answered for every file, because
+    they are not interchangeable:
+
+    ``covered``
+        Recorded per-test coverage intersecting the changed *lines*. The only
+        tier that knows about lines, and the only one that proves execution.
+    ``inferred``
+        No coverage row, so fall back to naming candidates. A changed file that
+        is itself a test is its own candidate (``via="changed-test"``) - it used
+        to be reported as a file with no test, which is true and useless. Then
+        the import graph (``via="import-graph"``): a test file that reaches this
+        one is a recorded edge, and it finds suites whose tests are named for
+        behaviour rather than for the file. The filename pattern answers when
+        the graph is silent (``via="filename-pattern"``). All are file-level and
+        all over-claim; none may be read as coverage.
+    ``unknown``
+        Nothing said anything. Run the full suite.
     """
     from repowise.core.analysis.health.coverage import paired_test_file
+    from repowise.core.analysis.test_reachability import load_test_files, tests_reaching
     from repowise.core.persistence.crud import tests_covering
 
     covered: dict[str, dict] = out["covered"]
+    uncovered: list[str] = []
     for source_file, lines in sorted(changed.items()):
         rows = await tests_covering(session, repo_id, source_file, lines=lines)
-        if rows:
-            for r in rows:
-                entry = covered.setdefault(
-                    r["test_id"],
-                    {"test_file": r["test_file"], "source_files": []},
-                )
-                if source_file not in entry["source_files"]:
-                    entry["source_files"].append(source_file)
+        if not rows:
+            uncovered.append(source_file)
             continue
-        # No per-test rows for this file: fall back to a filename guess.
+        for r in rows:
+            entry = covered.setdefault(
+                r["test_id"],
+                {"test_file": r["test_file"], "source_files": []},
+            )
+            if source_file not in entry["source_files"]:
+                entry["source_files"].append(source_file)
+
+    if not uncovered:
+        return out
+
+    # One walk for every uncovered file rather than one per file: the seed set
+    # is what makes this cheap, and splitting it would run the same query once
+    # per changed path.
+    try:
+        reaching = await tests_reaching(session, repo_id, uncovered)
+        test_files = await load_test_files(session, repo_id)
+    except Exception:
+        reaching, test_files = {}, set()
+
+    for source_file in uncovered:
+        if source_file in test_files:
+            out["inferred"].append(
+                {
+                    "source_file": source_file,
+                    "test_file": source_file,
+                    "via": "changed-test",
+                }
+            )
+            continue
+        graph_tests = reaching.get(source_file) or []
+        if graph_tests:
+            out["inferred"].extend(
+                {"source_file": source_file, "test_file": t, "via": "import-graph"}
+                for t in graph_tests
+            )
+            continue
         guess = paired_test_file(source_file, repo_keys)
         if guess:
-            out["guessed"].append({"source_file": source_file, "test_file": guess})
+            out["inferred"].append(
+                {
+                    "source_file": source_file,
+                    "test_file": guess,
+                    "via": "filename-pattern",
+                }
+            )
         else:
             out["unknown"].append(source_file)
     return out
 
 
 def _machine_test_ids(result: dict) -> list[str]:
-    """Test ids for --format list: covered node ids + guessed test files."""
+    """Test ids for --format list: covered node ids + inferred test files."""
     ids = list(result["covered"].keys())
-    ids += [g["test_file"] for g in result["guessed"]]
+    ids += [g["test_file"] for g in result["inferred"]]
     # Dedup while preserving order.
     seen: set[str] = set()
     return [i for i in ids if not (i in seen or seen.add(i))]
@@ -201,9 +258,7 @@ def _render(result: dict, fmt: str) -> None:
                         }
                         for tid, info in result["covered"].items()
                     ],
-                    "guessed_tests": [
-                        {**g, "via": "filename-pattern-guess"} for g in result["guessed"]
-                    ],
+                    "inferred_tests": result["inferred"],
                     "unknown_files": result["unknown"],
                 },
                 indent=2,
@@ -221,8 +276,9 @@ def _render(result: dict, fmt: str) -> None:
             err_console.print("[yellow]No index - run `repowise init`.[/yellow]")
         elif result["unknown"]:
             err_console.print(
-                f"[yellow]{len(result['unknown'])} changed file(s) have no coverage and "
-                f"no paired test; run the full suite to be safe.[/yellow]"
+                f"[yellow]{len(result['unknown'])} changed file(s) have no coverage, no "
+                f"test reaching them in the graph and no paired test; run the full suite "
+                f"to be safe.[/yellow]"
             )
         return
 
@@ -245,7 +301,7 @@ def _render_table(result: dict) -> None:
             "[yellow]No test-to-code map ingested.[/yellow] Run "
             "[cyan]repowise coverage add[/cyan] on a coverage.py report written with "
             "[cyan]coverage run --contexts=test[/cyan] to get exact impacted tests. "
-            "Falling back to filename-pattern guesses below."
+            "Falling back to the import graph and filename patterns below."
         )
 
     covered = result["covered"]
@@ -263,22 +319,27 @@ def _render_table(result: dict) -> None:
     elif not result["map_empty"]:
         console.print("[dim]No recorded test covers the changed lines directly.[/dim]")
 
-    if result["guessed"]:
-        gtable = Table(title="Filename-pattern guesses (NOT coverage-backed)")
+    if result["inferred"]:
+        gtable = Table(title="Inferred tests (NOT coverage-backed)")
         gtable.add_column("Changed file")
-        gtable.add_column("Guessed test", style="yellow")
-        for g in result["guessed"]:
-            gtable.add_row(g["source_file"], g["test_file"])
+        gtable.add_column("Candidate test", style="yellow")
+        gtable.add_column("From", style="dim")
+        for g in result["inferred"]:
+            gtable.add_row(g["source_file"], g["test_file"], g["via"])
         console.print(gtable)
+        files = len({g["source_file"] for g in result["inferred"]})
         console.print(
-            f"[yellow]{len(result['guessed'])} file(s)[/yellow] had no coverage; guessed "
-            "their test by filename. Verify these actually exercise the change."
+            f"[yellow]{len(result['inferred'])} candidate(s)[/yellow] for {files} file(s) with "
+            "no coverage. [dim]changed-test[/dim] = the changed file is itself a test; "
+            "[dim]import-graph[/dim] = a test file that reaches this one; "
+            "[dim]filename-pattern[/dim] = a name-shaped guess. None proves execution - "
+            "verify they exercise the change."
         )
 
     if result["unknown"]:
         console.print(
-            f"[red]{len(result['unknown'])} changed file(s)[/red] have no coverage and no "
-            "paired test - run the full suite to be safe:"
+            f"[red]{len(result['unknown'])} changed file(s)[/red] have no coverage, no test "
+            "reaching them in the graph and no paired test - run the full suite to be safe:"
         )
         for path in result["unknown"]:
             console.print(f"  [red]{path}[/red]")

--- a/packages/core/src/repowise/core/analysis/health/biomarkers/base.py
+++ b/packages/core/src/repowise/core/analysis/health/biomarkers/base.py
@@ -46,6 +46,14 @@ class FileContext:
     # Per-file git metadata (may be empty when git indexing skipped).
     git_meta: dict[str, Any] = field(default_factory=dict)
     # Graph-derived signals.
+    # True when a test file reaches this one through the import graph, within
+    # ``test_reachability.DEFAULT_MAX_DEPTH`` hops. Distinct from
+    # ``has_test_file``, which is a filename convention: this is a recorded
+    # edge, so it finds behaviour-named tests the convention cannot, and it
+    # over-claims, since importing a module is not exercising it. Sound as a
+    # floor ("something tests this"), never as a coverage quantity. ``False``
+    # when no graph was available - the documented "no signal" outcome.
+    reached_by_tests: bool = False
     dependents_count: int = 0
     # Repo-wide 80th percentile of file-level in-degree (dependents),
     # computed by the engine across files that have ≥1 dependent. ``None``

--- a/packages/core/src/repowise/core/analysis/health/biomarkers/untested_hotspot.py
+++ b/packages/core/src/repowise/core/analysis/health/biomarkers/untested_hotspot.py
@@ -4,16 +4,19 @@ Fires when a file is **all three** of:
 
 - a *hotspot* (``git_meta['is_hotspot']`` true OR commit_count_90d ≥ 8)
 - under-tested (``line_coverage_pct`` < 40 when coverage is available,
-  OR no paired test file when coverage isn't)
+  OR, when it isn't, neither a paired test file nor a test reaching it
+  through the import graph)
 - centrally depended on (``dependents_count`` ≥ 4 OR temporal_hotspot
   in the top decile)
 
 Severity grades on how bad the coverage is and how many dependents the
 file has.
 
-When no coverage report has been ingested the biomarker still fires for
-hotspots without a paired test file — this is the conservative fallback
-mode and matches the Phase 1 "has_test_file" heuristic.
+When no coverage report has been ingested the biomarker falls back to two
+signals that both mean "something tests this": the paired-test-file naming
+convention, and ``reached_by_tests``: a test file importing this one, recorded
+in the dependency graph. Either suppresses the finding. Both over-claim relative to real execution, which is the right
+direction of error for a check whose output is an accusation.
 """
 
 from __future__ import annotations
@@ -58,9 +61,17 @@ class UntestedHotspotDetector:
 
         cov = ctx.line_coverage_pct
         if cov is None:
-            # Fallback: no coverage data. Flag only when there's also
-            # no paired test file, to avoid noise.
-            if ctx.has_test_file:
+            # Fallback: no coverage data. Flag only when nothing says a test
+            # touches this file. Two independent things can say so, and either
+            # is enough. This is the one place the biomarker is asserting a
+            # negative, so the bar for asserting it is "no signal at all".
+            #
+            # ``reached_by_tests`` is the graph one, and it is what stops the
+            # long-standing false positive: a suite that names its tests for
+            # behaviour rather than for the file under test satisfies no naming
+            # convention, so ``has_test_file`` was False and this fired on files
+            # the graph records several test files importing.
+            if ctx.has_test_file or ctx.reached_by_tests:
                 return []
             cov_for_severity = 0.0
             reason = (
@@ -94,6 +105,7 @@ class UntestedHotspotDetector:
                     "dependents_count": ctx.dependents_count,
                     "commit_count_90d": meta.get("commit_count_90d"),
                     "has_test_file": ctx.has_test_file,
+                    "reached_by_tests": ctx.reached_by_tests,
                 },
                 reason=reason,
             )

--- a/packages/core/src/repowise/core/analysis/health/engine.py
+++ b/packages/core/src/repowise/core/analysis/health/engine.py
@@ -37,6 +37,10 @@ from ...ingestion.git_indexer.function_blame import (
 from ...ingestion.package_roots import module_for as _module_for
 from ...ingestion.package_roots import package_roots_from_paths as _package_roots
 from ...ingestion.package_roots import scan_package_roots as _scan_package_roots
+from ..test_reachability import (
+    files_reached_by_tests,
+    forward_dependencies_from_graph,
+)
 from .biomarkers import FileContext, detect_all
 from .biomarkers.base import HasEdge
 from .complexity import FileComplexity, FunctionComplexity, walk_file
@@ -83,7 +87,12 @@ log = structlog.get_logger(__name__)
 #
 # Not a licence to move a calibrated scoring weight — those are frozen
 # independently of this stamp.
-HEALTH_ANALYZER_VERSION = 1
+#
+# 2: ``untested_hotspot`` gained a second test signal, and the persisted
+# ``has_test_file`` widened to match it. Both stored values are wrong on an
+# index built before that, and wrong in the direction that accuses a tested
+# file, so they should not wait out the decay timer.
+HEALTH_ANALYZER_VERSION = 2
 
 # Method-level smells that make the dataflow / Extract Method pass worthwhile.
 # Only files carrying one of these get a CFG + def/use + reaching pass built.
@@ -324,6 +333,29 @@ class HealthAnalyzer:
         # only the manifests the traverser emitted.
         self.repo_root = repo_root
         self._package_roots_cache: set[str] | None = None
+        self._tests_reach_cache: set[str] | None = None
+
+    def _files_reached_by_tests(self) -> set[str]:
+        """Non-test files that some test file reaches through the import graph.
+
+        The graph-backed half of "is this file tested". Computed once per
+        analyzer over the whole file set (one multi-source walk, not one per
+        file), because every ``_evaluate_file`` call asks the same question of
+        the same graph.
+
+        Inferred, and it over-claims: a test importing a module reaches every
+        file that module depends on, whether or not the test body exercises
+        them. Consumers must use it only as a floor - "something tests this" -
+        never as a coverage quantity. See ``analysis.test_reachability``.
+        """
+        if self._tests_reach_cache is None:
+            test_files = {
+                pf.file_info.path for pf in self.parsed_files if pf.file_info.is_test
+            }
+            self._tests_reach_cache = files_reached_by_tests(
+                forward_dependencies_from_graph(self.graph), test_files
+            )
+        return self._tests_reach_cache
 
     def _package_boundaries(self, analyzed_paths: set[str]) -> set[str]:
         """Package roots for this repo, decided once per analyzer.
@@ -916,6 +948,13 @@ class HealthAnalyzer:
             or pf.file_info.is_test
             or _coverage_is_test_file(file_path)
             or fcx.has_inline_tests,
+            # Kept separate from ``has_test_file`` on purpose. That flag means
+            # "a file named like this one's test exists"; this one means "the
+            # graph records a test reaching this file". They disagree often -
+            # measured here, the graph finds 984 files the naming convention
+            # misses - and collapsing them would leave no way to say which
+            # signal answered, or that one of them over-claims.
+            reached_by_tests=file_path in self._files_reached_by_tests(),
             module=module,
             function_metrics=fn_metrics,
             class_metrics=fcx.classes,
@@ -957,7 +996,15 @@ class HealthAnalyzer:
             max_ccn=max_ccn,
             max_nesting=max_nesting,
             nloc=nloc,
-            has_test_file=ctx.has_test_file,
+            # The stored field answers "does something test this file" - that is
+            # how the MCP payload documents it and how every UI renders it
+            # ("has tests" / "untested"). So it carries the union, not just the
+            # naming convention. Keeping it filename-only left the file table
+            # labelling a file untested while ``untested_hotspot`` stayed
+            # silent about it, which is the same disagreement issue #1740 is
+            # about, one layer further out. The two inputs stay separable on
+            # ``FileContext`` and in the biomarker's ``details``.
+            has_test_file=ctx.has_test_file or ctx.reached_by_tests,
             module=module,
             line_coverage_pct=line_cov,
             branch_coverage_pct=branch_cov,

--- a/packages/core/src/repowise/core/analysis/pr_blast.py
+++ b/packages/core/src/repowise/core/analysis/pr_blast.py
@@ -265,23 +265,40 @@ class PRBlastRadiusAnalyzer:
         return reviewers[:5]
 
     async def _find_test_gaps(self, affected_files: list[str]) -> list[str]:
-        """Return files that lack a test, coverage-backed where the map has data.
+        """Return the files nothing can be shown to test.
 
-        A file with >=1 per-test coverage row (from ``repowise coverage add``) is
-        coverage-*proven* to be exercised by some test, so it is never a gap -
-        this supersedes the filename guess for files the map can speak to. Where
-        the per-test map has no data for a file, fall back to the filename
-        pattern (test_<name>, <name>_test, <name>.spec.*) - an honest "unknown",
-        never asserted as untested. Test files themselves are excluded; they
-        don't need their own tests.
+        Three signals, checked in descending order of what they can prove, and a
+        file only becomes a gap when all three stay silent. Asserting "nothing
+        tests this" is the one claim here that costs a reader something if it is
+        wrong, so the bar for making it is no evidence at all.
+
+        1. A per-test coverage row (from ``repowise coverage add``) is
+           execution-*proof*: never a gap.
+        2. A test file reaching it in the import graph is evidence, not proof -
+           importing a module is not exercising it - but it is a recorded edge
+           rather than a guess, and it finds the suites that name their tests
+           for behaviour instead of for the file under test. Used only as this
+           floor; nothing downstream reads a coverage figure off it.
+        3. Otherwise the filename pattern (test_<name>, <name>_test,
+           <name>.spec.*) - an honest "unknown", never asserted as untested.
+
+        Test files themselves are excluded; they don't need their own tests.
         """
         if not affected_files:
             return []
 
+        from repowise.core.analysis.test_reachability import tests_reaching
         from repowise.core.persistence.crud import covered_source_files
 
         # Coverage-proven-tested files: absent from gaps regardless of naming.
         covered = await covered_source_files(self._session, self._repo_id, set(affected_files))
+
+        # Graph-reached files: likewise absent. Degrades to "no signal" rather
+        # than raising - a failed walk must not turn into a false accusation.
+        try:
+            reached = set(await tests_reaching(self._session, self._repo_id, affected_files))
+        except Exception:
+            reached = set()
 
         node_res = await self._session.execute(
             select(GraphNode.node_id, GraphNode.is_test).where(
@@ -308,6 +325,9 @@ class PRBlastRadiusAnalyzer:
                 continue
             # Coverage proves a test exercises this file: not a gap.
             if path in covered:
+                continue
+            # The graph records a test reaching it: not a gap either.
+            if path in reached:
                 continue
             base = os.path.splitext(os.path.basename(path))[0]
             ext = os.path.splitext(path)[1].lstrip(".")
@@ -343,11 +363,22 @@ class PRBlastRadiusAnalyzer:
         file-level; ``repowise impacted-tests`` gives the line-level answer from
         a real diff.
 
-        Returns ``{map_present, tests_to_run, by_file}``. ``map_present`` is
-        False when no per-test map is ingested at all - the honest "unknown",
-        distinct from "this change has no guarding tests".
+        Falls back to the graph when no coverage report has been ingested, which
+        is most repositories: a test file that imports a changed file is a
+        candidate worth running. ``basis`` says which of the two answered, and
+        the two are never merged. A run-list the coverage map proved and one the
+        import graph suggests are different claims, and averaging them would
+        leave the reader unable to tell a measured test from a guessed one. The
+        inferred list names test *files* rather than test ids, because reaching
+        is a file-level fact; both forms are runnable arguments to pytest.
+
+        Returns ``{map_present, basis, tests_to_run, by_file}``.
+        ``map_present`` stays the measured-map flag it always was.
+        ``basis`` is ``"measured"``, ``"inferred"``, or ``"none"`` - and
+        ``"none"`` is the honest "unknown", distinct from "this change has no
+        guarding tests".
         """
-        empty = {"map_present": False, "tests_to_run": [], "by_file": {}}
+        empty = {"map_present": False, "basis": "none", "tests_to_run": [], "by_file": {}}
         if not changed_files:
             return empty
 
@@ -355,7 +386,7 @@ class PRBlastRadiusAnalyzer:
 
         summary = await get_test_coverage_summary(self._session, self._repo_id)
         if summary.get("pair_count", 0) == 0:
-            return empty
+            return await self._inferred_guarding_tests(changed_files, empty)
 
         by_file: dict[str, list[str]] = {}
         all_ids: set[str] = set()
@@ -367,9 +398,43 @@ class PRBlastRadiusAnalyzer:
             by_file[path] = ids
             all_ids.update(ids)
 
+        if not all_ids:
+            # The map exists but says nothing about these files. The graph may
+            # still know something, and saying so beats an empty list that
+            # reads as "nothing guards this change".
+            blank = {"map_present": True, "basis": "none", "tests_to_run": [], "by_file": {}}
+            return await self._inferred_guarding_tests(changed_files, blank)
+
         return {
             "map_present": True,
+            "basis": "measured",
             "tests_to_run": sorted(all_ids),
+            "by_file": by_file,
+        }
+
+    async def _inferred_guarding_tests(self, changed_files: list[str], empty: dict) -> dict:
+        """Graph-inferred run-list: test files that reach the changed files.
+
+        Never execution-proven. Isolated behind its own method and its own
+        ``basis`` value so no caller can pick it up while believing it read the
+        measured map. Degrades to *empty* rather than raising: a run-list is an
+        aid, and failing the whole risk assessment to withhold one is the wrong
+        trade.
+        """
+        from repowise.core.analysis.test_reachability import tests_reaching
+
+        try:
+            reaching = await tests_reaching(self._session, self._repo_id, changed_files)
+        except Exception:
+            return empty
+        if not reaching:
+            return empty
+        by_file = {path: sorted(tests) for path, tests in reaching.items() if tests}
+        all_tests = sorted({t for tests in by_file.values() for t in tests})
+        return {
+            "map_present": empty["map_present"],
+            "basis": "inferred",
+            "tests_to_run": all_tests,
             "by_file": by_file,
         }
 

--- a/packages/core/src/repowise/core/analysis/test_reachability.py
+++ b/packages/core/src/repowise/core/analysis/test_reachability.py
@@ -1,0 +1,278 @@
+"""Static test-to-code map, derived from the dependency graph.
+
+``test_coverage`` answers "which test executed this line" and is filled only by
+a coverage report. Most repositories have none, so ``tests_to_run`` came back
+empty, ``impacted_tests`` said "run the full suite", and ``untested_hotspot``
+fell back to matching filenames.
+
+Matching filenames fails both ways, and this repository is the proof. Of its six
+worst bug-magnet files, five - ``call_resolver.py``, ``dead_code/analyzer.py``,
+``pipeline/persist.py``, ``tool_answer/answer.py``, ``pr_blast.py`` - have no
+file named for them anywhere under ``tests/`` and so read as untested, while the
+graph names 7, 9, 23, 18 and 3 test files importing them. The sixth,
+``analysis/health/engine.py``, is worse: the convention matches on basename
+alone, so it paired with ``tests/unit/distill/test_engine.py`` - a different
+engine, in a different subsystem - and called the file tested on the strength of
+a name collision. The graph names the six ``tests/unit/health/`` files that
+actually import it.
+
+The graph already knows the answer in the shape it can honestly give: a test
+file that imports a source file *reaches* it. This module reads that relation.
+It is a second signal beside the measured one, never a replacement and never
+averaged with it.
+
+What it claims, and what it does not
+------------------------------------
+Reaching is not executing. A test that imports a module pulls in every symbol
+the module defines, while the test body may touch one function; the inferred
+map therefore **over-claims**, and the direction of the error is known and
+one-sided:
+
+* Sound as a floor. "Some test reaches this file, so do not call it untested"
+  is safe: the import is recorded, not guessed.
+* Unsound as a quantity. No percentage may be derived from it. There is no line
+  attribution here at all - reaching is a file-level fact - so a caller that
+  needs "are these changed *lines* covered" must use the measured map or say it
+  does not know.
+
+Every surface that consumes this labels the result ``inferred``. Nothing here
+writes to ``test_coverage``, and no row it produces is stored: the relation is
+a bounded walk over ``graph_edges``/``graph_nodes``, which are already indexed
+and already fresh. Materialising it would cost a transitive closure - on this
+repository tests reach 1,630 of 2,509 production files, so the stored form is
+O(tests x sources) rows that go stale the moment the graph moves, to answer a
+query that is a breadth-first search over data already in the database.
+
+Depth
+-----
+``max_depth`` bounds the chain, and the default of 1 was measured rather than
+picked. Dogfooded against a real ``coverage run --contexts=test`` on this
+repository, over a slice where per-test attribution was complete and both sides
+saw the same 38 test files:
+
+===========  =========  =========  ==========  ==========
+max_depth    reach      reach      run-list    run-list
+             precision  recall     precision   hit rate
+===========  =========  =========  ==========  ==========
+1            72.1%      30.4%      93.1%       96.8%
+2            40.7%      45.1%      73.8%       97.9%
+3            17.1%      45.1%      -           -
+===========  =========  =========  ==========  ==========
+
+Both uses want precision. A false "something reaches this" suppresses a real
+untested-hotspot finding, and a false entry in a run-list sends someone to run
+a test that cannot fail for their change; the extra recall a second hop buys is
+not worth halving either. Depth 3 is where the closure starts to blow up (269
+claims for the same 46 confirmations) and is never a sensible default.
+
+Recall at depth 1 already beats the filename convention it sits beside (30.4%
+against 23.5% on the same set) while resting on a recorded edge instead of a
+name, and the two are unioned rather than ranked, so the shipped floor is
+better than either.
+
+A repository whose tests import a package facade rather than the module under
+test will want ``max_depth=2``; it is a keyword argument on both walks for
+exactly that reason.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from typing import Any
+
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from repowise.core.ingestion.models import FILE_DEPENDENCY_EDGE_TYPES
+from repowise.core.persistence.models import GraphNode
+
+# How many dependency hops a test may take and still be said to reach a file.
+# 1 - a test imports the file - is the measured choice, not a conservative
+# guess; see the Depth section above for the numbers behind it.
+DEFAULT_MAX_DEPTH = 1
+
+# Cap on how many test files one target reports. The consumers all cut their
+# own lists shorter; the cap exists so a facade module imported by every test
+# in the suite cannot produce an unbounded intermediate.
+MAX_TESTS_PER_TARGET = 50
+
+__all__ = [
+    "DEFAULT_MAX_DEPTH",
+    "MAX_TESTS_PER_TARGET",
+    "files_reached_by_tests",
+    "forward_dependencies_from_graph",
+    "load_test_files",
+    "tests_reaching",
+]
+
+
+def files_reached_by_tests(
+    forward_deps: dict[str, set[str]],
+    test_files: set[str],
+    *,
+    max_depth: int = DEFAULT_MAX_DEPTH,
+) -> set[str]:
+    """Every non-test file some test reaches within *max_depth* hops.
+
+    One multi-source breadth-first search from the whole test set at once, so
+    the cost is O(V+E) however many test files there are - this is the batch
+    question ("which files are reached at all"), not the attributed one.
+    *forward_deps* maps a file to the files it depends on.
+
+    Returns the reached set with the test files themselves removed: a test does
+    not need a test.
+    """
+    if not test_files or max_depth < 1:
+        return set()
+
+    seen = set(test_files)
+    frontier = set(test_files)
+    for _ in range(max_depth):
+        nxt: set[str] = set()
+        for node in frontier:
+            nxt |= forward_deps.get(node, frozenset())
+        nxt -= seen
+        if not nxt:
+            break
+        seen |= nxt
+        frontier = nxt
+    return seen - test_files
+
+
+def forward_dependencies_from_graph(graph: Any) -> dict[str, set[str]]:
+    """Build the file -> depends-on map from an in-memory NetworkX graph.
+
+    Restricted to :data:`FILE_DEPENDENCY_EDGE_TYPES`, the codified answer to
+    "which edges mean one file depends on another". Containment edges are the
+    ones that matter to exclude: with ``defines`` in, a walk leaves the file
+    layer into symbol nodes and every file defining a called symbol reads as a
+    dependency of the caller's *file*.
+
+    Returns an empty map for ``None`` - the health engine runs without a graph
+    on some paths, and the documented outcome there is "no signal".
+    """
+    out: dict[str, set[str]] = {}
+    if graph is None:
+        return out
+    try:
+        edges = graph.edges(data=True)
+    except Exception:
+        return out
+    for src, dst, data in edges:
+        if (data or {}).get("edge_type") in FILE_DEPENDENCY_EDGE_TYPES:
+            out.setdefault(src, set()).add(dst)
+    return out
+
+
+async def load_test_files(session: AsyncSession, repo_id: str) -> set[str]:
+    """Paths of every file node ingestion classified as a test."""
+    res = await session.execute(
+        select(GraphNode.node_id).where(
+            GraphNode.repository_id == repo_id,
+            GraphNode.is_test == True,  # noqa: E712
+        )
+    )
+    return {row[0] for row in res.all()}
+
+
+async def tests_reaching(
+    session: AsyncSession,
+    repo_id: str,
+    targets: list[str],
+    *,
+    max_depth: int = DEFAULT_MAX_DEPTH,
+) -> dict[str, list[str]]:
+    """Test files that reach each of *targets*, keyed by target path.
+
+    The reverse of :func:`files_reached_by_tests`, and attributed: the walk
+    runs backwards along dependency edges from the targets, carrying the seed
+    each visited node came from, so the answer says *which* target each test
+    guards rather than only that some test does.
+
+    Attribution is why this is a separate walk rather than a filter over the
+    forward one. It stays cheap because the seed set is a change's files, not
+    the repository: one ``IN`` query per depth level, at most *max_depth* of
+    them, which is the shape ``pr_blast._transitive_affected`` already uses.
+
+    Targets nothing reaches are absent from the result. An empty dict is
+    "no test reaches these"; the caller decides whether that reads as untested
+    or as unknown.
+    """
+    seeds = sorted({t for t in targets if t})
+    if not seeds or max_depth < 1:
+        return {}
+
+    test_files = await load_test_files(session, repo_id)
+    if not test_files:
+        return {}
+
+    # node -> the seeds it was reached from. A node can serve several seeds (one
+    # shared helper changed alongside its caller), and dropping that would
+    # report the test against an arbitrary one of them.
+    origins: dict[str, set[str]] = {s: {s} for s in seeds}
+    found: dict[str, set[str]] = {}
+    seed_set = set(seeds)
+    frontier: deque[str] = deque(seeds)
+
+    for _ in range(max_depth):
+        level = list(frontier)
+        frontier.clear()
+        queued: set[str] = set()
+        if not level:
+            break
+        for dependent, dependency in await _dependents_of(session, repo_id, level):
+            carried = origins.get(dependency, frozenset())
+            if not carried:
+                continue
+            if dependent in test_files:
+                for seed in carried:
+                    found.setdefault(seed, set()).add(dependent)
+                # A test file is a leaf for this walk. Nothing imports a test,
+                # and treating one as an intermediary would let "test A imports
+                # test helper B" drag B's unrelated targets in.
+                continue
+            if dependent in seed_set:
+                continue
+            known = origins.setdefault(dependent, set())
+            fresh = carried - known
+            if not fresh:
+                # Already reached carrying nothing new. Without this, a diamond
+                # in the import graph re-walks the whole subtree once per path
+                # into it.
+                continue
+            known |= fresh
+            if dependent not in queued:
+                queued.add(dependent)
+                frontier.append(dependent)
+
+    return {seed: sorted(tests)[:MAX_TESTS_PER_TARGET] for seed, tests in found.items() if tests}
+
+
+async def _dependents_of(
+    session: AsyncSession, repo_id: str, paths: list[str]
+) -> list[tuple[str, str]]:
+    """``(dependent, dependency)`` pairs for every file that depends on *paths*.
+
+    Raw text SQL with an ``IN`` list, matching ``pr_blast._transitive_affected``:
+    the edge table is the one place a per-level parameterised ``IN`` beats
+    loading every row, and the two walks should not disagree about how they read
+    it.
+    """
+    if not paths:
+        return []
+    dep_types = sorted(FILE_DEPENDENCY_EDGE_TYPES)
+    ph = ",".join(f":p{i}" for i in range(len(paths)))
+    et = ",".join(f":e{i}" for i in range(len(dep_types)))
+    params: dict[str, Any] = {"repo_id": repo_id}
+    params.update({f"p{i}": v for i, v in enumerate(paths)})
+    params.update({f"e{i}": v for i, v in enumerate(dep_types)})
+    rows = await session.execute(
+        text(
+            f"SELECT DISTINCT source_node_id, target_node_id FROM graph_edges "
+            f"WHERE repository_id = :repo_id "
+            f"AND target_node_id IN ({ph}) "
+            f"AND edge_type IN ({et})"
+        ),
+        params,
+    )
+    return [(src, tgt) for src, tgt in rows]

--- a/packages/core/src/repowise/core/upgrade/_data/CHANGELOG.md
+++ b/packages/core/src/repowise/core/upgrade/_data/CHANGELOG.md
@@ -11,6 +11,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **A test-to-code map that needs no coverage report.** The per-test map only
+  ever existed if you ingested a coverage report with contexts, so on most
+  repositories `tests_to_run` was empty, `impacted_tests` said "run the full
+  suite", and `untested_hotspot` fell back to matching filenames. The dependency
+  graph already records which test files import which source files, and that
+  relation now answers when the measured one cannot. It is labelled `inferred`
+  everywhere, never blended with measured coverage, and never turned into a
+  percentage. Nothing is stored: it is a bounded walk over rows already indexed,
+  measured at 27 ms once per health run on a 3,700-file repository.
+
+  New fields: `tests_to_run_basis` on `get_risk`'s directive
+  (`measured` / `inferred` / `none`), `basis` and a `status: "inferred"` on
+  `get_change_risk`'s `impacted_tests`, and a `via` marker on every
+  `repowise impacted-tests` candidate.
+
+### Changed
+
+- **`untested_hotspot` stops accusing files that six tests import.** With no
+  coverage ingested it fired on any hotspot without a *paired test file*, which
+  is a filename convention, so a suite that names its tests for behaviour
+  satisfied nothing. A test reaching the file in the import graph now suppresses
+  it too. On this repository five of the six worst bug-magnet files had no test
+  named for them and read as untested; the sixth, `analysis/health/engine.py`,
+  was called tested because the convention matched `distill/test_engine.py` on
+  basename alone. The same floor now runs under `get_risk`'s `missing_tests`,
+  which had two separate filename heuristics that disagreed.
+
+  Measured on repowise's own index: 74 of its 110 standing `untested_hotspot`
+  findings are cleared, 18 of them graded critical. The persisted
+  `has_test_file` widens to match, so the file table stops labelling those same
+  files "untested" while the biomarker says nothing.
+
+  Both stored values are wrong on an index built before this, so
+  `HEALTH_ANALYZER_VERSION` moves to 2 and the next `repowise update` with
+  changed files re-scores health rather than waiting out the decay timer.
+
+- **`repowise impacted-tests --format json` renames `guessed_tests` to
+  `inferred_tests`.** The bucket no longer holds only filename guesses, so the
+  old name described the wrong thing; each entry carries `via`
+  (`import-graph` or `filename-pattern`) to say which tier answered.
+
 ---
 
 ## [0.44.0] — 2026-08-18

--- a/packages/server/src/repowise/server/mcp_server/tool_change_risk.py
+++ b/packages/server/src/repowise/server/mcp_server/tool_change_risk.py
@@ -48,29 +48,30 @@ async def get_change_risk(
     """Score a live commit, ``base..head`` range, or uncommitted work.
 
     Use this for a pre-merge read on a commit or PR range. Distinct from
-    ``get_risk``, which assesses indexed files and PR blast radius. Both filters
+    ``get_risk``, which assesses indexed files and PR blast radius. The filters
     below also apply to the baseline behind the repository percentile.
 
     Lead with ``fix_history``: the recency-weighted bug-fix record of the files
-    touched, ``files`` naming where the pressure sits. It is what separates a
-    surgical edit to a file that keeps breaking from a bulk rename of files that
-    never have. ``score`` measures diff size and spread, not where the change
-    lands (see ``score_measures``); calibrated per commit, so a PR-sized change
-    reads high by construction. ``risk_percentile`` ranks that diff shape against
-    recent commits.
+    touched, ``files`` naming where the pressure sits. It separates a surgical
+    edit to a file that keeps breaking from a bulk rename of files that never
+    have. ``score`` measures diff size and spread, not where the change lands
+    (see ``score_measures``); calibrated per commit, so a PR-sized change reads
+    high by construction. ``risk_percentile`` ranks that shape against recent
+    commits.
 
-    ``impacted_tests`` names the tests a coverage map proves execute the changed
-    *lines*, with ``missing_tests`` for lines no test covers; ``status`` is
-    ``no_map`` (unknown — run the full suite), never "untested", when no map is
-    ingested. ``prior_fixes`` asks the index the same question git answered
-    above, counting only fixes whose lines overlap this diff.
+    ``impacted_tests`` names the tests for this change; ``missing_tests`` the
+    uncovered lines. ``basis``: ``measured`` = a coverage map proves those tests
+    run the changed *lines*; ``inferred`` = test files the import graph shows
+    reaching it (candidates, file-level, no ingest needed). No map is never
+    "untested": ``status`` ``no_map`` means run the suite. ``prior_fixes``
+    counts past fixes whose lines overlap this diff.
 
     Args:
         revspec: Commit or ``base..head`` range to score. Omit it to score the
             uncommitted change, or ``HEAD`` when the working tree is clean.
-        repo: Repository alias in workspace mode; omit for the default repository.
-        extensions: File suffixes to count, for example ``[".py", ".ts"]``.
-        exclude_patterns: Gitignore-style paths to omit, for example ``["tests/", "*.md"]``.
+        repo: Repository alias in workspace mode; omit for the default.
+        extensions: File suffixes to count, e.g. ``[".py", ".ts"]``.
+        exclude_patterns: Gitignore-style paths to omit, e.g. ``["tests/"]``.
         baseline: Recent commits to sample for percentile ranking; 0 disables it.
     """
     if repo == "all":
@@ -418,6 +419,63 @@ def _overlap_count(changed_lines_now: set[int], old_ranges_json: str) -> int:
     return hits
 
 
+async def _inferred_impacted(
+    session: Any, repo_id: str, changed_files: list[str]
+) -> dict[str, Any]:
+    """Graph-inferred candidates for a repo with no coverage map.
+
+    "Run the full suite" is correct but useless on the repositories that have
+    no coverage report, which is most of them. The import graph can narrow it:
+    a test file that reaches a changed file is worth running first. That is a candidate list and is labelled one - ``basis`` is
+    ``"inferred"`` and ``map_present`` stays False, so nothing here can be read
+    as the line-precise measured answer.
+
+    Deliberately file-level and line-blind. Reaching carries no line
+    attribution, so ``missing_tests`` stays empty rather than being filled from
+    a signal that cannot speak to lines - the distinction this whole block
+    exists to keep.
+    """
+    from repowise.core.analysis.test_reachability import tests_reaching
+
+    hint = (
+        "Inferred from the import graph, not measured. For the line-precise "
+        "answer build the map with `coverage run --contexts=test` then "
+        "`repowise coverage add`."
+    )
+    try:
+        reaching = await tests_reaching(session, repo_id, changed_files)
+    except Exception:
+        reaching = {}
+    tests = sorted({t for group in reaching.values() for t in group})
+    if not tests:
+        return _empty_impacted(
+            "no_map",
+            "No per-test coverage map ingested and no test reaches the changed files "
+            "in the graph; run the full suite. " + hint,
+        )
+    total = len(tests)
+    block = _empty_impacted("inferred", "")
+    block.update(
+        {
+            "basis": "inferred",
+            "tests": tests[:_IMPACTED_TESTS_LIMIT],
+            "total": total,
+            "truncated": total > _IMPACTED_TESTS_LIMIT,
+            "summary": (
+                f"{total} test file(s) reach the changed files via the import graph"
+                + (
+                    f"; showing first {_IMPACTED_TESTS_LIMIT}"
+                    if total > _IMPACTED_TESTS_LIMIT
+                    else ""
+                )
+                + ". "
+                + hint
+            ),
+        }
+    )
+    return block
+
+
 async def _impacted_tests_block(
     ctx: Any,
     changed: dict[str, set[int]],
@@ -450,11 +508,7 @@ async def _impacted_tests_block(
             repo_id = (await _get_repo(session)).id
             report = await detect_missing_tests(session, repo_id, changed)
             if report.map_empty:
-                return _empty_impacted(
-                    "no_map",
-                    "No per-test coverage map ingested; run the full suite. Build the map "
-                    "with `coverage run --contexts=test` then `repowise coverage add`.",
-                )
+                return await _inferred_impacted(session, repo_id, sorted(changed))
             all_ids: set[str] = set()
             for source_file, lines in changed.items():
                 for row in await tests_covering(session, repo_id, source_file, lines=lines):
@@ -466,6 +520,7 @@ async def _impacted_tests_block(
     total = len(tests)
     return {
         "status": "map_present",
+        "basis": "measured",
         "map_present": True,
         "tests": tests[:_IMPACTED_TESTS_LIMIT],
         "total": total,

--- a/packages/server/src/repowise/server/mcp_server/tool_risk/assessment.py
+++ b/packages/server/src/repowise/server/mcp_server/tool_risk/assessment.py
@@ -180,11 +180,20 @@ def _compute_impact_surface(
 async def _check_test_gap(session: AsyncSession, repo_id: str, target: str) -> bool:
     """Return True if *target* has no test, coverage-backed where the map has data.
 
-    A file with a per-test coverage row (from ``repowise coverage add``) is
-    coverage-*proven* tested, so it is never a gap. Where the map has no data for
-    the file, fall back to the filename pattern (test_<name>, <name>_test,
-    <name>.spec.*) - an honest "unknown", never asserted as untested. Test files
-    themselves (is_test=True) are never a gap.
+    Three signals, in descending order of what they can prove, and the file is a
+    gap only when all three stay silent - the same ladder ``pr_blast``
+    ``_find_test_gaps`` uses, because the two answered this question differently
+    and a reader has no way to tell which one they are looking at.
+
+    1. A per-test coverage row (from ``repowise coverage add``) is
+       execution-proof: never a gap.
+    2. A test file reaching it in the import graph is evidence, not proof, but a
+       recorded edge rather than a guess - it catches the suites whose tests are
+       named for behaviour rather than for the file under test.
+    3. Otherwise the filename pattern (test_<name>, <name>_test, <name>.spec.*)
+       - an honest "unknown", never asserted as untested.
+
+    Test files themselves (is_test=True) are never a gap.
     """
     import os
 
@@ -206,6 +215,16 @@ async def _check_test_gap(session: AsyncSession, repo_id: str, target: str) -> b
     # Coverage proves a test exercises this file: not a gap.
     if await covered_source_files(session, repo_id, {target}):
         return False
+
+    # The graph records a test reaching it: not a gap either. Degrades to "no
+    # signal" rather than raising - a failed walk must not become an accusation.
+    from repowise.core.analysis.test_reachability import tests_reaching
+
+    try:
+        if await tests_reaching(session, repo_id, [target]):
+            return False
+    except Exception:
+        pass
 
     base = os.path.splitext(os.path.basename(target))[0]
     ext = os.path.splitext(target)[1].lstrip(".")

--- a/packages/server/src/repowise/server/mcp_server/tool_risk/directives.py
+++ b/packages/server/src/repowise/server/mcp_server/tool_risk/directives.py
@@ -334,13 +334,25 @@ def _build_pr_directive(
         exclude_spec,
     )[:3]
 
-    # Coverage-backed run-list: the tests the per-test map proves execute the
-    # changed files (the positive complement of missing_tests). Read from the
-    # untrimmed analyzer payload; _trim_blast_lists passes guarding_tests
-    # through, but reading it here keeps the source explicit. Test node ids,
-    # not file paths, so they are not exclude-filtered as paths.
+    # Run-list: the tests that exercise the changed files (the positive
+    # complement of missing_tests). Read from the untrimmed analyzer payload;
+    # _trim_blast_lists passes guarding_tests through, but reading it here keeps
+    # the source explicit.
     guarding = pr_blast_radius.get("guarding_tests") or {}
     all_tests_to_run = list(guarding.get("tests_to_run", []))
+    # One word saying where the list came from, because the two sources carry
+    # different weight and an agent cannot tell them apart from the ids alone.
+    # "measured" is coverage-proven execution; "inferred" is a test file the
+    # import graph shows reaching the change, which over-claims and is a
+    # candidate list, not a proof. Kept as a sibling field rather than mixed
+    # into the ids so no caller can read one as the other.
+    tests_to_run_basis = guarding.get("basis") or "none"
+    # Only the inferred list is exclude-filtered. Its entries are repo file
+    # paths, so a user who excluded a tree must not be handed paths out of it;
+    # measured entries are test node ids ("path::name"), which are not paths and
+    # would not survive a path filter intact.
+    if tests_to_run_basis == "inferred":
+        all_tests_to_run = filter_path_list(all_tests_to_run, exclude_spec)
     tests_to_run = all_tests_to_run[:_TESTS_TO_RUN_LIMIT]
     if len(all_tests_to_run) > _TESTS_TO_RUN_LIMIT:
         collector.add(
@@ -348,11 +360,17 @@ def _build_pr_directive(
             f"({len(all_tests_to_run) - _TESTS_TO_RUN_LIMIT} dropped)",
             all_tests_to_run[_TESTS_TO_RUN_LIMIT:],
         )
-    tests_to_run_suffix = (
-        f" {len(all_tests_to_run)} coverage-backed test(s) guard the change - run these."
-        if all_tests_to_run
-        else ""
-    )
+    if not all_tests_to_run:
+        tests_to_run_suffix = ""
+    elif tests_to_run_basis == "measured":
+        tests_to_run_suffix = (
+            f" {len(all_tests_to_run)} coverage-backed test(s) guard the change - run these."
+        )
+    else:
+        tests_to_run_suffix = (
+            f" {len(all_tests_to_run)} test file(s) reach the change per the import graph "
+            f"(inferred, not coverage-proven) - run these first."
+        )
 
     gov_count = len(governance_risk)
     gov_suffix = f" {gov_count} governance risk(s) detected." if gov_count > 0 else ""
@@ -401,6 +419,7 @@ def _build_pr_directive(
         "missing_cochanges": missing_cochanges,
         "missing_tests": missing_tests,
         "tests_to_run": tests_to_run,
+        "tests_to_run_basis": tests_to_run_basis,
         "will_break_consumers": will_break_consumers,
         "missing_cross_repo_cochanges": missing_cross_repo_cochanges,
         "breaking_changes": breaking_changes,

--- a/packages/server/src/repowise/server/mcp_server/tool_risk/get_risk.py
+++ b/packages/server/src/repowise/server/mcp_server/tool_risk/get_risk.py
@@ -44,23 +44,22 @@ async def get_risk(
     and security findings. Consult before editing a bug-fixed or busy file. Pass
     changed_files for PR mode: the response leads with a directive block
     (will_break, missing_cochanges, missing_tests, tests_to_run) — read it
-    first. tests_to_run is coverage-backed: the tests the per-test map proves
-    exercise the changed files, empty when no coverage map is ingested. To
-    score a commit or ``base..head`` range instead, use ``get_change_risk``.
+    first. tests_to_run_basis backs the run-list: measured (a coverage map
+    proves those tests run the changed files) or inferred (test files the import
+    graph shows reaching them; candidates, no ingest needed). To score a commit
+    or ``base..head`` range instead, use ``get_change_risk``.
 
     defect_profile appears only on files with counted bug fixes: how many landed
     in the trailing 6 months, how long ago the last one was, a bug_magnet flag
     for sustained recent fix pressure, and top_symbols. Read top_symbols as
     "mostly here" rather than exact — symbol spans are current-tree while each
     fix's line ranges are numbered on its own parent commit. Nothing names the
-    commit that introduced a bug. global_hotspots ranks the same way: fix
-    history first, churn as fallback.
+    commit that introduced a bug. global_hotspots ranks the same way.
 
     episodes counts the dated records bound to a target — what happened here and
     why, evidenced by a commit or a filesystem fact. It appears only when there
     is at least one, and get_why serves the bodies. A directory target
-    aggregates everything beneath it, so compare the numbers within a kind of
-    target, not across kinds.
+    aggregates everything beneath it, so compare within a kind of target.
 
     Args:
         targets: file paths to assess.

--- a/plugins/claude-code/commands/impacted-tests.md
+++ b/plugins/claude-code/commands/impacted-tests.md
@@ -34,13 +34,15 @@ repowise impacted-tests main..HEAD --format list | xargs pytest
 
 ## Notes
 
-- Requires a per-test map from `repowise coverage add` on a report with
-  contexts. If none is ingested, the command prompts to run
-  `/repowise:coverage` / `repowise coverage add` — it does **not** invent an
-  empty "no tests needed" result.
-- A changed file with no coverage rows may get a filename-pattern **guess**
-  labelled as a guess — never present guesses as coverage-backed.
-- A brand-new file with neither coverage nor a paired test is "unknown, run
-  the full suite".
+- Line-precise answers need a per-test map from `repowise coverage add` on a
+  report with contexts. If none is ingested, the command still prompts to run
+  `/repowise:coverage` / `repowise coverage add`. It does **not** invent an empty
+  "no tests needed" result.
+- A changed file with no coverage rows gets *candidates* instead, in a table
+  headed "NOT coverage-backed", each carrying a `via` marker: `changed-test`
+  (the changed file is itself a test), `import-graph` (a test file that reaches
+  it, no ingest needed), or `filename-pattern` (a name-shaped guess). Report
+  them as candidates. Only `via: coverage` proves a test executed the change.
+- A file none of those can speak to is "unknown, run the full suite".
 - For a whole-change defect-risk score, use `/repowise:risk`. For per-file
   blast radius / `tests_to_run`, use the `get_risk` MCP tool.

--- a/plugins/claude-code/skills/change-review/SKILL.md
+++ b/plugins/claude-code/skills/change-review/SKILL.md
@@ -61,10 +61,13 @@ The response carries a `directive` block — read it first, it's a few short lis
 - **`missing_cochanges`** — files that historically change together with the
   changed files but were left untouched. Often a forgotten update.
 - **`missing_tests`** — changed code with a test gap. Flag for new/updated tests.
-- **`tests_to_run`** — the positive complement of `missing_tests`: the tests the
-  per-test coverage map proves execute the changed files (pytest-runnable ids).
-  Recommend running these to validate the change. Empty until a coverage map is
-  ingested (`repowise coverage add`); empty is "unknown", never "no tests exist".
+- **`tests_to_run`**: the positive complement of `missing_tests`, the tests that
+  exercise the changed files. Recommend running these to validate the change.
+  Read **`tests_to_run_basis`** with it: `measured` means a coverage map proves
+  those tests execute the changed files (pytest-runnable ids); `inferred` means
+  the import graph shows those test *files* reaching the change, which needs no
+  coverage ingest but is a candidate list, so say so rather than presenting it as
+  proof; `none` with an empty list is "unknown", never "no tests exist".
 
 `pr_blast_radius` holds the fuller dossier behind those lists (including the
 per-changed-file `guarding_tests` breakdown behind `tests_to_run`).

--- a/plugins/codex/skills/change-review/SKILL.md
+++ b/plugins/codex/skills/change-review/SKILL.md
@@ -56,10 +56,13 @@ The response carries a `directive` block — read it first, it's a few short lis
 - **`missing_cochanges`** — files that historically change together with the
   changed files but were left untouched. Often a forgotten update.
 - **`missing_tests`** — changed code with a test gap. Flag for new/updated tests.
-- **`tests_to_run`** — the positive complement of `missing_tests`: the tests the
-  per-test coverage map proves execute the changed files (pytest-runnable ids).
-  Recommend running these to validate the change. Empty until a coverage map is
-  ingested (`repowise coverage add`); empty is "unknown", never "no tests exist".
+- **`tests_to_run`**: the positive complement of `missing_tests`, the tests that
+  exercise the changed files. Recommend running these to validate the change.
+  Read **`tests_to_run_basis`** with it: `measured` means a coverage map proves
+  those tests execute the changed files (pytest-runnable ids); `inferred` means
+  the import graph shows those test *files* reaching the change, which needs no
+  coverage ingest but is a candidate list, so say so rather than presenting it as
+  proof; `none` with an empty list is "unknown", never "no tests exist".
 
 `pr_blast_radius` holds the fuller dossier behind those lists (including the
 per-changed-file `guarding_tests` breakdown behind `tests_to_run`).

--- a/plugins/shared/commands/impacted-tests.md
+++ b/plugins/shared/commands/impacted-tests.md
@@ -35,13 +35,15 @@ repowise impacted-tests main..HEAD --format list | xargs pytest
 
 ## Notes
 
-- Requires a per-test map from `repowise coverage add` on a report with
-  contexts. If none is ingested, the command prompts to run
-  `{{cmd:coverage}}` / `repowise coverage add` — it does **not** invent an
-  empty "no tests needed" result.
-- A changed file with no coverage rows may get a filename-pattern **guess**
-  labelled as a guess — never present guesses as coverage-backed.
-- A brand-new file with neither coverage nor a paired test is "unknown, run
-  the full suite".
+- Line-precise answers need a per-test map from `repowise coverage add` on a
+  report with contexts. If none is ingested, the command still prompts to run
+  `{{cmd:coverage}}` / `repowise coverage add`. It does **not** invent an empty
+  "no tests needed" result.
+- A changed file with no coverage rows gets *candidates* instead, in a table
+  headed "NOT coverage-backed", each carrying a `via` marker: `changed-test`
+  (the changed file is itself a test), `import-graph` (a test file that reaches
+  it, no ingest needed), or `filename-pattern` (a name-shaped guess). Report
+  them as candidates. Only `via: coverage` proves a test executed the change.
+- A file none of those can speak to is "unknown, run the full suite".
 - For a whole-change defect-risk score, use `{{cmd:risk}}`. For per-file
   blast radius / `tests_to_run`, use the `get_risk` MCP tool.

--- a/plugins/shared/skills/change-review.md
+++ b/plugins/shared/skills/change-review.md
@@ -69,10 +69,13 @@ The response carries a `directive` block — read it first, it's a few short lis
 - **`missing_cochanges`** — files that historically change together with the
   changed files but were left untouched. Often a forgotten update.
 - **`missing_tests`** — changed code with a test gap. Flag for new/updated tests.
-- **`tests_to_run`** — the positive complement of `missing_tests`: the tests the
-  per-test coverage map proves execute the changed files (pytest-runnable ids).
-  Recommend running these to validate the change. Empty until a coverage map is
-  ingested (`repowise coverage add`); empty is "unknown", never "no tests exist".
+- **`tests_to_run`**: the positive complement of `missing_tests`, the tests that
+  exercise the changed files. Recommend running these to validate the change.
+  Read **`tests_to_run_basis`** with it: `measured` means a coverage map proves
+  those tests execute the changed files (pytest-runnable ids); `inferred` means
+  the import graph shows those test *files* reaching the change, which needs no
+  coverage ingest but is a candidate list, so say so rather than presenting it as
+  proof; `none` with an empty list is "unknown", never "no tests exist".
 
 `pr_blast_radius` holds the fuller dossier behind those lists (including the
 per-changed-file `guarding_tests` breakdown behind `tests_to_run`).

--- a/tests/unit/analysis/test_test_reachability.py
+++ b/tests/unit/analysis/test_test_reachability.py
@@ -1,0 +1,101 @@
+"""Static test-to-code reachability: the pure walks over an adjacency map.
+
+A test file that imports a source file, directly or within ``max_depth`` hops,
+*reaches* it. Pins the edge-type filter (containment must not leak the walk into
+symbol nodes) and the measured depth default. The attributed reverse walk needs
+a database, so it lives in ``tests/unit/persistence`` beside the session
+fixture.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from repowise.core.analysis.test_reachability import (
+    DEFAULT_MAX_DEPTH,
+    files_reached_by_tests,
+    forward_dependencies_from_graph,
+)
+
+# ---------------------------------------------------------------------------
+# files_reached_by_tests: the batch "is anything testing this" walk
+# ---------------------------------------------------------------------------
+
+
+def test_direct_import_is_reached():
+    fwd = {"tests/test_a.py": {"src/a.py"}}
+    assert files_reached_by_tests(fwd, {"tests/test_a.py"}) == {"src/a.py"}
+
+
+def test_the_default_is_one_hop():
+    """A second hop is opt-in, because it was measured to cost more than it buys.
+
+    Dogfooded against a real coverage run, depth 2 halved reach precision
+    (72.1% -> 40.7%) and cut run-list precision from 93.1% to 73.8%. Repos whose
+    tests import a package facade pass ``max_depth=2`` explicitly.
+    """
+    assert DEFAULT_MAX_DEPTH == 1
+    fwd = {"tests/test_a.py": {"src/__init__.py"}, "src/__init__.py": {"src/a.py"}}
+    assert files_reached_by_tests(fwd, {"tests/test_a.py"}) == {"src/__init__.py"}
+    assert files_reached_by_tests(fwd, {"tests/test_a.py"}, max_depth=2) == {
+        "src/__init__.py",
+        "src/a.py",
+    }
+
+
+def test_depth_bound_is_respected():
+    fwd = {"t.py": {"a.py"}, "a.py": {"b.py"}, "b.py": {"c.py"}}
+    assert files_reached_by_tests(fwd, {"t.py"}, max_depth=1) == {"a.py"}
+    assert files_reached_by_tests(fwd, {"t.py"}, max_depth=2) == {"a.py", "b.py"}
+    assert files_reached_by_tests(fwd, {"t.py"}, max_depth=3) == {"a.py", "b.py", "c.py"}
+
+
+def test_test_files_are_excluded_from_the_result():
+    # A test does not need a test, so a helper test module that another test
+    # imports must not come back as a file needing coverage.
+    fwd = {"tests/test_a.py": {"tests/helpers.py", "src/a.py"}}
+    reached = files_reached_by_tests(fwd, {"tests/test_a.py", "tests/helpers.py"})
+    assert reached == {"src/a.py"}
+
+
+def test_cycle_terminates():
+    fwd = {"t.py": {"a.py"}, "a.py": {"b.py"}, "b.py": {"a.py"}}
+    assert files_reached_by_tests(fwd, {"t.py"}, max_depth=10) == {"a.py", "b.py"}
+
+
+@pytest.mark.parametrize("tests,depth", [(set(), 2), ({"t.py"}, 0)])
+def test_degenerate_inputs_return_empty(tests, depth):
+    assert files_reached_by_tests({"t.py": {"a.py"}}, tests, max_depth=depth) == set()
+
+
+# ---------------------------------------------------------------------------
+# forward_dependencies_from_graph: the edge-type filter
+# ---------------------------------------------------------------------------
+
+
+class _FakeGraph:
+    def __init__(self, edges):
+        self._edges = edges
+
+    def edges(self, data=False):
+        return [(s, t, d) for s, t, d in self._edges]
+
+
+def test_only_file_dependency_edges_are_followed():
+    # ``defines`` is the one that matters: with containment in, the walk leaves
+    # the file layer into symbol nodes, and every file defining a called symbol
+    # reads as a dependency of the caller's file.
+    graph = _FakeGraph(
+        [
+            ("tests/test_a.py", "src/a.py", {"edge_type": "imports"}),
+            ("tests/test_a.py", "tests/test_a.py::test_x", {"edge_type": "defines"}),
+            ("src/a.py", "src/b.py", {"edge_type": "co_changes"}),
+            ("src/a.py", "src/c.py", {"edge_type": "type_use"}),
+        ]
+    )
+    fwd = forward_dependencies_from_graph(graph)
+    assert fwd == {"tests/test_a.py": {"src/a.py"}, "src/a.py": {"src/c.py"}}
+
+
+def test_missing_graph_is_no_signal_not_an_error():
+    assert forward_dependencies_from_graph(None) == {}

--- a/tests/unit/health/test_coverage_biomarkers.py
+++ b/tests/unit/health/test_coverage_biomarkers.py
@@ -17,6 +17,7 @@ def _ctx(
     path: str = "src/example.py",
     dependents: int = 0,
     has_test_file: bool = False,
+    reached_by_tests: bool = False,
     git_meta: dict | None = None,
     line_cov: float | None = None,
     branch_cov: float | None = None,
@@ -28,6 +29,7 @@ def _ctx(
         language="python",
         nloc=100,
         has_test_file=has_test_file,
+        reached_by_tests=reached_by_tests,
         module=None,
         git_meta=git_meta or {},
         dependents_count=dependents,
@@ -173,3 +175,53 @@ def test_coverage_gradient_silent_at_full_coverage() -> None:
 def test_coverage_gradient_skips_test_files() -> None:
     ctx = _ctx(path="tests/test_thing.py", line_cov=10.0)
     assert CoverageGradientDetector().detect(ctx) == []
+
+
+# ---------------------------------------------------------------------------
+# untested_hotspot: the graph-backed half of the no-coverage fallback
+# ---------------------------------------------------------------------------
+
+
+def _uncovered_hotspot(**kw) -> FileContext:
+    """A file that fires untested_hotspot on every axis except the test signal."""
+    return _ctx(git_meta={"is_hotspot": True}, dependents=10, line_cov=None, **kw)
+
+
+def test_untested_hotspot_fires_when_nothing_says_a_test_touches_it() -> None:
+    assert len(UntestedHotspotDetector().detect(_uncovered_hotspot())) == 1
+
+
+def test_a_test_reaching_it_in_the_graph_suppresses_the_finding() -> None:
+    """The live false positive: no test is *named* for the file, but six import it.
+
+    Suites that name their tests for behaviour satisfy no naming convention, so
+    ``has_test_file`` stays False and this used to fire on files the graph
+    records several test files importing.
+    """
+    ctx = _uncovered_hotspot(has_test_file=False, reached_by_tests=True)
+    assert UntestedHotspotDetector().detect(ctx) == []
+
+
+def test_either_signal_alone_is_enough() -> None:
+    # Asserting "nothing tests this" is the one accusation this biomarker makes,
+    # so the bar for making it is no evidence from either source.
+    for kw in ({"has_test_file": True}, {"reached_by_tests": True}):
+        assert UntestedHotspotDetector().detect(_uncovered_hotspot(**kw)) == []
+
+
+def test_reachability_does_not_override_a_real_coverage_number() -> None:
+    """Measured coverage decides on its own; the inferred signal never blends in.
+
+    Reaching cannot speak to how much of a file runs, so a file the graph
+    reaches and coverage measures at 12% is still an untested hotspot.
+    """
+    ctx = _ctx(
+        git_meta={"is_hotspot": True},
+        dependents=10,
+        line_cov=12.0,
+        total_lines=50,
+        reached_by_tests=True,
+    )
+    results = UntestedHotspotDetector().detect(ctx)
+    assert len(results) == 1
+    assert results[0].details["reached_by_tests"] is True

--- a/tests/unit/health/test_reachability_wiring.py
+++ b/tests/unit/health/test_reachability_wiring.py
@@ -1,0 +1,112 @@
+"""The health engine reads ``reached_by_tests`` off the real graph.
+
+The helper walks are unit-tested in ``tests/unit/analysis``; what this pins is
+the wiring, because the walk can be right while the engine still hands the
+biomarker ``False``. Runs the real analyzer over a real parsed tree with a real
+graph, and asserts on the finding the biomarker actually emits.
+"""
+
+from __future__ import annotations
+
+import networkx as nx
+import pytest
+
+from repowise.core.analysis.health import HealthAnalyzer
+from repowise.core.ingestion.parser import parse_file
+from repowise.core.ingestion.traverser import FileTraverser
+
+# Enough churn and centrality for untested_hotspot's other two gates to pass, so
+# the only thing left deciding the finding is the test signal.
+_HOTSPOT_META = {"is_hotspot": True, "commit_count_90d": 30, "commit_count_total": 30}
+
+
+def _tree(tmp_path):
+    """A source file whose only test is named for behaviour, not for the file."""
+    (tmp_path / "src").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "tests").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "src" / "parser.py").write_text("def parse(s):\n    return s\n", encoding="utf-8")
+    (tmp_path / "tests" / "test_round_trips.py").write_text(
+        "from src.parser import parse\n\n\ndef test_it():\n    assert parse('a') == 'a'\n",
+        encoding="utf-8",
+    )
+    return [
+        parse_file(f, (tmp_path / f.path).read_bytes()) for f in FileTraverser(tmp_path).traverse()
+    ]
+
+
+def _graph(*edges):
+    g = nx.DiGraph()
+    for src, dst in edges:
+        g.add_edge(src, dst, edge_type="imports")
+    # Dependents for the centrality gate; untested_hotspot wants at least four.
+    for i in range(6):
+        g.add_edge(f"src/consumer_{i}.py", "src/parser.py", edge_type="imports")
+    return g
+
+
+def _findings(parsed, graph):
+    report = HealthAnalyzer(
+        graph,
+        parsed_files=parsed,
+        git_meta_map={"src/parser.py": dict(_HOTSPOT_META)},
+    ).analyze()
+    return [f for f in report.findings if f.biomarker_type == "untested_hotspot"]
+
+
+def test_a_test_importing_the_file_clears_the_untested_hotspot(tmp_path):
+    parsed = _tree(tmp_path)
+    graph = _graph(("tests/test_round_trips.py", "src/parser.py"))
+    assert [f for f in _findings(parsed, graph) if f.file_path == "src/parser.py"] == []
+
+
+def test_without_that_edge_the_same_tree_still_fires(tmp_path):
+    """The control: the finding is suppressed by the edge, not by the fixture."""
+    parsed = _tree(tmp_path)
+    fired = _findings(parsed, _graph())
+    assert [f.file_path for f in fired if f.file_path == "src/parser.py"] == ["src/parser.py"]
+
+
+@pytest.mark.parametrize("edge_type", ["co_changes", "defines"])
+def test_a_non_dependency_edge_does_not_clear_it(tmp_path, edge_type):
+    """Changing together, or containment, is not testing."""
+    parsed = _tree(tmp_path)
+    graph = _graph()
+    graph.add_edge("tests/test_round_trips.py", "src/parser.py", edge_type=edge_type)
+    fired = [f.file_path for f in _findings(parsed, graph) if f.file_path == "src/parser.py"]
+    assert fired == ["src/parser.py"]
+
+
+def test_no_graph_is_no_signal_not_a_crash(tmp_path):
+    """The engine runs graphless on some paths; the walk must degrade, not raise.
+
+    Asserting on the finding would prove nothing here: without a graph there is
+    no dependents count either, so untested_hotspot's centrality gate closes
+    before the test signal is ever consulted. What is worth pinning is that the
+    pass completes and still scores the file.
+    """
+    report = HealthAnalyzer(
+        None,
+        parsed_files=_tree(tmp_path),
+        git_meta_map={"src/parser.py": dict(_HOTSPOT_META)},
+    ).analyze()
+    assert "src/parser.py" in {m.file_path for m in report.metrics}
+
+
+def test_the_stored_metric_agrees_with_the_biomarker(tmp_path):
+    """The file table and the biomarker must not disagree about the same file.
+
+    ``has_test_file`` on the persisted metric is what every UI renders as
+    "has tests" / "untested" and what the MCP payload documents as "does
+    something test this file". Left filename-only it labelled a file untested
+    while ``untested_hotspot`` stayed silent about it - issue #1740's
+    disagreement, one layer further out.
+    """
+    parsed = _tree(tmp_path)
+    graph = _graph(("tests/test_round_trips.py", "src/parser.py"))
+    report = HealthAnalyzer(
+        graph,
+        parsed_files=parsed,
+        git_meta_map={"src/parser.py": dict(_HOTSPOT_META)},
+    ).analyze()
+    metric = next(m for m in report.metrics if m.file_path == "src/parser.py")
+    assert metric.has_test_file is True

--- a/tests/unit/persistence/test_impacted_tests_resolution.py
+++ b/tests/unit/persistence/test_impacted_tests_resolution.py
@@ -1,9 +1,10 @@
 """The ``impacted-tests`` resolution path: changed lines -> impacted tests.
 
 Exercises :func:`_resolve_impacted` against a seeded ``test_coverage`` table so
-the three honest outcomes are pinned: coverage-backed hit, filename-pattern
-guess when a changed file has no coverage rows, and "unknown" when it has
-neither. The diff parser and CRUD line-intersection are tested separately.
+the honest outcomes are pinned and stay distinguishable: a coverage-backed hit,
+an inferred candidate when a changed file has no coverage rows (the import graph
+first, a filename-pattern guess second), and "unknown" when nothing knows of a
+test. The diff parser and CRUD line-intersection are tested separately.
 """
 
 from __future__ import annotations
@@ -54,7 +55,7 @@ async def test_covered_change_returns_exact_tests(async_session) -> None:
 
     assert set(out["covered"]) == {"tests/test_foo.py::test_a|run"}
     assert out["covered"]["tests/test_foo.py::test_a|run"]["source_files"] == ["src/foo.py"]
-    assert out["guessed"] == []
+    assert out["inferred"] == []
     assert out["unknown"] == []
 
 
@@ -66,12 +67,14 @@ async def test_change_missing_covered_lines_falls_to_guess_or_unknown(async_sess
     changed = {"src/foo.py": {99}, "src/bar.py": {5}, "src/lonely.py": {1}}
     await _resolve_impacted(async_session, repo.id, changed, _REPO_KEYS, out)
 
-    # foo.py: had rows for the file but none intersect line 99 -> guessed (no
-    # test_foo.py in repo keys, so it should look for foo's pair). foo's pair
-    # (test_foo.py) is NOT in _REPO_KEYS, so foo.py lands in unknown.
+    # foo.py: had rows for the file but none intersect line 99, and its pair
+    # (test_foo.py) is NOT in _REPO_KEYS, so it lands in unknown.
     assert "src/foo.py" in out["unknown"]
     assert "src/lonely.py" in out["unknown"]
-    assert out["guessed"] == [{"source_file": "src/bar.py", "test_file": "tests/test_bar.py"}]
+    # No graph rows are seeded here, so the filename pattern is what answers.
+    assert out["inferred"] == [
+        {"source_file": "src/bar.py", "test_file": "tests/test_bar.py", "via": "filename-pattern"}
+    ]
     assert out["covered"] == {}
 
 
@@ -94,3 +97,72 @@ async def test_one_test_covering_multiple_changed_files_dedupes(async_session) -
     )
     assert set(out["covered"]) == {"t::shared|run"}
     assert sorted(out["covered"]["t::shared|run"]["source_files"]) == ["src/bar.py", "src/foo.py"]
+
+
+async def test_import_graph_answers_before_the_filename_pattern(async_session) -> None:
+    """A recorded edge beats a name-shaped guess, and says so.
+
+    ``src/bar.py`` has both: a graph edge from a behaviour-named test and a
+    conventionally named ``tests/test_bar.py``. The graph is the one with
+    evidence behind it, so it is the one reported.
+    """
+    from repowise.core.persistence.models import GraphEdge, GraphNode
+
+    repo = await insert_repo(async_session)
+    for path, is_test in (
+        ("tests/test_round_trips.py", True),
+        ("tests/test_bar.py", True),
+        ("src/bar.py", False),
+    ):
+        async_session.add(
+            GraphNode(repository_id=repo.id, node_id=path, node_type="file", is_test=is_test)
+        )
+    async_session.add(
+        GraphEdge(
+            repository_id=repo.id,
+            source_node_id="tests/test_round_trips.py",
+            target_node_id="src/bar.py",
+            edge_type="imports",
+        )
+    )
+    await async_session.commit()
+
+    out = _empty_result(1)
+    await _resolve_impacted(async_session, repo.id, {"src/bar.py": {5}}, _REPO_KEYS, out)
+
+    assert out["inferred"] == [
+        {
+            "source_file": "src/bar.py",
+            "test_file": "tests/test_round_trips.py",
+            "via": "import-graph",
+        }
+    ]
+    assert out["unknown"] == []
+
+
+async def test_a_changed_test_file_is_its_own_candidate(async_session) -> None:
+    """"That test has no test" is true and useless; run the test you changed."""
+    from repowise.core.persistence.models import GraphNode
+
+    repo = await insert_repo(async_session)
+    async_session.add(
+        GraphNode(
+            repository_id=repo.id,
+            node_id="tests/test_bar.py",
+            node_type="file",
+            is_test=True,
+        )
+    )
+    await async_session.commit()
+
+    out = _empty_result(1)
+    await _resolve_impacted(async_session, repo.id, {"tests/test_bar.py": {1}}, _REPO_KEYS, out)
+
+    assert out["inferred"] == [
+        {
+            "source_file": "tests/test_bar.py",
+            "test_file": "tests/test_bar.py",
+            "via": "changed-test",
+        }
+    ]
+    assert out["unknown"] == []

--- a/tests/unit/persistence/test_pr_blast_guarding_tests.py
+++ b/tests/unit/persistence/test_pr_blast_guarding_tests.py
@@ -106,7 +106,7 @@ async def test_guarding_tests_map_empty_is_honest_unknown(async_session):
     result = await analyzer._guarding_tests(["src/math.py"])
 
     # No map -> "unknown", never an empty-because-untested claim.
-    assert result == {"map_present": False, "tests_to_run": [], "by_file": {}}
+    assert result == {"map_present": False, "basis": "none", "tests_to_run": [], "by_file": {}}
 
 
 async def test_guarding_tests_file_with_no_rows_omitted_but_map_present(async_session):
@@ -134,4 +134,95 @@ async def test_guarding_tests_empty_changed_set(async_session):
     analyzer = PRBlastRadiusAnalyzer(async_session, repo.id)
     result = await analyzer._guarding_tests([])
 
-    assert result == {"map_present": False, "tests_to_run": [], "by_file": {}}
+    assert result == {"map_present": False, "basis": "none", "tests_to_run": [], "by_file": {}}
+
+
+# ---------------------------------------------------------------------------
+# The graph fallback: what happens on the repos with no coverage report at all
+# ---------------------------------------------------------------------------
+
+
+def _graph(session, repo_id, nodes, edges):
+    from repowise.core.persistence.models import GraphEdge, GraphNode
+
+    for path, is_test in nodes:
+        session.add(
+            GraphNode(repository_id=repo_id, node_id=path, node_type="file", is_test=is_test)
+        )
+    for src, dst in edges:
+        session.add(
+            GraphEdge(
+                repository_id=repo_id,
+                source_node_id=src,
+                target_node_id=dst,
+                edge_type="imports",
+            )
+        )
+
+
+async def test_no_map_falls_back_to_the_graph_and_says_so(async_session):
+    repo = await insert_repo(async_session)
+    _graph(
+        async_session,
+        repo.id,
+        [("tests/test_math.py", True), ("src/math.py", False)],
+        [("tests/test_math.py", "src/math.py")],
+    )
+    await async_session.commit()
+
+    result = await PRBlastRadiusAnalyzer(async_session, repo.id)._guarding_tests(["src/math.py"])
+
+    # map_present stays the measured-map flag it always was; basis is what tells
+    # a caller which of the two answered, and the two are never merged.
+    assert result["map_present"] is False
+    assert result["basis"] == "inferred"
+    assert result["tests_to_run"] == ["tests/test_math.py"]
+    assert result["by_file"] == {"src/math.py": ["tests/test_math.py"]}
+
+
+async def test_a_measured_map_is_never_diluted_by_the_graph(async_session):
+    """Coverage answered, so the graph is not consulted at all."""
+    repo = await insert_repo(async_session)
+    await _seed_map(async_session, repo.id)
+    _graph(
+        async_session,
+        repo.id,
+        [("tests/test_unrelated.py", True), ("src/math.py", False)],
+        [("tests/test_unrelated.py", "src/math.py")],
+    )
+    await async_session.commit()
+
+    result = await PRBlastRadiusAnalyzer(async_session, repo.id)._guarding_tests(["src/math.py"])
+
+    assert result["basis"] == "measured"
+    assert "tests/test_unrelated.py" not in result["tests_to_run"]
+
+
+async def test_a_map_that_is_silent_about_this_file_still_asks_the_graph(async_session):
+    """The map exists but knows nothing here - better than an empty list."""
+    repo = await insert_repo(async_session)
+    await _seed_map(async_session, repo.id)
+    _graph(
+        async_session,
+        repo.id,
+        [("tests/test_new.py", True), ("src/new.py", False)],
+        [("tests/test_new.py", "src/new.py")],
+    )
+    await async_session.commit()
+
+    result = await PRBlastRadiusAnalyzer(async_session, repo.id)._guarding_tests(["src/new.py"])
+
+    assert result["map_present"] is True
+    assert result["basis"] == "inferred"
+    assert result["tests_to_run"] == ["tests/test_new.py"]
+
+
+async def test_nothing_anywhere_stays_an_honest_unknown(async_session):
+    repo = await insert_repo(async_session)
+    _graph(async_session, repo.id, [("src/lonely.py", False)], [])
+    await async_session.commit()
+
+    result = await PRBlastRadiusAnalyzer(async_session, repo.id)._guarding_tests(["src/lonely.py"])
+
+    assert result["basis"] == "none"
+    assert result["tests_to_run"] == []

--- a/tests/unit/persistence/test_test_gap_graph_floor.py
+++ b/tests/unit/persistence/test_test_gap_graph_floor.py
@@ -1,0 +1,99 @@
+"""A test reaching a file in the graph stops it being called a test gap.
+
+Issue #1740: two filename heuristics answered "does this file have a test" and
+disagreed - ``pr_blast._find_test_gaps`` (substring match over every test path)
+and ``assessment._check_test_gap`` (SQL LIKE over the same). Both now consult
+the graph before falling back to a name, so the answer they share comes from a
+recorded edge rather than from whichever pattern each happened to implement.
+
+Pinned here for both call sites at once, because the defect was precisely that
+they were tested and maintained apart.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from repowise.core.analysis.pr_blast import PRBlastRadiusAnalyzer
+from repowise.core.persistence.models import GraphEdge, GraphNode
+from repowise.server.mcp_server.tool_risk.assessment import _check_test_gap
+from tests.unit.persistence.helpers import insert_repo
+
+
+async def _seed(session, edges, nodes):
+    repo = await insert_repo(session)
+    for path, is_test in nodes:
+        session.add(
+            GraphNode(repository_id=repo.id, node_id=path, node_type="file", is_test=is_test)
+        )
+    for src, dst in edges:
+        session.add(
+            GraphEdge(
+                repository_id=repo.id,
+                source_node_id=src,
+                target_node_id=dst,
+                edge_type="imports",
+            )
+        )
+    await session.commit()
+    return repo
+
+
+# The shape the naming convention cannot see: the test is named for what it
+# checks, not for the file it checks it in.
+_BEHAVIOUR_NAMED = (
+    [("tests/test_round_trips_cleanly.py", "src/parser.py")],
+    [("tests/test_round_trips_cleanly.py", True), ("src/parser.py", False)],
+)
+
+
+async def test_pr_blast_does_not_call_a_reached_file_a_gap(async_session):
+    repo = await _seed(async_session, *_BEHAVIOUR_NAMED)
+    analyzer = PRBlastRadiusAnalyzer(async_session, repo.id)
+    assert await analyzer._find_test_gaps(["src/parser.py"]) == []
+
+
+async def test_assessment_does_not_call_a_reached_file_a_gap(async_session):
+    repo = await _seed(async_session, *_BEHAVIOUR_NAMED)
+    assert await _check_test_gap(async_session, repo.id, "src/parser.py") is False
+
+
+@pytest.mark.parametrize("check", ["pr_blast", "assessment"])
+async def test_a_file_nothing_reaches_is_still_a_gap(async_session, check):
+    """The floor only clears files with evidence; it does not clear everything."""
+    repo = await _seed(
+        async_session,
+        [("tests/test_round_trips_cleanly.py", "src/parser.py")],
+        [
+            ("tests/test_round_trips_cleanly.py", True),
+            ("src/parser.py", False),
+            ("src/lonely.py", False),
+        ],
+    )
+    if check == "pr_blast":
+        analyzer = PRBlastRadiusAnalyzer(async_session, repo.id)
+        assert await analyzer._find_test_gaps(["src/lonely.py"]) == ["src/lonely.py"]
+    else:
+        assert await _check_test_gap(async_session, repo.id, "src/lonely.py") is True
+
+
+async def test_a_co_change_edge_does_not_clear_a_gap(async_session):
+    """Files that change together are not files that test each other."""
+    repo = await insert_repo(async_session)
+    for path, is_test in (("tests/test_x.py", True), ("src/lonely.py", False)):
+        async_session.add(
+            GraphNode(repository_id=repo.id, node_id=path, node_type="file", is_test=is_test)
+        )
+    async_session.add(
+        GraphEdge(
+            repository_id=repo.id,
+            source_node_id="tests/test_x.py",
+            target_node_id="src/lonely.py",
+            edge_type="co_changes",
+        )
+    )
+    await async_session.commit()
+
+    analyzer = PRBlastRadiusAnalyzer(async_session, repo.id)
+    assert await analyzer._find_test_gaps(["src/lonely.py"]) == ["src/lonely.py"]
+    assert await _check_test_gap(async_session, repo.id, "src/lonely.py") is True

--- a/tests/unit/persistence/test_test_reachability_walk.py
+++ b/tests/unit/persistence/test_test_reachability_walk.py
@@ -1,0 +1,153 @@
+"""The attributed reverse walk: which tests reach each changed file.
+
+Runs against real ``graph_nodes`` / ``graph_edges`` rows rather than a stub,
+because the walk's whole job is reading those two tables correctly - the edge
+type filter, the depth bound, and the per-seed attribution that lets one walk
+serve every file in a diff.
+
+``tests_reaching`` is imported under an alias: pytest collects module-level
+names matching ``test*``, and the unaliased import would be collected as a test
+and error on its missing arguments.
+"""
+
+from __future__ import annotations
+
+from repowise.core.analysis.test_reachability import tests_reaching as reaching
+from repowise.core.persistence.models import GraphEdge, GraphNode
+from tests.unit.persistence.helpers import insert_repo
+
+
+async def _seed(session, repo_id, *, nodes, edges):
+    for path, is_test in nodes.items():
+        session.add(
+            GraphNode(
+                repository_id=repo_id, node_id=path, node_type="file", is_test=is_test
+            )
+        )
+    for src, dst, etype in edges:
+        session.add(
+            GraphEdge(
+                repository_id=repo_id,
+                source_node_id=src,
+                target_node_id=dst,
+                edge_type=etype,
+            )
+        )
+    await session.flush()
+
+
+async def test_names_the_tests_that_import_a_changed_file(async_session):
+    repo = await insert_repo(async_session)
+    await _seed(
+        async_session,
+        repo.id,
+        nodes={"tests/test_a.py": True, "tests/test_z.py": True, "src/a.py": False},
+        edges=[
+            ("tests/test_a.py", "src/a.py", "imports"),
+            ("tests/test_z.py", "src/z.py", "imports"),
+        ],
+    )
+    assert await reaching(async_session, repo.id, ["src/a.py"]) == {
+        "src/a.py": ["tests/test_a.py"]
+    }
+
+
+async def test_finds_a_behaviour_named_test_two_hops_out(async_session):
+    """Opt-in second hop, for repos whose tests go through a package facade."""
+    repo = await insert_repo(async_session)
+    await _seed(
+        async_session,
+        repo.id,
+        nodes={"tests/test_round_trips.py": True, "src/api.py": False, "src/parser.py": False},
+        edges=[
+            ("tests/test_round_trips.py", "src/api.py", "imports"),
+            ("src/api.py", "src/parser.py", "imports"),
+        ],
+    )
+    result = await reaching(async_session, repo.id, ["src/parser.py"], max_depth=2)
+    assert result == {"src/parser.py": ["tests/test_round_trips.py"]}
+
+    # The default stops at one hop, so the facade case is not claimed by default.
+    assert await reaching(async_session, repo.id, ["src/parser.py"]) == {}
+
+
+async def test_attribution_is_per_changed_file(async_session):
+    """One walk, several seeds: each test lands against the file it reaches."""
+    repo = await insert_repo(async_session)
+    await _seed(
+        async_session,
+        repo.id,
+        nodes={
+            "tests/test_a.py": True,
+            "tests/test_b.py": True,
+            "tests/test_both.py": True,
+            "src/a.py": False,
+            "src/b.py": False,
+        },
+        edges=[
+            ("tests/test_a.py", "src/a.py", "imports"),
+            ("tests/test_b.py", "src/b.py", "imports"),
+            ("tests/test_both.py", "src/a.py", "imports"),
+            ("tests/test_both.py", "src/b.py", "imports"),
+        ],
+    )
+    assert await reaching(async_session, repo.id, ["src/a.py", "src/b.py"]) == {
+        "src/a.py": ["tests/test_a.py", "tests/test_both.py"],
+        "src/b.py": ["tests/test_b.py", "tests/test_both.py"],
+    }
+
+
+async def test_a_test_file_is_a_leaf(async_session):
+    """A shared test helper must not drag its other importers' targets in."""
+    repo = await insert_repo(async_session)
+    await _seed(
+        async_session,
+        repo.id,
+        nodes={
+            "tests/helpers.py": True,
+            "tests/test_unrelated.py": True,
+            "src/a.py": False,
+        },
+        edges=[
+            ("tests/helpers.py", "src/a.py", "imports"),
+            # test_unrelated imports the helper, not src/a.py.
+            ("tests/test_unrelated.py", "tests/helpers.py", "imports"),
+        ],
+    )
+    result = await reaching(async_session, repo.id, ["src/a.py"])
+    assert result == {"src/a.py": ["tests/helpers.py"]}
+
+
+async def test_co_change_edges_are_not_reachability(async_session):
+    """Files that change together are not files that test each other."""
+    repo = await insert_repo(async_session)
+    await _seed(
+        async_session,
+        repo.id,
+        nodes={"tests/test_a.py": True, "src/a.py": False},
+        edges=[("tests/test_a.py", "src/a.py", "co_changes")],
+    )
+    assert await reaching(async_session, repo.id, ["src/a.py"]) == {}
+
+
+async def test_unreached_file_is_absent_not_empty(async_session):
+    repo = await insert_repo(async_session)
+    await _seed(
+        async_session,
+        repo.id,
+        nodes={"tests/test_a.py": True, "src/a.py": False, "src/lonely.py": False},
+        edges=[("tests/test_a.py", "src/a.py", "imports")],
+    )
+    result = await reaching(async_session, repo.id, ["src/a.py", "src/lonely.py"])
+    assert "src/lonely.py" not in result
+
+
+async def test_repo_with_no_test_nodes_returns_empty(async_session):
+    repo = await insert_repo(async_session)
+    await _seed(
+        async_session,
+        repo.id,
+        nodes={"src/a.py": False, "src/b.py": False},
+        edges=[("src/b.py", "src/a.py", "imports")],
+    )
+    assert await reaching(async_session, repo.id, ["src/a.py"]) == {}

--- a/tests/unit/server/mcp/test_change_risk.py
+++ b/tests/unit/server/mcp/test_change_risk.py
@@ -214,6 +214,7 @@ async def test_impacted_tests_line_precise_hit_and_miss(tmp_path, monkeypatch) -
 
     it = result["impacted_tests"]
     assert it["status"] == "map_present"
+    assert it["basis"] == "measured"
     assert it["map_present"] is True
     # app.py line 3 is covered -> its test is named; other/new are not covering.
     assert it["tests"] == ["tests/test_app.py::test_app"]
@@ -250,12 +251,62 @@ async def test_impacted_tests_no_map_is_unknown_not_untested(tmp_path, monkeypat
     result = await module.get_change_risk(baseline=0)
 
     it = result["impacted_tests"]
+    # Nothing is seeded in the graph either, so neither tier can speak.
     assert it["status"] == "no_map"
     assert it["map_present"] is False
     assert it["tests"] == []
     # Honest degradation: no untested claim, a "run the suite" summary instead.
     assert it["missing_tests"]["untested_changes"] == []
     assert "run the full suite" in it["summary"]
+
+
+@pytest.mark.asyncio
+async def test_impacted_tests_falls_back_to_the_graph_without_a_map(tmp_path, monkeypatch) -> None:
+    """No coverage map, but the graph knows a test imports the changed file.
+
+    Replaces a bare "run the full suite" with a candidate list on every repo
+    that never ingested a report. Labelled ``inferred`` and file-level: reaching
+    carries no line attribution, so ``missing_tests`` stays empty rather than
+    being filled from a signal that cannot speak to lines.
+    """
+    from repowise.core.persistence.models import GraphEdge, GraphNode
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(["init", "-q"], repo)
+    _commit(repo, {"src/app.py": "a\nb\n"}, "chore: seed")
+    _commit(repo, {"src/app.py": "a\nb\nc\n"}, "feat: add line")
+
+    factory = await _factory_with_repo(None)
+    async with factory() as s:
+        for path, is_test in (("tests/test_round_trips.py", True), ("src/app.py", False)):
+            s.add(
+                GraphNode(repository_id="repo1", node_id=path, node_type="file", is_test=is_test)
+            )
+        s.add(
+            GraphEdge(
+                repository_id="repo1",
+                source_node_id="tests/test_round_trips.py",
+                target_node_id="src/app.py",
+                edge_type="imports",
+            )
+        )
+        await s.commit()
+
+    module = importlib.import_module("repowise.server.mcp_server.tool_change_risk")
+
+    async def _context(_: str | None) -> SimpleNamespace:
+        return SimpleNamespace(path=str(repo), session_factory=factory)
+
+    monkeypatch.setattr(module, "_resolve_repo_context", _context)
+    it = (await module.get_change_risk(baseline=0))["impacted_tests"]
+
+    assert it["status"] == "inferred"
+    assert it["basis"] == "inferred"
+    assert it["map_present"] is False
+    assert it["tests"] == ["tests/test_round_trips.py"]
+    assert it["missing_tests"]["untested_changes"] == []
+    assert "import graph" in it["summary"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/server/mcp/test_risk.py
+++ b/tests/unit/server/mcp/test_risk.py
@@ -150,19 +150,41 @@ async def test_get_risk_pr_directive_surfaces_coverage_backed_tests_to_run(setup
         "tests/test_service.py::test_login",
         "tests/test_service.py::test_logout",
     ]
+    # The graph also reaches this file, and must not dilute a measured answer.
+    assert directive["tests_to_run_basis"] == "measured"
     assert "coverage-backed test(s) guard the change" in directive["summary"]
 
 
 @pytest.mark.asyncio
-async def test_get_risk_pr_directive_tests_to_run_empty_without_map(setup_mcp):
-    """No per-test map -> tests_to_run is an empty list, never invented."""
+async def test_get_risk_pr_directive_falls_back_to_the_graph_without_a_map(setup_mcp):
+    """No per-test map -> the import graph answers, labelled as inferred.
+
+    The fixture records ``tests/test_service.py`` importing ``service.py``. That
+    is not proof it executes it, so the ids are test *files* and the basis says
+    ``inferred``; what it replaces is an empty list on every repo that has never
+    ingested a coverage report.
+    """
     from repowise.server.mcp_server import get_risk
 
     result = await get_risk(["src/auth/service.py"], changed_files=["src/auth/service.py"])
     directive = result["directive"]
 
-    assert directive["tests_to_run"] == []
+    assert directive["tests_to_run"] == ["tests/test_service.py"]
+    assert directive["tests_to_run_basis"] == "inferred"
+    assert "inferred, not coverage-proven" in directive["summary"]
     assert "coverage-backed test(s) guard the change" not in directive["summary"]
+
+
+@pytest.mark.asyncio
+async def test_get_risk_pr_directive_names_no_tests_when_nothing_reaches(setup_mcp):
+    """Neither map nor graph -> an empty list and a ``none`` basis, not a guess."""
+    from repowise.server.mcp_server import get_risk
+
+    result = await get_risk(["src/db/models.py"], changed_files=["src/db/models.py"])
+    directive = result["directive"]
+
+    assert directive["tests_to_run"] == []
+    assert directive["tests_to_run_basis"] == "none"
 
 
 # ---- _classify_risk_type small-team calibration (issue #361) ---------------


### PR DESCRIPTION
## What

Answer "what tests this file?" from the dependency graph when no coverage report has been ingested.

The per-test coverage map only exists if you run your suite under per-test recording and ingest the report. Most repositories never do, so `tests_to_run` came back empty, `impacted_tests` said "run the full suite", and `untested_hotspot` fell back to matching filenames.

Filename matching fails in both directions. Of this repository's six worst bug-magnet files, five have no file named for them anywhere under `tests/` and so read as untested:

| File | Filename convention | Graph |
|---|---|---|
| `ingestion/call_resolver.py` | nothing | 7 test files |
| `analysis/dead_code/analyzer.py` | nothing | 9 |
| `pipeline/persist.py` | nothing | 23 |
| `mcp_server/tool_answer/answer.py` | nothing | 18 |
| `analysis/pr_blast.py` | nothing | 3 |
| `analysis/health/engine.py` | `tests/unit/distill/test_engine.py` | 6, all under `tests/unit/health/` |

The last row is the worse failure: the convention matches on basename alone, so it paired the health engine with the distill engine's tests and called the file tested on the strength of a name collision.

## How

New `core/analysis/test_reachability.py`. A test file that imports a source file *reaches* it, which the graph already records from parsing. Two walks: a multi-source forward walk for the whole-repo question the health pass asks, and an attributed reverse walk for the per-change question.

Importing is not executing, so this over-claims, in a known direction. That makes it sound as a floor ("something reaches this, do not call it untested") and unsound as a quantity. It is labelled `inferred` at every surface and never blended with measured coverage. Where a coverage report exists the graph is not consulted at all.

Nothing is persisted. Writing inferred rows into `test_coverage` behind a marker column works until one reader forgets to check the marker, and the relation is a transitive closure (tests reach 1,630 of 2,509 production files here) that goes stale the moment an import changes. It is a bounded walk over rows already indexed instead.

## Accuracy

`max_depth` defaults to 1 because that was measured. Dogfooded against a real `coverage run --contexts=test`, on a slice where per-test attribution was complete and both sides saw the same 38 test files:

| `max_depth` | reach precision | reach recall | run-list precision | run-list hit rate |
|---|---|---|---|---|
| **1** (default) | **72.1%** | 30.4% | **93.1%** | 96.8% |
| 2 | 40.7% | 45.1% | 73.8% | 97.9% |
| 3 | 17.1% | 45.1% | n/a | n/a |

Both uses want precision. A false "something reaches this" suppresses a real finding, and a false entry in a run-list sends someone to run a test that cannot fail for their change. By depth 3 the closure has begun to blow up: 269 claims for the same 46 confirmations.

The filename convention it sits beside scores 23.5% recall on the same set, so depth 1 beats it on recall while resting on a recorded edge rather than a name. The two are unioned, not ranked. `max_depth=2` stays a keyword argument for repositories whose tests import a package facade.

## Behaviour

- `untested_hotspot` suppresses on a graph-reaching test as well as on a paired test file. On this repository's index that clears 74 of 110 standing findings, 18 of them graded critical.
- The persisted `has_test_file` widens to the union. The MCP payload documents it as "does something test this file" and every UI renders it "has tests" / "untested", so leaving it filename-only left the file table and the biomarker disagreeing about the same file.
- `get_risk`'s directive gains `tests_to_run_basis` (`measured` / `inferred` / `none`) and falls back to the graph when the map is empty or silent about a file. Only the inferred list is exclude-filtered, since its entries are repo paths while measured entries are test node ids.
- `get_change_risk`'s `impacted_tests` gains `basis` and `status: "inferred"`. `missing_tests` stays empty there because reaching carries no line attribution.
- `_find_test_gaps` and `_check_test_gap` both consult the graph before the filename pattern, so the two heuristics that answered this question differently now share an answer.
- `repowise impacted-tests` reports candidates with a `via` marker: `changed-test` (the changed file is itself a test), `import-graph`, or `filename-pattern`.

## Compatibility

`repowise impacted-tests --format json` renames `guessed_tests` to `inferred_tests`. The bucket no longer holds only filename guesses, so the old name described the wrong contents; each entry carries `via` to say which tier answered.

`HEALTH_ANALYZER_VERSION` moves to 2. Both stored values are wrong on an index built before this, and wrong in the direction that accuses a tested file, so the next update with changed files re-scores rather than waiting out the decay timer.

## Cost

27 ms once per health run on this 3,700-file repository, computed in one multi-source walk and cached, so indexing time is unchanged. Per-change queries are one `IN` query over the same edge table `pr_blast` already reads.

## Verification

13,869 unit tests pass. Two pre-existing failures remain on this machine (`test_pascal_no_class_metrics`, `test_tokenize_file_pascal_normalizes_identifiers_and_literals`), confirmed to fail identically on a clean tree because the Pascal grammar is not installed locally.

New tests cover both walks over real graph rows, the edge-type filter, the depth bound, the test-files-are-leaves rule, per-seed attribution, the biomarker suppression and its controls, the shared test-gap floor at both call sites, the three-tier CLI classification, and the two MCP fields.

Dogfooded end to end against this repository's own index: `repowise impacted-tests` with no coverage map named the three test files reaching the changed file, including the one written for that change.
