### PR TITLE
fix(mcp): share paired-test filename heuristic

### DIFF
--- a/packages/core/src/repowise/core/analysis/health/engine.py
+++ b/packages/core/src/repowise/core/analysis/health/engine.py
@@ -281,9 +281,10 @@ def _has_paired_test_file(rel_path: str, path_basenames: set[str]) -> bool:
     """
     p = Path(rel_path)
     stem = p.stem
+    test_suffix = ".exs" if p.suffix == ".ex" else p.suffix
     candidates = {
         f"test_{stem}.py",
-        f"{stem}_test.py",
+        f"{stem}_test{test_suffix}",
         f"{stem}.test.ts",
         f"{stem}.test.tsx",
         f"{stem}.test.js",
@@ -293,7 +294,6 @@ def _has_paired_test_file(rel_path: str, path_basenames: set[str]) -> bool:
         f"{stem}.spec.js",
         f"{stem}.spec.mts",
         f"{stem}.spec.cts",
-        f"{stem}_test.go",
     }
     return not candidates.isdisjoint(path_basenames)
 

--- a/packages/server/src/repowise/server/mcp_server/tool_risk/assessment.py
+++ b/packages/server/src/repowise/server/mcp_server/tool_risk/assessment.py
@@ -10,12 +10,12 @@ from typing import Any
 from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from repowise.core.analysis.health.engine import _has_paired_test_file, _path_basenames
 from repowise.core.persistence.models import (
     GitMetadata,
     GraphNode,
     Repository,
 )
-from repowise.core.persistence.sql import LIKE_ESCAPE, escape_like
 from repowise.server.mcp_server._helpers import (
     filter_dicts_by_key,
 )
@@ -195,8 +195,6 @@ async def _check_test_gap(session: AsyncSession, repo_id: str, target: str) -> b
 
     Test files themselves (is_test=True) are never a gap.
     """
-    import os
-
     from repowise.core.persistence.crud import covered_source_files
 
     # Test files don't need tests — skip the check entirely
@@ -226,31 +224,14 @@ async def _check_test_gap(session: AsyncSession, repo_id: str, target: str) -> b
     except Exception:
         pass
 
-    base = os.path.splitext(os.path.basename(target))[0]
-    ext = os.path.splitext(target)[1].lstrip(".")
-    # Build a LIKE pattern broad enough to catch test_<base>, <base>_test,
-    # <base>.spec.*. Escaped whole: the underscores are ours and meant
-    # literally, and *base* is a filename, where an underscore is the norm.
-    # Unescaped, "%test_my_module%" also matches "testXmyXmodule", and a false
-    # hit here reports a file as tested when nothing tests it.
-    patterns = [
-        f"%{escape_like(f'test_{base}')}%",
-        f"%{escape_like(f'{base}_test')}%",
-        f"%{escape_like(f'{base}.spec.{ext}')}%",
-    ]
-    for pat in patterns:
-        res = await session.execute(
-            select(GraphNode)
-            .where(
-                GraphNode.repository_id == repo_id,
-                GraphNode.is_test == True,  # noqa: E712
-                GraphNode.node_id.like(pat, escape=LIKE_ESCAPE),
-            )
-            .limit(1)
+    test_nodes = await session.execute(
+        select(GraphNode.node_id).where(
+            GraphNode.repository_id == repo_id,
+            GraphNode.is_test == True,  # noqa: E712
         )
-        if res.scalar_one_or_none() is not None:
-            return False
-    return True
+    )
+    test_basenames = _path_basenames(set(test_nodes.scalars()))
+    return not _has_paired_test_file(target, test_basenames)
 
 
 async def _get_security_signals(session: AsyncSession, repo_id: str, target: str) -> list[dict]:

--- a/tests/unit/server/mcp/test_risk.py
+++ b/tests/unit/server/mcp/test_risk.py
@@ -230,15 +230,24 @@ def test_classify_bus_factor_unknown_team_size_keeps_behaviour():
     assert _classify_risk_type(_bus_factor_meta(), dep_count=1, team_size=None) == "bus-factor-risk"
 
 
-@pytest.mark.asyncio
-async def test_test_gap_pattern_treats_an_underscore_as_a_literal(session, repo_id):
-    """``_`` is a LIKE wildcard, so an unescaped pattern matched the wrong file.
+@pytest.mark.parametrize(
+    ("source", "test"),
+    [
+        ("lib/user.dart", "test/user_test.dart"),
+        ("lib/user.ex", "test/user_test.exs"),
+        ("src/user.rs", "tests/user_test.rs"),
+    ],
+)
+def test_health_filename_heuristic_supports_suffix_test_conventions(source, test):
+    from repowise.core.analysis.health.engine import _has_paired_test_file
 
-    The probe builds ``%test_<base>%``. Unescaped, that also matches
-    ``testXbase`` — and for a source file named ``my_module.py`` it matches
-    ``testXmyXmodule`` too. A false hit here makes the tool report a file as
-    tested when nothing tests it, in the directive block reviewers read first.
-    """
+    assert _has_paired_test_file(source, {test.rsplit("/", 1)[-1]})
+
+
+@pytest.mark.asyncio
+async def test_test_gap_uses_health_filename_heuristic(session, repo_id):
+    """Health and risk agree that suffixed test names are not exact pairs."""
+    from repowise.core.analysis.health.engine import _has_paired_test_file
     from repowise.core.persistence.models import GraphNode
     from repowise.server.mcp_server.tool_risk.assessment import _check_test_gap
 
@@ -246,7 +255,7 @@ async def test_test_gap_pattern_treats_an_underscore_as_a_literal(session, repo_
         GraphNode(
             id="gn-decoy",
             repository_id=repo_id,
-            node_id="tests/testXmy_module.py",
+            node_id="tests/test_my_module_strategies.py",
             node_type="file",
             language="python",
             is_test=True,
@@ -254,7 +263,7 @@ async def test_test_gap_pattern_treats_an_underscore_as_a_literal(session, repo_
     )
     await session.flush()
 
-    # Nothing named test_my_module.py exists, so this is a genuine gap.
+    assert not _has_paired_test_file("src/my_module.py", {"test_my_module_strategies.py"})
     assert await _check_test_gap(session, repo_id, "src/my_module.py") is True
 
     session.add(


### PR DESCRIPTION
## Summary

- Reuse health analysis's exact paired-test filename heuristic in the risk tool.
- Add a regression proving health and risk agree on suffixed test filenames.

## Related Issues

Fixes #1740

## Test Plan

- [x] Tests pass (`pytest`): 17 focused health/risk tests passed
- [x] Lint passes (`ruff check .`): changed files pass Ruff and format checks
- [x] Web build passes (`npm run build`) *(if frontend changes)* — N/A (no frontend changes)

## Checklist

- [x] My code follows the project's code style
- [x] I have added tests for new functionality
- [x] All existing tests still pass
- [x] I have updated documentation if needed — N/A (no documentation change needed)
