### PR TITLE
refactor(perf): share the sink-reachability walk between crossfn and gated

### DIFF
--- a/packages/core/src/repowise/core/analysis/health/perf/crossfn.py
+++ b/packages/core/src/repowise/core/analysis/health/perf/crossfn.py
@@ -48,13 +48,10 @@ from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any
 
 from .callgraph import CallGraphIndex
-from .reachability import path_to_sink, reachable_to_sink
+from .sink_reach import collect_sink_reaching_hits
 
 if TYPE_CHECKING:
-    # Imported lazily at runtime (see ``_hits_for_function``) to avoid a cycle:
-    # the walker pulls in ``perf.io_boundaries`` while the ``complexity``
-    # package is still initialising, so ``crossfn`` cannot import it eagerly.
-    from ..complexity import FileComplexity, PerfFnFacts, PerfHit
+    from ..complexity import FileComplexity, PerfHit
 
 # Cross-function hits carry this so the biomarker can phrase them distinctly
 # while still scoring under the same ``io_in_loop`` / ``performance`` budget.
@@ -75,104 +72,20 @@ def collect_crossfn_io_in_loop(
     edges), or ``None``. ``index`` is an optional pre-built
     :class:`CallGraphIndex` (the engine builds one and shares it across the
     graph passes); when omitted it is built from ``graph``. Each returned
-    :class:`PerfHit` carries the sink's boundary kind in ``detail`` and the
+    :class:`PerfHit` carries the sink's boundary kind in ``detail``, the
     ``A -> ... -> sink`` symbol path in ``path`` (non-empty ``path`` is what
-    marks a hit as cross-function).
+    marks a hit as cross-function), and the ``resolution_basis`` the index
+    used to select the exact first-hop edge.
+
+    The walk itself lives in :func:`.sink_reach.collect_sink_reaching_hits`,
+    shared with the lock-held-I/O pass; only the entry set and the hit kind
+    differ between the two.
     """
-    walked_list = list(walked)
-    if graph is None or not walked_list:
-        return {}
-
-    # Cheap pre-checks over the already-computed facts, before touching the
-    # graph at all: a cross-function N+1 needs BOTH a function holding a bare
-    # sink (a reachability target) and a function with a loop-nested call (an
-    # entry). On a repo with neither, this returns without scanning the graph.
-    has_sink = any(
-        fact.bare_sink_kind is not None for _pf, fcx in walked_list for fact in fcx.perf_fn_facts
-    )
-    has_entry = any(
-        fact.loop_call_targets for _pf, fcx in walked_list for fact in fcx.perf_fn_facts
-    )
-    if not (has_sink and has_entry):
-        return {}
-
-    if index is None:
-        index = CallGraphIndex(graph)
-    if not index.forward:
-        return {}  # no resolved call edges → nothing cross-function to find
-
-    # --- sink set: functions that execute a bare (loop_depth 0) I/O sink ------
-    sink_kind: dict[str, str] = {}
-    for pf, fcx in walked_list:
-        path = pf.file_info.path
-        for fact in fcx.perf_fn_facts:
-            if fact.bare_sink_kind is None:
-                continue
-            sid = index.resolve_function(path, fact.func_start)
-            if sid is not None:
-                sink_kind.setdefault(sid, fact.bare_sink_kind)
-
-    if not sink_kind:
-        return {}
-
-    reach = reachable_to_sink(
-        sink_kind.keys(),
-        lambda node: index.reverse.get(node, ()),
+    return collect_sink_reaching_hits(
+        walked,
+        graph,
+        entries=lambda fact: fact.loop_call_targets,
+        kind=CROSSFN_KIND,
+        index=index,
         max_depth=max_depth,
     )
-
-    # --- match each loop owner's loop-nested callees against the reach map ----
-    out: dict[str, list[PerfHit]] = {}
-    for pf, fcx in walked_list:
-        path = pf.file_info.path
-        for fact in fcx.perf_fn_facts:
-            if not fact.loop_call_targets:
-                continue
-            hits = _hits_for_function(path, fact, index, reach, sink_kind)
-            if hits:
-                out.setdefault(path, []).extend(hits)
-    return out
-
-
-def _hits_for_function(
-    path: str,
-    fact: PerfFnFacts,
-    index: CallGraphIndex,
-    reach: dict[str, Any],
-    sink_kind: dict[str, str],
-) -> list[PerfHit]:
-    from ..complexity import PerfHit
-
-    a_sid = index.resolve_function(path, fact.func_start)
-    if a_sid is None:
-        return []
-    callees = index.forward.get(a_sid)
-    if not callees:
-        return []
-    hits: list[PerfHit] = []
-    seen: set[str] = set()
-    for target_name, call_line in fact.loop_call_targets:
-        if target_name in seen:
-            continue
-        targets, basis = index.resolve_call_targets(a_sid, call_line, target_name)
-        for callee in targets:
-            info = reach.get(callee)
-            if info is None:
-                continue
-            chain = path_to_sink(callee, reach)
-            if not chain:
-                continue
-            seen.add(target_name)
-            kind = sink_kind.get(info.sink, "")
-            hits.append(
-                PerfHit(
-                    kind=CROSSFN_KIND,
-                    line=call_line,
-                    function=fact.function,
-                    detail=kind,
-                    path=(a_sid, *chain),
-                    resolution_basis=basis,
-                )
-            )
-            break
-    return hits

--- a/packages/core/src/repowise/core/analysis/health/perf/gated.py
+++ b/packages/core/src/repowise/core/analysis/health/perf/gated.py
@@ -29,10 +29,10 @@ from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any
 
 from .callgraph import CallGraphIndex
-from .reachability import path_to_sink, reachable_to_sink
+from .sink_reach import collect_sink_reaching_hits
 
 if TYPE_CHECKING:
-    from ..complexity import FileComplexity, PerfFnFacts, PerfHit
+    from ..complexity import FileComplexity, PerfHit
     from .ranking import PerfRanker
 
 # The boundary-kind detail convention shared with the cross-function N+1 pass.
@@ -98,103 +98,22 @@ def collect_blocking_io_under_lock(
     """Cross-function ``blocking_io_under_lock`` hits, keyed by the lock-owning file.
 
     A function acquires a lock and, while holding it, calls a helper that reaches
-    an I/O boundary within ``max_depth`` hops — the I/O round-trip runs under the
-    lock, serializing every thread on a network/db/fs wait. Mirrors
-    ``crossfn.collect_crossfn_io_in_loop`` exactly: the only difference is the
-    entry set is ``PerfFnFacts.lock_call_targets`` (callees invoked under a held
-    lock) instead of loop-nested callees. The same-function case (an I/O sink
-    lexically inside a ``lock``/``synchronized`` block) is emitted directly by
-    the walker.
+    an I/O boundary within ``max_depth`` hops -- the I/O round-trip runs under the
+    lock, serializing every thread on a network/db/fs wait. The same-function case
+    (an I/O sink lexically inside a ``lock``/``synchronized`` block) is emitted
+    directly by the walker.
+
+    The walk is :func:`.sink_reach.collect_sink_reaching_hits`, shared with
+    ``crossfn.collect_crossfn_io_in_loop``: the only difference is the entry set
+    is ``PerfFnFacts.lock_call_targets`` (callees invoked under a held lock)
+    instead of loop-nested callees.
     """
-    from ..complexity import PerfHit
-
-    walked_list = list(walked)
-    if graph is None or not walked_list:
-        return {}
-
-    has_sink = any(
-        fact.bare_sink_kind is not None for _pf, fcx in walked_list for fact in fcx.perf_fn_facts
-    )
-    has_entry = any(
-        fact.lock_call_targets for _pf, fcx in walked_list for fact in fcx.perf_fn_facts
-    )
-    if not (has_sink and has_entry):
-        return {}
-
-    if index is None:
-        index = CallGraphIndex(graph)
-    if not index.forward:
-        return {}
-
-    sink_kind: dict[str, str] = {}
-    for pf, fcx in walked_list:
-        path = pf.file_info.path
-        for fact in fcx.perf_fn_facts:
-            if fact.bare_sink_kind is None:
-                continue
-            sid = index.resolve_function(path, fact.func_start)
-            if sid is not None:
-                sink_kind.setdefault(sid, fact.bare_sink_kind)
-    if not sink_kind:
-        return {}
-
-    reach = reachable_to_sink(
-        sink_kind.keys(),
-        lambda node: index.reverse.get(node, ()),
+    return collect_sink_reaching_hits(
+        walked,
+        graph,
+        entries=lambda fact: fact.lock_call_targets,
+        kind=LOCK_IO_KIND,
+        index=index,
         max_depth=max_depth,
+        carry_func_start=True,
     )
-
-    out: dict[str, list[PerfHit]] = {}
-    for pf, fcx in walked_list:
-        path = pf.file_info.path
-        for fact in fcx.perf_fn_facts:
-            if not fact.lock_call_targets:
-                continue
-            hits = _lock_hits_for_function(path, fact, index, reach, sink_kind, PerfHit)
-            if hits:
-                out.setdefault(path, []).extend(hits)
-    return out
-
-
-def _lock_hits_for_function(
-    path: str,
-    fact: PerfFnFacts,
-    index: CallGraphIndex,
-    reach: dict[str, Any],
-    sink_kind: dict[str, str],
-    perf_hit_cls: type,
-) -> list[PerfHit]:
-    a_sid = index.resolve_function(path, fact.func_start)
-    if a_sid is None:
-        return []
-    callees = index.forward.get(a_sid)
-    if not callees:
-        return []
-    hits: list[PerfHit] = []
-    seen: set[str] = set()
-    for target_name, call_line in fact.lock_call_targets:
-        if target_name in seen:
-            continue
-        targets, basis = index.resolve_call_targets(a_sid, call_line, target_name)
-        for callee in targets:
-            info = reach.get(callee)
-            if info is None:
-                continue
-            chain = path_to_sink(callee, reach)
-            if not chain:
-                continue
-            seen.add(target_name)
-            kind = sink_kind.get(info.sink, "")
-            hits.append(
-                perf_hit_cls(
-                    kind=LOCK_IO_KIND,
-                    line=call_line,
-                    function=fact.function,
-                    detail=kind,
-                    func_start=fact.func_start,
-                    path=(a_sid, *chain),
-                    resolution_basis=basis,
-                )
-            )
-            break
-    return hits

--- a/packages/core/src/repowise/core/analysis/health/perf/sink_reach.py
+++ b/packages/core/src/repowise/core/analysis/health/perf/sink_reach.py
@@ -1,0 +1,177 @@
+"""Shared entry-set to sink reachability collector.
+
+Two of the engine's differentiating markers ask the same question of the same
+graph and differ only in which callees count as an entry:
+
+  * :func:`.crossfn.collect_crossfn_io_in_loop` enters from the callees a
+    function invokes inside a loop body (``PerfFnFacts.loop_call_targets``);
+  * :func:`.gated.collect_blocking_io_under_lock` enters from the callees it
+    invokes while holding a lock (``PerfFnFacts.lock_call_targets``).
+
+Everything between those two ends was written twice: the same pre-checks, the
+same index, the same bare-sink set, the same multi-source reverse BFS, and the
+same per-function first-hop resolution. A fix to the walk had to be made in
+both places or it silently applied to one marker only, which is what this
+module exists to prevent.
+
+First-hop resolution goes through :meth:`ExecutionGraphIndex.resolve_call_targets`
+and each hit carries the ``resolution_basis`` it came back with, so the
+exact-edge matching stays exact here -- collapsing the two copies must not cost
+the call-line accuracy the shared index provides.
+
+The soundness limits are the ones documented on :mod:`.crossfn` -- static call
+graph, depth bound, and incremental runs -- since this is that walk, not a new
+one.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable, Sequence
+from typing import TYPE_CHECKING, Any
+
+from .callgraph import CallGraphIndex
+from .reachability import path_to_sink, reachable_to_sink
+
+if TYPE_CHECKING:
+    # Imported lazily at runtime (see ``_hits_for_function``) to avoid a cycle:
+    # the walker pulls in ``perf.io_boundaries`` while the ``complexity``
+    # package is still initialising, so this module cannot import it eagerly.
+    from ..complexity import FileComplexity, PerfFnFacts, PerfHit
+
+# ``(callee name, call line)`` pairs: which of a function's callees are entries.
+EntrySelector = Callable[["PerfFnFacts"], Sequence[tuple[str, int]]]
+
+
+def collect_sink_reaching_hits(
+    walked: Iterable[tuple[Any, FileComplexity]],
+    graph: Any,
+    *,
+    entries: EntrySelector,
+    kind: str,
+    index: CallGraphIndex | None = None,
+    max_depth: int = 3,
+    carry_func_start: bool = False,
+) -> dict[str, list[PerfHit]]:
+    """Hits for entry callees that reach a bare I/O sink, keyed by owning file.
+
+    ``entries`` selects the entry callees from a function's facts and ``kind``
+    is the :class:`~..complexity.PerfHit` kind the caller reports under. See the
+    two callers for what each combination means.
+
+    ``carry_func_start`` sets ``PerfHit.func_start``. It exists because the two
+    callers disagree today: the lock pass carries it and the loop pass does not.
+    Preserved rather than unified, since making them agree is a behaviour change
+    and this is a de-duplication.
+    """
+    walked_list = list(walked)
+    if graph is None or not walked_list:
+        return {}
+
+    # Cheap pre-checks over the already-computed facts, before touching the
+    # graph at all: a hit needs BOTH a function holding a bare sink (a
+    # reachability target) and a function with an entry callee. On a repo with
+    # neither, this returns without scanning the graph.
+    has_sink = any(
+        fact.bare_sink_kind is not None for _pf, fcx in walked_list for fact in fcx.perf_fn_facts
+    )
+    has_entry = any(entries(fact) for _pf, fcx in walked_list for fact in fcx.perf_fn_facts)
+    if not (has_sink and has_entry):
+        return {}
+
+    if index is None:
+        index = CallGraphIndex(graph)
+    if not index.forward:
+        return {}  # no resolved call edges → nothing cross-function to find
+
+    # --- sink set: functions that execute a bare (loop_depth 0) I/O sink ------
+    sink_kind: dict[str, str] = {}
+    for pf, fcx in walked_list:
+        path = pf.file_info.path
+        for fact in fcx.perf_fn_facts:
+            if fact.bare_sink_kind is None:
+                continue
+            sid = index.resolve_function(path, fact.func_start)
+            if sid is not None:
+                sink_kind.setdefault(sid, fact.bare_sink_kind)
+    if not sink_kind:
+        return {}
+
+    reach = reachable_to_sink(
+        sink_kind.keys(),
+        lambda node: index.reverse.get(node, ()),
+        max_depth=max_depth,
+    )
+
+    # --- match each owner's entry callees against the reach map ---------------
+    out: dict[str, list[PerfHit]] = {}
+    for pf, fcx in walked_list:
+        path = pf.file_info.path
+        for fact in fcx.perf_fn_facts:
+            if not entries(fact):
+                continue
+            hits = _hits_for_function(
+                path,
+                fact,
+                index,
+                reach,
+                sink_kind,
+                entries=entries,
+                kind=kind,
+                carry_func_start=carry_func_start,
+            )
+            if hits:
+                out.setdefault(path, []).extend(hits)
+    return out
+
+
+def _hits_for_function(
+    path: str,
+    fact: PerfFnFacts,
+    index: CallGraphIndex,
+    reach: dict[str, Any],
+    sink_kind: dict[str, str],
+    *,
+    entries: EntrySelector,
+    kind: str,
+    carry_func_start: bool,
+) -> list[PerfHit]:
+    from ..complexity import PerfHit
+
+    a_sid = index.resolve_function(path, fact.func_start)
+    if a_sid is None:
+        return []
+    callees = index.forward.get(a_sid)
+    if not callees:
+        return []
+
+    extra: dict[str, Any] = {"func_start": fact.func_start} if carry_func_start else {}
+    hits: list[PerfHit] = []
+    seen: set[str] = set()
+    for target_name, call_line in entries(fact):
+        if target_name in seen:
+            continue
+        # Call-line accurate first-hop resolution: the index picks the exact
+        # graph edge for this call site and reports how it got there, so the
+        # basis travels onto the hit rather than being re-derived by name.
+        targets, basis = index.resolve_call_targets(a_sid, call_line, target_name)
+        for callee in targets:
+            info = reach.get(callee)
+            if info is None:
+                continue
+            chain = path_to_sink(callee, reach)
+            if not chain:
+                continue
+            seen.add(target_name)
+            hits.append(
+                PerfHit(
+                    kind=kind,
+                    line=call_line,
+                    function=fact.function,
+                    detail=sink_kind.get(info.sink, ""),
+                    path=(a_sid, *chain),
+                    resolution_basis=basis,
+                    **extra,
+                )
+            )
+            break
+    return hits

--- a/tests/unit/health/test_perf_crossfn.py
+++ b/tests/unit/health/test_perf_crossfn.py
@@ -28,6 +28,7 @@ from repowise.core.analysis.health.complexity import (
     walk_file,
 )
 from repowise.core.analysis.health.perf import (
+    collect_blocking_io_under_lock,
     collect_crossfn_io_in_loop,
     path_to_sink,
     reachable_to_sink,
@@ -197,13 +198,7 @@ def test_crossfn_scheduler_pattern_is_caught(tmp_path):
 
 
 def test_resolver_preserves_every_call_site_on_the_collapsed_edge(tmp_path):
-    source = (
-        "def load(x):\n"
-        "    return x\n\n"
-        "def run(x):\n"
-        "    load(x)\n"
-        "    return load(x)\n"
-    )
+    source = "def load(x):\n    return x\n\ndef run(x):\n    load(x)\n    return load(x)\n"
     _walked, graph = _build(tmp_path, {"calls.py": source})
 
     edge = graph["calls.py::run"]["calls.py::load"]
@@ -407,9 +402,81 @@ def test_unresolved_loop_call_does_not_reuse_same_name_outside_loop():
         functions=[], classes=[], perf_fn_facts=[PerfFnFacts("load", 1, (), "db")]
     )
 
-    assert collect_crossfn_io_in_loop(
-        [(_pf("owner.py"), owner), (_pf("db.py"), db_sink)], graph
-    ) == {}
+    assert (
+        collect_crossfn_io_in_loop([(_pf("owner.py"), owner), (_pf("db.py"), db_sink)], graph) == {}
+    )
+
+
+def _two_same_named_callees_graph():
+    """Owner calls `load` at line 4; two `load` symbols exist on different lines."""
+    graph = nx.DiGraph()
+    for node_id, path, name in (
+        ("owner.py::run", "owner.py", "run"),
+        ("pure.py::load", "pure.py", "load"),
+        ("db.py::load", "db.py", "load"),
+    ):
+        graph.add_node(
+            node_id, node_type="symbol", name=name, file_path=path, start_line=1, end_line=8
+        )
+    # Same callee name from the same owner, distinguishable only by call line.
+    graph.add_edge("owner.py::run", "pure.py::load", edge_type="calls", call_lines=[9])
+    graph.add_edge("owner.py::run", "db.py::load", edge_type="calls", call_lines=[4])
+    return graph
+
+
+def test_crossfn_first_hop_uses_the_call_site_not_the_callee_name():
+    """The entry at line 4 must resolve to the sink-holding `load`, not the pure one.
+
+    Name-based first-hop matching cannot tell these two apart -- both are called
+    `load` by the same owner. The shared walk resolves through the index, which
+    picks the edge recorded for this call line and reports the basis it used.
+    """
+    graph = _two_same_named_callees_graph()
+    owner = FileComplexity(
+        functions=[], classes=[], perf_fn_facts=[PerfFnFacts("run", 1, (("load", 4),), None)]
+    )
+    pure = FileComplexity(
+        functions=[], classes=[], perf_fn_facts=[PerfFnFacts("load", 1, (), None)]
+    )
+    sink = FileComplexity(
+        functions=[], classes=[], perf_fn_facts=[PerfFnFacts("load", 1, (), "db")]
+    )
+
+    result = collect_crossfn_io_in_loop(
+        [(_pf("owner.py"), owner), (_pf("pure.py"), pure), (_pf("db.py"), sink)],
+        graph,
+    )
+
+    hit = next(hit for hits in result.values() for hit in hits)
+    assert hit.path == ("owner.py::run", "db.py::load")
+    assert hit.resolution_basis == "call-site"
+
+
+def test_lock_io_first_hop_also_carries_the_resolution_basis():
+    """The lock pass shares the walk, so it must keep the same exact-edge matching."""
+    graph = _two_same_named_callees_graph()
+    owner = FileComplexity(
+        functions=[],
+        classes=[],
+        perf_fn_facts=[PerfFnFacts("run", 1, (), None, lock_call_targets=(("load", 4),))],
+    )
+    pure = FileComplexity(
+        functions=[], classes=[], perf_fn_facts=[PerfFnFacts("load", 1, (), None)]
+    )
+    sink = FileComplexity(
+        functions=[], classes=[], perf_fn_facts=[PerfFnFacts("load", 1, (), "db")]
+    )
+
+    result = collect_blocking_io_under_lock(
+        [(_pf("owner.py"), owner), (_pf("pure.py"), pure), (_pf("db.py"), sink)],
+        graph,
+    )
+
+    hit = next(hit for hits in result.values() for hit in hits)
+    assert hit.path == ("owner.py::run", "db.py::load")
+    assert hit.resolution_basis == "call-site"
+    # The lock pass carries func_start; the loop pass deliberately does not.
+    assert hit.func_start == 1
 
 
 def test_dispatch_edge_connects_a_resolved_call_to_its_sink():


### PR DESCRIPTION
Closes #1741.

## What changed

`collect_crossfn_io_in_loop` and `collect_blocking_io_under_lock` are the same function twice — the same pre-checks, the same index, the same bare-sink set, the same multi-source reverse BFS, and the same per-function first-hop resolution, down to `_hits_for_function` / `_lock_hits_for_function`.

The walk now lives once in `perf/sink_reach.py`, parameterised by the entry-set accessor and the hit kind, next to the other perf primitives. Both entry points keep their names and signatures and become thin callers:

```python
return collect_sink_reaching_hits(
    walked, graph,
    entries=lambda fact: fact.loop_call_targets,   # lock_call_targets in gated
    kind=CROSSFN_KIND,                             # LOCK_IO_KIND in gated
    index=index, max_depth=max_depth,
)
```

## Rebuilt on current `main`, not rebased

#1832 moved first-hop matching from callee-name to call-line accurate, via `index.resolve_call_targets(...)`, stamping each hit with `resolution_basis`. @sloemo01 [pointed out](https://github.com/repowise-dev/repowise/pull/1752#issuecomment-5380278075) that resolving the textual conflict would have quietly reinstated the old name-based loop and dropped that.

So this branch was reset onto `main` and the de-duplication re-derived on top, rather than merged. The shared walk resolves the same way `main` does and passes the basis through, so collapsing the two copies costs none of the exact-edge accuracy:

```python
targets, basis = index.resolve_call_targets(a_sid, call_line, target_name)
```

`callees_by_name` is gone from the branch entirely.

## New coverage

Nothing asserted `resolution_basis` in the perf suite before — the only assertions on it live under `tests/unit/server/`. Two cases added, one per pass, where a single owner calls two same-named callees on different lines so name matching cannot pick the right one:

```python
graph.add_edge("owner.py::run", "pure.py::load", edge_type="calls", call_lines=[9])
graph.add_edge("owner.py::run", "db.py::load",   edge_type="calls", call_lines=[4])
...
assert hit.path == ("owner.py::run", "db.py::load")
assert hit.resolution_basis == "call-site"
```

Simulating the naive resolve (swapping `resolve_call_targets` for a name-based loop) fails 4 tests: these two plus the existing `test_unresolved_loop_call_does_not_reuse_same_name_outside_loop`. These also answer the bot's "no test file imports the changed files" note.

## One difference preserved rather than unified

The lock pass sets `PerfHit.func_start` and the loop pass does not. That is carried through as `carry_func_start` rather than made consistent, because making them agree would move behaviour and this is a de-duplication. The new lock test asserts it, so the asymmetry is at least written down. Happy to unify in a follow-up.

## Test plan

- Ran: `uv run python -m pytest tests/unit/health/ -q` — **1215 passed**.
- Ran: `uv run python -m pytest tests/unit/health/test_perf_crossfn.py tests/unit/health/test_perf_phase7b.py -q` — **47 passed**.
- Ran: `uv run ruff check` and `uv run ruff format --check` on all four changed files — clean.