### PR TITLE
fix(perf): only count a prisma verb as a database sink on a member call

### DIFF
--- a/packages/core/src/repowise/core/analysis/health/perf/dialects/ts_js.py
+++ b/packages/core/src/repowise/core/analysis/health/perf/dialects/ts_js.py
@@ -163,7 +163,12 @@ class TsJsPerfDialect(BasePerfDialect):
             if method in TS_SINK_METHODS or awaited:
                 return root_kind
             return None
-        if method in PRISMA_METHODS:  # distinctive prisma-client verbs
+        # Distinctive prisma-client verbs, but only as a MEMBER call. A prisma
+        # query is always reached through the client (``prisma.user.aggregate``),
+        # so a bare ``aggregate(xs)`` / ``groupBy(xs)`` / ``upsert(x)`` is an
+        # ordinary local function and was being reported as a database round
+        # trip -- an N+1 finding on pure arithmetic, in code with no database.
+        if is_attribute and method in PRISMA_METHODS:
             return "db"
         if method in TS_FS_METHODS:  # distinctive sync-fs verbs
             return "filesystem"

--- a/tests/unit/health/test_perf_dialects.py
+++ b/tests/unit/health/test_perf_dialects.py
@@ -442,6 +442,33 @@ def test_ts_nested_io_requires_collection_outer_loop():
     assert ("nested_loop_with_io", "db") in _hits("typescript", nested)
 
 
+def test_ts_prisma_verb_is_a_sink_only_as_a_member_call():
+    """A bare ``aggregate(xs)`` is a local function, not a database round trip.
+
+    The prisma lexicon is reached through the client (``prisma.user.aggregate``),
+    so matching the bare name flagged pure arithmetic as an N+1 in a codebase
+    with no database at all.
+    """
+    pure = (
+        "function aggregate(xs){ return xs.reduce(roll); }"
+        " function view(sorted, ratio){ for (const chunk of sorted) {"
+        " const rolled = aggregate(chunk); } }"
+    )
+    assert _hits("typescript", pure) == []
+
+    # The real thing still reports, through the client object.
+    real = (
+        "async function f(prisma, xs){ for (const x of xs) {"
+        " await prisma.user.aggregate({ where: x }); } }"
+    )
+    assert ("io_in_loop", "db") in _hits("typescript", real)
+
+    # And the other bare names the lexicon carries are equally not sinks.
+    for verb in ("groupBy", "upsert", "findMany"):
+        src = f"function {verb}(xs){{ return xs; }} function g(xs){{ for (const x of xs) {{ {verb}(x); }} }}"
+        assert _hits("typescript", src) == [], verb
+
+
 # ---------------------------------------------------------------------------
 # Phase-7d language-specific markers
 # ---------------------------------------------------------------------------
@@ -547,7 +574,9 @@ def test_python_os_and_shutil_verbs_gated_on_the_module_root():
     # Non-I/O members of the same module never fire.
     assert not any(
         k == "io_in_loop"
-        for k, _ in _hits("python", "import os\ndef f(ps):\n    for p in ps:\n        os.getpid()\n")
+        for k, _ in _hits(
+            "python", "import os\ndef f(ps):\n    for p in ps:\n        os.getpid()\n"
+        )
     )
     # ``remove`` / ``move`` / ``replace`` are ordinary collection verbs off the
     # module root, so an unrelated receiver must stay silent.
@@ -581,7 +610,10 @@ def test_python_chained_os_call_is_not_a_filesystem_sink():
     # Other chained-root shapes off the same ceiling.
     for expr in ("os.environ.get(k).replace('a', 'b')", "os.path.relpath(p).replace('a', 'b')"):
         assert not any(
-            k == "io_in_loop" for k, _ in _hits("python", f"import os\ndef f(xs):\n    for x in xs:\n        {expr}\n")
+            k == "io_in_loop"
+            for k, _ in _hits(
+                "python", f"import os\ndef f(xs):\n    for x in xs:\n        {expr}\n"
+            )
         ), expr
     # The genuine two-segment call is unaffected.
     assert ("io_in_loop", "filesystem") in _hits(


### PR DESCRIPTION
Fixes #1501.

## The problem

`ts_js.sink_kind` matched `PRISMA_METHODS` on the bare method name, with no member-call requirement:

```python
if method in PRISMA_METHODS:  # distinctive prisma-client verbs
    return "db"
```

`aggregate` is in that set, so a locally defined pure function called it a database round trip:

```ts
export function aggregate(values: readonly Ohlc[]): Ohlc | null { ... }   // no I/O anywhere

for (const chunk of sorted) {
  const rolled = aggregate(chunk);        // io_in_loop, boundary_kind: "db"
}
```

The reporter saw 6 of 20 performance findings come from this in a browser-side codebase with no database, direct and cross-function, and the tests that loop over fixtures inherited them. `groupBy`, `upsert` and `findMany` are the same shape.

## The change

A prisma query is always reached through the client — `prisma.user.aggregate(...)` — so that arm is now gated on `is_attribute`, which the walker already computes and passes.

`prisma.user.aggregate(...)` still reports. A bare `aggregate(...)` no longer does.

This is the rule the module's own header already states — "Only DISTINCTIVE method names are trusted without import resolution". These names are distinctive as *client methods*; as free functions they are ordinary vocabulary, which is exactly the collision the header excludes `create` / `update` / `count` / `exec` for.

`TS_FS_METHODS` is deliberately left matching bare, since `import { readFileSync } from "node:fs"` is a real destructured binding with no root to resolve.

## Test plan

- Ran: `uv run pytest tests/unit/health/test_perf_dialects.py -q` — 131 passed (130 pre-existing + 1 new).
- Ran: `uv run pytest tests/unit/health/ -q` — 1163 passed.
- Ran: `uv run ruff check` and `uv run ruff format --check` on both changed files — clean.
- Checked: with `ts_js.py` reverted the new test fails, so it is pinned to the behaviour.

The new case reproduces the issue's snippet (a local `aggregate` called in a loop → no hits), asserts `prisma.user.aggregate` in a loop still reports `("io_in_loop", "db")`, and sweeps `groupBy` / `upsert` / `findMany` as bare local functions.