### PR TITLE
fix(pages): scope and rank a module page's decision records

### DIFF
--- a/packages/core/src/repowise/core/analysis/health/perf/dialects/ts_js.py
+++ b/packages/core/src/repowise/core/analysis/health/perf/dialects/ts_js.py
@@ -163,7 +163,12 @@ class TsJsPerfDialect(BasePerfDialect):
             if method in TS_SINK_METHODS or awaited:
                 return root_kind
             return None
-        if method in PRISMA_METHODS:  # distinctive prisma-client verbs
+        # Distinctive prisma-client verbs, but only as a MEMBER call. A prisma
+        # query is always reached through the client (``prisma.user.aggregate``),
+        # so a bare ``aggregate(xs)`` / ``groupBy(xs)`` / ``upsert(x)`` is an
+        # ordinary local function and was being reported as a database round
+        # trip -- an N+1 finding on pure arithmetic, in code with no database.
+        if is_attribute and method in PRISMA_METHODS:
             return "db"
         if method in TS_FS_METHODS:  # distinctive sync-fs verbs
             return "filesystem"

--- a/packages/core/src/repowise/core/generation/page_generator/helpers.py
+++ b/packages/core/src/repowise/core/generation/page_generator/helpers.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import re
 from collections import defaultdict
+from collections.abc import Iterable
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -241,6 +242,47 @@ def build_dead_code_map(dead_code_report: Any | None) -> dict[str, list[dict]]:
                 }
             )
     return dead_code_by_file
+
+
+def _decision_confidence(payload: dict) -> float:
+    """A decision's confidence as a float, 0.0 when it is missing or unusable."""
+    try:
+        return float(payload.get("confidence") or 0.0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def rank_decisions(decisions: Iterable[dict]) -> list[dict]:
+    """Most confident first, ties in discovery order (the sort is stable).
+
+    A page has room for a handful, so which handful matters -- the list is both
+    rendered and fed to the model as context. Taking a raw slice showed whichever
+    happened to be written first.
+    """
+    ranked = list(decisions)
+    ranked.sort(key=lambda payload: -_decision_confidence(payload))
+    return ranked
+
+
+def decisions_for_files(
+    decisions_by_file: dict[str, list[dict]], paths: Iterable[str]
+) -> list[dict]:
+    """The decisions governing *paths*, de-duplicated and ranked.
+
+    A decision that affects several of a module's files appears once. The key
+    matches the ``decision_records`` uniqueness constraint (title, source,
+    evidence file), so two genuinely distinct records are never collapsed.
+    """
+    seen: set[tuple[Any, Any, Any]] = set()
+    scoped: list[dict] = []
+    for path in paths:
+        for payload in decisions_by_file.get(path) or ():
+            key = (payload.get("title"), payload.get("source"), payload.get("evidence_file"))
+            if key in seen:
+                continue
+            seen.add(key)
+            scoped.append(payload)
+    return rank_decisions(scoped)
 
 
 def build_decision_maps(

--- a/packages/core/src/repowise/core/generation/page_generator/levels.py
+++ b/packages/core/src/repowise/core/generation/page_generator/levels.py
@@ -19,7 +19,7 @@ from repowise.core.ids import is_external
 from .. import onboarding as _onboarding
 from ..context_assembler import FilePageContext
 from ..models import compute_page_id
-from .helpers import _is_infra_file
+from .helpers import _is_infra_file, decisions_for_files, rank_decisions
 
 if TYPE_CHECKING:
     from ..concept_tree.vocabulary import HouseTerm
@@ -285,7 +285,13 @@ def build_level4_coros(run: _GenerationRun) -> list[tuple[str, Any]]:
                     run.graph,
                     git_meta_map=run.git_meta_map,
                     page_summaries=run.completed_page_summaries,
-                    decision_records=run.decisions_all,
+                    # The module's own decisions, not the repository's. File
+                    # pages already scope this way; passing the flat list here
+                    # showed the first five written, which on a repo with
+                    # decisions concentrated in one area is the same five on
+                    # every module page -- and they are prompt context, not
+                    # just rendered output.
+                    decision_records=decisions_for_files(run.decisions_by_file, material),
                     dead_code_findings=[
                         d for fc in fcs for d in run.dead_code_by_file.get(fc.file_path, [])
                     ],
@@ -440,7 +446,9 @@ async def build_level6_coros(run: _GenerationRun) -> list[tuple[str, Any]]:
                     graph_builder=run.graph_builder,
                     repo_name=run.repo_name,
                     external_systems=run.external_systems,
-                    decision_records=run.decisions_all[:10],
+                    # Repo-wide scope is right here; only the choice of ten was
+                    # list position.
+                    decision_records=rank_decisions(run.decisions_all)[:10],
                     overview_mermaid=overview_mermaid,
                     source_map=run.source_map,
                     # Per-package file counts come from the files this run

--- a/tests/unit/generation/test_decision_scoping.py
+++ b/tests/unit/generation/test_decision_scoping.py
@@ -1,0 +1,91 @@
+"""Module pages get their own decisions, ranked (#1587).
+
+Two halves. The behaviour half exercises the helpers directly. The guard half
+is an architecture check in the style of ``test_no_test_path_copies``: a page
+type must not go back to slicing the repo-wide list, because the slice is not
+only rendered, it is prompt context for the page being written.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from repowise.core.generation.page_generator.helpers import (
+    decisions_for_files,
+    rank_decisions,
+)
+
+LEVELS = Path(__file__).resolve().parents[3] / (
+    "packages/core/src/repowise/core/generation/page_generator/levels.py"
+)
+
+
+def _decision(title: str, *, confidence: float | None = 1.0, evidence: str = "e.py") -> dict:
+    payload = {"title": title, "source": "git", "evidence_file": evidence}
+    if confidence is not None:
+        payload["confidence"] = confidence
+    return payload
+
+
+def test_module_decisions_are_scoped_to_the_modules_files():
+    a1 = _decision("a1", confidence=0.4, evidence="a/x.py")
+    a2 = _decision("a2", confidence=0.9, evidence="a/y.py")
+    b1 = _decision("b1", confidence=1.0, evidence="b/z.py")
+    by_file = {"a/x.py": [a1, a2], "a/y.py": [a2], "b/z.py": [b1]}
+
+    module_a = decisions_for_files(by_file, ["a/x.py", "a/y.py"])
+    assert [d["title"] for d in module_a] == ["a2", "a1"], "most confident first"
+
+    module_b = decisions_for_files(by_file, ["b/z.py"])
+    assert [d["title"] for d in module_b] == ["b1"], "another module's decisions do not leak in"
+
+    assert decisions_for_files(by_file, ["unindexed.py"]) == []
+
+
+def test_a_decision_affecting_several_files_appears_once():
+    shared = _decision("shared", evidence="a/x.py")
+    by_file = {"a/x.py": [shared], "a/y.py": [shared], "a/z.py": [shared]}
+
+    assert len(decisions_for_files(by_file, ["a/x.py", "a/y.py", "a/z.py"])) == 1
+
+
+def test_two_records_sharing_a_title_are_not_collapsed():
+    # The dedupe key mirrors the decision_records uniqueness constraint
+    # (title, source, evidence_file), so a repeated title from a different
+    # source or file is a different decision.
+    same_title_other_file = [
+        _decision("Use X", evidence="a/x.py"),
+        _decision("Use X", evidence="b/z.py"),
+    ]
+    by_file = {"a/x.py": same_title_other_file}
+
+    assert len(decisions_for_files(by_file, ["a/x.py"])) == 2
+
+
+def test_ranking_is_stable_and_tolerates_a_missing_confidence():
+    ranked = rank_decisions(
+        [_decision("low", confidence=0.1), _decision("none", confidence=None), _decision("high")]
+    )
+    assert [d["title"] for d in ranked] == ["high", "low", "none"]
+
+    # Equal confidence keeps discovery order rather than reshuffling.
+    tied = rank_decisions([_decision("first"), _decision("second"), _decision("third")])
+    assert [d["title"] for d in tied] == ["first", "second", "third"]
+
+
+def test_no_page_type_slices_the_repo_wide_decision_list_unranked():
+    """A raw ``decisions_all`` slice is the bug this closes.
+
+    Repo-wide scope is correct for the overview; taking its first N is not.
+    Anything reaching for ``decisions_all`` has to say how it ordered them.
+    """
+    source = LEVELS.read_text(encoding="utf-8")
+    offenders = [
+        line.strip()
+        for line in source.splitlines()
+        if re.search(r"decisions_all\s*\[", line) and "rank_decisions" not in line
+    ]
+    assert not offenders, "slice a ranked list, or scope it with decisions_for_files: " + "; ".join(
+        offenders
+    )

--- a/tests/unit/health/test_perf_dialects.py
+++ b/tests/unit/health/test_perf_dialects.py
@@ -442,6 +442,33 @@ def test_ts_nested_io_requires_collection_outer_loop():
     assert ("nested_loop_with_io", "db") in _hits("typescript", nested)
 
 
+def test_ts_prisma_verb_is_a_sink_only_as_a_member_call():
+    """A bare ``aggregate(xs)`` is a local function, not a database round trip.
+
+    The prisma lexicon is reached through the client (``prisma.user.aggregate``),
+    so matching the bare name flagged pure arithmetic as an N+1 in a codebase
+    with no database at all.
+    """
+    pure = (
+        "function aggregate(xs){ return xs.reduce(roll); }"
+        " function view(sorted, ratio){ for (const chunk of sorted) {"
+        " const rolled = aggregate(chunk); } }"
+    )
+    assert _hits("typescript", pure) == []
+
+    # The real thing still reports, through the client object.
+    real = (
+        "async function f(prisma, xs){ for (const x of xs) {"
+        " await prisma.user.aggregate({ where: x }); } }"
+    )
+    assert ("io_in_loop", "db") in _hits("typescript", real)
+
+    # And the other bare names the lexicon carries are equally not sinks.
+    for verb in ("groupBy", "upsert", "findMany"):
+        src = f"function {verb}(xs){{ return xs; }} function g(xs){{ for (const x of xs) {{ {verb}(x); }} }}"
+        assert _hits("typescript", src) == [], verb
+
+
 # ---------------------------------------------------------------------------
 # Phase-7d language-specific markers
 # ---------------------------------------------------------------------------
@@ -547,7 +574,9 @@ def test_python_os_and_shutil_verbs_gated_on_the_module_root():
     # Non-I/O members of the same module never fire.
     assert not any(
         k == "io_in_loop"
-        for k, _ in _hits("python", "import os\ndef f(ps):\n    for p in ps:\n        os.getpid()\n")
+        for k, _ in _hits(
+            "python", "import os\ndef f(ps):\n    for p in ps:\n        os.getpid()\n"
+        )
     )
     # ``remove`` / ``move`` / ``replace`` are ordinary collection verbs off the
     # module root, so an unrelated receiver must stay silent.
@@ -581,7 +610,10 @@ def test_python_chained_os_call_is_not_a_filesystem_sink():
     # Other chained-root shapes off the same ceiling.
     for expr in ("os.environ.get(k).replace('a', 'b')", "os.path.relpath(p).replace('a', 'b')"):
         assert not any(
-            k == "io_in_loop" for k, _ in _hits("python", f"import os\ndef f(xs):\n    for x in xs:\n        {expr}\n")
+            k == "io_in_loop"
+            for k, _ in _hits(
+                "python", f"import os\ndef f(xs):\n    for x in xs:\n        {expr}\n"
+            )
         ), expr
     # The genuine two-segment call is unaffected.
     assert ("io_in_loop", "filesystem") in _hits(


### PR DESCRIPTION
Fixes #1587.

## The problem

`levels.py` handed every module page the whole repository's list and the template showed the first five of it:

```python
# levels.py:174, file pages
decision_records=run.decisions_by_file.get(p.file_info.path),
# levels.py:288, module pages
decision_records=run.decisions_all,
```

The scoped map already existed, 114 lines earlier in the same file — the wrong one was being passed. On a repo whose decisions cluster in one area that is the same five on every module page, about parts of the codebase the page does not document. And since `module_page` is LLM-written, that list is prompt context, not just rendered output.

## The change

`decisions_for_files(decisions_by_file, paths)` collects the decisions governing the module's own files. Two details:

- **De-duplicated** on `(title, source, evidence_file)` — the `decision_records` uniqueness constraint — so a decision affecting several of a module's files appears once, while two genuinely distinct records sharing a title are kept apart.
- **Ranked** by `confidence`, descending, with a stable sort so ties keep discovery order. A missing or unparseable confidence sorts last rather than raising.

`repo_overview` keeps its repo-wide scope, which is correct there; only the choice of ten was list position, so it takes `rank_decisions(...)[:10]`.

## Guard test

The issue asks for one in the style of `test_no_test_path_copies`, so `test_no_page_type_slices_the_repo_wide_decision_list_unranked` reads `levels.py` and fails on any `decisions_all[...]` slice that does not go through `rank_decisions`. Repo-wide scope stays available; taking its first N by position does not.

Its ceiling is the same as its model's: it matches on the name `decisions_all`, so a future copy under another name is invisible to it. It catches the shape that actually occurred here.

## Test plan

- Ran: `uv run pytest tests/unit/generation/test_decision_scoping.py -q` — 5 passed (all new).
- Ran: `uv run pytest tests/unit/generation/ -q` — 1448 passed.
- Ran: `uv run ruff check` on `page_generator/` and the new test, and `ruff format --check` — clean, and both changed files were format-clean before the change.
- Checked: with `levels.py` reverted the guard test fails, so it is pinned to the call site rather than to the helper.

Behaviour cases cover scoping (another module's decisions do not leak in, an unindexed path yields nothing), the ordering, the de-duplication, and that a repeated title from a different evidence file is not collapsed.

## Not changed

`staleness_score` is not part of the ranking: `build_decision_maps` does not carry it into the payload, and threading it through is a wider change than this. `confidence` alone already replaces "whichever was written first" with a real signal — happy to fold staleness in as a follow-up if you want both.