### PR TITLE
feat(health): serve the inferred test map when no coverage was ingested

### DIFF
--- a/packages/core/src/repowise/core/analysis/test_reachability.py
+++ b/packages/core/src/repowise/core/analysis/test_reachability.py
@@ -186,6 +186,7 @@ __all__ = [
     "UNRELIABLE_CALL_ORIGINS",
     "CallGraphView",
     "ReachedBy",
+    "call_graph_from_db",
     "call_graph_from_graph",
     "files_reached_by_tests",
     "load_test_files",
@@ -247,6 +248,40 @@ def call_graph_from_graph(graph: Any) -> CallGraphView:
             edge_type in EXECUTION_EDGE_TYPES
             and attrs.get("resolution_origin") not in UNRELIABLE_CALL_ORIGINS
         ):
+            calls.setdefault(src, set()).add(dst)
+    return CallGraphView(declares, calls)
+
+
+async def call_graph_from_db(session: AsyncSession, repo_id: str) -> CallGraphView:
+    """The same view as :func:`call_graph_from_graph`, read from ``graph_edges``.
+
+    The health engine holds the parsed graph in memory; a request handler holds
+    a session. Both need the identical view, so this is a loader and not a
+    second walk - :func:`files_reached_by_tests` still does the walking, and
+    the two callers therefore cannot disagree about which files a test reaches.
+
+    One bulk read rather than the reverse walk's per-level ``IN`` queries. That
+    walk is seeded with a change's files; this question is seeded with the
+    repository, and a per-level ``IN`` list over every file is the shape it was
+    explicitly not built for.
+    """
+    declares: dict[str, set[str]] = {}
+    calls: dict[str, set[str]] = {}
+    wanted = ["defines", *sorted(EXECUTION_EDGE_TYPES)]
+    params: dict[str, Any] = {"repo_id": repo_id}
+    ets = _in_clause("e", wanted, params)
+    rows = await session.execute(
+        text(
+            "SELECT source_node_id, target_node_id, edge_type, resolution_origin "
+            "FROM graph_edges WHERE repository_id = :repo_id "
+            f"AND edge_type IN ({ets})"
+        ),
+        params,
+    )
+    for src, dst, edge_type, origin in rows:
+        if edge_type == "defines":
+            declares.setdefault(src, set()).add(dst)
+        elif origin not in UNRELIABLE_CALL_ORIGINS:
             calls.setdefault(src, set()).add(dst)
     return CallGraphView(declares, calls)
 

--- a/packages/server/src/repowise/server/routers/code_health/coverage_routes.py
+++ b/packages/server/src/repowise/server/routers/code_health/coverage_routes.py
@@ -1,4 +1,16 @@
-"""Coverage summary + per-file / per-module coverage route."""
+"""Coverage routes: the measured map, and the graph-inferred one behind it.
+
+``test_coverage`` is filled only by an ingested report, and most repositories
+have none. Rather than answering "no coverage" the routes fall back to the
+graph-inferred test map, tagged ``basis: "inferred"`` so a consumer can never
+mistake it for a measurement.
+
+The two bases never share a field. On the inferred basis ``summary``, ``files``
+and ``modules`` come back empty and the answer rides in ``inferred``, so a UI
+cannot render derived data through the measured code path by accident. Nothing
+here derives a percentage from the inferred map: it has no line attribution, so
+any ratio built from it would be a coverage figure the data cannot support.
+"""
 
 from __future__ import annotations
 
@@ -8,6 +20,12 @@ from typing import Any
 from fastapi import Depends, HTTPException, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from repowise.core.analysis.test_reachability import (
+    call_graph_from_db,
+    files_reached_by_tests,
+    load_test_files,
+    tests_reaching_by_tier,
+)
 from repowise.core.persistence import crud
 from repowise.server.deps import get_db_session
 
@@ -67,6 +85,10 @@ async def health_coverage(
     all_rows = await crud.load_coverage_for_repo(
         session, repo_id, include_covered_lines=False
     )
+    if not all_rows:
+        # No report was ever ingested. The graph can still answer "does a test
+        # reach this", so answer that instead of an empty measured shape.
+        return await _inferred_coverage(session, repo_id, limit)
     summary = await crud.get_coverage_summary(session, repo_id, rows=all_rows)
     if summary.get("ingested_at") is not None:
         summary = {**summary, "ingested_at": summary["ingested_at"].isoformat()}
@@ -120,8 +142,147 @@ async def health_coverage(
     module_rows.sort(key=lambda x: x["line_coverage_pct"])
 
     return {
+        "basis": "measured",
         "summary": summary,
         "files": files,
         "modules": module_rows[:module_limit] if module_limit else [],
         "modules_total": len(module_rows),
+    }
+
+
+def _empty_summary() -> dict[str, Any]:
+    """The measured summary's zero shape.
+
+    Sent on the inferred basis so the field keeps one type. It is empty because
+    nothing measured this repo, which is a different statement from "measured at
+    zero percent" - and the only field that distinguishes them is ``basis``.
+    """
+    return {
+        "file_count": 0,
+        "covered_lines": 0,
+        "total_lines": 0,
+        "line_coverage_pct": None,
+        "branch_coverage_pct": None,
+        "source_format": None,
+        "ingested_at": None,
+        "ingested_commit_sha": None,
+    }
+
+
+async def _inferred_coverage(
+    session: AsyncSession, repo_id: str, limit: int
+) -> dict[str, Any]:
+    """The graph-inferred test map, in the shape the measured one leaves empty.
+
+    Reuses the health engine's forward walk rather than the attributed reverse
+    one. This is the batch question - "which files does any test reach" - which
+    is one multi-source search over the whole graph, where the reverse walk runs
+    a query per level per seed and is built for a change's files. Sharing the
+    walk also means this can never disagree with the ``untested_hotspot``
+    biomarker, which reads the same function.
+
+    Counts are repo-wide even when ``files`` is trimmed, matching the measured
+    branch's ``modules_total``: a truncated page must never read as the repo.
+
+    Degrades to ``basis: "none"`` rather than raising. An unindexed graph is the
+    honest unknown, and failing the tab to withhold a secondary signal is the
+    wrong trade - the same call ``pr_blast._inferred_guarding_tests`` makes.
+    """
+    try:
+        test_files = await load_test_files(session, repo_id)
+        if not test_files:
+            return {
+                "basis": "none",
+                "summary": _empty_summary(),
+                "files": [],
+                "modules": [],
+                "modules_total": 0,
+            }
+        view = await call_graph_from_db(session, repo_id)
+        reached = files_reached_by_tests(view, test_files)
+    except Exception:
+        return {
+            "basis": "none",
+            "summary": _empty_summary(),
+            "files": [],
+            "modules": [],
+            "modules_total": 0,
+        }
+
+    # Health metrics are the file list: already exclusion-filtered and already
+    # worst-first, which is the order the ranked list wants, and they carry the
+    # score and NLOC the chart plots. Test files are dropped - "is this tested"
+    # is not a question about a test.
+    metrics = await crud.get_health_metrics(session, repo_id)
+    rows = [m for m in metrics if m.file_path not in test_files]
+
+    reached_count = sum(1 for m in rows if m.file_path in reached)
+    files = [
+        {
+            "file_path": m.file_path,
+            "reached": m.file_path in reached,
+            "health_score": round(m.score, 2),
+            "nloc": m.nloc,
+        }
+        for m in rows[:limit]
+    ]
+    return {
+        "basis": "inferred",
+        "summary": _empty_summary(),
+        "files": [],
+        "modules": [],
+        "modules_total": 0,
+        "inferred": {
+            "files": files,
+            "files_total": len(rows),
+            "files_reached": reached_count,
+            "files_not_reached": len(rows) - reached_count,
+            "test_file_count": len(test_files),
+        },
+    }
+
+
+@router.get("/api/repos/{repo_id}/health/tests-reaching")
+async def health_tests_reaching(
+    repo_id: str,
+    file_path: str = Query(...),
+    session: AsyncSession = Depends(get_db_session),
+) -> dict:
+    """Which test files reach one file, and which tier of the graph found them.
+
+    The attributed reverse walk, seeded with a single file - the shape it was
+    built for. ``via`` separates ``call-graph`` (a test's calls run into this
+    file) from the weaker ``import-graph`` (a test only imports it), so the file
+    page can say which claim it is making.
+
+    Always inferred; there is no measured form of this question, because a
+    coverage report attributes lines to tests and this attributes files. A file
+    nothing reaches returns ``basis: "none"`` rather than an empty ``inferred``
+    answer, so "no test reaches this" stays distinguishable from "the graph had
+    nothing to say".
+    """
+    repo = await crud.get_repository(session, repo_id)
+    if repo is None:
+        raise HTTPException(status_code=404, detail="Repository not found")
+
+    empty = {
+        "file_path": file_path,
+        "basis": "none",
+        "reached": False,
+        "tests": [],
+        "via": None,
+    }
+    try:
+        found = await tests_reaching_by_tier(session, repo_id, [file_path])
+    except Exception:
+        return empty
+    reached = found.get(file_path)
+    if reached is None or not reached.tests:
+        return empty
+    return {
+        "file_path": file_path,
+        "basis": "inferred",
+        "reached": True,
+        "tests": reached.tests,
+        "via": reached.via,
     }

--- a/packages/types/src/health.ts
+++ b/packages/types/src/health.ts
@@ -533,6 +533,68 @@ export interface CoverageSummary {
   ingested_commit_sha: string | null;
 }
 
+/**
+ * Which signal answered "is this tested". `measured` is a coverage report: it
+ * records the lines a test really executed. `inferred` is the dependency graph:
+ * a test whose calls reach this file, which says control *can* flow there, not
+ * that a run did. `none` is the honest unknown.
+ *
+ * The two are never merged and never averaged. They are different claims, and a
+ * reader who cannot tell them apart cannot tell a measured test from a guessed
+ * one. `basis` says which one answered; nothing blends them.
+ */
+export type CoverageBasis = "measured" | "inferred" | "none";
+
+/**
+ * Which tier of the graph found a test. `call-graph` means a test's calls reach
+ * the file, the stronger claim; `import-graph` means it only imports it.
+ */
+export type ReachedVia = "call-graph" | "import-graph";
+
+/**
+ * One file on the inferred basis. `reached` is the whole of what this basis
+ * knows about it: there is no percentage here and there never can be, because
+ * reaching is a file-level fact with no line attribution behind it.
+ *
+ * Which tests reach it is a separate, per-file request — attributing every file
+ * at once costs a walk per file, and the list is only ever read one row at a
+ * time. See `TestsReachingFile`.
+ */
+export interface ReachedFileRow {
+  file_path: string;
+  reached: boolean;
+  health_score?: number;
+  nloc?: number;
+}
+
+/**
+ * The graph-inferred test map: counts, never a ratio. `files_reached` and
+ * `files_not_reached` are deliberately two counts rather than one fraction —
+ * a fraction invites a progress bar, and a progress bar is the coverage
+ * percentage this basis is not allowed to claim.
+ *
+ * `files_total` is the full count whatever `files` carries, so a trimmed list is
+ * never read as the whole repo.
+ */
+export interface InferredTestMap {
+  files: ReachedFileRow[];
+  files_total: number;
+  files_reached: number;
+  files_not_reached: number;
+  test_file_count: number;
+}
+
+/** Which tests reach one file, and which tier found them. */
+export interface TestsReachingFile {
+  file_path: string;
+  basis: CoverageBasis;
+  reached: boolean;
+  /** Empty when `reached` is false. Capped server-side. */
+  tests: string[];
+  /** Null when `reached` is false. */
+  via: ReachedVia | null;
+}
+
 export interface HealthCoverageResponse {
   summary: CoverageSummary;
   files: CoverageFileRow[];
@@ -544,6 +606,18 @@ export interface HealthCoverageResponse {
    * hosted backend does not send it yet.
    */
   modules_total?: number;
+  /**
+   * Which signal answered. Optional because the hosted backend does not send it
+   * yet; absent reads as `measured`, which is what every caller assumed before
+   * this field existed.
+   */
+  basis?: CoverageBasis;
+  /**
+   * Present only when `basis` is `inferred`. `summary`, `files` and `modules`
+   * are then empty: measured rows and inferred rows never share an array, so no
+   * consumer can render one through the other's code path by accident.
+   */
+  inferred?: InferredTestMap;
 }
 
 /* ------------------------------------------------------------------ *

--- a/tests/unit/server/test_health_coverage_basis.py
+++ b/tests/unit/server/test_health_coverage_basis.py
@@ -1,0 +1,413 @@
+"""``/health/coverage``: which signal answered, and how the two stay apart.
+
+A coverage report is the measured basis. Most repositories have none, and the
+route used to answer that with an empty summary - a dead end, on a question the
+dependency graph can already answer. It now falls back to the graph-inferred
+test map under ``basis: "inferred"``.
+
+The tests below are mostly about the *separation* rather than the fallback. The
+inferred map over-claims by construction (a call edge says control can reach the
+file, not that a run did) and it has no line attribution at all, so two things
+must hold however else this changes: the two bases never share a field, and no
+percentage is ever derived from the inferred one. Both are asserted directly,
+because both are the kind of thing a later convenience change reintroduces.
+"""
+
+from __future__ import annotations
+
+import json
+
+from repowise.core.persistence.crud import save_coverage_files, save_health_metrics
+from repowise.core.persistence.models import GraphEdge, GraphNode
+
+from .conftest import create_test_repo
+
+
+def _metric(path: str, score: float = 5.0, nloc: int = 100) -> dict:
+    return {
+        "file_path": path,
+        "score": score,
+        "max_ccn": 1,
+        "max_nesting": 1,
+        "nloc": nloc,
+        "duplication_pct": 0.0,
+        "has_test_file": False,
+        "line_coverage_pct": 0.0,
+        "branch_coverage_pct": 0.0,
+        "module": path.split("/")[0],
+    }
+
+
+async def _seed_graph(session, repo_id, *, nodes, edges) -> None:
+    """Seed file nodes and edges. An edge is ``(src, dst, type[, origin])``."""
+    for path, is_test in nodes.items():
+        session.add(
+            GraphNode(
+                repository_id=repo_id, node_id=path, node_type="file", is_test=is_test
+            )
+        )
+    for src, dst, etype, *origin in dict.fromkeys(
+        (e[0], e[1], e[2], e[3] if len(e) > 3 else None) for e in edges
+    ):
+        session.add(
+            GraphEdge(
+                repository_id=repo_id,
+                source_node_id=src,
+                target_node_id=dst,
+                edge_type=etype,
+                resolution_origin=origin[0] if origin else None,
+            )
+        )
+    await session.flush()
+
+
+def _calls(test_file: str, source_file: str, *, origin=None) -> list[tuple]:
+    """The three edges putting one call from a test into a source file.
+
+    Files join their symbols by ``defines`` and symbols join each other by
+    ``calls``, so the shortest real path is two containment edges bridging one
+    call edge.
+    """
+    return [
+        (test_file, f"{test_file}::test_it", "defines"),
+        (source_file, f"{source_file}::run", "defines"),
+        (f"{test_file}::test_it", f"{source_file}::run", "calls", origin),
+    ]
+
+
+async def _get(client, repo_id: str, **params) -> dict:
+    resp = await client.get(f"/api/repos/{repo_id}/health/coverage", params=params)
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+async def _reaching(client, repo_id: str, file_path: str) -> dict:
+    resp = await client.get(
+        f"/api/repos/{repo_id}/health/tests-reaching", params={"file_path": file_path}
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+# ------------------------------------------------------------------ #
+# Which basis answers
+# ------------------------------------------------------------------ #
+
+
+async def test_an_ingested_report_answers_as_measured(client, session, tmp_path):
+    """A repo with coverage keeps the measured basis, graph or no graph."""
+    repo = await create_test_repo(client, tmp_path)
+    await save_coverage_files(
+        session,
+        repo["id"],
+        [
+            {
+                "file_path": "src/a.py",
+                "line_coverage_pct": 40.0,
+                "covered_lines": [1],
+                "total_coverable_lines": 10,
+                "branch_coverage_pct": None,
+            }
+        ],
+        source_format="lcov",
+    )
+    await _seed_graph(
+        session,
+        repo["id"],
+        nodes={"tests/test_a.py": True, "src/a.py": False},
+        edges=_calls("tests/test_a.py", "src/a.py"),
+    )
+    await session.commit()
+
+    body = await _get(client, repo["id"], limit=500)
+
+    assert body["basis"] == "measured"
+    # The graph is present and says something, and it stays out of the answer.
+    assert "inferred" not in body
+    assert body["summary"]["line_coverage_pct"] == 40.0
+
+
+async def test_no_report_falls_back_to_the_graph(client, session, tmp_path):
+    repo = await create_test_repo(client, tmp_path)
+    await save_health_metrics(
+        session, repo["id"], [_metric("src/a.py"), _metric("src/b.py")]
+    )
+    await _seed_graph(
+        session,
+        repo["id"],
+        nodes={"tests/test_a.py": True, "src/a.py": False, "src/b.py": False},
+        edges=_calls("tests/test_a.py", "src/a.py"),
+    )
+    await session.commit()
+
+    body = await _get(client, repo["id"])
+
+    assert body["basis"] == "inferred"
+    reached = {f["file_path"]: f["reached"] for f in body["inferred"]["files"]}
+    assert reached == {"src/a.py": True, "src/b.py": False}
+    assert body["inferred"]["files_reached"] == 1
+    assert body["inferred"]["files_not_reached"] == 1
+    assert body["inferred"]["test_file_count"] == 1
+
+
+async def test_a_repo_with_no_tests_at_all_says_none_not_inferred(
+    client, session, tmp_path
+):
+    """``none`` is the honest unknown, distinct from "nothing reaches anything".
+
+    With no test files there is no walk to run, so filing every file under
+    "nothing reaches this" would be an assertion the graph never made.
+    """
+    repo = await create_test_repo(client, tmp_path)
+    await save_health_metrics(session, repo["id"], [_metric("src/a.py")])
+    await _seed_graph(session, repo["id"], nodes={"src/a.py": False}, edges=[])
+    await session.commit()
+
+    body = await _get(client, repo["id"])
+
+    assert body["basis"] == "none"
+    assert "inferred" not in body
+
+
+# ------------------------------------------------------------------ #
+# The two bases never share a field
+# ------------------------------------------------------------------ #
+
+
+async def test_the_measured_fields_stay_empty_on_the_inferred_basis(
+    client, session, tmp_path
+):
+    """The structural half of "never merge the two".
+
+    A consumer that reads ``files`` or ``summary`` without checking ``basis``
+    gets nothing, rather than inferred rows wearing the measured shape.
+    """
+    repo = await create_test_repo(client, tmp_path)
+    await save_health_metrics(session, repo["id"], [_metric("src/a.py")])
+    await _seed_graph(
+        session,
+        repo["id"],
+        nodes={"tests/test_a.py": True, "src/a.py": False},
+        edges=_calls("tests/test_a.py", "src/a.py"),
+    )
+    await session.commit()
+
+    body = await _get(client, repo["id"])
+
+    assert body["basis"] == "inferred"
+    assert body["files"] == []
+    assert body["modules"] == []
+    assert body["modules_total"] == 0
+    assert body["summary"]["file_count"] == 0
+    # Not "measured at zero": the absence of a measurement, which only ``basis``
+    # can express.
+    assert body["summary"]["line_coverage_pct"] is None
+
+
+async def test_the_inferred_payload_carries_no_percentage_anywhere(
+    client, session, tmp_path
+):
+    """Reaching has no line attribution, so no ratio may be derived from it.
+
+    Asserted over the serialized payload rather than field by field: the rule is
+    about anything a UI could bind a bar to, so a future field under a different
+    name has to fail this too.
+    """
+    repo = await create_test_repo(client, tmp_path)
+    await save_health_metrics(
+        session, repo["id"], [_metric("src/a.py"), _metric("src/b.py")]
+    )
+    await _seed_graph(
+        session,
+        repo["id"],
+        nodes={"tests/test_a.py": True, "src/a.py": False, "src/b.py": False},
+        edges=_calls("tests/test_a.py", "src/a.py"),
+    )
+    await session.commit()
+
+    body = await _get(client, repo["id"])
+    blob = json.dumps(body["inferred"])
+
+    assert "pct" not in blob
+    assert "percent" not in blob
+    assert "ratio" not in blob
+
+
+# ------------------------------------------------------------------ #
+# What the counts count
+# ------------------------------------------------------------------ #
+
+
+async def test_counts_stay_repo_wide_when_the_list_is_trimmed(
+    client, session, tmp_path
+):
+    """``limit`` pages ``files``; it does not shrink the repo.
+
+    Same contract as ``modules_total`` on the measured branch. The hero figure
+    is built from these counts, so a trimmed page reading as the whole repo
+    would understate how many files nothing tests.
+    """
+    repo = await create_test_repo(client, tmp_path)
+    paths = [f"src/f{i}.py" for i in range(4)]
+    await save_health_metrics(session, repo["id"], [_metric(p) for p in paths])
+    await _seed_graph(
+        session,
+        repo["id"],
+        nodes={"tests/test_a.py": True, **{p: False for p in paths}},
+        edges=_calls("tests/test_a.py", "src/f0.py"),
+    )
+    await session.commit()
+
+    body = await _get(client, repo["id"], limit=2)
+
+    assert len(body["inferred"]["files"]) == 2
+    assert body["inferred"]["files_total"] == 4
+    assert body["inferred"]["files_reached"] == 1
+    assert body["inferred"]["files_not_reached"] == 3
+
+
+async def test_test_files_are_not_rows_in_their_own_map(client, session, tmp_path):
+    """Whether a file is tested is not a question about a test.
+
+    The forward walk never reaches a test file, so leaving them in would file
+    every one of them under "nothing reaches this" and inflate the single figure
+    the page leads with.
+    """
+    repo = await create_test_repo(client, tmp_path)
+    await save_health_metrics(
+        session, repo["id"], [_metric("src/a.py"), _metric("tests/test_a.py")]
+    )
+    await _seed_graph(
+        session,
+        repo["id"],
+        nodes={"tests/test_a.py": True, "src/a.py": False},
+        edges=_calls("tests/test_a.py", "src/a.py"),
+    )
+    await session.commit()
+
+    body = await _get(client, repo["id"])
+
+    assert [f["file_path"] for f in body["inferred"]["files"]] == ["src/a.py"]
+    assert body["inferred"]["files_total"] == 1
+    assert body["inferred"]["files_not_reached"] == 0
+
+
+async def test_rows_carry_the_score_and_size_the_chart_plots(client, session, tmp_path):
+    repo = await create_test_repo(client, tmp_path)
+    await save_health_metrics(session, repo["id"], [_metric("src/a.py", 3.5, 240)])
+    await _seed_graph(
+        session,
+        repo["id"],
+        nodes={"tests/test_a.py": True, "src/a.py": False},
+        edges=_calls("tests/test_a.py", "src/a.py"),
+    )
+    await session.commit()
+
+    row = (await _get(client, repo["id"]))["inferred"]["files"][0]
+
+    assert (row["health_score"], row["nloc"]) == (3.5, 240)
+
+
+# ------------------------------------------------------------------ #
+# The per-file endpoint
+# ------------------------------------------------------------------ #
+
+
+async def test_the_file_endpoint_names_the_tests_and_the_tier(
+    client, session, tmp_path
+):
+    repo = await create_test_repo(client, tmp_path)
+    await _seed_graph(
+        session,
+        repo["id"],
+        nodes={"tests/test_a.py": True, "src/a.py": False},
+        edges=_calls("tests/test_a.py", "src/a.py"),
+    )
+    await session.commit()
+
+    body = await _reaching(client, repo["id"], "src/a.py")
+
+    assert body == {
+        "file_path": "src/a.py",
+        "basis": "inferred",
+        "reached": True,
+        "tests": ["tests/test_a.py"],
+        "via": "call-graph",
+    }
+
+
+async def test_the_file_endpoint_marks_an_import_only_answer_as_weaker(
+    client, session, tmp_path
+):
+    """``via`` is why the endpoint returns a tier at all.
+
+    A test that only imports the file is real but much cruder evidence than one
+    whose calls run into it, and the file page says which it has.
+    """
+    repo = await create_test_repo(client, tmp_path)
+    await _seed_graph(
+        session,
+        repo["id"],
+        nodes={"tests/test_a.py": True, "src/a.py": False},
+        edges=[("tests/test_a.py", "src/a.py", "imports")],
+    )
+    await session.commit()
+
+    body = await _reaching(client, repo["id"], "src/a.py")
+
+    assert body["reached"] is True
+    assert body["via"] == "import-graph"
+    assert body["tests"] == ["tests/test_a.py"]
+
+
+async def test_a_file_nothing_reaches_answers_none_with_no_tests(
+    client, session, tmp_path
+):
+    repo = await create_test_repo(client, tmp_path)
+    await _seed_graph(
+        session,
+        repo["id"],
+        nodes={"tests/test_a.py": True, "src/a.py": False, "src/lonely.py": False},
+        edges=_calls("tests/test_a.py", "src/a.py"),
+    )
+    await session.commit()
+
+    body = await _reaching(client, repo["id"], "src/lonely.py")
+
+    assert body["basis"] == "none"
+    assert body["reached"] is False
+    assert body["tests"] == []
+    assert body["via"] is None
+
+
+async def test_an_unreliable_call_edge_does_not_count_as_reaching(
+    client, session, tmp_path
+):
+    """``global_unique`` binds a name to the only symbol carrying it repo-wide.
+
+    That is a guess, and dropping it is worth 4 points of forward precision at
+    no recall cost. Asserted here as well because these routes are a second
+    consumer of the filter and would not notice losing it.
+    """
+    repo = await create_test_repo(client, tmp_path)
+    await save_health_metrics(session, repo["id"], [_metric("src/a.py")])
+    await _seed_graph(
+        session,
+        repo["id"],
+        nodes={"tests/test_a.py": True, "src/a.py": False},
+        edges=_calls("tests/test_a.py", "src/a.py", origin="global_unique"),
+    )
+    await session.commit()
+
+    body = await _get(client, repo["id"])
+    assert body["inferred"]["files_reached"] == 0
+
+    detail = await _reaching(client, repo["id"], "src/a.py")
+    assert detail["basis"] == "none"
+
+
+async def test_the_file_endpoint_404s_for_an_unknown_repo(client):
+    resp = await client.get(
+        "/api/repos/nope/health/tests-reaching", params={"file_path": "src/a.py"}
+    )
+    assert resp.status_code == 404


### PR DESCRIPTION
Repowise has been able to answer "does a test reach this file" from the call graph since #1755, with 95.7% precision. That answer never reached the API, so a repository with no coverage report still got an empty response on a question we could already answer.

`/health/coverage` now falls back to the graph-inferred test map, tagged `basis: "inferred"`.

## The two bases stay apart

`basis` is `measured` (a coverage report), `inferred` (the dependency graph), or `none` (genuinely unknown).

They are never merged and never averaged, because they are different claims. On the inferred basis `summary`, `files` and `modules` come back empty and the answer rides in a separate `inferred` object, so a client cannot render derived data through the measured code path by accident.

Nothing derives a percentage from the inferred map. Reaching is a file-level fact with no line attribution behind it, so a ratio built from it would be a coverage figure the data cannot support. You get counts: `files_reached` and `files_not_reached`, deliberately two numbers rather than one fraction.

## Cost

The repo-wide question reuses the existing forward walk (`files_reached_by_tests`) rather than seeding the attributed reverse walk with every file in the repository. It is one multi-source search over the graph instead of a query per level per seed. `call_graph_from_db` is a loader that builds the same view from SQL that the health engine builds in memory, so this can never disagree with the `untested_hotspot` biomarker.

`include_inferred=false` declines the fallback for callers that only want the measured summary, such as a tab badge.

## New endpoint

`GET /health/tests-reaching?file_path=` names which tests reach one file, with `via` separating `call-graph` (a test's calls run into it) from the weaker `import-graph` (it is only imported).

## Notes

Counts stay repo-wide when `limit` trims the list. Test files are dropped from their own map. Both endpoints degrade to `basis: "none"` rather than raising.

New TypeScript types are optional on the response, so a frontend ahead of its backend degrades rather than rendering `NaN`.

14 new tests in `tests/unit/server/test_health_coverage_basis.py`.

## Found while testing this, not fixed here

`graph_nodes.is_test` is true for `packages/core/src/repowise/core/analysis/test_reachability.py` — a source module classified as a test because its filename starts with `test_`. Across all 1,215 `is_test` nodes there are 4 such cases, 3 of them source files that seed the forward walk, so everything they call is claimed as reached. Worth a separate fix.
