### PR TITLE
feat(providers): add claude_cli provider backed by the Claude Code CLI

### DIFF
--- a/packages/cli/src/repowise/cli/commands/init_cmd/command.py
+++ b/packages/cli/src/repowise/cli/commands/init_cmd/command.py
@@ -411,7 +411,7 @@ def _run_generation_phase(
     default=None,
     help=(
         "LLM provider name (anthropic, openai, openrouter, gemini, "
-        "deepseek, kimi, ollama, litellm, codex_cli, opencode, mock)."
+        "deepseek, kimi, ollama, litellm, claude_cli, codex_cli, opencode, mock)."
     ),
 )
 @click.option("--model", default=None, help="Model identifier override.")

--- a/packages/cli/src/repowise/cli/helpers.py
+++ b/packages/cli/src/repowise/cli/helpers.py
@@ -982,9 +982,10 @@ def resolve_provider(
         "No provider configured. Use --provider, set REPOWISE_PROVIDER, "
         "or set ANTHROPIC_API_KEY / OPENAI_API_KEY / OPENROUTER_API_KEY / "
         "OLLAMA_BASE_URL / GEMINI_API_KEY / GOOGLE_API_KEY / DEEPSEEK_API_KEY / "
-        "KIMI_API_KEY / LITELLM_API_KEY. Use REPOWISE_PROVIDER=codex_cli to use "
-        "an authenticated Codex CLI subscription, or REPOWISE_PROVIDER=opencode "
-        "to use opencode."
+        "KIMI_API_KEY / LITELLM_API_KEY. Use REPOWISE_PROVIDER=claude_cli to use "
+        "an authenticated Claude Code CLI subscription, REPOWISE_PROVIDER=codex_cli "
+        "to use an authenticated Codex CLI subscription, or "
+        "REPOWISE_PROVIDER=opencode to use opencode."
     )
 
 
@@ -1083,6 +1084,16 @@ def validate_provider_config(provider_name: str | None = None) -> list[str]:
     }
 
     if provider_name:
+        if provider_name == "claude_cli":
+            import shutil
+
+            if not shutil.which("claude"):
+                warnings.append(
+                    "Provider 'claude_cli' requires the Claude Code CLI. "
+                    "Install it with: npm install -g @anthropic-ai/claude-code"
+                )
+            return warnings
+
         if provider_name == "codex_cli":
             if not _is_codex_cli_available():
                 warnings.append(

--- a/packages/core/src/repowise/core/cost_estimator/pricing.py
+++ b/packages/core/src/repowise/core/cost_estimator/pricing.py
@@ -56,6 +56,7 @@ _COST_TABLE_PREFIX: dict[str, tuple[float, float]] = {
     "gemini": (0.00025, 0.0015),
     "llama": (0.0, 0.0),
     "mock": (0.0, 0.0),
+    "claude_cli/": (0.0, 0.0),
     "codex_cli/": (0.0, 0.0),
     "opencode/": (0.0, 0.0),
 }
@@ -66,8 +67,9 @@ def _lookup_cost(model_name: str) -> tuple[float, float]:
     lower = model_name.lower()
     # OpenRouter/LiteLLM slugs carry a routing prefix (`google/gemini-3.5-flash-lite`)
     # that hides the model from every entry below, which priced them at zero.
-    # `codex_cli/` and `opencode/` are genuinely free, so they keep their prefixes.
-    if "/" in lower and not lower.startswith(("codex_cli/", "opencode/")):
+    # `claude_cli/`, `codex_cli/` and `opencode/` are genuinely free (subscription
+    # billing out of band), so they keep their prefixes.
+    if "/" in lower and not lower.startswith(("claude_cli/", "codex_cli/", "opencode/")):
         lower = lower.rsplit("/", 1)[-1]
     if lower in _COST_TABLE_EXACT:
         return _COST_TABLE_EXACT[lower]

--- a/packages/core/src/repowise/core/generation/cost_tracker.py
+++ b/packages/core/src/repowise/core/generation/cost_tracker.py
@@ -90,12 +90,13 @@ def is_local_model(model: str) -> bool:
 
     Both the cost ledger and the savings estimate price these at $0: no dollars
     change hands per token. Covers Ollama/LM Studio/llama.cpp model strings and
-    the agent-CLI passthrough prefixes (``codex_cli/``, ``opencode/``).
+    the agent-CLI passthrough prefixes (``claude_cli/``, ``codex_cli/``,
+    ``opencode/``).
     """
     return (
         model == "mock"
         or model.startswith(_LOCAL_MODEL_PREFIXES)
-        or model.startswith(("codex_cli/", "opencode/"))
+        or model.startswith(("claude_cli/", "codex_cli/", "opencode/"))
         # Bare Ollama tags carry no prefix — the default is plain `qwen3.5:4b`,
         # and a `family:size` tag is not a shape any hosted vendor uses.
         or (":" in model and "/" not in model)

--- a/packages/core/src/repowise/core/providers/llm/claude_cli.py
+++ b/packages/core/src/repowise/core/providers/llm/claude_cli.py
@@ -1,0 +1,395 @@
+"""Claude CLI provider for repowise.
+
+This provider delegates generation to the authenticated local Claude Code CLI
+via ``claude -p``. It is intended for users with a Claude subscription already
+configured by ``claude`` OAuth login and does not require an Anthropic API key.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import os
+import shutil
+from pathlib import Path
+from typing import Any
+
+import structlog
+
+from repowise.core.providers.llm.base import (
+    BaseProvider,
+    CacheHint,
+    GeneratedResponse,
+    ProviderError,
+    ProviderModelOption,
+)
+from repowise.core.rate_limiter import RateLimiter
+from repowise.core.reasoning import ReasoningMode, normalize_reasoning
+
+log = structlog.get_logger(__name__)
+
+_DEFAULT_MODEL_LABEL = "claude_cli/default"
+_EXEC_TIMEOUT_SECONDS = 600
+
+# Efforts the Claude CLI accepts for --effort. Reasoning modes outside this
+# set are mapped in _claude_effort_for_reasoning.
+_CLI_EFFORTS = ("low", "medium", "high", "xhigh", "max")
+
+# Model aliases the CLI resolves itself. Offered as options; any other slug
+# (e.g. a dated model id) is passed through to --model verbatim.
+_KNOWN_MODEL_ALIASES = ("sonnet", "opus", "haiku")
+
+# Never inherited by the subprocess. With ANTHROPIC_API_KEY in the
+# environment the Claude CLI switches to per-token API billing and, on a key
+# it has not seen before, blocks on an interactive trust prompt — a headless
+# `claude -p` then hangs until the exec timeout. This provider exists for
+# subscription OAuth; the `anthropic` provider is the API-key path.
+_SCRUBBED_ENV_VARS = ("ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN")
+
+
+def _subprocess_env() -> dict[str, str]:
+    return {k: v for k, v in os.environ.items() if k not in _SCRUBBED_ENV_VARS}
+
+
+async def _close_subprocess_transport(proc: asyncio.subprocess.Process) -> None:
+    """Close asyncio's subprocess transport before the event loop shuts down."""
+
+    transport = getattr(proc, "_transport", None)
+    close = getattr(transport, "close", None)
+    if not callable(close):
+        return
+    with contextlib.suppress(Exception):
+        close()
+    await asyncio.sleep(0)
+
+
+def _resolve_claude_executable() -> str | None:
+    """Return the executable path used to launch Claude Code, or None."""
+
+    return shutil.which("claude")
+
+
+def _normalize_model(model: str | None) -> str | None:
+    """Return the native Claude model slug, or None to use CLI config."""
+    if not model:
+        return None
+    if model == _DEFAULT_MODEL_LABEL:
+        return None
+    if model.startswith("claude_cli/"):
+        suffix = model.removeprefix("claude_cli/")
+        return suffix or None
+    return model
+
+
+def _model_label(model: str | None) -> str:
+    """Return the persisted attribution label for a Claude CLI model."""
+    native = _normalize_model(model)
+    return f"claude_cli/{native}" if native else _DEFAULT_MODEL_LABEL
+
+
+def _claude_effort_for_reasoning(reasoning: ReasoningMode) -> str | None:
+    """Map a repowise reasoning mode onto a --effort value, or None to omit."""
+    mode = normalize_reasoning(reasoning)
+    if mode == "auto":
+        return None
+    if mode in ("off", "none", "minimal"):
+        return "low"
+    return mode  # low | medium | high | xhigh | max — all CLI-native
+
+
+_SUPPORTED_REASONING_MODES: tuple[ReasoningMode, ...] = (
+    "auto",
+    "off",
+    "none",
+    "minimal",
+    "low",
+    "medium",
+    "high",
+    "xhigh",
+    "max",
+)
+
+
+def _tail(text: str, max_chars: int = 2_000) -> str:
+    text = text.strip()
+    if len(text) <= max_chars:
+        return text
+    return text[-max_chars:]
+
+
+def _error_message(stderr: str, stdout: str, returncode: int) -> str:
+    for candidate in (_tail(stderr), _tail(stdout)):
+        if not candidate:
+            continue
+        if candidate.lstrip().startswith(("{", "[")):
+            continue
+        return candidate
+    return f"claude -p exited with {returncode}"
+
+
+def _parse_result(stdout: str) -> tuple[str, dict[str, Any], bool, str | None]:
+    """Parse ``claude -p --output-format json`` output.
+
+    Returns (content, usage, is_error, error_detail). The CLI prints one JSON
+    object; anything else on stdout (warnings from wrappers) is skipped by
+    scanning lines for the result object.
+    """
+    payload: dict[str, Any] | None = None
+    try:
+        candidate = json.loads(stdout)
+        if isinstance(candidate, dict):
+            payload = candidate
+    except json.JSONDecodeError:
+        for raw_line in stdout.splitlines():
+            line = raw_line.strip()
+            if not line.startswith("{"):
+                continue
+            try:
+                candidate = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(candidate, dict) and candidate.get("type") == "result":
+                payload = candidate
+                break
+
+    if payload is None:
+        return "", {}, True, "no JSON result object found in claude output"
+
+    content = payload.get("result")
+    usage = payload.get("usage")
+    is_error = bool(payload.get("is_error"))
+    subtype = payload.get("subtype")
+    error_detail = None
+    if is_error or (subtype and subtype != "success"):
+        is_error = True
+        error_detail = (
+            content
+            if isinstance(content, str) and content
+            else f"claude reported subtype={subtype!r}"
+        )
+    return (
+        content if isinstance(content, str) else "",
+        usage if isinstance(usage, dict) else {},
+        is_error,
+        error_detail,
+    )
+
+
+class ClaudeCliProvider(BaseProvider):
+    """LLM provider backed by ``claude -p``.
+
+    Args:
+        model: Optional native Claude model slug or alias (``opus``,
+            ``sonnet``, ``claude-opus-5``). If omitted, the Claude CLI config
+            chooses the model. Persisted labels like ``claude_cli/opus`` are
+            accepted and normalized before calling the CLI.
+        repo_path: Working directory for the subprocess, so relative paths in
+            prompts resolve against the indexed repo.
+        rate_limiter: Accepted for interface consistency, but the provider
+            serializes subprocess calls by default.
+    """
+
+    # A process spawn plus a full model turn: budget in minutes, mirroring
+    # codex_cli's rationale (#1119).
+    interactive_timeout_s: float = 180.0
+
+    def __init__(
+        self,
+        model: str | None = None,
+        repo_path: str | Path | None = None,
+        rate_limiter: RateLimiter | None = None,
+    ) -> None:
+        claude_cmd = _resolve_claude_executable()
+        if not claude_cmd:
+            raise ProviderError(
+                "claude_cli",
+                "Claude Code CLI not found. Install it with: "
+                "npm install -g @anthropic-ai/claude-code",
+            )
+        self._claude_cmd = claude_cmd
+        self._model = _normalize_model(model)
+        self._repo_path = (
+            Path(repo_path).resolve() if repo_path is not None else Path.cwd().resolve()
+        )
+        self._rate_limiter = rate_limiter
+        self._subprocess_semaphore: asyncio.Semaphore | None = None
+        self._semaphore_loop: asyncio.AbstractEventLoop | None = None
+
+    @property
+    def provider_name(self) -> str:
+        return "claude_cli"
+
+    @property
+    def model_name(self) -> str:
+        return _model_label(self._model)
+
+    def supported_reasoning_modes(self) -> tuple[ReasoningMode, ...]:
+        return _SUPPORTED_REASONING_MODES
+
+    def available_model_options(self) -> tuple[ProviderModelOption, ...]:
+        options = [
+            ProviderModelOption(
+                model=_DEFAULT_MODEL_LABEL,
+                label="Claude CLI default",
+                reasoning_modes=_SUPPORTED_REASONING_MODES,
+                recommended=True,
+                source="local",
+                notes="uses Claude CLI config",
+            )
+        ]
+        for alias in _KNOWN_MODEL_ALIASES:
+            options.append(
+                ProviderModelOption(
+                    model=_model_label(alias),
+                    label=alias,
+                    reasoning_modes=_SUPPORTED_REASONING_MODES,
+                    recommended=False,
+                    source="local",
+                    notes="CLI alias, resolved by claude",
+                )
+            )
+        return tuple(options)
+
+    def _get_semaphore(self) -> asyncio.Semaphore:
+        loop = asyncio.get_running_loop()
+        if self._semaphore_loop is not loop:
+            self._subprocess_semaphore = asyncio.Semaphore(1)
+            self._semaphore_loop = loop
+        return self._subprocess_semaphore  # type: ignore[return-value]
+
+    def _build_command(
+        self,
+        system_prompt: str,
+        *,
+        reasoning: ReasoningMode = "auto",
+    ) -> list[str]:
+        cmd = [
+            self._claude_cmd,
+            "-p",
+            "--output-format",
+            "json",
+            "--no-session-persistence",
+            # One-shot prose generation: never load project instruction files
+            # or user settings into the prompt, and never allow tool use to
+            # mutate anything (the prompt carries all needed context).
+            "--setting-sources",
+            "",
+            "--tools",
+            "",
+        ]
+        # Unlike codex_cli's combined-prompt stdin, the Claude CLI assigns
+        # the system role natively, so the model sees a true system turn
+        # rather than instructions quoted inside the user message.
+        if system_prompt.strip():
+            cmd.extend(["--system-prompt", system_prompt.strip()])
+        if self._model:
+            cmd.extend(["--model", self._model])
+        effort = _claude_effort_for_reasoning(reasoning)
+        if effort:
+            cmd.extend(["--effort", effort])
+        return cmd
+
+    async def generate(
+        self,
+        system_prompt: str,
+        user_prompt: str,
+        max_tokens: int = 4096,
+        temperature: float = 0.3,
+        request_id: str | None = None,
+        reasoning: ReasoningMode = "auto",
+        cache_hints: tuple[CacheHint, ...] = (),
+    ) -> GeneratedResponse:
+        if self._rate_limiter:
+            await self._rate_limiter.acquire(estimated_tokens=max_tokens)
+
+        cmd = self._build_command(system_prompt, reasoning=reasoning)
+        log.debug(
+            "claude_cli.generate.start",
+            model=self.model_name,
+            repo_path=str(self._repo_path),
+            request_id=request_id,
+        )
+
+        async with self._get_semaphore():
+            try:
+                proc = await asyncio.create_subprocess_exec(
+                    *cmd,
+                    stdin=asyncio.subprocess.PIPE,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                    cwd=str(self._repo_path),
+                    env=_subprocess_env(),
+                )
+            except FileNotFoundError as exc:
+                raise ProviderError(
+                    "claude_cli",
+                    "Claude Code CLI not found. Install it with: "
+                    "npm install -g @anthropic-ai/claude-code",
+                ) from exc
+
+            try:
+                stdout_bytes, stderr_bytes = await asyncio.wait_for(
+                    proc.communicate(user_prompt.encode("utf-8")),
+                    timeout=_EXEC_TIMEOUT_SECONDS,
+                )
+            except TimeoutError as exc:
+                proc.kill()
+                with contextlib.suppress(ProcessLookupError):
+                    await proc.wait()
+                raise ProviderError(
+                    "claude_cli",
+                    f"claude -p timed out after {_EXEC_TIMEOUT_SECONDS} seconds.",
+                ) from exc
+            finally:
+                await _close_subprocess_transport(proc)
+
+        stdout = stdout_bytes.decode("utf-8", errors="replace") if stdout_bytes else ""
+        stderr = stderr_bytes.decode("utf-8", errors="replace") if stderr_bytes else ""
+
+        if proc.returncode != 0:
+            raise ProviderError(
+                "claude_cli",
+                _error_message(stderr, stdout, proc.returncode),
+                status_code=proc.returncode,
+            )
+
+        content, usage, is_error, error_detail = _parse_result(stdout)
+        if is_error:
+            raise ProviderError(
+                "claude_cli",
+                error_detail or "claude -p reported an error result.",
+            )
+        if not content:
+            raise ProviderError(
+                "claude_cli",
+                "claude -p completed but returned an empty result.",
+            )
+
+        input_tokens = int(usage.get("input_tokens", 0) or 0)
+        output_tokens = int(usage.get("output_tokens", 0) or 0)
+        cached_tokens = int(usage.get("cache_read_input_tokens", 0) or 0)
+
+        log.debug(
+            "claude_cli.generate.done",
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cached_tokens=cached_tokens,
+            request_id=request_id,
+        )
+        usage_payload: dict[str, Any] = {
+            **usage,
+            "source": "claude_p",
+            "model": self.model_name,
+            "stderr": _tail(stderr, max_chars=1_000) if stderr.strip() else "",
+        }
+        if not usage:
+            usage_payload["estimated"] = True
+
+        return GeneratedResponse(
+            content=content,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cached_tokens=cached_tokens,
+            usage=usage_payload,
+        )

--- a/packages/core/src/repowise/core/providers/llm/registry.py
+++ b/packages/core/src/repowise/core/providers/llm/registry.py
@@ -12,6 +12,7 @@ Built-in providers:
     - kimi        → KimiProvider
     - ollama      → OllamaProvider
     - litellm     → LiteLLMProvider
+    - claude_cli  → ClaudeCliProvider
     - codex_cli   → CodexCliProvider
     - opencode    → OpenCodeProvider
     - mock        → MockProvider (testing only)
@@ -49,6 +50,7 @@ _BUILTIN_PROVIDERS: dict[str, tuple[str, str]] = {
     "litellm": ("repowise.core.providers.llm.litellm", "LiteLLMProvider"),
     "deepseek": ("repowise.core.providers.llm.deepseek", "DeepSeekProvider"),
     "kimi": ("repowise.core.providers.llm.kimi", "KimiProvider"),
+    "claude_cli": ("repowise.core.providers.llm.claude_cli", "ClaudeCliProvider"),
     "codex_cli": ("repowise.core.providers.llm.codex_cli", "CodexCliProvider"),
     "opencode": ("repowise.core.providers.llm.opencode", "OpenCodeProvider"),
     "mock": ("repowise.core.providers.llm.mock", "MockProvider"),
@@ -89,13 +91,15 @@ PROVIDER_BASE_URL_ENVS: dict[str, tuple[str, ...]] = {
 # proxy the user secured elsewhere). Resolution must never reject one of these
 # for a "missing" key, and must never fall through to a different provider
 # because it could not find one.
-KEYLESS_PROVIDERS = frozenset({"codex_cli", "opencode", "ollama", "litellm", "mock"})
+KEYLESS_PROVIDERS = frozenset(
+    {"claude_cli", "codex_cli", "opencode", "ollama", "litellm", "mock"}
+)
 
 # Providers that shell out to a CLI and therefore need to be told which repo
 # they are reasoning about: they pass it as the subprocess working directory.
 # Omitting it silently runs the CLI against whatever cwd the host process had,
 # which for an MCP server launched by an editor is not the user's repo.
-REPO_PATH_PROVIDERS = frozenset({"codex_cli", "opencode"})
+REPO_PATH_PROVIDERS = frozenset({"claude_cli", "codex_cli", "opencode"})
 
 # Order to try providers in when nothing was configured and we are guessing
 # from whatever credentials the environment happens to carry. This is the CLI's
@@ -276,7 +280,7 @@ def get_provider(
         raise ValueError(f"Unknown provider: {name!r}. Available providers: {available}")
 
     # Attach rate limiter (skip for mock — tests should run without limits)
-    if with_rate_limiter and name not in ("mock", "codex_cli", "opencode"):
+    if with_rate_limiter and name not in ("mock", "claude_cli", "codex_cli", "opencode"):
         config = rate_limit_config or PROVIDER_DEFAULTS.get(name)
         if config and "rate_limiter" not in kwargs:
             kwargs["rate_limiter"] = RateLimiter(config)
@@ -295,6 +299,7 @@ def get_provider(
             "deepseek": "openai",  # deepseek uses the openai package
             "kimi": "openai",  # kimi uses the openai package
             "litellm": "litellm",
+            "claude_cli": "@anthropic-ai/claude-code",
             "codex_cli": "@openai/codex",
             "opencode": "opencode",
         }

--- a/tests/unit/test_providers/test_claude_cli_provider.py
+++ b/tests/unit/test_providers/test_claude_cli_provider.py
@@ -1,0 +1,389 @@
+"""Unit tests for ClaudeCliProvider.
+
+All tests mock the Claude subprocess; no real Claude CLI calls are made.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+import pytest
+
+from repowise.core.providers.llm.base import GeneratedResponse, ProviderError
+from repowise.core.providers.llm.claude_cli import (
+    ClaudeCliProvider,
+    _parse_result,
+    _subprocess_env,
+)
+
+
+class FakeProcess:
+    def __init__(
+        self,
+        *,
+        returncode: int = 0,
+        stdout: str = "",
+        stderr: str = "",
+        on_communicate: Any | None = None,
+        transport: Any | None = None,
+    ) -> None:
+        self.returncode = returncode
+        self._stdout = stdout
+        self._stderr = stderr
+        self._on_communicate = on_communicate
+        self._transport = transport
+        self.stdin_input: bytes | None = None
+        self.killed = False
+
+    async def communicate(self, input: bytes | None = None) -> tuple[bytes, bytes]:
+        self.stdin_input = input
+        if self._on_communicate is not None:
+            await self._on_communicate()
+        return self._stdout.encode("utf-8"), self._stderr.encode("utf-8")
+
+    def kill(self) -> None:
+        self.killed = True
+
+    async def wait(self) -> int:
+        return self.returncode
+
+
+class FakeTransport:
+    def __init__(self) -> None:
+        self.closed = False
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def _result_json(
+    text: str = "OK",
+    *,
+    is_error: bool = False,
+    subtype: str = "success",
+    usage: dict[str, Any] | None = None,
+) -> str:
+    payload: dict[str, Any] = {
+        "type": "result",
+        "subtype": subtype,
+        "is_error": is_error,
+        "result": text,
+        "session_id": "s1",
+    }
+    if usage is not None:
+        payload["usage"] = usage
+    return json.dumps(payload)
+
+
+_USAGE = {
+    "input_tokens": 120,
+    "cache_read_input_tokens": 30,
+    "output_tokens": 40,
+}
+
+
+def _which_claude(cmd: str) -> str | None:
+    return "claude" if cmd == "claude" else None
+
+
+def test_provider_name_and_default_model(monkeypatch, tmp_path):
+    monkeypatch.setattr("shutil.which", _which_claude)
+
+    provider = ClaudeCliProvider(repo_path=tmp_path)
+
+    assert provider.provider_name == "claude_cli"
+    assert provider.model_name == "claude_cli/default"
+
+
+def test_custom_model_is_normalized_for_attribution(monkeypatch, tmp_path):
+    monkeypatch.setattr("shutil.which", _which_claude)
+
+    assert ClaudeCliProvider(model="opus", repo_path=tmp_path).model_name == "claude_cli/opus"
+    assert (
+        ClaudeCliProvider(model="claude_cli/opus", repo_path=tmp_path).model_name
+        == "claude_cli/opus"
+    )
+    assert (
+        ClaudeCliProvider(model="claude_cli/default", repo_path=tmp_path).model_name
+        == "claude_cli/default"
+    )
+
+
+def test_missing_cli_raises(monkeypatch, tmp_path):
+    monkeypatch.setattr("shutil.which", lambda _cmd: None)
+
+    with pytest.raises(ProviderError, match="Claude Code CLI not found"):
+        ClaudeCliProvider(repo_path=tmp_path)
+
+
+def test_available_model_options_lead_with_cli_default(monkeypatch, tmp_path):
+    monkeypatch.setattr("shutil.which", _which_claude)
+
+    options = ClaudeCliProvider(repo_path=tmp_path).available_model_options()
+
+    assert options[0].model == "claude_cli/default"
+    assert options[0].recommended is True
+    assert {option.model for option in options[1:]} == {
+        "claude_cli/sonnet",
+        "claude_cli/opus",
+        "claude_cli/haiku",
+    }
+
+
+def test_parse_result_reads_verified_payload_shape():
+    content, usage, is_error, detail = _parse_result(_result_json("hello", usage=_USAGE))
+
+    assert content == "hello"
+    assert usage == _USAGE
+    assert is_error is False
+    assert detail is None
+
+
+def test_parse_result_skips_wrapper_noise_lines():
+    stdout = "npm warn deprecated something\n" + _result_json("hello", usage=_USAGE) + "\n"
+
+    content, usage, is_error, _ = _parse_result(stdout)
+
+    assert content == "hello"
+    assert usage == _USAGE
+    assert is_error is False
+
+
+def test_parse_result_flags_error_payload():
+    content, _usage, is_error, detail = _parse_result(
+        _result_json("Credit balance too low", is_error=True, subtype="error_during_execution")
+    )
+
+    assert is_error is True
+    assert detail == "Credit balance too low"
+    assert content == "Credit balance too low"
+
+
+def test_subprocess_env_scrubs_api_credentials(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+    monkeypatch.setenv("ANTHROPIC_AUTH_TOKEN", "token-test")
+    monkeypatch.setenv("UNRELATED_VAR", "kept")
+
+    env = _subprocess_env()
+
+    assert "ANTHROPIC_API_KEY" not in env
+    assert "ANTHROPIC_AUTH_TOKEN" not in env
+    assert env["UNRELATED_VAR"] == "kept"
+
+
+async def test_generate_invokes_claude_p_with_stdin(monkeypatch, tmp_path):
+    claude_cmd = str(tmp_path / "bin" / "claude.CMD")
+    monkeypatch.setattr("shutil.which", lambda cmd: claude_cmd if cmd == "claude" else None)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-should-be-scrubbed")
+    captured: dict[str, Any] = {}
+    proc = FakeProcess(stdout=_result_json("Hello from Claude", usage=_USAGE))
+
+    async def fake_exec(*args: str, **kwargs: Any) -> FakeProcess:
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return proc
+
+    monkeypatch.setattr("asyncio.create_subprocess_exec", fake_exec)
+
+    provider = ClaudeCliProvider(model="opus", repo_path=tmp_path)
+    result = await provider.generate("system rules", "user context", reasoning="high")
+
+    assert isinstance(result, GeneratedResponse)
+    assert result.content == "Hello from Claude"
+    assert proc.stdin_input is not None
+    assert proc.stdin_input.decode("utf-8") == "user context"
+    args = list(captured["args"])
+    assert args[:4] == [claude_cmd, "-p", "--output-format", "json"]
+    assert "--no-session-persistence" in args
+    assert args[args.index("--setting-sources") + 1] == ""
+    assert args[args.index("--tools") + 1] == ""
+    assert args[args.index("--system-prompt") + 1] == "system rules"
+    assert args[args.index("--model") + 1] == "opus"
+    assert args[args.index("--effort") + 1] == "high"
+    assert captured["kwargs"]["stdin"] == asyncio.subprocess.PIPE
+    assert captured["kwargs"]["cwd"] == str(tmp_path.resolve())
+    assert "ANTHROPIC_API_KEY" not in captured["kwargs"]["env"]
+
+
+async def test_generate_auto_reasoning_omits_effort(monkeypatch, tmp_path):
+    monkeypatch.setattr("shutil.which", _which_claude)
+    captured: dict[str, Any] = {}
+
+    async def fake_exec(*args: str, **_kwargs: Any) -> FakeProcess:
+        captured["args"] = args
+        return FakeProcess(stdout=_result_json(usage=_USAGE))
+
+    monkeypatch.setattr("asyncio.create_subprocess_exec", fake_exec)
+
+    await ClaudeCliProvider(repo_path=tmp_path).generate("sys", "user", reasoning="auto")
+
+    assert "--effort" not in captured["args"]
+
+
+async def test_generate_maps_minimal_reasoning_to_low_effort(monkeypatch, tmp_path):
+    monkeypatch.setattr("shutil.which", _which_claude)
+    captured: dict[str, Any] = {}
+
+    async def fake_exec(*args: str, **_kwargs: Any) -> FakeProcess:
+        captured["args"] = args
+        return FakeProcess(stdout=_result_json(usage=_USAGE))
+
+    monkeypatch.setattr("asyncio.create_subprocess_exec", fake_exec)
+
+    await ClaudeCliProvider(repo_path=tmp_path).generate("sys", "user", reasoning="minimal")
+
+    args = list(captured["args"])
+    assert args[args.index("--effort") + 1] == "low"
+
+
+async def test_generate_uses_result_usage(monkeypatch, tmp_path):
+    monkeypatch.setattr("shutil.which", _which_claude)
+
+    async def fake_exec(*_args: str, **_kwargs: Any) -> FakeProcess:
+        return FakeProcess(stdout=_result_json(usage=_USAGE))
+
+    monkeypatch.setattr("asyncio.create_subprocess_exec", fake_exec)
+
+    result = await ClaudeCliProvider(repo_path=tmp_path).generate("sys", "user")
+
+    assert result.input_tokens == 120
+    assert result.output_tokens == 40
+    assert result.cached_tokens == 30
+    assert result.usage["source"] == "claude_p"
+    assert "estimated" not in result.usage
+
+
+async def test_generate_marks_missing_usage_as_estimated(monkeypatch, tmp_path):
+    monkeypatch.setattr("shutil.which", _which_claude)
+
+    async def fake_exec(*_args: str, **_kwargs: Any) -> FakeProcess:
+        return FakeProcess(stdout=_result_json("OK"))
+
+    monkeypatch.setattr("asyncio.create_subprocess_exec", fake_exec)
+
+    result = await ClaudeCliProvider(repo_path=tmp_path).generate("sys", "user")
+
+    assert result.input_tokens == 0
+    assert result.output_tokens == 0
+    assert result.usage["estimated"] is True
+
+
+async def test_generate_closes_subprocess_transport(monkeypatch, tmp_path):
+    monkeypatch.setattr("shutil.which", _which_claude)
+    transport = FakeTransport()
+
+    async def fake_exec(*_args: str, **_kwargs: Any) -> FakeProcess:
+        return FakeProcess(stdout=_result_json(usage=_USAGE), transport=transport)
+
+    monkeypatch.setattr("asyncio.create_subprocess_exec", fake_exec)
+
+    await ClaudeCliProvider(repo_path=tmp_path).generate("sys", "user")
+
+    assert transport.closed is True
+
+
+async def test_generate_raises_on_nonzero_exit(monkeypatch, tmp_path):
+    monkeypatch.setattr("shutil.which", _which_claude)
+
+    async def fake_exec(*_args: str, **_kwargs: Any) -> FakeProcess:
+        return FakeProcess(returncode=1, stdout="", stderr="not logged in")
+
+    monkeypatch.setattr("asyncio.create_subprocess_exec", fake_exec)
+
+    with pytest.raises(ProviderError, match="not logged in"):
+        await ClaudeCliProvider(repo_path=tmp_path).generate("sys", "user")
+
+
+async def test_generate_hides_structured_error_stdout(monkeypatch, tmp_path):
+    monkeypatch.setattr("shutil.which", _which_claude)
+
+    async def fake_exec(*_args: str, **_kwargs: Any) -> FakeProcess:
+        return FakeProcess(returncode=2, stdout='{"error":{"message":"secret details"}}')
+
+    monkeypatch.setattr("asyncio.create_subprocess_exec", fake_exec)
+
+    with pytest.raises(ProviderError, match="claude -p exited with 2") as exc_info:
+        await ClaudeCliProvider(repo_path=tmp_path).generate("sys", "user")
+
+    assert "secret details" not in str(exc_info.value)
+
+
+async def test_generate_raises_on_error_result(monkeypatch, tmp_path):
+    monkeypatch.setattr("shutil.which", _which_claude)
+
+    async def fake_exec(*_args: str, **_kwargs: Any) -> FakeProcess:
+        return FakeProcess(
+            stdout=_result_json(
+                "Credit balance too low",
+                is_error=True,
+                subtype="error_during_execution",
+            )
+        )
+
+    monkeypatch.setattr("asyncio.create_subprocess_exec", fake_exec)
+
+    with pytest.raises(ProviderError, match="Credit balance too low"):
+        await ClaudeCliProvider(repo_path=tmp_path).generate("sys", "user")
+
+
+async def test_generate_raises_on_empty_result(monkeypatch, tmp_path):
+    monkeypatch.setattr("shutil.which", _which_claude)
+
+    async def fake_exec(*_args: str, **_kwargs: Any) -> FakeProcess:
+        return FakeProcess(stdout=_result_json("", usage=_USAGE))
+
+    monkeypatch.setattr("asyncio.create_subprocess_exec", fake_exec)
+
+    with pytest.raises(ProviderError, match="empty result"):
+        await ClaudeCliProvider(repo_path=tmp_path).generate("sys", "user")
+
+
+async def test_generate_serializes_subprocess_calls(monkeypatch, tmp_path):
+    monkeypatch.setattr("shutil.which", _which_claude)
+    active = 0
+    max_active = 0
+
+    async def on_communicate() -> None:
+        nonlocal active, max_active
+        active += 1
+        max_active = max(max_active, active)
+        await asyncio.sleep(0.01)
+        active -= 1
+
+    async def fake_exec(*_args: str, **_kwargs: Any) -> FakeProcess:
+        return FakeProcess(stdout=_result_json(usage=_USAGE), on_communicate=on_communicate)
+
+    monkeypatch.setattr("asyncio.create_subprocess_exec", fake_exec)
+    provider = ClaudeCliProvider(repo_path=tmp_path)
+
+    await asyncio.gather(
+        provider.generate("sys", "user 1"),
+        provider.generate("sys", "user 2"),
+    )
+
+    assert max_active == 1
+
+
+async def test_generate_times_out_and_kills_claude(monkeypatch, tmp_path):
+    monkeypatch.setattr("shutil.which", _which_claude)
+    monkeypatch.setattr(
+        "repowise.core.providers.llm.claude_cli._EXEC_TIMEOUT_SECONDS",
+        0.01,
+    )
+
+    async def on_communicate() -> None:
+        await asyncio.sleep(1)
+
+    proc = FakeProcess(stdout="", on_communicate=on_communicate)
+
+    async def fake_exec(*_args: str, **_kwargs: Any) -> FakeProcess:
+        return proc
+
+    monkeypatch.setattr("asyncio.create_subprocess_exec", fake_exec)
+
+    with pytest.raises(ProviderError, match="timed out"):
+        await ClaudeCliProvider(repo_path=tmp_path).generate("sys", "user")
+
+    assert proc.killed


### PR DESCRIPTION
Delegates prose generation to the locally authenticated Claude Code CLI via 'claude -p', mirroring the codex_cli precedent: subscription OAuth, no ANTHROPIC_API_KEY required, priced as passthrough (billing happens out of band).

- one-shot calls: --output-format json, --no-session-persistence, system prompt via --system-prompt (the CLI assigns the system role natively), user prompt on stdin
- --setting-sources '' and --tools '' so the subprocess never loads project instruction files and cannot touch the repo
- ANTHROPIC_API_KEY / ANTHROPIC_AUTH_TOKEN are scrubbed from the subprocess env: with a key present the CLI switches to per-token API billing and can block on an interactive trust prompt, hanging a headless run
- registry/pricing/cost-tracker/CLI wiring follows the codex_cli entries one-for-one; unit tests mirror test_codex_cli_provider.py

## Summary

<!-- What does this PR do? Keep it to 1-3 bullet points. -->

-

## Related Issues

<!-- Link any related issues: Fixes #123, Closes #456 -->

## Test Plan

<!-- How did you verify this works? -->

- [x] Tests pass (`pytest`)
- [ ] Lint passes (`ruff check .`)
- [ ] Web build passes (`npm run build`) *(if frontend changes)*

## Checklist

- [ ] My code follows the project's code style
- [ ] I have added tests for new functionality
- [ ] All existing tests still pass
- [ ] I have updated documentation if needed
