### PR TITLE
fix(ci): regenerate the plugin prompt and bundled changelog from their sources

### DIFF
--- a/packages/cli/src/repowise/cli/agent_targets/_data/codex_prompts/repowise-impacted-tests.md
+++ b/packages/cli/src/repowise/cli/agent_targets/_data/codex_prompts/repowise-impacted-tests.md
@@ -41,8 +41,8 @@ repowise impacted-tests main..HEAD --format list | xargs pytest
   headed "NOT coverage-backed", each carrying a `via` marker: `changed-test`
   (the changed file is itself a test), `call-graph` or `import-graph` (a test
   file that reaches it, no ingest needed), or `filename-pattern` (a name-shaped
-  guess). Report
-  them as candidates. Only `via: coverage` proves a test executed the change.
+  guess). Report them as candidates. Only `via: coverage` proves a test
+  executed the change.
 - A file none of those can speak to is "unknown, run the full suite".
 - For a whole-change defect-risk score, use `/prompts:repowise-risk`. For per-file
   blast radius / `tests_to_run`, use the `get_risk` MCP tool.

--- a/packages/core/src/repowise/core/upgrade/_data/CHANGELOG.md
+++ b/packages/core/src/repowise/core/upgrade/_data/CHANGELOG.md
@@ -16,43 +16,55 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **A test-to-code map that needs no coverage report.** The per-test map only
   ever existed if you ingested a coverage report with contexts, so on most
   repositories `tests_to_run` was empty, `impacted_tests` said "run the full
-  suite", and `untested_hotspot` fell back to matching filenames. The dependency
-  graph already records which test files import which source files, and that
+  suite", and `untested_hotspot` fell back to matching filenames. The call graph
+  already records which test can execute into which source file, and that
   relation now answers when the measured one cannot. It is labelled `inferred`
   everywhere, never blended with measured coverage, and never turned into a
   percentage. Nothing is stored: it is a bounded walk over rows already indexed,
-  measured at 27 ms once per health run on a 3,700-file repository.
+  measured at 63 ms once per health run on a 3,700-file repository.
+
+  The call graph is the primary signal and the import graph the weaker fallback,
+  which is a measured choice rather than a preference. Dogfooded against a real
+  `coverage run --contexts=test` over a slice where per-test attribution is
+  complete, with both sides seeing the same 37 test files: walking imports one
+  hop scored 72.1% precision at 19.5% recall, walking calls three hops scored
+  91.7% at 27.7%, and dropping the one call-resolution strategy that only
+  matches a name repo-wide (`global_unique`) took that to 95.7% at no cost to
+  recall. Unioning the two is worse than either lead, so the import tier is
+  spent only on the files the call graph says nothing about, where it answers
+  one more of them at no loss of precision.
 
   New fields: `tests_to_run_basis` on `get_risk`'s directive
   (`measured` / `inferred` / `none`), `basis` and a `status: "inferred"` on
   `get_change_risk`'s `impacted_tests`, and a `via` marker on every
-  `repowise impacted-tests` candidate.
+  `repowise impacted-tests` candidate saying which tier answered.
 
 ### Changed
 
-- **`untested_hotspot` stops accusing files that six tests import.** With no
+- **`untested_hotspot` stops accusing files that the tests run.** With no
   coverage ingested it fired on any hotspot without a *paired test file*, which
   is a filename convention, so a suite that names its tests for behaviour
-  satisfied nothing. A test reaching the file in the import graph now suppresses
-  it too. On this repository five of the six worst bug-magnet files had no test
-  named for them and read as untested; the sixth, `analysis/health/engine.py`,
-  was called tested because the convention matched `distill/test_engine.py` on
-  basename alone. The same floor now runs under `get_risk`'s `missing_tests`,
-  which had two separate filename heuristics that disagreed.
+  satisfied nothing. A test whose calls reach the file now suppresses it too. On
+  this repository five of the six worst bug-magnet files had no test named for
+  them and read as untested; the sixth, `analysis/health/engine.py`, was called
+  tested because the convention matched `distill/test_engine.py` on basename
+  alone. The same floor now runs under `get_risk`'s `missing_tests`, which had
+  two separate filename heuristics that disagreed.
 
-  Measured on repowise's own index: 74 of its 110 standing `untested_hotspot`
-  findings are cleared, 18 of them graded critical. The persisted
-  `has_test_file` widens to match, so the file table stops labelling those same
-  files "untested" while the biomarker says nothing.
+  Measured on repowise's own index, against the 80 standing `untested_hotspot`
+  findings the filename convention leaves behind: the call graph clears 32 of
+  them, 22 graded high and 3 critical, where a one-hop import walk clears 11.
+  The persisted `has_test_file` widens to match, so the file table stops
+  labelling those same files "untested" while the biomarker says nothing.
 
   Both stored values are wrong on an index built before this, so
-  `HEALTH_ANALYZER_VERSION` moves to 2 and the next `repowise update` with
+  `HEALTH_ANALYZER_VERSION` moves to 3 and the next `repowise update` with
   changed files re-scores health rather than waiting out the decay timer.
 
 - **`repowise impacted-tests --format json` renames `guessed_tests` to
   `inferred_tests`.** The bucket no longer holds only filename guesses, so the
-  old name described the wrong thing; each entry carries `via`
-  (`import-graph` or `filename-pattern`) to say which tier answered.
+  old name described the wrong thing; each entry carries `via` (`call-graph`,
+  `import-graph` or `filename-pattern`) to say which tier answered.
 
 ---
 

--- a/plugins/claude-code/commands/impacted-tests.md
+++ b/plugins/claude-code/commands/impacted-tests.md
@@ -40,9 +40,10 @@ repowise impacted-tests main..HEAD --format list | xargs pytest
   "no tests needed" result.
 - A changed file with no coverage rows gets *candidates* instead, in a table
   headed "NOT coverage-backed", each carrying a `via` marker: `changed-test`
-  (the changed file is itself a test), `import-graph` (a test file that reaches
-  it, no ingest needed), or `filename-pattern` (a name-shaped guess). Report
-  them as candidates. Only `via: coverage` proves a test executed the change.
+  (the changed file is itself a test), `call-graph` or `import-graph` (a test
+  file that reaches it, no ingest needed), or `filename-pattern` (a name-shaped
+  guess). Report them as candidates. Only `via: coverage` proves a test
+  executed the change.
 - A file none of those can speak to is "unknown, run the full suite".
 - For a whole-change defect-risk score, use `/repowise:risk`. For per-file
   blast radius / `tests_to_run`, use the `get_risk` MCP tool.

--- a/plugins/shared/commands/impacted-tests.md
+++ b/plugins/shared/commands/impacted-tests.md
@@ -41,9 +41,10 @@ repowise impacted-tests main..HEAD --format list | xargs pytest
   "no tests needed" result.
 - A changed file with no coverage rows gets *candidates* instead, in a table
   headed "NOT coverage-backed", each carrying a `via` marker: `changed-test`
-  (the changed file is itself a test), `import-graph` (a test file that reaches
-  it, no ingest needed), or `filename-pattern` (a name-shaped guess). Report
-  them as candidates. Only `via: coverage` proves a test executed the change.
+  (the changed file is itself a test), `call-graph` or `import-graph` (a test
+  file that reaches it, no ingest needed), or `filename-pattern` (a name-shaped
+  guess). Report them as candidates. Only `via: coverage` proves a test
+  executed the change.
 - A file none of those can speak to is "unknown, run the full suite".
 - For a whole-change defect-risk score, use `{{cmd:risk}}`. For per-file
   blast radius / `tests_to_run`, use the `get_risk` MCP tool.


### PR DESCRIPTION
Main has been red since #1755. `d439f991` was the last green commit; every run from `68b29bde` onward fails the same three tests on all three Python versions.

Two generated artefacts were edited at their output instead of their source, and each has a guard test that catches exactly that.

## The plugin prompt

`packages/cli/.../codex_prompts/repowise-impacted-tests.md` is rendered from `plugins/shared/commands/impacted-tests.md` by `scripts/gen_plugin_content.py`. #1755 added `call-graph` to the generated copy and left the shared source saying `import-graph`, so `test_generated_plugin_file_matches_the_shared_source` and `test_rendering_is_idempotent` both fail.

Fixed at the source and regenerated. That also updates `plugins/claude-code/commands/impacted-tests.md`, which was missed the same way, and reflows a paragraph the hand-edit had left wrapped mid-sentence.

## The bundled changelog

The CLI ships a copy of `docs/CHANGELOG.md` as package data so `repowise whats-new` works offline from an installed wheel. #1755 rewrote the entry in `docs/` only, so the bundled copy still described the import-graph version of the feature: the superseded 27 ms figure, "which test files import which source files", and "stops accusing files that six tests import". Resynced with the copy `test_bundled_changelog_in_sync` prescribes.

## Worth knowing

The plugin content tests write to the working tree. A failing run leaves the generated file reverted on disk rather than only reporting the drift, so a local `pytest` can look like it modified a file you never touched.
