### PR TITLE
fix(health): say how many tests reach a file, not how many we listed

### DIFF
--- a/packages/core/src/repowise/core/analysis/test_reachability.py
+++ b/packages/core/src/repowise/core/analysis/test_reachability.py
@@ -210,10 +210,18 @@ class CallGraphView:
 
 @dataclass(frozen=True)
 class ReachedBy:
-    """Tests reaching one target, and which tier found them."""
+    """Tests reaching one target, and which tier found them.
+
+    ``total`` is how many the walk actually found, before
+    ``MAX_TESTS_PER_TARGET`` trimmed ``tests``. A surface that prints
+    ``len(tests)`` as the answer is stating a cap as a measurement, and the cut
+    is alphabetical, so *which* ones survive is arbitrary. Carry the total and
+    say the bound.
+    """
 
     tests: list[str]
     via: ReachedVia
+    total: int = 0
 
 
 def _file_of(symbol_id: str) -> str:
@@ -390,7 +398,7 @@ async def tests_reaching_by_tier(
     if call_depth >= 1:
         found = await _call_reaching(session, repo_id, seeds, test_files, call_depth)
         for seed, tests in found.items():
-            out[seed] = ReachedBy(_cut(tests), "call-graph")
+            out[seed] = ReachedBy(_cut(tests), "call-graph", len(tests))
 
     unanswered = [seed for seed in seeds if seed not in out]
     if unanswered and import_depth >= 1:
@@ -398,7 +406,7 @@ async def tests_reaching_by_tier(
             session, repo_id, unanswered, test_files, import_depth
         )
         for seed, tests in found.items():
-            out[seed] = ReachedBy(_cut(tests), "import-graph")
+            out[seed] = ReachedBy(_cut(tests), "import-graph", len(tests))
     return out
 
 

--- a/packages/server/src/repowise/server/routers/code_health/coverage_routes.py
+++ b/packages/server/src/repowise/server/routers/code_health/coverage_routes.py
@@ -271,6 +271,10 @@ async def health_tests_reaching(
     file) from the weaker ``import-graph`` (a test only imports it), so the file
     page can say which claim it is making.
 
+    ``tests`` is capped at ``MAX_TESTS_PER_TARGET``; ``total`` is what the walk
+    found and ``truncated`` says whether the two differ. A file reached by 124
+    tests would otherwise report 50 as though that were the number.
+
     Always inferred; there is no measured form of this question, because a
     coverage report attributes lines to tests and this attributes files. A file
     nothing reaches returns ``basis: "none"`` rather than an empty ``inferred``
@@ -287,6 +291,8 @@ async def health_tests_reaching(
         "reached": False,
         "tests": [],
         "via": None,
+        "total": 0,
+        "truncated": False,
     }
     try:
         found = await tests_reaching_by_tier(session, repo_id, [file_path])
@@ -295,10 +301,15 @@ async def health_tests_reaching(
     reached = found.get(file_path)
     if reached is None or not reached.tests:
         return empty
+    total = reached.total or len(reached.tests)
     return {
         "file_path": file_path,
         "basis": "inferred",
         "reached": True,
         "tests": reached.tests,
         "via": reached.via,
+        # The walk's own count, which ``tests`` may be a trimmed alphabetical
+        # slice of. Without it a caller renders the cap as the answer.
+        "total": total,
+        "truncated": total > len(reached.tests),
     }

--- a/packages/types/src/health.ts
+++ b/packages/types/src/health.ts
@@ -589,10 +589,18 @@ export interface TestsReachingFile {
   file_path: string;
   basis: CoverageBasis;
   reached: boolean;
-  /** Empty when `reached` is false. Capped server-side. */
+  /**
+   * Empty when `reached` is false, and capped server-side. Render `total`
+   * beside it, never `tests.length` on its own: the cut is alphabetical, so a
+   * trimmed list states a cap as if it were the answer.
+   */
   tests: string[];
   /** Null when `reached` is false. */
   via: ReachedVia | null;
+  /** How many tests the walk found, before the cap trimmed `tests`. */
+  total?: number;
+  /** Whether `tests` is a trimmed slice of `total`. */
+  truncated?: boolean;
 }
 
 export interface HealthCoverageResponse {

--- a/packages/ui/__tests__/health/inferred-tests.test.tsx
+++ b/packages/ui/__tests__/health/inferred-tests.test.tsx
@@ -253,6 +253,23 @@ describe("TestsReachingList", () => {
     expect(screen.getByText(/framework hook/)).toBeInTheDocument();
   });
 
+  it("names the true total when the list was cut, not the length shown", async () => {
+    // The cap is an alphabetical slice, so printing tests.length would state
+    // the cap as the answer and hide which evidence was dropped.
+    render(
+      <TestsReachingList
+        filePath="src/a.py"
+        cacheKey="k5"
+        fetcher={async () => answer({ total: 124, truncated: true })}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByText("124 test files")).toBeInTheDocument(),
+    );
+    expect(screen.getByText(/listing 2 of 124, cut alphabetically/)).toBeInTheDocument();
+  });
+
   it("renders nothing when the host has not wired the endpoint", () => {
     const { container } = render(
       <TestsReachingList filePath="src/a.py" cacheKey="k4" />,

--- a/packages/ui/src/health/tests-reaching-list.tsx
+++ b/packages/ui/src/health/tests-reaching-list.tsx
@@ -69,7 +69,11 @@ export function TestsReachingList({
     );
   }
 
-  const count = data.tests.length;
+  // The walk's count, not the length of what survived the cap. A file reached by
+  // 124 tests ships 50 of them, and printing that 50 as the answer would be a
+  // silent truncation of exactly the kind this tab exists to avoid.
+  const count = data.total ?? data.tests.length;
+  const shown = data.tests.length;
 
   return (
     <div className="flex flex-col gap-2">
@@ -106,6 +110,9 @@ export function TestsReachingList({
       <p className="border-t border-[var(--color-border-default)] pt-2 font-mono text-[10px] uppercase tracking-[0.12em] text-[var(--color-text-tertiary)]">
         {data.via === "call-graph" ? "call graph" : "import graph"} · no report
         needed
+        {count > shown
+          ? ` · listing ${shown} of ${count}, cut alphabetically`
+          : ""}
       </p>
     </div>
   );

--- a/tests/unit/server/test_health_coverage_basis.py
+++ b/tests/unit/server/test_health_coverage_basis.py
@@ -364,6 +364,8 @@ async def test_the_file_endpoint_names_the_tests_and_the_tier(
         "reached": True,
         "tests": ["tests/test_a.py"],
         "via": "call-graph",
+        "total": 1,
+        "truncated": False,
     }
 
 
@@ -435,6 +437,53 @@ async def test_an_unreliable_call_edge_does_not_count_as_reaching(
 
     detail = await _reaching(client, repo["id"], "src/a.py")
     assert detail["basis"] == "none"
+
+
+async def test_the_file_endpoint_says_when_the_list_was_cut(
+    client, session, tmp_path, monkeypatch
+):
+    """``tests`` is capped; the count beside it must not be.
+
+    The cut is ``sorted(tests)[:cap]``, so a surface printing ``len(tests)``
+    reports the cap as the answer and shows an arbitrary alphabetical slice of
+    the evidence. Measured on this repository, one file is reached by 124 tests
+    and would have rendered as 50.
+    """
+    import repowise.core.analysis.test_reachability as tr
+
+    monkeypatch.setattr(tr, "MAX_TESTS_PER_TARGET", 2)
+    repo = await create_test_repo(client, tmp_path)
+    tests = [f"tests/test_{i}.py" for i in range(5)]
+    edges = [e for t in tests for e in _calls(t, "src/a.py")]
+    await _seed_graph(
+        session,
+        repo["id"],
+        nodes={**{t: True for t in tests}, "src/a.py": False},
+        edges=edges,
+    )
+    await session.commit()
+
+    body = await _reaching(client, repo["id"], "src/a.py")
+
+    assert len(body["tests"]) == 2
+    assert body["total"] == 5
+    assert body["truncated"] is True
+
+
+async def test_an_uncut_list_is_not_marked_truncated(client, session, tmp_path):
+    repo = await create_test_repo(client, tmp_path)
+    await _seed_graph(
+        session,
+        repo["id"],
+        nodes={"tests/test_a.py": True, "src/a.py": False},
+        edges=_calls("tests/test_a.py", "src/a.py"),
+    )
+    await session.commit()
+
+    body = await _reaching(client, repo["id"], "src/a.py")
+
+    assert body["total"] == 1
+    assert body["truncated"] is False
 
 
 async def test_the_file_endpoint_404s_for_an_unknown_repo(client):


### PR DESCRIPTION
`tests_reaching_by_tier` caps each target at `MAX_TESTS_PER_TARGET`, and the cut is `sorted(tests)[:50]`. The file page rendered `tests.length` as the answer, so a capped list stated the cap as a measurement and showed an arbitrary alphabetical slice of the evidence behind it.

Measured against a live index of this repository:

```
packages/api-client/src/types.ts
  page said : 50 test files
  actually  : 124
  hidden    : 74  (60%)
```

The 74 it dropped begin at `tests/unit/health/test_duplication.py`, for no reason other than that the cut stops at `test_wiki_tour_adoption.py`.

## The change

`ReachedBy` carries `total`, the count before trimming. `/health/tests-reaching` returns `total` and `truncated` beside `tests`. The list leads with the true count and says what it is showing:

> **124 test files** run into this file
> call graph · no report needed · listing 50 of 124, cut alphabetically

## What this does not change

The cap stays. It exists so a helper called from every test in the suite cannot build an unbounded intermediate, and that reasoning is untouched. What was wrong was not the bound but hiding it.

Ranking the cut, so the surviving 50 are the most relevant rather than the alphabetically earliest, is a separate question. The module's own notes already flag it as one, and it needs a definition of "most relevant" that does not exist yet.

## Tests

Two on the endpoint, one pinning that an uncut list is not marked truncated, and one on the list component asserting it renders the total rather than the length shown. 96 Python tests and 14 UI tests pass.
