### PR TITLE
fix(parser): avoid duplicate Python decorators

### DIFF
--- a/packages/core/src/repowise/core/ingestion/parser.py
+++ b/packages/core/src/repowise/core/ingestion/parser.py
@@ -688,10 +688,6 @@ class ASTParser:
 
             # Visibility
             modifier_texts = [_node_text(m, src) for m in modifier_nodes]
-            if def_node.parent and def_node.parent.type == "decorated_definition":
-                for sibling in def_node.parent.children:
-                    if sibling.type == "decorator":
-                        modifier_texts.append(_node_text(sibling, src))
 
             # Rust: outer attributes (#[...]) are preceding siblings of the item
             rust_attrs: list[str] = []

--- a/packages/core/src/repowise/core/ingestion/queries/python.scm
+++ b/packages/core/src/repowise/core/ingestion/queries/python.scm
@@ -40,7 +40,7 @@
 
 ; Decorated function or class — captures the decorator as a modifier
 (decorated_definition
-  (decorator) @symbol.modifiers
+  (decorator)+ @symbol.modifiers
   (function_definition
     name: (identifier) @symbol.name
     parameters: (parameters) @symbol.params
@@ -48,7 +48,7 @@
 )
 
 (decorated_definition
-  (decorator) @symbol.modifiers
+  (decorator)+ @symbol.modifiers
   (class_definition
     name: (identifier) @symbol.name
   ) @symbol.def

--- a/tests/unit/ingestion/parser/test_python.py
+++ b/tests/unit/ingestion/parser/test_python.py
@@ -86,6 +86,26 @@ class TestPythonParser:
         )
         assert calc_add.parent_name == "Calculator"
 
+    def test_function_single_decorator_recorded_once(self, parser: ASTParser) -> None:
+        fi = _make_file_info("pkg/routes.py", "python")
+        result = parser.parse_file(
+            fi,
+            b"@app.get('/users')\ndef list_users():\n    return []\n",
+        )
+        list_users = next(s for s in result.symbols if s.name == "list_users")
+        assert list_users.decorators == ["@app.get('/users')"]
+
+    def test_function_multiple_decorators_recorded_once_in_source_order(
+        self, parser: ASTParser
+    ) -> None:
+        fi = _make_file_info("pkg/routes.py", "python")
+        result = parser.parse_file(
+            fi,
+            b"@cache\n@app.post('/items')\ndef create_item():\n    pass\n",
+        )
+        create_item = next(s for s in result.symbols if s.name == "create_item")
+        assert create_item.decorators == ["@cache", "@app.post('/items')"]
+
     def test_private_visibility(self, parser: ASTParser) -> None:
         fi = _make_file_info("pkg/calc.py", "python")
         result = parser.parse_file(fi, PYTHON_SOURCE)


### PR DESCRIPTION
## Summary

- Remove the redundant parser-side Python decorator collection.
- Capture one or more decorators through the Python Tree-sitter query and add regression tests for single and multiple decorators.

## Related Issues

Closes #1698

## Test Plan

- [x] Python parser tests pass (`31 passed`)
- [x] Complete parser test suite passes (`223 passed`)
- [x] Lint passes (`ruff check`)
- [x] `git diff --check` passes
- [x] Web build not applicable because this change does not affect the frontend
- [x] Related generation integration tests pass (`52 passed`)

## Checklist

- [x] My code follows the project's code style
- [x] I have added tests for the bug fix
- [x] All relevant existing tests pass
- [x] Documentation changes are not required for this internal parser fix