### PR TITLE
feat(providers,cli): add devin_cli provider

### DIFF
--- a/docs/agent/DEVIN.md
+++ b/docs/agent/DEVIN.md
@@ -1,0 +1,86 @@
+# Devin Integration
+
+Repowise can integrate with Devin in two independent ways. This document explains both, the trade-offs between them, and why the first implementation will be the `devin_cli` CLI wrapper.
+
+## The two options
+
+| Option | What it is | Complexity | Dependencies | Token usage | Output |
+|---|---|---|---|---|---|
+| **`devin_cli` provider** (first) | Wrap the local `devin` CLI binary and run `devin -p` for one-shot generation. | Low. Follows the same pattern as `codex_cli` and `opencode`. | None new. | Estimated/missing — the CLI returns plain text, not token counts. | Plain text stdout. |
+| Direct `devin` network provider | Re-implement the Devin/Codeium chat API client from `oh-my-pi` in Python. | High. Requires Connect/gRPC protobuf, streaming, JWT auth, and model discovery. | `protobuf`/`grpcio` (or `httpx` + `protobuf` for Connect over HTTP/1.1), generated Python schemas. | Real token counts from streaming frames. | Full streaming response with thinking, tool calls, usage. |
+
+The two options are **not mutually exclusive**. `devin_cli` is the pragmatic starting point. A direct network provider can be added later if we need real usage data, reasoning controls, or model routing.
+
+## What `oh-my-pi` did
+
+The `oh-my-pi` codebase implements the direct network provider:
+
+- `packages/ai/src/providers/devin.ts` streams to `https://server.codeium.com` using the Connect protocol, protobuf `GetChatMessage` requests, gzip framing, and a JWT from `GetUserJwt`.
+- `packages/ai/src/registry/oauth/devin.ts` runs a PKCE OAuth flow against `https://app.devin.ai` and exchanges the code at `https://api.devin.ai/auth/cli/token`.
+- `packages/catalog/src/discovery/devin.ts` fetches the model catalog via the unary Connect RPC `GetCliModelConfigs`.
+
+That implementation is valuable reference material, but it is not a CLI wrapper. Reproducing it in repowise means porting ~600+ lines of TypeScript, a large set of protobuf definitions, and the variant-collapse reasoning effort routing into Python.
+
+## Why `devin_cli` first
+
+1. **Familiar pattern.** Repowise already has `codex_cli` and `opencode` providers that shell out to a local agent CLI. Adding `devin_cli` uses the same registry, CLI selection, validation, and test patterns.
+2. **Low dependency footprint.** No new Python packages, no protobuf code generation, no OAuth server.
+3. **Fast validation.** A single `devin -p` call is enough to prove the provider works end-to-end.
+4. **Good enough for docs generation.** Repowise primarily needs markdown output from a system + user prompt. Plain-text stdout satisfies that.
+
+The main downsides are the lack of real token counts and the CLI's potential to make file edits depending on its permission mode. The implementation will choose a safe non-interactive mode and add "do not edit files" guidance to the prompt.
+
+## `devin_cli` design
+
+### How it runs
+
+The provider will invoke the Devin CLI in non-interactive print mode:
+
+```bash
+devin -p --prompt-file <tmpfile> --cd /absolute/path/to/repo --model <model> --respect-workspace-trust false --permission-mode <safe-mode>
+```
+
+- `-p` / `--print` — single-turn, print the response and exit.
+- `--prompt-file <tmpfile>` — avoids command-line length limits and shell-escaping issues.
+- `--cd /absolute/path/to/repo` — makes the CLI reason about the target repository.
+- `--model <model>` — only passed when the user selects a specific model; `devin_cli/default` omits the flag.
+- `--respect-workspace-trust false` — required for non-interactive runs; otherwise the CLI can hang on a trust prompt.
+- `--permission-mode <safe-mode>` — will be chosen to avoid unsolicited file edits.
+
+The combined `system_prompt` and `user_prompt` are written to a temp file. The provider parses stdout as the response and sets `usage["estimated"] = True` because the CLI does not emit token counts.
+
+### Model discovery
+
+```bash
+devin models list --format json
+```
+
+The provider will attempt to parse the JSON output and produce `ProviderModelOption` entries. The exact JSON shape is not documented, so the parser will be defensive and fall back to a single `devin_cli/default` option if it cannot understand the output.
+
+### Registry and wiring
+
+- Add `devin_cli.py` under `packages/core/src/repowise/core/providers/llm/`.
+- Register it in `packages/core/src/repowise/core/providers/llm/registry.py` as a built-in provider.
+- Add it to the CLI provider selection and validation (`provider_selection.py`, `helpers.py`).
+- Add it to the server provider catalog (`provider_config.py`).
+- Add it to the web settings UI (`provider-section.tsx`).
+- Add unit tests in `tests/unit/test_providers/test_devin_cli_provider.py` following `test_codex_cli_provider.py`.
+
+## Future: direct `devin` network provider
+
+If real token usage, streaming, or reasoning effort control become important, the next step is to port the `oh-my-pi` network client. That provider would be named `devin` (not `devin_cli`) and would:
+
+- Send `GetUserJwt` to exchange a `DEVIN_API_KEY` session token for a JWT.
+- Open a Connect streaming session to `https://server.codeium.com/exa.api_server_pb.ApiServerService/GetChatMessage`.
+- Serialize protobuf `GetChatMessageRequest` messages with gzip framing.
+- Parse the streamed `GetChatMessageResponse` frames for text, thinking, tool calls, and usage.
+- Discover models via `GetCliModelConfigs`.
+- Route reasoning effort by selecting sibling model IDs, matching `oh-my-pi`'s variant-collapse behavior.
+
+This is intentionally out of scope for the first milestone.
+
+## Official Devin docs
+
+- [Devin CLI](https://docs.devin.ai/cli)
+- [Devin CLI commands and flags](https://docs.devin.ai/cli/reference/commands)
+- [Devin CLI models](https://docs.devin.ai/cli/models)

--- a/packages/cli/src/repowise/cli/commands/init_cmd/command.py
+++ b/packages/cli/src/repowise/cli/commands/init_cmd/command.py
@@ -335,7 +335,10 @@ def _run_generation_phase(
         console.print(f"  Languages: {', '.join(lang_parts)}")
 
     # Warn when a local provider runs with default concurrency
-    if provider.provider_name in ("ollama", "codex_cli", "opencode") and concurrency > 4:
+    if (
+        provider.provider_name in ("ollama", "codex_cli", "opencode", "devin_cli")
+        and concurrency > 4
+    ):
         console.print(
             f"  [{WARN}]Warning:[/] {provider.provider_name} is a local provider "
             f"running with concurrency={concurrency}. "
@@ -411,7 +414,7 @@ def _run_generation_phase(
     default=None,
     help=(
         "LLM provider name (anthropic, openai, openrouter, gemini, "
-        "deepseek, kimi, ollama, litellm, codex_cli, opencode, mock)."
+        "deepseek, kimi, ollama, litellm, codex_cli, opencode, devin_cli, mock)."
     ),
 )
 @click.option("--model", default=None, help="Model identifier override.")
@@ -824,9 +827,7 @@ def init_command(
             include_submodules=include_submodules,
         )
         if seeded:
-            console.print(
-                f"[{OK}]Worktree index seeded successfully. Delegating to update...[/]"
-            )
+            console.print(f"[{OK}]Worktree index seeded successfully. Delegating to update...[/]")
             from repowise.cli.commands.update_cmd.command import run_update
 
             is_workspace = len(scan.repos) > 1 and not no_workspace

--- a/packages/cli/src/repowise/cli/commands/init_cmd/workspace.py
+++ b/packages/cli/src/repowise/cli/commands/init_cmd/workspace.py
@@ -242,9 +242,9 @@ def _workspace_generation_provider_for_repo(provider: Any, repo_path: Path) -> A
     and returned unchanged.
     """
 
-    if getattr(provider, "provider_name", None) != "codex_cli":
+    if provider.provider_name not in ("codex_cli", "devin_cli"):
         return provider
-    return resolve_provider("codex_cli", getattr(provider, "model_name", None), repo_path)
+    return resolve_provider(provider.provider_name, provider.model_name, repo_path)
 
 
 @dataclass
@@ -382,8 +382,7 @@ def _ingest_and_generate_repo(repo: Any, idx: int, total: int, ctx: _WorkspaceCt
         pages_generated = len(generated_pages)
         docs_mode = "deterministic"
         console.print(
-            f"    [{OK}]✓[/] Rendered {len(generated_pages)} pages from structure "
-            "(no model)\n"
+            f"    [{OK}]✓[/] Rendered {len(generated_pages)} pages from structure (no model)\n"
         )
 
     if ctx.dry_run:

--- a/packages/cli/src/repowise/cli/helpers.py
+++ b/packages/cli/src/repowise/cli/helpers.py
@@ -1105,6 +1105,21 @@ def validate_provider_config(provider_name: str | None = None) -> list[str]:
                 )
             return warnings
 
+        if provider_name == "devin_cli":
+            import shutil
+
+            if not shutil.which("devin"):
+                warnings.append(
+                    "Provider 'devin_cli' requires the Devin CLI.\n"
+                    "  Install macOS/Linux/WSL: curl -fsSL https://cli.devin.ai/install.sh | bash\n"
+                    "  Install Windows:         irm https://static.devin.ai/cli/setup.ps1 | iex\n"
+                    "  Log in:                  devin auth login\n"
+                    "  Models:                  devin models list\n"
+                    "  More:                    https://docs.devin.ai/cli\n"
+                    "  Usage:                   repowise init --provider devin_cli --model devin_cli/opus"
+                )
+            return warnings
+
         # Validate specific provider
         if provider_name not in provider_env_vars:
             warnings.append(f"Unknown provider '{provider_name}' - cannot validate configuration")

--- a/packages/cli/src/repowise/cli/ui/provider_selection.py
+++ b/packages/cli/src/repowise/cli/ui/provider_selection.py
@@ -33,6 +33,7 @@ _PROVIDER_DEFAULTS: dict[str, str] = {
     "edenai": "mistral/mistral-small-latest",
     "codex_cli": "codex_cli/default",
     "opencode": "opencode/default",
+    "devin_cli": "devin_cli/default",
     "ollama": "qwen3.5:4b",
     "openrouter": "google/gemini-3.5-flash-lite",
     "litellm": "groq/llama-3.1-70b-versatile",
@@ -47,6 +48,7 @@ _PROVIDER_ENV: dict[str, str] = {
     "edenai": "EDENAI_API_KEY",
     "codex_cli": "__CODEX_CLI__",
     "opencode": "__OPENCODE_CLI__",
+    "devin_cli": "__DEVIN_CLI__",
     "ollama": "OLLAMA_BASE_URL",
     "openrouter": "OPENROUTER_API_KEY",
     # The picker iterates this map, so a provider missing here never renders a
@@ -64,6 +66,7 @@ _PROVIDER_SIGNUP: dict[str, str] = {
     "edenai": "https://app.edenai.run/user/register",
     "codex_cli": "https://developers.openai.com/codex/cli",
     "opencode": "https://opencode.ai",
+    "devin_cli": "https://docs.devin.ai/cli",
     "ollama": "https://ollama.com/download",
     "openrouter": "https://openrouter.ai/keys",
     "litellm": "https://docs.litellm.ai/docs/providers",
@@ -77,6 +80,7 @@ _PROVIDER_NOTES: dict[str, str] = {
     "gemini": "recommended",
     "codex_cli": "uses your Codex CLI login",
     "opencode": "uses your opencode CLI setup",
+    "devin_cli": "uses your Devin CLI login",
     "ollama": "runs on your machine, no key",
     "litellm": "proxy in front of another provider",
 }
@@ -109,6 +113,26 @@ def _detect_opencode_status() -> bool:
     import shutil
 
     return shutil.which("opencode") is not None
+
+
+def _detect_devin_cli_status() -> tuple[bool, bool]:
+    """Return ``(installed, logged_in)`` for the local Devin CLI."""
+    import shutil
+    import subprocess
+
+    devin_cmd = shutil.which("devin")
+    if not devin_cmd:
+        return False, False
+    try:
+        result = subprocess.run(
+            [devin_cmd, "auth", "status"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return True, False
+    return True, result.returncode == 0
 
 
 def ollama_base_url() -> str:
@@ -181,6 +205,10 @@ def _detect_provider_status() -> dict[str, str]:
         elif prov == "opencode":
             if _detect_opencode_status():
                 status[prov] = "opencode CLI"
+        elif prov == "devin_cli":
+            installed, logged_in = _detect_devin_cli_status()
+            if installed and logged_in:
+                status[prov] = "devin CLI"
         elif prov == "ollama":
             if _detect_ollama_status():
                 status[prov] = ollama_base_url()
@@ -219,6 +247,25 @@ def _opencode_setup_lines() -> list[str]:
     ]
 
 
+def _devin_cli_setup_lines() -> list[str]:
+    installed, logged_in = _detect_devin_cli_status()
+    if not installed:
+        problem = "Devin CLI is not on PATH."
+    elif not logged_in:
+        problem = "Devin CLI is on PATH but not logged in."
+    else:
+        problem = "Devin CLI is on PATH and logged in."
+    return [
+        "  [bold]devin_cli[/bold] uses the Devin CLI's own session. No API key here.",
+        f"  Install:  [{BRAND}]curl -fsSL https://cli.devin.ai/install.sh | bash[/]",
+        f"  Install Windows: [{BRAND}]irm https://static.devin.ai/cli/setup.ps1 | iex[/]",
+        f"  Log in:   [{BRAND}]devin auth login[/]",
+        f"  Models:   [{BRAND}]devin models list[/]",
+        "",
+        f"  [{WARN}]{problem}[/] Set it up and retry, or select another provider.",
+    ]
+
+
 def _ollama_setup_lines() -> list[str]:
     base_url = ollama_base_url()
     lines = ["  [bold]ollama[/bold] runs models on your machine. No key needed.", ""]
@@ -248,6 +295,7 @@ def _ollama_setup_lines() -> list[str]:
 _LOCAL_PROVIDER_SETUP: dict[str, Callable[[], list[str]]] = {
     "codex_cli": _codex_cli_setup_lines,
     "opencode": _opencode_setup_lines,
+    "devin_cli": _devin_cli_setup_lines,
     "ollama": _ollama_setup_lines,
 }
 

--- a/packages/core/src/repowise/core/providers/llm/__init__.py
+++ b/packages/core/src/repowise/core/providers/llm/__init__.py
@@ -20,6 +20,7 @@ Built-in providers:
     litellm    — 100+ providers via LiteLLM proxy
     codex_cli  — local authenticated Codex CLI via codex exec
     opencode   — local opencode CLI via opencode run
+    devin_cli  — local authenticated Devin CLI via devin -p
     mock       — deterministic test provider
 """
 

--- a/packages/core/src/repowise/core/providers/llm/devin_cli.py
+++ b/packages/core/src/repowise/core/providers/llm/devin_cli.py
@@ -1,0 +1,423 @@
+"""Devin CLI provider for repowise.
+
+This provider delegates generation to the authenticated local Devin CLI via
+``devin -p``. It is intended for users with a Devin subscription/auth already
+configured by ``devin auth login`` and does not require a separate API key.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+import uuid
+from functools import lru_cache
+from pathlib import Path
+
+import structlog
+
+from repowise.core.providers.llm.base import (
+    BaseProvider,
+    CacheHint,
+    GeneratedResponse,
+    ProviderError,
+    ProviderModelOption,
+)
+from repowise.core.rate_limiter import RateLimiter
+from repowise.core.reasoning import ReasoningMode
+
+log = structlog.get_logger(__name__)
+
+_DEFAULT_MODEL_LABEL = "devin_cli/default"
+_EXEC_TIMEOUT_SECONDS = 600
+_CATALOG_TIMEOUT_SECONDS = 10
+_MAX_STDERR_CHARS = 1_000
+
+# Devin model uids/aliases are alphanumeric with underscores, dots, hyphens
+# and slashes (e.g. "claude-opus-5-medium", "MODEL_GPT_5_2_LOW", "opus").
+_MODEL_NAME_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._/\-]*$")
+
+
+def _resolve_devin_executable() -> str | None:
+    """Return the executable path used to launch Devin, or None if unavailable."""
+
+    return shutil.which("devin")
+
+
+def _validate_model_name(model: str) -> None:
+    if not _MODEL_NAME_RE.match(model):
+        raise ProviderError(
+            "devin_cli",
+            f"Invalid model name {model!r}. Model names may only contain "
+            "alphanumeric characters, dots, hyphens, underscores, and forward slashes.",
+        )
+
+
+def _normalize_model(model: str | None) -> str | None:
+    """Return the native Devin model slug, or None to use CLI config."""
+    if not model:
+        return None
+    if model == _DEFAULT_MODEL_LABEL:
+        return None
+    if model.startswith("devin_cli/"):
+        suffix = model.removeprefix("devin_cli/")
+        return suffix or None
+    return model
+
+
+def _model_label(model: str | None) -> str:
+    """Return the persisted attribution label for a Devin CLI model."""
+    native = _normalize_model(model)
+    return f"devin_cli/{native}" if native else _DEFAULT_MODEL_LABEL
+
+
+def _combine_prompt(system_prompt: str, user_prompt: str) -> str:
+    return (
+        "System instructions for this task:\n\n"
+        f"{system_prompt.strip()}\n\n"
+        "---\n\n"
+        "User request and context:\n\n"
+        f"{user_prompt.strip()}\n\n"
+        "Do not edit any files. Answer only in Markdown."
+    )
+
+
+def _tail(text: str, max_chars: int = _MAX_STDERR_CHARS) -> str:
+    text = text.strip()
+    if len(text) <= max_chars:
+        return text
+    return text[-max_chars:]
+
+
+def _error_message(stderr: str, stdout: str, returncode: int) -> str:
+    for candidate in (_tail(stderr), _tail(stdout)):
+        if not candidate:
+            continue
+        if candidate.lstrip().startswith(("{", "[")):
+            continue
+        return candidate
+    return f"devin -p exited with {returncode}"
+
+
+def _parse_devin_models(raw: object) -> list[tuple[str, str, int, int]]:
+    """Parse ``devin models list --format json`` into model tuples.
+
+    Returns tuples of (model_uid, label, max_context_tokens, max_output_tokens).
+    Falls back to conservative defaults when a field is missing or malformed.
+    """
+    if not isinstance(raw, dict):
+        return []
+
+    families = raw.get("families")
+    if not isinstance(families, list):
+        return []
+
+    models: list[tuple[str, str, int, int]] = []
+    for raw_family in families:
+        if not isinstance(raw_family, dict):
+            continue
+        variants = raw_family.get("variants")
+        if not isinstance(variants, list):
+            continue
+        for raw_variant in variants:
+            if not isinstance(raw_variant, dict):
+                continue
+            model_uid = raw_variant.get("model_uid")
+            if not isinstance(model_uid, str) or not model_uid.strip():
+                continue
+            label = raw_variant.get("label")
+            if not isinstance(label, str) or not label.strip():
+                label = model_uid
+            context_tokens = raw_variant.get("max_context_tokens", 0)
+            output_tokens = raw_variant.get("max_output_tokens", 0)
+            try:
+                context_tokens = int(context_tokens or 0)
+            except (TypeError, ValueError):
+                context_tokens = 0
+            try:
+                output_tokens = int(output_tokens or 0)
+            except (TypeError, ValueError):
+                output_tokens = 0
+            models.append((model_uid, label.strip(), context_tokens, output_tokens))
+
+    return models
+
+
+@lru_cache(maxsize=4)
+def _load_devin_model_catalog(devin_cmd: str) -> list[tuple[str, str, int, int]] | None:
+    """Ask the installed Devin CLI for its model catalog."""
+
+    try:
+        completed = subprocess.run(
+            [devin_cmd, "models", "list", "--format", "json"],
+            capture_output=True,
+            check=False,
+            text=True,
+            timeout=_CATALOG_TIMEOUT_SECONDS,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+
+    if completed.returncode != 0:
+        return None
+
+    try:
+        raw = json.loads(completed.stdout)
+    except json.JSONDecodeError:
+        return None
+
+    catalog = _parse_devin_models(raw)
+    return catalog or None
+
+
+def _devin_model_options(
+    devin_cmd: str,
+) -> tuple[ProviderModelOption, ...]:
+    catalog = _load_devin_model_catalog(devin_cmd)
+    if catalog is None:
+        return (
+            ProviderModelOption(
+                model=_DEFAULT_MODEL_LABEL,
+                label="Devin CLI default",
+                reasoning_modes=("auto",),
+                recommended=True,
+                source="fallback",
+                notes="uses Devin CLI config",
+            ),
+        )
+
+    default_context = 200_000
+    options: list[ProviderModelOption] = [
+        ProviderModelOption(
+            model=_DEFAULT_MODEL_LABEL,
+            label="Devin CLI default",
+            reasoning_modes=("auto",),
+            recommended=True,
+            source="local",
+            notes="uses Devin CLI config",
+        )
+    ]
+    for model_uid, label, context_tokens, output_tokens in sorted(
+        catalog, key=lambda item: item[1].lower()
+    ):
+        notes = f"{context_tokens or default_context} context"
+        if output_tokens:
+            notes += f", {output_tokens} output"
+        options.append(
+            ProviderModelOption(
+                model=_model_label(model_uid),
+                label=label,
+                reasoning_modes=("auto",),
+                recommended=False,
+                source="local",
+                notes=notes,
+            )
+        )
+    return tuple(options)
+
+
+async def _close_subprocess_transport(proc: asyncio.subprocess.Process) -> None:
+    """Close asyncio's subprocess transport before the event loop shuts down."""
+
+    transport = getattr(proc, "_transport", None)
+    close = getattr(transport, "close", None)
+    if not callable(close):
+        return
+    with contextlib.suppress(Exception):
+        close()
+    await asyncio.sleep(0)
+
+
+class DevinCliProvider(BaseProvider):
+    """LLM provider backed by ``devin -p``.
+
+    Args:
+        model: Optional native Devin model slug. If omitted, Devin CLI config
+            chooses the model. Persisted labels like ``devin_cli/opus`` are
+            accepted and normalized before calling the CLI.
+        repo_path: Working directory passed to the Devin subprocess.
+        rate_limiter: Accepted for interface consistency; the provider
+            serializes subprocess calls by default.
+    """
+
+    # A process spawn plus a full Devin turn. The floor is tens of seconds even
+    # for a short prompt, so an interactive caller has to budget in minutes.
+    # Stays under _EXEC_TIMEOUT_SECONDS so the caller gives up before the
+    # subprocess does and the error names the real cause.
+    interactive_timeout_s: float = 180.0
+
+    def __init__(
+        self,
+        model: str | None = None,
+        repo_path: str | Path | None = None,
+        rate_limiter: RateLimiter | None = None,
+    ) -> None:
+        devin_cmd = _resolve_devin_executable()
+        if not devin_cmd:
+            raise ProviderError(
+                "devin_cli",
+                "Devin CLI not found.\n\n"
+                "Installation:\n"
+                "  macOS/Linux/WSL: curl -fsSL https://cli.devin.ai/install.sh | bash\n"
+                "  Windows: irm https://static.devin.ai/cli/setup.ps1 | iex\n\n"
+                "After installing, run 'devin auth login' to authenticate.",
+            )
+        self._devin_cmd = devin_cmd
+        native = _normalize_model(model)
+        if native is not None:
+            _validate_model_name(native)
+        self._model = native
+        self._repo_path = (
+            Path(repo_path).resolve() if repo_path is not None else Path.cwd().resolve()
+        )
+        self._rate_limiter = rate_limiter
+        self._subprocess_semaphore: asyncio.Semaphore | None = None
+        self._semaphore_loop: asyncio.AbstractEventLoop | None = None
+
+    @property
+    def provider_name(self) -> str:
+        return "devin_cli"
+
+    @property
+    def model_name(self) -> str:
+        return _model_label(self._model)
+
+    def supported_reasoning_modes(self) -> tuple[ReasoningMode, ...]:
+        return ("auto",)
+
+    def available_model_options(self) -> tuple[ProviderModelOption, ...]:
+        return _devin_model_options(self._devin_cmd)
+
+    def _get_semaphore(self) -> asyncio.Semaphore:
+        loop = asyncio.get_running_loop()
+        if self._semaphore_loop is not loop:
+            self._subprocess_semaphore = asyncio.Semaphore(1)
+            self._semaphore_loop = loop
+        return self._subprocess_semaphore  # type: ignore[return-value]
+
+    def _build_command(self, prompt_file: Path) -> list[str]:
+        cmd = [
+            self._devin_cmd,
+            "-p",
+            "--prompt-file",
+            str(prompt_file),
+            "--respect-workspace-trust",
+            "false",
+            "--permission-mode",
+            "auto",
+        ]
+        if self._model:
+            cmd.extend(["--model", self._model])
+        return cmd
+
+    async def generate(
+        self,
+        system_prompt: str,
+        user_prompt: str,
+        max_tokens: int = 4096,
+        temperature: float = 0.3,
+        request_id: str | None = None,
+        reasoning: ReasoningMode = "auto",
+        cache_hints: tuple[CacheHint, ...] = (),
+    ) -> GeneratedResponse:
+        if self._rate_limiter:
+            await self._rate_limiter.acquire(estimated_tokens=max_tokens)
+
+        prompt = _combine_prompt(system_prompt, user_prompt)
+        prompt_file = (
+            Path(tempfile.gettempdir()) / f"devin_prompt_{os.getpid()}_{uuid.uuid4().hex}.txt"
+        )
+        try:
+            try:
+                prompt_file.write_text(prompt, encoding="utf-8")
+            except OSError as exc:
+                raise ProviderError(
+                    "devin_cli",
+                    f"Failed to write Devin prompt file {prompt_file}: {exc}",
+                ) from exc
+
+            cmd = self._build_command(prompt_file)
+            log.debug(
+                "devin_cli.generate.start",
+                model=self.model_name,
+                repo_path=str(self._repo_path),
+                request_id=request_id,
+            )
+
+            async with self._get_semaphore():
+                try:
+                    proc = await asyncio.create_subprocess_exec(
+                        *cmd,
+                        stdout=asyncio.subprocess.PIPE,
+                        stderr=asyncio.subprocess.PIPE,
+                        cwd=str(self._repo_path),
+                    )
+                except FileNotFoundError as exc:
+                    raise ProviderError(
+                        "devin_cli",
+                        "Devin CLI not found.\n\n"
+                        "Installation:\n"
+                        "  macOS/Linux/WSL: curl -fsSL https://cli.devin.ai/install.sh | bash\n"
+                        "  Windows: irm https://static.devin.ai/cli/setup.ps1 | iex",
+                    ) from exc
+
+                try:
+                    stdout_bytes, stderr_bytes = await asyncio.wait_for(
+                        proc.communicate(),
+                        timeout=_EXEC_TIMEOUT_SECONDS,
+                    )
+                except TimeoutError as exc:
+                    proc.kill()
+                    with contextlib.suppress(ProcessLookupError):
+                        await proc.wait()
+                    raise ProviderError(
+                        "devin_cli",
+                        f"devin -p timed out after {_EXEC_TIMEOUT_SECONDS} seconds.",
+                    ) from exc
+                finally:
+                    await _close_subprocess_transport(proc)
+
+            stdout = stdout_bytes.decode("utf-8", errors="replace") if stdout_bytes else ""
+            stderr = stderr_bytes.decode("utf-8", errors="replace") if stderr_bytes else ""
+
+            returncode = proc.returncode if proc.returncode is not None else 1
+            if returncode != 0:
+                raise ProviderError(
+                    "devin_cli",
+                    _error_message(stderr, stdout, returncode),
+                    status_code=returncode,
+                )
+
+            content = stdout.strip()
+            if not content:
+                raise ProviderError(
+                    "devin_cli",
+                    "devin -p completed but produced no output.",
+                )
+
+            log.debug(
+                "devin_cli.generate.done",
+                request_id=request_id,
+            )
+            usage_payload = {
+                "source": "devin_cli",
+                "model": self.model_name,
+                "stderr": _tail(stderr) if stderr.strip() else "",
+                "estimated": True,
+            }
+
+            return GeneratedResponse(
+                content=content,
+                input_tokens=0,
+                output_tokens=0,
+                cached_tokens=0,
+                usage=usage_payload,
+            )
+        finally:
+            with contextlib.suppress(OSError):
+                prompt_file.unlink(missing_ok=True)

--- a/packages/core/src/repowise/core/providers/llm/registry.py
+++ b/packages/core/src/repowise/core/providers/llm/registry.py
@@ -53,6 +53,7 @@ _BUILTIN_PROVIDERS: dict[str, tuple[str, str]] = {
     "edenai": ("repowise.core.providers.llm.edenai", "EdenAIProvider"),
     "codex_cli": ("repowise.core.providers.llm.codex_cli", "CodexCliProvider"),
     "opencode": ("repowise.core.providers.llm.opencode", "OpenCodeProvider"),
+    "devin_cli": ("repowise.core.providers.llm.devin_cli", "DevinCliProvider"),
     "mock": ("repowise.core.providers.llm.mock", "MockProvider"),
 }
 
@@ -93,13 +94,13 @@ PROVIDER_BASE_URL_ENVS: dict[str, tuple[str, ...]] = {
 # proxy the user secured elsewhere). Resolution must never reject one of these
 # for a "missing" key, and must never fall through to a different provider
 # because it could not find one.
-KEYLESS_PROVIDERS = frozenset({"codex_cli", "opencode", "ollama", "litellm", "mock"})
+KEYLESS_PROVIDERS = frozenset({"codex_cli", "opencode", "devin_cli", "ollama", "litellm", "mock"})
 
 # Providers that shell out to a CLI and therefore need to be told which repo
 # they are reasoning about: they pass it as the subprocess working directory.
 # Omitting it silently runs the CLI against whatever cwd the host process had,
 # which for an MCP server launched by an editor is not the user's repo.
-REPO_PATH_PROVIDERS = frozenset({"codex_cli", "opencode"})
+REPO_PATH_PROVIDERS = frozenset({"codex_cli", "opencode", "devin_cli"})
 
 # Order to try providers in when nothing was configured and we are guessing
 # from whatever credentials the environment happens to carry. This is the CLI's
@@ -284,7 +285,7 @@ def get_provider(
         raise ValueError(f"Unknown provider: {name!r}. Available providers: {available}")
 
     # Attach rate limiter (skip for mock — tests should run without limits)
-    if with_rate_limiter and name not in ("mock", "codex_cli", "opencode"):
+    if with_rate_limiter and name not in ("mock", "codex_cli", "opencode", "devin_cli"):
         config = rate_limit_config or PROVIDER_DEFAULTS.get(name)
         if config and "rate_limiter" not in kwargs:
             kwargs["rate_limiter"] = RateLimiter(config)
@@ -306,6 +307,7 @@ def get_provider(
             "litellm": "litellm",
             "codex_cli": "@openai/codex",
             "opencode": "opencode",
+            "devin_cli": "devin",
         }
         package = _missing.get(name, name)
         raise ImportError(

--- a/packages/core/src/repowise/core/rate_limiter.py
+++ b/packages/core/src/repowise/core/rate_limiter.py
@@ -68,6 +68,8 @@ PROVIDER_DEFAULTS: dict[str, RateLimitConfig] = {
     "deepseek": RateLimitConfig(requests_per_minute=1_000, tokens_per_minute=5_000_000),
     "kimi": RateLimitConfig(requests_per_minute=1_000, tokens_per_minute=5_000_000),
     "edenai": RateLimitConfig(requests_per_minute=1_000, tokens_per_minute=2_000_000),
+    # Local Devin CLI (devin -p) — usage is controlled by the CLI, but keep a cap
+    "devin_cli": RateLimitConfig(requests_per_minute=1_000, tokens_per_minute=10_000_000),
 }
 
 

--- a/packages/server/src/repowise/server/provider_config.py
+++ b/packages/server/src/repowise/server/provider_config.py
@@ -141,6 +141,19 @@ PROVIDER_CATALOG: list[dict[str, Any]] = [
         "env_keys": [],
         "requires_key": False,
     },
+    {
+        "id": "devin_cli",
+        "name": "Devin CLI",
+        "default_model": "devin_cli/default",
+        "models": [
+            "devin_cli/default",
+            "devin_cli/opus",
+            "devin_cli/claude-sonnet-5-medium",
+            "devin_cli/swe-1-6",
+        ],
+        "env_keys": [],
+        "requires_key": False,
+    },
 ]
 
 _CATALOG_BY_ID = {p["id"]: p for p in PROVIDER_CATALOG}

--- a/packages/web/src/components/settings/provider-section.tsx
+++ b/packages/web/src/components/settings/provider-section.tsx
@@ -19,7 +19,7 @@ import {
   type SaveState,
 } from "@repowise-dev/ui/settings";
 
-const PROVIDERS = ["gemini", "openai", "anthropic", "deepseek", "kimi", "edenai", "opencode", "ollama", "litellm", "mock"] as const;
+const PROVIDERS = ["gemini", "openai", "anthropic", "deepseek", "kimi", "edenai", "opencode", "devin_cli", "ollama", "litellm", "mock"] as const;
 const EMBEDDERS = ["mock", "gemini", "openai", "openrouter", "edenai", "ollama"] as const;
 
 const MODEL_PLACEHOLDERS: Record<string, string> = {
@@ -30,6 +30,7 @@ const MODEL_PLACEHOLDERS: Record<string, string> = {
   kimi: "kimi-for-coding",
   edenai: "mistral/mistral-small-latest",
   opencode: "opencode/default",
+  devin_cli: "devin_cli/default",
   ollama: "qwen3.5:4b",
   litellm: "groq/llama-3.1-70b-versatile",
   mock: "mock",
@@ -45,6 +46,7 @@ const PROVIDER_ENV_VARS: Record<string, { vars: string[]; installHint: string }>
   edenai: { vars: ["EDENAI_API_KEY"], installHint: "pip install openai" },
   litellm: { vars: ["LITELLM_*"], installHint: "pip install litellm" },
   opencode: { vars: [], installHint: "curl -fsSL https://opencode.ai/install | bash" },
+  devin_cli: { vars: [], installHint: "curl -fsSL https://cli.devin.ai/install.sh | bash" },
   mock: { vars: [], installHint: "No key needed" },
 };
 

--- a/tests/providers/test_registry.py
+++ b/tests/providers/test_registry.py
@@ -27,6 +27,7 @@ class TestListProviders:
         assert "ollama" in providers
         assert "litellm" in providers
         assert "codex_cli" in providers
+        assert "devin_cli" in providers
         assert "mock" in providers
         assert "kimi" in providers
 
@@ -117,5 +118,5 @@ class TestCustomProviderRegistration:
         assert received.get("api_key") == "key-123"
 
     def test_builtin_count(self) -> None:
-        """Sanity check: we have exactly 11 built-in providers."""
-        assert len(_BUILTIN_PROVIDERS) == 12
+        """Sanity check: we have exactly 13 built-in providers."""
+        assert len(_BUILTIN_PROVIDERS) == 13

--- a/tests/unit/cli/test_init_ux.py
+++ b/tests/unit/cli/test_init_ux.py
@@ -241,7 +241,12 @@ def test_an_unusable_ollama_url_says_so_instead_of_blaming_the_daemon(
 def test_the_keyless_providers_get_setup_help_instead_of_a_key_prompt() -> None:
     """Ollama used to be registered like a hosted provider, so selecting it
     asked for an API key it does not have and bounced forever on Enter."""
-    assert set(provider_selection._LOCAL_PROVIDER_SETUP) == {"codex_cli", "opencode", "ollama"}
+    assert set(provider_selection._LOCAL_PROVIDER_SETUP) == {
+        "codex_cli",
+        "devin_cli",
+        "opencode",
+        "ollama",
+    }
     for name, lines in provider_selection._LOCAL_PROVIDER_SETUP.items():
         rendered = "\n".join(lines()).lower()
         assert rendered.strip(), f"{name} has no setup help"

--- a/tests/unit/server/mcp/test_answer_synthesis_timeout.py
+++ b/tests/unit/server/mcp/test_answer_synthesis_timeout.py
@@ -136,6 +136,7 @@ def test_every_builtin_provider_has_a_deliberate_budget():
         "ollama": 120.0,
         "litellm": 120.0,
         "codex_cli": 180.0,
+        "devin_cli": 180.0,
         "opencode": 180.0,
     }
     assert set(expected) == set(_BUILTIN_PROVIDERS), (
@@ -147,9 +148,10 @@ def test_every_builtin_provider_has_a_deliberate_budget():
 
 def test_agent_cli_budget_stays_under_its_own_subprocess_ceiling():
     """The caller must give up before the subprocess does, or the error is wrong."""
-    from repowise.core.providers.llm import codex_cli, opencode
+    from repowise.core.providers.llm import codex_cli, devin_cli, opencode
 
     assert codex_cli.CodexCliProvider.interactive_timeout_s < codex_cli._EXEC_TIMEOUT_SECONDS
+    assert devin_cli.DevinCliProvider.interactive_timeout_s < devin_cli._EXEC_TIMEOUT_SECONDS
     assert opencode.OpenCodeProvider.interactive_timeout_s < opencode._EXEC_TIMEOUT_SECONDS
 
 

--- a/tests/unit/test_providers/test_devin_cli_provider.py
+++ b/tests/unit/test_providers/test_devin_cli_provider.py
@@ -1,0 +1,418 @@
+"""Unit tests for DevinCliProvider.
+
+All tests mock the Devin subprocess; no real Devin CLI calls are made.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from repowise.core.providers.llm.base import GeneratedResponse, ProviderError
+from repowise.core.providers.llm.devin_cli import (
+    DevinCliProvider,
+    _load_devin_model_catalog,
+    _model_label,
+    _normalize_model,
+    _parse_devin_models,
+    _validate_model_name,
+)
+
+
+class FakeProcess:
+    def __init__(
+        self,
+        *,
+        returncode: int = 0,
+        stdout: str = "",
+        stderr: str = "",
+        on_communicate: Any | None = None,
+        transport: Any | None = None,
+    ) -> None:
+        self.returncode = returncode
+        self._stdout = stdout
+        self._stderr = stderr
+        self._on_communicate = on_communicate
+        self._transport = transport
+        self.killed = False
+
+    async def communicate(self, _input: bytes | None = None) -> tuple[bytes, bytes]:
+        if self._on_communicate is not None:
+            await self._on_communicate()
+        return self._stdout.encode("utf-8"), self._stderr.encode("utf-8")
+
+    def kill(self) -> None:
+        self.killed = True
+
+    async def wait(self) -> int:
+        return self.returncode
+
+
+class FakeTransport:
+    def __init__(self) -> None:
+        self.closed = False
+
+    def close(self) -> None:
+        self.closed = True
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_model():
+    assert _normalize_model(None) is None
+    assert _normalize_model("devin_cli/default") is None
+    assert _normalize_model("opus") == "opus"
+    assert _normalize_model("devin_cli/opus") == "opus"
+    assert _normalize_model("devin_cli/MODEL_GPT_5_2_LOW") == "MODEL_GPT_5_2_LOW"
+
+
+def test_model_label():
+    assert _model_label(None) == "devin_cli/default"
+    assert _model_label("opus") == "devin_cli/opus"
+    assert _model_label("devin_cli/claude-opus-5-medium") == "devin_cli/claude-opus-5-medium"
+
+
+def test_validate_model_name_accepts_valid_names():
+    for name in [
+        "opus",
+        "claude-opus-5-medium",
+        "MODEL_GPT_5_2_LOW",
+        "swe-1-6-fast",
+        "gpt-5-6-luna-medium",
+    ]:
+        _validate_model_name(name)
+
+
+def test_validate_model_name_rejects_shell_metacharacters():
+    for name in ["bad; ls", "name$(whoami)", "name|cat", "`evil`", "name name"]:
+        with pytest.raises(ProviderError, match="Invalid model name"):
+            _validate_model_name(name)
+
+
+def test_parse_devin_models_extracts_variants():
+    raw = {
+        "families": [
+            {
+                "family_label": "Claude Opus 5",
+                "family_uid": "claude-opus-5",
+                "slug": "claude-opus-5",
+                "aliases": ["opus"],
+                "variants": [
+                    {
+                        "model_uid": "claude-opus-5-medium",
+                        "label": "Claude Opus 5 Medium",
+                        "max_context_tokens": 1000000,
+                        "max_output_tokens": 128000,
+                    },
+                    {
+                        "model_uid": "claude-opus-5-low",
+                        "label": "Claude Opus 5 Low",
+                        "max_context_tokens": 1000000,
+                        "max_output_tokens": 128000,
+                    },
+                ],
+            },
+            {
+                "family_label": "Unknown",
+                "variants": [
+                    {"bad": "entry"},
+                ],
+            },
+        ]
+    }
+
+    models = _parse_devin_models(raw)
+    assert len(models) == 2
+    assert set(models) == {
+        ("claude-opus-5-low", "Claude Opus 5 Low", 1000000, 128000),
+        ("claude-opus-5-medium", "Claude Opus 5 Medium", 1000000, 128000),
+    }
+
+
+def test_parse_devin_models_ignores_invalid_input():
+    assert _parse_devin_models(None) == []
+    assert _parse_devin_models({"not_families": []}) == []
+    assert _parse_devin_models([]) == []
+
+
+def test_load_devin_model_catalog_with_valid_json(monkeypatch):
+    completed = type(
+        "Completed",
+        (),
+        {
+            "returncode": 0,
+            "stdout": json.dumps(
+                {
+                    "families": [
+                        {
+                            "variants": [
+                                {
+                                    "model_uid": "swe-1-6",
+                                    "label": "SWE-1.6",
+                                    "max_context_tokens": 200000,
+                                    "max_output_tokens": 128000,
+                                },
+                            ]
+                        }
+                    ]
+                }
+            ),
+        },
+    )()
+    _load_devin_model_catalog.cache_clear()
+    monkeypatch.setattr("subprocess.run", lambda *_a, **_k: completed)
+    catalog = _load_devin_model_catalog("devin")
+    assert catalog == [("swe-1-6", "SWE-1.6", 200000, 128000)]
+
+
+# ---------------------------------------------------------------------------
+# Provider metadata
+# ---------------------------------------------------------------------------
+
+
+def test_provider_name_and_default_model(monkeypatch, tmp_path):
+    monkeypatch.setattr("shutil.which", lambda _cmd: "devin")
+
+    provider = DevinCliProvider(repo_path=tmp_path)
+
+    assert provider.provider_name == "devin_cli"
+    assert provider.model_name == "devin_cli/default"
+
+
+def test_custom_model_is_normalized(monkeypatch, tmp_path):
+    monkeypatch.setattr("shutil.which", lambda _cmd: "devin")
+
+    assert DevinCliProvider(model="opus", repo_path=tmp_path).model_name == "devin_cli/opus"
+    assert (
+        DevinCliProvider(model="devin_cli/claude-opus-5-medium", repo_path=tmp_path).model_name
+        == "devin_cli/claude-opus-5-medium"
+    )
+    assert (
+        DevinCliProvider(model="devin_cli/default", repo_path=tmp_path).model_name
+        == "devin_cli/default"
+    )
+
+
+def test_invalid_model_name_raises(monkeypatch, tmp_path):
+    monkeypatch.setattr("shutil.which", lambda _cmd: "devin")
+
+    with pytest.raises(ProviderError, match="Invalid model name"):
+        DevinCliProvider(model="bad; name", repo_path=tmp_path)
+
+
+def test_missing_cli_raises(monkeypatch, tmp_path):
+    monkeypatch.setattr("shutil.which", lambda _cmd: None)
+
+    with pytest.raises(ProviderError, match="Devin CLI not found"):
+        DevinCliProvider(repo_path=tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# Generation
+# ---------------------------------------------------------------------------
+
+
+async def test_generate_invokes_devin_with_prompt_file(monkeypatch, tmp_path):
+    devin_cmd = str(tmp_path / "bin" / "devin")
+    monkeypatch.setattr("shutil.which", lambda _cmd: devin_cmd)
+    captured: dict[str, Any] = {}
+    proc = FakeProcess(stdout="Hello from Devin", stderr="")
+
+    async def fake_exec(*args: str, **kwargs: Any) -> FakeProcess:
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        prompt_file = Path(args[args.index("--prompt-file") + 1])
+        assert prompt_file.exists()
+        captured["prompt_content"] = prompt_file.read_text(encoding="utf-8")
+        return proc
+
+    monkeypatch.setattr("asyncio.create_subprocess_exec", fake_exec)
+
+    provider = DevinCliProvider(model="opus", repo_path=tmp_path)
+    result = await provider.generate("system rules", "user context")
+
+    assert isinstance(result, GeneratedResponse)
+    assert result.content == "Hello from Devin"
+    assert result.usage["estimated"] is True
+    assert result.usage["source"] == "devin_cli"
+
+    args = list(captured["args"])
+    assert args[0] == devin_cmd
+    assert "-p" in args
+    assert "--prompt-file" in args
+    assert "--respect-workspace-trust" in args
+    assert "false" in args
+    assert "--permission-mode" in args
+    assert "auto" in args
+    assert args[args.index("--model") + 1] == "opus"
+    assert "devin_prompt_" in args[args.index("--prompt-file") + 1]
+    assert captured["kwargs"]["cwd"] == str(tmp_path.resolve())
+
+    # Verify the prompt file was written and contains the combined prompt
+    written = captured["prompt_content"]
+    assert "system rules" in written
+    assert "user context" in written
+    assert "Do not edit any files" in written
+
+
+async def test_generate_default_model_omits_model_flag(monkeypatch, tmp_path):
+    monkeypatch.setattr("shutil.which", lambda _cmd: "devin")
+    captured: dict[str, Any] = {}
+
+    async def fake_exec(*args: str, **kwargs: Any) -> FakeProcess:
+        captured["args"] = args
+        return FakeProcess(stdout="OK")
+
+    monkeypatch.setattr("asyncio.create_subprocess_exec", fake_exec)
+
+    await DevinCliProvider(repo_path=tmp_path).generate("sys", "user")
+
+    args = list(captured["args"])
+    assert "--model" not in args
+
+
+async def test_generate_raises_on_nonzero_exit(monkeypatch, tmp_path):
+    monkeypatch.setattr("shutil.which", lambda _cmd: "devin")
+
+    async def fake_exec(*_args: str, **_kwargs: Any) -> FakeProcess:
+        return FakeProcess(returncode=1, stdout="", stderr="not logged in")
+
+    monkeypatch.setattr("asyncio.create_subprocess_exec", fake_exec)
+
+    with pytest.raises(ProviderError, match="not logged in"):
+        await DevinCliProvider(repo_path=tmp_path).generate("sys", "user")
+
+
+async def test_generate_raises_when_stdout_is_empty(monkeypatch, tmp_path):
+    monkeypatch.setattr("shutil.which", lambda _cmd: "devin")
+
+    async def fake_exec(*_args: str, **_kwargs: Any) -> FakeProcess:
+        return FakeProcess(stdout="", stderr="")
+
+    monkeypatch.setattr("asyncio.create_subprocess_exec", fake_exec)
+
+    with pytest.raises(ProviderError, match="no output"):
+        await DevinCliProvider(repo_path=tmp_path).generate("sys", "user")
+
+
+async def test_generate_closes_subprocess_transport(monkeypatch, tmp_path):
+    monkeypatch.setattr("shutil.which", lambda _cmd: "devin")
+    transport = FakeTransport()
+
+    async def fake_exec(*_args: str, **_kwargs: Any) -> FakeProcess:
+        return FakeProcess(stdout="OK", transport=transport)
+
+    monkeypatch.setattr("asyncio.create_subprocess_exec", fake_exec)
+
+    await DevinCliProvider(repo_path=tmp_path).generate("sys", "user")
+
+    assert transport.closed is True
+
+
+async def test_generate_serializes_subprocess_calls(monkeypatch, tmp_path):
+    monkeypatch.setattr("shutil.which", lambda _cmd: "devin")
+    active = 0
+    max_active = 0
+
+    async def on_communicate() -> None:
+        nonlocal active, max_active
+        active += 1
+        max_active = max(max_active, active)
+        await asyncio.sleep(0.01)
+        active -= 1
+
+    async def fake_exec(*_args: str, **_kwargs: Any) -> FakeProcess:
+        return FakeProcess(stdout="OK", on_communicate=on_communicate)
+
+    monkeypatch.setattr("asyncio.create_subprocess_exec", fake_exec)
+    provider = DevinCliProvider(repo_path=tmp_path)
+
+    await asyncio.gather(
+        provider.generate("sys", "user 1"),
+        provider.generate("sys", "user 2"),
+    )
+
+    assert max_active == 1
+
+
+async def test_generate_times_out_and_kills_process(monkeypatch, tmp_path):
+    monkeypatch.setattr("shutil.which", lambda _cmd: "devin")
+    monkeypatch.setattr(
+        "repowise.core.providers.llm.devin_cli._EXEC_TIMEOUT_SECONDS",
+        0.01,
+    )
+
+    async def on_communicate() -> None:
+        await asyncio.sleep(1)
+
+    proc = FakeProcess(stdout="", on_communicate=on_communicate)
+
+    async def fake_exec(*_args: str, **_kwargs: Any) -> FakeProcess:
+        return proc
+
+    monkeypatch.setattr("asyncio.create_subprocess_exec", fake_exec)
+
+    with pytest.raises(ProviderError, match="timed out"):
+        await DevinCliProvider(repo_path=tmp_path).generate("sys", "user")
+
+    assert proc.killed
+
+
+async def test_generate_handles_file_not_found(monkeypatch, tmp_path):
+    monkeypatch.setattr("shutil.which", lambda _cmd: "devin")
+
+    async def fake_exec(*_args: str, **_kwargs: Any) -> FakeProcess:
+        raise FileNotFoundError("No such file")
+
+    monkeypatch.setattr("asyncio.create_subprocess_exec", fake_exec)
+
+    with pytest.raises(ProviderError, match="Devin CLI not found"):
+        await DevinCliProvider(repo_path=tmp_path).generate("sys", "user")
+
+
+# ---------------------------------------------------------------------------
+# Model catalog
+# ---------------------------------------------------------------------------
+
+
+def test_available_model_options_with_catalog(monkeypatch, tmp_path):
+    monkeypatch.setattr("shutil.which", lambda _cmd: "devin")
+    monkeypatch.setattr(
+        "repowise.core.providers.llm.devin_cli._load_devin_model_catalog",
+        lambda _cmd: [
+            ("swe-1-6", "SWE-1.6", 200000, 128000),
+            ("claude-opus-5-medium", "Claude Opus 5 Medium", 1000000, 128000),
+        ],
+    )
+
+    options = DevinCliProvider(repo_path=tmp_path).available_model_options()
+
+    assert options[0].model == "devin_cli/default"
+    assert options[0].recommended is True
+    assert options[0].source == "local"
+    assert options[1].model == "devin_cli/claude-opus-5-medium"
+    assert options[1].label == "Claude Opus 5 Medium"
+    assert options[1].reasoning_modes == ("auto",)
+    assert options[2].model == "devin_cli/swe-1-6"
+
+
+def test_available_model_options_fallback(monkeypatch, tmp_path):
+    monkeypatch.setattr("shutil.which", lambda _cmd: "devin")
+    monkeypatch.setattr(
+        "repowise.core.providers.llm.devin_cli._load_devin_model_catalog",
+        lambda _cmd: None,
+    )
+
+    options = DevinCliProvider(repo_path=tmp_path).available_model_options()
+
+    assert len(options) == 1
+    assert options[0].model == "devin_cli/default"
+    assert options[0].recommended is True
+    assert options[0].source == "fallback"

--- a/website/devin-cli.md
+++ b/website/devin-cli.md
@@ -1,0 +1,98 @@
+---
+layout: default
+title: Devin CLI Integration
+nav_order: 5.7
+---
+
+# Devin CLI Integration
+{: .no_toc }
+
+Use Repowise with Devin via the `devin_cli` LLM provider. No API keys — the Devin CLI manages authentication and billing.
+{: .fs-6 .fw-300 }
+
+---
+
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+---
+
+## Quick setup
+
+```bash
+curl -fsSL https://cli.devin.ai/install.sh | bash  # macOS / Linux / WSL
+irm https://static.devin.ai/cli/setup.ps1 | iex     # Windows
+
+devin auth login
+
+cd /path/to/your-repo
+repowise init --provider devin_cli --yes
+```
+
+Devin is detected automatically when `devin` is on `PATH` and logged in. No API keys to store.
+
+## Provider
+
+`devin_cli` uses your local Devin CLI:
+
+```bash
+repowise init --provider devin_cli --yes
+```
+
+It runs:
+
+```bash
+devin -p --prompt-file <tmp> --cd <repo> --model <model> --permission-mode auto --respect-workspace-trust false
+```
+
+Repowise writes the combined system + user prompt to a temp file, runs a non-interactive Devin session, and uses stdout as the response. Token usage is not available from the CLI, so `devin_cli/*` cost is reported as `$0.00`.
+
+### Model selection
+
+`devin_cli/default` uses Devin's configured default model. To pick a specific model:
+
+```bash
+repowise init --provider devin_cli --model devin_cli/opus
+```
+
+Models can be listed with:
+
+```bash
+devin models list
+```
+
+### Interactive selection
+
+When you run `repowise init` interactively, the provider table includes `devin_cli` with a status indicator. If Devin is installed and authenticated, it shows as available and you can select it directly.
+
+If Devin is not installed, the interactive prompt shows the install and login commands.
+
+## Reasoning
+
+The `devin_cli` provider does not pass explicit reasoning effort flags. Devin selects the reasoning level through the model ID (for example, `claude-opus-5-low` vs `claude-opus-5-high`). Pick the model variant that matches the desired reasoning effort.
+
+## Safety
+
+The provider invokes Devin with:
+
+- `--permission-mode auto` — only auto-approves read-only tools.
+- `--respect-workspace-trust false` — prevents an interactive workspace trust prompt.
+- An explicit "do not edit any files" instruction in the prompt.
+
+## Comparison with other CLI providers
+
+| Aspect | `devin_cli` | `codex_cli` | `opencode` |
+|---|---|---|---|
+| CLI | `devin -p` | `codex exec` | `opencode run` |
+| Auth | `devin auth login` | `codex login` | OpenCode providers |
+| Output | plain text | JSONL | JSONL |
+| Model list | `devin models list --format json` | `codex debug models` | `opencode models` |
+| Key storage | No | No | No |
+
+## Official docs
+
+- [Devin CLI](https://docs.devin.ai/cli)
+- [Devin CLI commands](https://docs.devin.ai/cli/reference/commands)


### PR DESCRIPTION
## Summary

- Adds a new local `devin_cli` provider that shells out to the authenticated Devin CLI (`devin -p`) for one-shot documentation generation.
- Wires the provider into the registry, CLI picker, server catalog, rate-limiter defaults, and web settings.
- Discovers available models via `devin models list --format json`.
- Adds unit tests, a design doc (`docs/agent/DEVIN.md`), and user docs (`website/devin-cli.md`).

## Related Issues

None

## Test Plan

- [x] `uv run pytest tests/unit/test_providers tests/providers` — 309 passed
- [x] `uv run ruff check` / `ruff format` on changed Python files
- [x] `npm run lint` — no ESLint warnings
- [x] `npm run type-check` — passed
- [x] `npm run build` — built successfully
- [x] Manual end-to-end test on local project with `devin_cli/swe-1-7` produced a complete 14-page wiki

## Checklist

- [x] My code follows the project's code style
- [x] I have added tests for new functionality
- [x] All existing tests still pass
- [x] I have updated documentation if needed