### PR TITLE
docs: count COMMERCIAL.md's tools the way the doc counts them

### DIFF
--- a/tests/unit/cli/test_agent_matrix.py
+++ b/tests/unit/cli/test_agent_matrix.py
@@ -234,8 +234,15 @@ COUNT_CLAIMS: tuple[tuple[str, str, str], ...] = (
     ("docs/README.md", "flagship", "The {w} task-shaped tools,"),
     ("docs/agent/MCP_TOOLS.md", "total", "{n} tools are registered in total"),
     ("docs/agent/MCP_TOOLS.md", "single_repo", "advertises {n} by default"),
-    ("docs/business/COMMERCIAL.md", "single_repo", "the {w} MCP tools,"),
-    ("docs/business/COMMERCIAL.md", "single_repo", "| {W} MCP tools |"),
+    # COMMERCIAL.md counts the flagship tools and names `list_repos` alongside
+    # them, the same convention the README uses.
+    ("docs/business/COMMERCIAL.md", "flagship", "the {w} MCP tools,"),
+    ("docs/business/COMMERCIAL.md", "flagship", "**{W} task-shaped MCP tools**"),
+    (
+        "docs/business/COMMERCIAL.md",
+        "flagship",
+        "| {W} task-shaped MCP tools (plus `list_repos`) |",
+    ),
     ("docs/start/USER_GUIDE.md", "single_repo", "**{W} tools, task-shaped.**"),
     ("docs/architecture/pluggable-storage.md", "single_repo", "{w} MCP tools still expose"),
     ("website/mcp-server.md", "total", "It registers {n} tools:"),


### PR DESCRIPTION
Main has been red since #1766 on every push, across all three Python versions. Three failures in `tests/unit/cli/test_agent_matrix.py`:

```
docs/business/COMMERCIAL.md does not say 'the eleven MCP tools,'
docs/business/COMMERCIAL.md does not say '| Eleven MCP tools |'
docs/business/COMMERCIAL.md still carries a superseded count: ['the ten MCP tools,']
```

Nothing about the MCP surface changed. #1766 moved COMMERCIAL.md onto the flagship convention, which is the right copy:

```diff
-intelligence layers, the eleven MCP tools, …
+intelligence layers, the ten MCP tools, …
-| Eleven MCP tools | ✅ | ✅ |
+| Ten task-shaped MCP tools (plus `list_repos`) | ✅ | ✅ |
```

`COUNT_CLAIMS` still pinned both of those sentences to the `single_repo` key, so the guard demanded "eleven" of a file that was already correct, and the second row's phrase no longer matched the rewritten table cell at all. The doc was right and the test was stale.

Both rows now point at `flagship` and match the new wording. The bullet above the table (`**Ten task-shaped MCP tools**`) publishes the same count and had no row of its own, which made it the next sentence to drift unnoticed, so it gets one.

No production code touched. 85 passed in the module, `ruff check .` clean.
