### PR TITLE
fix(pipeline): report dynamic hint extraction failures on update path…

### DIFF
--- a/packages/core/src/repowise/core/pipeline/incremental.py
+++ b/packages/core/src/repowise/core/pipeline/incremental.py
@@ -210,11 +210,13 @@ def build_repo_graph(
         graph_builder.add_dynamic_edges(dynamic_edges)
         if dynamic_edges:
             log(f"Dynamic hint edges added: [cyan]{len(dynamic_edges)}[/cyan]")
-            
+
     except Exception as exc:
-        logger.warning("dynamic_hints_extraction_failed", error=str(exc), exc_info=True)
-        log(f"[yellow]Dynamic hint extraction failed: {exc}. Dynamic edges will be missing from this update.[/yellow]")
-        
+        logger.warning("dynamic_hints_extraction_failed", error=str(exc))
+        log(
+            f"[yellow]Dynamic hint extraction failed: {exc}. Dynamic edges"
+            "will be missing from this update.[/yellow]"
+        )
 
     return parsed_files, source_map, graph_builder, repo_structure, len(file_infos)
 

--- a/packages/core/src/repowise/core/pipeline/incremental.py
+++ b/packages/core/src/repowise/core/pipeline/incremental.py
@@ -210,8 +210,11 @@ def build_repo_graph(
         graph_builder.add_dynamic_edges(dynamic_edges)
         if dynamic_edges:
             log(f"Dynamic hint edges added: [cyan]{len(dynamic_edges)}[/cyan]")
-    except Exception:
-        pass  # dynamic hints are best-effort, same as the init phase
+            
+    except Exception as exc:
+        logger.warning("dynamic_hints_extraction_failed", error=str(exc), exc_info=True)
+        log(f"[yellow]Dynamic hint extraction failed: {exc}. Dynamic edges will be missing from this update.[/yellow]")
+        
 
     return parsed_files, source_map, graph_builder, repo_structure, len(file_infos)
 

--- a/tests/unit/pipeline/test_update_graph_convergence.py
+++ b/tests/unit/pipeline/test_update_graph_convergence.py
@@ -11,17 +11,17 @@ These tests build both graph shapes over the same small git repo and assert
 node/edge convergence plus equality of the centrality-cache signatures (the
 exact keys the cache hits on).
 """
-
 from __future__ import annotations
 
 from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import patch
 
 from repowise.core.ingestion import ASTParser, FileTraverser, GraphBuilder
 from repowise.core.ingestion.git_indexer import GitIndexer
 from repowise.core.ingestion.git_indexer.tiers import GitIndexTier
 from repowise.core.ingestion.graph._centrality_cache import subgraph_signature
-from repowise.core.pipeline.incremental import rebuild_graph_and_git
+from repowise.core.pipeline.incremental import build_repo_graph, rebuild_graph_and_git
 
 
 def _build_git_repo(tmp_path: Path) -> None:
@@ -109,3 +109,30 @@ async def test_update_graph_converges_with_init_graph(tmp_path: Path) -> None:
     assert subgraph_signature(init_gb.symbol_subgraph()) == subgraph_signature(
         upd_gb.symbol_subgraph()
     )
+
+
+def test_dynamic_hint_failure_logs_warning_and_does_not_raise(tmp_path: Path) -> None:
+    """Dynamic hint extraction errors must log a structured warning and continue best-effort."""
+    logged_lines: list[str] = []
+
+    def capture_log(msg: str) -> None:
+        logged_lines.append(msg)
+
+    # Empty repo with one dummy file
+    (tmp_path / "main.py").write_text("x = 1\n")
+
+    with patch(
+        "repowise.core.ingestion.dynamic_hints.HintRegistry.extract_all",
+        side_effect=RuntimeError("Simulated hint extraction crash"),
+    ):
+        parsed_files, source_map, graph_builder, repo_structure, count = build_repo_graph(
+            repo_path=tmp_path,
+            exclude_patterns=[],
+            log=capture_log,
+        )
+
+
+    assert graph_builder is not None
+   
+    assert any("Dynamic hint extraction failed" in line and "Dynamic edges will be missing" in line for line in logged_lines)
+    

--- a/tests/unit/pipeline/test_update_graph_convergence.py
+++ b/tests/unit/pipeline/test_update_graph_convergence.py
@@ -11,6 +11,7 @@ These tests build both graph shapes over the same small git repo and assert
 node/edge convergence plus equality of the centrality-cache signatures (the
 exact keys the cache hits on).
 """
+
 from __future__ import annotations
 
 from pathlib import Path
@@ -103,9 +104,7 @@ async def test_update_graph_converges_with_init_graph(tmp_path: Path) -> None:
 
     # The exact property the centrality cache keys on: identical file and
     # symbol subgraph signatures, so a first post-init update can hit.
-    assert subgraph_signature(init_gb.file_subgraph()) == subgraph_signature(
-        upd_gb.file_subgraph()
-    )
+    assert subgraph_signature(init_gb.file_subgraph()) == subgraph_signature(upd_gb.file_subgraph())
     assert subgraph_signature(init_gb.symbol_subgraph()) == subgraph_signature(
         upd_gb.symbol_subgraph()
     )
@@ -118,21 +117,20 @@ def test_dynamic_hint_failure_logs_warning_and_does_not_raise(tmp_path: Path) ->
     def capture_log(msg: str) -> None:
         logged_lines.append(msg)
 
-    # Empty repo with one dummy file
     (tmp_path / "main.py").write_text("x = 1\n")
 
     with patch(
         "repowise.core.ingestion.dynamic_hints.HintRegistry.extract_all",
         side_effect=RuntimeError("Simulated hint extraction crash"),
     ):
-        parsed_files, source_map, graph_builder, repo_structure, count = build_repo_graph(
+        _parsed_files, _source_map, graph_builder, _repo_structure, _count = build_repo_graph(
             repo_path=tmp_path,
             exclude_patterns=[],
             log=capture_log,
         )
 
-
     assert graph_builder is not None
-   
-    assert any("Dynamic hint extraction failed" in line and "Dynamic edges will be missing" in line for line in logged_lines)
-    
+    assert any(
+        "Dynamic hint extraction failed" in line and "missing from this update" in line
+        for line in logged_lines
+    )


### PR DESCRIPTION
… (#1697)

## Summary

- Replaced silent `except Exception: pass` block in `repowise.core.pipeline.incremental` with structured `structlog` warning and a    
   user-facing consequence log.
- Preserved best-effort non-failing behavior during incremental updates when dynamic hint extraction fails.
- Added regression test `test_dynamic_hint_failure_logs_warning_and_does_not_raise` to assert proper warning emission without            
   crashing graph construction.

-

## Related Issues

Fixes #1697

## Test Plan

Ran unit test suite locally:
```bash
pytest tests/unit/pipeline/test_update_graph_convergence.py

- [ x ] Tests pass (`pytest`)
- [ ] Lint passes (`ruff check .`)
- [ ] Web build passes (`npm run build`) *(if frontend changes)*

## Checklist

- [ x ] My code follows the project's code style
- [ x ] I have added tests for new functionality
- [ x ] All existing tests still pass
- [ ] I have updated documentation if needed
