### PR TITLE
fix(ci): restore deterministic unit-test contracts

### DIFF
--- a/packages/server/src/repowise/server/mcp_server/tool_health.py
+++ b/packages/server/src/repowise/server/mcp_server/tool_health.py
@@ -917,32 +917,30 @@ async def get_health(
 ) -> dict:
     """Code-health scores and findings — self-check a file before/after editing.
 
-    No ``targets`` → repo dashboard, led by a ``directive`` naming the one file
-    to fix first. With ``targets`` → per-file scores + findings. Rank by
-    ``weighted_deficit`` (score-points x NLOC), not ``score``, which floors at
-    1.0; ``share_of_repo_gap_pct`` is the same quantity as a percentage.
+    No ``targets`` → dashboard led by a ``directive`` naming the first file to
+    fix. With ``targets`` → per-file scores and findings. Rank by
+    ``weighted_deficit`` (score-points x NLOC), not ``score``;
+    ``share_of_repo_gap_pct`` expresses the same quantity as a percentage.
 
     Per file: ``score`` is defect risk *and* the headline — there is no
     ``defect_score`` — beside ``maintainability_score`` / ``performance_score``
     (never blended in).
 
     Args:
-        targets: file paths or ``module:<name>``. Empty → dashboard. A target
-            matching nothing is named in ``unresolved`` with a reason (so empty
-            ``findings`` means healthy); it survives any ``only``.
+        targets: file paths or ``module:<name>``. Empty → dashboard. Unmatched
+            targets appear in ``unresolved`` and survive any ``only``.
         include: ``biomarkers`` | ``refactoring`` | ``trend`` | ``coverage`` |
             ``accuracy`` | ``signals`` | ``churn_complexity`` |
             ``performance``/``defect``/``maintainability`` (dimension).
-            ``performance`` also adds the causal ``performance_opportunities``
-            head, while raw findings remain available for line inspection. Only
-            *adds*, and the ranked lists compose — pair with ``only``, e.g.
-            ``include=['refactoring'], only=['refactoring_plans']``. Over-cap
-            responses are trimmed (``_meta.truncated_to_fit``).
-        only: keep just these top-level keys; ``["directive"]`` is cheapest and
-            ``*_total`` siblings survive. Only the three block names
-            alias (``biomarkers``/``accuracy``/``refactoring``); the dimension
-            names ``performance``/``defect``/``maintainability`` and ``signals``
-            do not, and land in ``unknown_only_keys``.
+            ``performance`` also adds causal ``performance_opportunities``;
+            raw findings remain available for line inspection. This only adds
+            blocks; pair it with ``only`` to project the response. Over-budget
+            responses set ``_meta.truncated_to_fit``.
+        only: top-level keys to keep; ``["directive"]`` is cheapest and
+            ``*_total`` siblings survive. The block names ``biomarkers``,
+            ``accuracy`` and ``refactoring`` alias. Dimension names
+            ``performance``, ``defect`` and ``maintainability`` do not;
+            unknown keys are reported.
         repo: usually omitted.
         limit: max rows per ranked list (max 50, ``0`` for none).
     """

--- a/tests/unit/cli/test_command_target.py
+++ b/tests/unit/cli/test_command_target.py
@@ -8,7 +8,6 @@ auto-detection contract stays stable across refactors.
 from __future__ import annotations
 
 import json
-import os
 from pathlib import Path
 
 import click
@@ -136,9 +135,9 @@ def test_unknown_repo_alias_raises(fake_workspace, chdir):
 # ---------------------------------------------------------------------------
 
 
-def test_explicit_path_to_workspace_root_auto_promotes(fake_workspace, tmp_path):
+def test_explicit_path_to_workspace_root_auto_promotes(fake_workspace, tmp_path, monkeypatch):
     # Run from somewhere unrelated, but point path at the workspace root.
-    os.chdir(tmp_path)
+    monkeypatch.chdir(tmp_path)
     target = resolve_command_target(path=str(fake_workspace))
     assert target.mode == "workspace"
     assert target.ws_root == fake_workspace

--- a/tests/unit/server/test_graph_provenance_wire.py
+++ b/tests/unit/server/test_graph_provenance_wire.py
@@ -29,10 +29,9 @@ _LEAF = "src/app/service.py::persist"
 async def _seed(session_factory, repo_id: str) -> None:
     """A two-hop chain, each hop stamped with a different origin.
 
-    The two origins are chosen from opposite ends of the vocabulary —
-    ``same_file`` is direct evidence, ``global_unique`` is a bare name guess —
-    so a test asserting the pair also proves the field is per-edge and not a
-    constant.
+    The origins differ so asserting the pair proves the field is per-edge and
+    not a constant. Both are reliable execution evidence; ``global_unique`` is
+    deliberately excluded from execution walks because it is only a name guess.
     """
     async with get_session(session_factory) as session:
         for node_id in (_ENTRY, _MID, _LEAF):
@@ -62,7 +61,7 @@ async def _seed(session_factory, repo_id: str) -> None:
             )
         for src, tgt, origin in (
             (_ENTRY, _MID, "same_file"),
-            (_MID, _LEAF, "global_unique"),
+            (_MID, _LEAF, "import_scoped"),
         ):
             session.add(
                 GraphEdge(
@@ -107,7 +106,7 @@ async def test_a_traced_flow_carries_an_origin_per_hop(client: AsyncClient, app)
     )
     flow = resp.json()["flows"][0]
 
-    assert flow["trace_via"] == ["same_file", "global_unique"]
+    assert flow["trace_via"] == ["same_file", "import_scoped"]
     assert len(flow["trace_via"]) == len(flow["trace"]) - 1
 
 
@@ -141,7 +140,7 @@ async def test_callers_callees_carry_the_origin(client: AsyncClient, app) -> Non
     body = resp.json()
 
     assert [c["resolution_origin"] for c in body["callers"]] == ["same_file"]
-    assert [c["resolution_origin"] for c in body["callees"]] == ["global_unique"]
+    assert [c["resolution_origin"] for c in body["callees"]] == ["import_scoped"]
 
 
 @pytest.mark.asyncio
@@ -216,4 +215,4 @@ async def test_symbol_detail_carries_the_origin(client: AsyncClient, app) -> Non
     graph = resp.json()["graph"]
 
     assert [c["resolution_origin"] for c in graph["callers"]] == ["same_file"]
-    assert [c["resolution_origin"] for c in graph["callees"]] == ["global_unique"]
+    assert [c["resolution_origin"] for c in graph["callees"]] == ["import_scoped"]


### PR DESCRIPTION
## Summary

- trim `get_health` documentation from 1,741 to 1,523 characters so the generated MCP schema stays within its 1,600-character budget
- keep execution-flow provenance tests on resolver origins that are valid execution evidence
- restore the working directory after the command-target test so later source-inspection tests do not depend on suite order

## Why main was red

The latest Python matrix had five failures. One was the MCP schema budget regression introduced by the expanded performance guidance. Two graph assertions still expected traversal through `global_unique`, even though the shared execution policy correctly treats that origin as an unreliable name guess. The remaining two BLAS tests failed only in the full suite because an earlier test leaked its temporary working directory.

## Verification

- `31 passed`: command-target, BLAS-thread, graph-provenance, and MCP-docstring suites
- `99 passed`: health, coverage-decay, and performance-ranking suites
- Ruff passes on all changed files
- `git diff --check` passes
