### PR TITLE
feat(languages): add GDScript / Godot support at the Good tier

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,11 +487,7 @@ the orchestrators. Full matrix and the contributor recipe:
 
 ## Supported languages
 
-**19 languages parsed to AST · 35 on a five-rung ladder · framework-aware across
-all of them.**
-
-"Do you support X" has five useful answers, not two, so languages land on a
-ladder and every rung says what it buys you.
+**20 languages parsed to AST · 13 at the Full tier · framework-aware across all of them.**
 
 <details>
 <summary><strong>See the complete language ladder</strong></summary>
@@ -519,6 +515,7 @@ ladder and every rung says what it buys you.
   <img src="https://img.shields.io/badge/PHP-777BB4?style=flat-square&logo=php&logoColor=white" alt="PHP" />
   <img src="https://img.shields.io/badge/Dart-0175C2?style=flat-square&logo=dart&logoColor=white" alt="Dart" />
   <img src="https://img.shields.io/badge/Delphi-EE1F35?style=flat-square&logo=delphi&logoColor=white" alt="Object Pascal / Delphi" />
+  <img src="https://img.shields.io/badge/GDScript-478CBF?style=flat-square&logo=godotengine&logoColor=white" alt="GDScript / Godot" />
   &nbsp;<strong>· Partial &nbsp;</strong>
   <img src="https://img.shields.io/badge/Luau-00A2FF?style=flat-square&logo=lua&logoColor=white" alt="Luau" />
 </p>
@@ -529,7 +526,7 @@ still doing real work rather than being ignored:
 | Rung | Languages | What you get |
 |---|---|---|
 | **Full** (13) | Python · TypeScript · JavaScript · Svelte · Vue · Java · Kotlin · Go · Rust · C++ · C# · Scala · Ruby | The whole pipeline: AST symbols, import resolution, a resolved call graph, heritage, docstrings, framework edges, **and code-health markers** |
-| **Good** (5) | C · Swift · PHP · Dart · Object Pascal | All of the above except the full health suite |
+| **Good** (6) | C · Swift · PHP · Dart · Object Pascal · GDScript | All of the above except the full health suite |
 | **Partial** (1) | Luau / Roblox | AST symbols and `require()` resolution, Rojo and `.luaurc` aware |
 | | | ⎯⎯ *tree-sitter parsing stops here; the rungs below come from git and imports* ⎯⎯ |
 | **Lightweight** (7) | Elixir · Clojure · Haskell · Lean 4 · Erlang · F# · HTML | A real file-to-file import graph, and no symbol-level claims |

--- a/docs/README.md
+++ b/docs/README.md
@@ -59,7 +59,7 @@ your agent in under five minutes, with no API key.
 | [layers/DECISIONS.md](layers/DECISIONS.md) | Architectural decisions mined from your repo and from your own agent sessions |
 | [layers/DEAD_CODE.md](layers/DEAD_CODE.md) | Unreachable files, unused exports, and zombie packages by confidence tier |
 | [layers/SECURITY.md](layers/SECURITY.md) | The local pattern scan: what the eleven patterns catch, what they do not, and how far to trust the result |
-| [layers/LANGUAGE_SUPPORT.md](layers/LANGUAGE_SUPPORT.md) | What works per language: 19 parsed to a full AST, 35 on the five-rung ladder |
+| [layers/LANGUAGE_SUPPORT.md](layers/LANGUAGE_SUPPORT.md) | What works per language, across 20 parsed languages and 13 at the Full tier |
 | [layers/WIKI.md](layers/WIKI.md) | The generated wiki: page types, what `update` re-renders, styles, output language |
 
 ## Scale it

--- a/docs/business/COMMERCIAL.md
+++ b/docs/business/COMMERCIAL.md
@@ -41,12 +41,11 @@ scale, in a regulated or security-sensitive environment**:
 
 All of the following ship in `pip install repowise` today, free for internal use.
 
-- **[Five intelligence layers](../layers/INTELLIGENCE_LAYERS.md)**: Graph
-  (tree-sitter AST across 19 languages, two-tier dependency graph, call
-  resolution, heritage extraction, Leiden communities, PageRank / betweenness /
-  SCC), Git (hotspots, ownership, co-change pairs, bus factor, significant
-  commits, contributor profiles, module health), Documentation (a wiki page per
-  module and file, freshness scoring, hybrid search), Decision (architectural
+- **Five intelligence layers** — Graph (tree-sitter AST across 20 languages, two-tier
+  dependency graph, call resolution, heritage extraction, Leiden communities,
+  PageRank / betweenness / SCC), Git (hotspots, ownership, co-change pairs, bus
+  factor, significant commits, contributor profiles, module health), Documentation
+  (LLM-generated wiki, freshness scoring, RAG search), Decision (architectural
   decision records linked to graph nodes, staleness tracking), and Code Health
   (49 deterministic detectors, 1–10 score per file, coverage ingestion, trend
   alerts). Full detail on each, and what every layer costs to build:
@@ -99,7 +98,7 @@ All of the following ship in `pip install repowise` today, free for internal use
 
 ## 3. First-class language coverage
 
-Repowise parses **19 languages to a full AST** and places **35 on a five-rung
+Repowise parses **20 languages to a full AST** and places **35 on a five-rung
 ladder**, so "do you support X" gets the rung as its answer rather than a yes or a
 no. Both numbers matter and neither is worth quoting alone.
 

--- a/docs/layers/INTELLIGENCE_LAYERS.md
+++ b/docs/layers/INTELLIGENCE_LAYERS.md
@@ -43,7 +43,7 @@ requirement for the index.
 ## Graph Intelligence
 
 tree-sitter parses your source into a **two-tier dependency graph**: file nodes
-and symbol nodes (functions, classes, methods). 19 languages parse to a full
+and symbol nodes (functions, classes, methods). 20 languages parse to a full
 AST; see [`LANGUAGE_SUPPORT.md`](LANGUAGE_SUPPORT.md) for per-language tiers.
 
 A **confidence-scored call resolver** handles import aliases, barrel

--- a/docs/layers/LANGUAGE_SUPPORT.md
+++ b/docs/layers/LANGUAGE_SUPPORT.md
@@ -1,12 +1,11 @@
 # Language Support
 
-**19 languages parsed to a full AST · 35 on the five-rung ladder ·
+**20 languages parsed to a full AST · 35 on the five-rung ladder ·
 framework-aware across all of them.** "Do you support X" has five useful answers
 rather than two, so every language lands on a rung and the rung says what it
 buys you. Everything else in your repo still appears in the wiki and is tracked
 through git history. This page is the "what works for my language today"
 reference.
-
 <p>
   <strong>Full tier &nbsp;</strong>
   <img src="https://img.shields.io/badge/Python-3776AB?style=flat-square&logo=python&logoColor=white" alt="Python" />
@@ -52,13 +51,12 @@ produce meaningful output.
 | Tier | Languages | What you get |
 |------|-----------|--------------|
 | **Full** (13) | Python · TypeScript · JavaScript · Svelte · Vue · Java · Kotlin · Go · Rust · C++ · C# · Scala · Ruby | The whole pipeline: AST symbols, import resolution, a resolved call graph, heritage, docstrings, framework edges, **and code-health markers** |
-| **Good** (5) | C · Swift · PHP · Dart · Object Pascal | Everything above except the full health suite. Dart and Object Pascal *do* get health markers; C, Swift and PHP don't yet |
+| **Good** (6) | C · Swift · PHP · Dart · Object Pascal · GDScript | Everything above except the full health suite. Dart and Object Pascal *do* get health markers; C, Swift, PHP and GDScript don't yet |
 | **Partial** (1) | Luau / Roblox | AST symbols and `require()` resolution (Rojo / `.luaurc` aware). No health markers yet |
 | | | ⎯⎯ *tree-sitter parsing stops here. The rungs below are derived from git and imports, not from an AST.* ⎯⎯ |
 | **Lightweight** (7) | Elixir · Clojure · Haskell · Lean 4 · Erlang · F# · HTML | A real file-to-file import graph, no symbol-level claims |
 | **Structural** (9) | Objective-C · R · Zig · Julia · Elm · OCaml · Crystal · Nim · D | Git history only: blame, hotspots, co-change. No AST parsing |
-
-The first three rungs are the **19 languages parsed to a full AST**; all five are
+The first three rungs are the **20 languages parsed to a full AST**; all five are
 the **35** on the ladder. Both numbers are worth stating and neither is worth
 stating alone, so if you only take one thing from this page, take the rung your
 language sits on rather than either count.
@@ -242,6 +240,27 @@ bindings and heritage, with a dedicated workspace resolver per language.
 | **PHP** | `.php` | `use Foo\Bar\Baz` with composer.json PSR-4 longest-prefix resolution; Laravel, TYPO3 edges |
 | **Dart** | `.dart` | `import` / `export` / `part` URIs, `package:` via every `pubspec.yaml`, Flutter route tables and `runApp()` edges. **Health markers included** |
 | **Object Pascal** | `.pas` `.pp` `.dpr` `.dpk` `.lpr` `.inc` | `uses` clauses via the generic unit-name → file-stem fallback; project files as entry points. **Health markers included** |
+| **GDScript** | `.gd` | `preload(...)` / `load(...)` / `extends "res://..."` resolved as absolute paths from the nearest `project.godot`, so a repo holding many Godot projects keeps each project's `res://` namespace separate |
+### GDScript known gaps
+
+Both dialects parse: GDScript 4 (`@export var`) and GDScript 3 (`export var`,
+`.method()` parent calls).
+
+- **A script without `class_name` gets no class symbol**, so its `extends`
+  produces no symbol-level heritage edge. Synthesizing a name from the file
+  stem would point the edge at a node that isn't in the graph. The
+  `extends "res://..."` import edge is unaffected and carries the dependency.
+- **`extends "res://base.gd"` is an import, not heritage** — a path is not a
+  type name.
+- **Engine methods on implicit `self`** (`get_node`, `emit_signal`, `connect`)
+  are unresolved targets; only Godot's *global* scope is filtered as builtin.
+  Same tradeoff as Pascal's framework calls.
+- **`uid://` paths and `load(some_variable)` stay external** — the first needs
+  the excluded `.uid` sidecars, the second needs dataflow. Neither is guessed.
+- **Signals share the `variable` kind** (no `signal` member in `SymbolKind`).
+- **No code-health markers yet**, and no `.tscn` / autoload / engine-callback
+  awareness — until that lands, dead-code output on a Godot project is not
+  trustworthy.
 
 ---
 

--- a/packages/core/src/repowise/core/ingestion/extractors/heritage/__init__.py
+++ b/packages/core/src/repowise/core/ingestion/extractors/heritage/__init__.py
@@ -24,6 +24,7 @@ from ..helpers import node_text
 from .cpp import _extract_cpp_heritage
 from .csharp import _extract_csharp_heritage
 from .dart import _extract_dart_heritage
+from .gdscript import _extract_gdscript_heritage
 from .go import _extract_go_heritage
 from .java import _extract_java_heritage
 from .kotlin import _extract_kotlin_heritage
@@ -62,6 +63,7 @@ HERITAGE_EXTRACTORS: dict[str, Callable[..., None]] = {
     "scala": _extract_scala_heritage,
     "php": _extract_php_heritage,
     "pascal": _extract_pascal_heritage,
+    "gdscript": _extract_gdscript_heritage,
 }
 
 

--- a/packages/core/src/repowise/core/ingestion/extractors/heritage/gdscript.py
+++ b/packages/core/src/repowise/core/ingestion/extractors/heritage/gdscript.py
@@ -1,0 +1,82 @@
+"""GDScript heritage extraction."""
+
+from __future__ import annotations
+
+from tree_sitter import Node
+
+from ...models import HeritageRelation
+from ..helpers import node_text
+
+
+def _parent_from_extends(extends_node: Node, src: str) -> str | None:
+    """Return the parent type named by an ``extends_statement``.
+
+    The grammar is ``"extends" choice($.string, $.type)`` with no field
+    names, so the payload is located by child *type*:
+
+    - ``(type)``   -> ``extends Node2D`` / ``extends Foo.Bar``. The text is
+      the parent name, matched against symbol names by HeritageResolver.
+    - ``(string)`` -> ``extends "res://base.gd"``. A *path*, not a name, so
+      it is deliberately NOT emitted as a heritage relation: HeritageResolver
+      matches ``parent_name`` against symbol names only, and a path never
+      matches one. The same statement is already captured as an import by
+      queries/gdscript.scm and resolved to a real file by resolvers/gdscript.py,
+      which is where that dependency belongs.
+    """
+    for child in extends_node.named_children:
+        if child.type == "type":
+            text = node_text(child, src).strip()
+            return text or None
+    return None
+
+
+def _extract_gdscript_heritage(
+    def_node: Node, name: str, line: int, src: str, out: list[HeritageRelation]
+) -> None:
+    """GDScript: ``extends Node2D`` / ``class_name Foo extends Bar`` /
+    ``class Inner extends Baz:``.
+
+    Two node types reach this function (see ``heritage_node_types`` in
+    languages/specs/gdscript.py):
+
+    ``class_definition`` -- an inner class. Always carries its own
+    ``extends`` field, so the lookup is direct.
+
+    ``class_name_statement`` -- the script-level class. The grammar gives it
+    an optional ``extends`` field, which is populated only for the one-line
+    form ``class_name Foo extends Bar``. Both of these are equally idiomatic
+    and far more common::
+
+        extends Node          class_name Player
+        class_name Player     extends Node
+
+    and in both the ``extends_statement`` is a *sibling* under ``source``,
+    not a child. So when the field is absent, scan the file's top level for
+    a standalone ``extends_statement``. A script may legally have only one,
+    so the first hit is the answer.
+    """
+    extends_node = def_node.child_by_field_name("extends")
+
+    if extends_node is None and def_node.type == "class_name_statement":
+        parent = def_node.parent
+        if parent is not None:
+            for sibling in parent.named_children:
+                if sibling.type == "extends_statement":
+                    extends_node = sibling
+                    break
+
+    if extends_node is None:
+        return
+
+    parent_name = _parent_from_extends(extends_node, src)
+    if not parent_name or parent_name == name:
+        return
+
+    out.append(
+        HeritageRelation(
+            child_name=name,
+            parent_name=parent_name,
+            kind="extends",
+            line=line,
+        )
+    )

--- a/packages/core/src/repowise/core/ingestion/language_configs.py
+++ b/packages/core/src/repowise/core/ingestion/language_configs.py
@@ -400,6 +400,41 @@ LANGUAGE_CONFIGS: dict[str, LanguageConfig] = {
         # guessed).
         parent_class_types=frozenset({"declType"}),
     ),
+    "gdscript": LanguageConfig(
+        symbol_node_types={
+            # `class_name Foo` names the script-level class. The node spans
+            # only that statement, not the whole file -- GDScript has no
+            # syntactic node for "the implicit outer class", so there is
+            # nothing wider to point at.
+            "class_name_statement": "class",
+            "class_definition": "class",  # inner `class Foo:` blocks
+            "function_definition": "function",
+            "constructor_definition": "function",  # `func _init(...)`
+            "variable_statement": "variable",
+            "export_variable_statement": "variable",  # GDScript 3 `export var`
+            "onready_variable_statement": "variable",  # GDScript 3 `onready var`
+            "const_statement": "constant",
+            "enum_definition": "enum",
+            # No "signal"/"event" member in the SymbolKind literal. "variable"
+            # is the same bucket Pascal's `declProp` and C#'s
+            # `property_declaration` land in -- a declared member that is not
+            # a callable of this class.
+            "signal_statement": "variable",
+        },
+        # `preload(...)`/`load(...)` are ordinary calls; see queries/gdscript.scm.
+        import_node_types=["call", "extends_statement"],
+        export_node_types=[],  # GDScript has no re-export syntax
+        # GDScript's privacy convention is Python's, leading underscore and
+        # all -- including the engine callbacks (`_ready`, `_process`), which
+        # genuinely are not meant to be called by other scripts. Reusing
+        # py_visibility rather than adding a byte-identical gdscript_visibility.
+        visibility_fn=py_visibility,
+        parent_extraction="nesting",
+        # Only class_definition: `class_name_statement` is a sibling of the
+        # members it logically owns, not their ancestor, so a script-level
+        # func gets no parent -- which is correct, it belongs to the file.
+        parent_class_types=frozenset({"class_definition"}),
+    ),
     "luau": LanguageConfig(
         symbol_node_types={
             "function_declaration": "function",

--- a/packages/core/src/repowise/core/ingestion/languages/specs/__init__.py
+++ b/packages/core/src/repowise/core/ingestion/languages/specs/__init__.py
@@ -24,6 +24,7 @@ from .elixir import SPEC as _ELIXIR
 from .elm import SPEC as _ELM
 from .erlang import SPEC as _ERLANG
 from .fsharp import SPEC as _FSHARP
+from .gdscript import SPEC as _GDSCRIPT
 from .go import SPEC as _GO
 from .graphql import SPEC as _GRAPHQL
 from .haskell import SPEC as _HASKELL
@@ -93,6 +94,7 @@ ALL_SPECS: tuple[LanguageSpec, ...] = (
     _SCALA,
     _DART,
     _PASCAL,
+    _GDSCRIPT,
     # -----------------------------------------------------------------
     # Config / data / markup languages (passthrough — no AST)
     # -----------------------------------------------------------------

--- a/packages/core/src/repowise/core/ingestion/languages/specs/gdscript.py
+++ b/packages/core/src/repowise/core/ingestion/languages/specs/gdscript.py
@@ -1,0 +1,100 @@
+"""LanguageSpec for GDScript (Godot Engine).
+
+Grammar: tree-sitter-gdscript (import name ``tree_sitter_gdscript``),
+maintained by Preston Knopp
+(https://github.com/PrestonKnopp/tree-sitter-gdscript), MIT.
+
+``heritage_node_types`` covers both places a parent can be declared:
+``class_name_statement`` (the script-level class, whose grammar carries an
+optional ``extends`` field AND may be preceded by a standalone
+``extends_statement`` sibling) and ``class_definition`` (inner classes,
+which always carry their own ``extends`` field). See
+extractors/heritage/gdscript.py for the sibling walk the first case needs.
+
+A .gd file with no ``class_name`` declares an *anonymous* class. It gets no
+class symbol and therefore no symbol-level heritage edge -- see the note in
+queries/gdscript.scm on why a synthesized file-stem name would produce a
+dangling graph node. Its ``extends "res://..."`` still yields a file-level
+import edge, which is the edge that actually carries the dependency.
+"""
+
+from ..spec import LanguageSpec
+
+SPEC = LanguageSpec(
+    tag="gdscript",
+    display_name="GDScript",
+    extensions=frozenset({".gd"}),
+    grammar_package="tree_sitter_gdscript",
+    scm_file="gdscript.scm",
+    heritage_node_types=frozenset({"class_name_statement", "class_definition"}),
+    # Dedicated resolver: `res://` is an absolute path from the directory
+    # holding project.godot, so resolution is exact rather than a stem guess.
+    import_support="full",
+    # project.godot both defines the res:// root for the resolver and marks
+    # its directory as a package boundary -- godot-demo-projects is one repo
+    # holding dozens of separate Godot projects, each with its own root.
+    manifest_files=("project.godot",),
+    # `.godot/` is the Godot 4 build/import cache and `.import/` its Godot 3
+    # equivalent; both are full of generated files. Left unblocked, they
+    # dominate any corpus measurement.
+    blocked_dirs=(".godot", ".import"),
+    # Godot re-imports assets from these and rewrites them without human
+    # involvement.
+    blocked_extensions=(".import", ".uid"),
+    shebang_tokens=(),
+    # @GlobalScope / @GDScript global functions plus the built-in *variant*
+    # constructors (Vector2, Color, ...). Engine *classes* (Node, Sprite2D,
+    # ...) are deliberately absent: those are referenced as receivers
+    # (`Node.new()`), not as bare call targets, so listing them here would
+    # buy nothing. Conservative on purpose -- a name filtered here can never
+    # form a project call edge, and project code is free to define a method
+    # that shadows one of these.
+    builtin_calls=frozenset({
+        # Output / diagnostics
+        "print", "printerr", "printraw", "printt", "prints", "print_rich",
+        "push_error", "push_warning", "assert", "breakpoint",
+        # Conversion / reflection
+        "str", "int", "float", "bool", "char", "ord", "hash", "typeof",
+        "type_string", "type_exists", "var_to_str", "str_to_var",
+        "var_to_bytes", "bytes_to_var", "weakref", "is_instance_valid",
+        "is_instance_id_valid", "instance_from_id", "len", "range",
+        # Resource loading (also captured as imports -- excluded here so the
+        # call graph does not gain a dangling `preload` node alongside the
+        # import edge the same expression already produced)
+        "preload", "load",
+        # Math
+        "abs", "absi", "absf", "min", "mini", "minf", "max", "maxi", "maxf",
+        "clamp", "clampi", "clampf", "round", "roundi", "roundf", "floor",
+        "floori", "floorf", "ceil", "ceili", "ceilf", "sign", "signi",
+        "signf", "snapped", "snappedi", "snappedf", "fmod", "fposmod",
+        "posmod", "wrap", "wrapi", "wrapf", "sqrt", "pow", "exp", "log",
+        "sin", "cos", "tan", "asin", "acos", "atan", "atan2", "sinh",
+        "cosh", "tanh", "deg_to_rad", "rad_to_deg", "linear_to_db",
+        "db_to_linear", "lerp", "lerpf", "lerp_angle", "inverse_lerp",
+        "remap", "smoothstep", "move_toward", "rotate_toward", "ease",
+        "step_decimals", "nearest_po2", "pingpong", "is_equal_approx",
+        "is_zero_approx", "is_nan", "is_inf", "is_finite",
+        # Randomness
+        "randi", "randf", "randfn", "randi_range", "randf_range",
+        "randomize", "seed", "rand_from_seed",
+        # Built-in variant constructors
+        "Vector2", "Vector2i", "Vector3", "Vector3i", "Vector4", "Vector4i",
+        "Rect2", "Rect2i", "Color", "Color8", "Plane", "Quaternion", "AABB",
+        "Basis", "Transform2D", "Transform3D", "Projection", "Callable",
+        "Signal", "StringName", "NodePath", "RID", "Dictionary", "Array",
+        "PackedByteArray", "PackedInt32Array", "PackedInt64Array",
+        "PackedFloat32Array", "PackedFloat64Array", "PackedStringArray",
+        "PackedVector2Array", "PackedVector3Array", "PackedColorArray",
+    }),
+    # The engine root types only, matching the Pascal `TObject` / Swift
+    # `NSObject` precedent. Godot ships ~800 classes and enumerating them
+    # would be arbitrary and stale within a release; an unlisted engine
+    # parent costs nothing, because HeritageResolver drops any relation
+    # whose parent name resolves to no symbol in the graph.
+    builtin_parents=frozenset({
+        "Object", "RefCounted", "Reference", "Resource", "Node",
+        "CanvasItem", "Node2D", "Node3D", "Spatial", "Control",
+    }),
+    # Godot's own brand blue.
+    color_hex="#478CBF",
+)

--- a/packages/core/src/repowise/core/ingestion/models.py
+++ b/packages/core/src/repowise/core/ingestion/models.py
@@ -39,6 +39,7 @@ LanguageTag = Literal[
     "luau",
     "dart",
     "pascal",
+    "gdscript",
     # Passthrough code languages (no AST parser yet — empty ParsedFile,
     # files enter the graph via the generic resolver). Before these tags
     # existed the traverser silently skipped such files as unknown, so e.g.

--- a/packages/core/src/repowise/core/ingestion/queries/gdscript.scm
+++ b/packages/core/src/repowise/core/ingestion/queries/gdscript.scm
@@ -1,0 +1,201 @@
+; =============================================================================
+; repowise — GDScript (Godot) symbol, import and call queries
+; tree-sitter-gdscript (PrestonKnopp/tree-sitter-gdscript) >= 6.1
+; =============================================================================
+;
+; Node-shape reference, read off src/node-types.json + grammar.js at 6.1.0
+; (not guessed -- every field name below is verified against those two files):
+;
+;   source                     := top-level; statements are DIRECT children
+;                                 (_compound_statement is an inlined rule, so
+;                                  function_definition / class_definition /
+;                                  enum_definition are children of `source`
+;                                  itself, not of a wrapper node)
+;   class_name_statement       := name:(name) icon_path:(string)?
+;                                 extends:(extends_statement)?
+;   extends_statement          := "extends" (string | type)   -- NO field names
+;   class_definition           := name:(name) extends:(extends_statement)?
+;                                 body:(class_body)
+;   function_definition        := name:(name)? parameters:(parameters)
+;                                 return_type:(type)? body:(body)?
+;   constructor_definition     := "func" "_init" parameters:(parameters) ...
+;                                 -- carries NO `name` field; the name is the
+;                                    anonymous "_init" token, captured as such
+;   variable_statement         := name:(name) type:? value:? setget:? static:?
+;   export_variable_statement  := GDScript 3 `export var x` (GDScript 4 spells
+;                                 it `@export var x`, which parses as an
+;                                 ordinary variable_statement carrying an
+;                                 `annotations` child -- both are covered)
+;   onready_variable_statement := GDScript 3 `onready var x`
+;   const_statement            := name:(name) type:? value:(_expression)
+;   signal_statement           := name:(name) parameters:(parameters)?
+;   enum_definition            := name:(name)? body:(enumerator_list)
+;   call                       := (_primary_expression) arguments:(arguments)
+;   attribute_call             := (identifier) arguments:(arguments)
+;                                 -- `obj.method()` parses as an `attribute`
+;                                    holding an attribute_call, NOT as `call`
+;   base_call                  := "." (identifier) arguments:(arguments)
+;
+; Full res:// import resolution lives in resolvers/gdscript.py; this file only
+; emits the raw quoted path as @import.module. parser.py strips the quotes
+; before the resolver sees it (`.strip("\"'` ")`), so `preload("res://a.gd")`
+; arrives there as `res://a.gd`.
+
+; ---------------------------------------------------------------
+; Script-level class declaration -- `class_name Player`.
+;
+; A .gd file IS a class, but the class has a *name* only when the
+; script declares one. Scripts without `class_name` therefore
+; contribute no class symbol and no symbol-level heritage edge (the
+; file-level import edge from `extends "res://..."` is unaffected).
+; Documented as a known gap in docs/layers/LANGUAGE_SUPPORT.md
+; rather than papered over with a synthesized file-stem name:
+; HeritageResolver builds `child_id` as f"{path}::{child_name}"
+; without checking that the symbol exists, so a synthesized name
+; would emit an edge to a node that is not in the graph.
+; ---------------------------------------------------------------
+
+(source
+  (class_name_statement
+    name: (name) @symbol.name) @symbol.def)
+
+; ---------------------------------------------------------------
+; Inner classes -- `class Inner extends Node: ...`
+; ---------------------------------------------------------------
+
+(class_definition
+  name: (name) @symbol.name) @symbol.def
+
+; ---------------------------------------------------------------
+; Functions. Not anchored to source/class_body: GDScript has no
+; nested `func`, and ASTParser._has_callable_ancestor already drops
+; anything that somehow sits inside another callable.
+; ---------------------------------------------------------------
+
+(function_definition
+  name: (name) @symbol.name
+  parameters: (parameters) @symbol.params) @symbol.def
+
+; `func _init(...)` is its own node type with no `name` field at all --
+; the grammar spells `_init` as a literal token. Anonymous nodes are
+; capturable, and node_text over the token yields exactly "_init".
+(constructor_definition
+  "_init" @symbol.name
+  parameters: (parameters) @symbol.params) @symbol.def
+
+; ---------------------------------------------------------------
+; Members. These ARE anchored to `source` / `class_body`: unlike
+; `func`, a `var`/`const`/`enum` is legal inside a function body and
+; inside a lambda body. The parser's callable-ancestor filter catches
+; the function-body case but not the lambda one (`lambda` is not a
+; symbol node type, so it is not "callable" to that check), so the
+; anchor is what keeps loop-local scratch variables out of the
+; top-level symbol list.
+; ---------------------------------------------------------------
+
+(source
+  (variable_statement
+    name: (name) @symbol.name) @symbol.def)
+
+(class_body
+  (variable_statement
+    name: (name) @symbol.name) @symbol.def)
+
+(source
+  (export_variable_statement
+    name: (name) @symbol.name) @symbol.def)
+
+(class_body
+  (export_variable_statement
+    name: (name) @symbol.name) @symbol.def)
+
+(source
+  (onready_variable_statement
+    name: (name) @symbol.name) @symbol.def)
+
+(class_body
+  (onready_variable_statement
+    name: (name) @symbol.name) @symbol.def)
+
+(source
+  (const_statement
+    name: (name) @symbol.name) @symbol.def)
+
+(class_body
+  (const_statement
+    name: (name) @symbol.name) @symbol.def)
+
+(source
+  (signal_statement
+    name: (name) @symbol.name
+    parameters: (parameters)? @symbol.params) @symbol.def)
+
+(class_body
+  (signal_statement
+    name: (name) @symbol.name
+    parameters: (parameters)? @symbol.params) @symbol.def)
+
+; `name` is optional on enum_definition -- an anonymous `enum {A, B}`
+; declares its enumerators into the enclosing scope and has no symbol
+; of its own to name, so requiring the field here skips exactly the
+; declarations that have nothing to record.
+(source
+  (enum_definition
+    name: (name) @symbol.name) @symbol.def)
+
+(class_body
+  (enum_definition
+    name: (name) @symbol.name) @symbol.def)
+
+; ---------------------------------------------------------------
+; Imports -- `preload("res://a.gd")`, `load("res://b.tscn")` and
+; `extends "res://base.gd"`.
+;
+; Two single-`#eq?` patterns rather than one `#any-of?`: no query in
+; this tree uses `#any-of?` yet, and `#eq?` is the form luau.scm has
+; in production.
+;
+; Only string-literal arguments are captured. `load(some_var)` is
+; unresolvable without dataflow, and emitting the variable's *name*
+; as a module path would manufacture a wrong edge.
+; ---------------------------------------------------------------
+
+(call
+  (identifier) @_preload_fn
+  arguments: (arguments (string) @import.module)
+  (#eq? @_preload_fn "preload")) @import.statement
+
+(call
+  (identifier) @_load_fn
+  arguments: (arguments (string) @import.module)
+  (#eq? @_load_fn "load")) @import.statement
+
+(extends_statement
+  (string) @import.module) @import.statement
+
+; ---------------------------------------------------------------
+; Call graph
+; ---------------------------------------------------------------
+
+; Plain call -- `foo(...)`. Godot's global scope (`print`, `range`,
+; `Vector2`, ...) is filtered out via the spec's builtin_calls.
+(call
+  (identifier) @call.target
+  arguments: (arguments) @call.arguments) @call.site
+
+; Method call -- `obj.method(...)`. The receiver is the FIRST child of
+; the `attribute` node (anchored with `.`); `a.b.c()` therefore reports
+; receiver `a`, which is the same simplification the other languages'
+; receiver captures make.
+(attribute
+  . (_) @call.receiver
+  (attribute_call
+    (identifier) @call.target
+    arguments: (arguments) @call.arguments)) @call.site
+
+; GDScript 3 parent-method call -- `.method(...)`. The GDScript 4
+; spelling `super.method(...)` parses as an ordinary attribute call
+; with receiver `super` and is captured by the pattern above.
+(base_call
+  (identifier) @call.target
+  arguments: (arguments) @call.arguments) @call.site

--- a/packages/core/src/repowise/core/ingestion/resolvers/__init__.py
+++ b/packages/core/src/repowise/core/ingestion/resolvers/__init__.py
@@ -12,6 +12,7 @@ from .dart import resolve_dart_import
 from .elixir import resolve_elixir_import
 from .erlang import resolve_erlang_import
 from .fsharp import resolve_fsharp_import
+from .gdscript import resolve_gdscript_import
 from .generic import resolve_generic_import
 from .go import resolve_go_import
 from .haskell import resolve_haskell_import
@@ -47,6 +48,8 @@ _RESOLVERS: dict[str, ResolverFn] = {
     "java": resolve_java_import,
     "kotlin": resolve_kotlin_import,
     "luau": resolve_luau_import,
+    # res:// resolved against the nearest project.godot, not the repo root.
+    "gdscript": resolve_gdscript_import,
     "ruby": resolve_ruby_import,
     "csharp": resolve_csharp_import,
     "swift": resolve_swift_import,

--- a/packages/core/src/repowise/core/ingestion/resolvers/gdscript.py
+++ b/packages/core/src/repowise/core/ingestion/resolvers/gdscript.py
@@ -1,0 +1,140 @@
+"""GDScript import resolution.
+
+GDScript names dependencies three ways, all of which reach this function as
+the raw quoted path after ``parser.py`` strips the surrounding quotes (see
+queries/gdscript.scm)::
+
+    preload("res://actors/player.gd")
+    load("res://ui/menu.tscn")
+    extends "res://actors/base_actor.gd"
+
+``res://`` is an *absolute* path from the Godot project root -- the directory
+holding ``project.godot`` -- not from the repo root. The two coincide in a
+single-project repo and diverge in exactly the repo the validation corpus
+leads with: ``godotengine/godot-demo-projects`` is one checkout containing
+dozens of independent projects, each with its own ``project.godot`` and its
+own ``res://`` namespace. Resolving against the repo root there would map
+every project's ``res://player.gd`` onto whichever one sorted first.
+
+So the resolver finds the *nearest* ``project.godot`` at or above the
+importing file and resolves against that directory. A repo with no
+``project.godot`` at all (a loose bag of scripts, or a plugin checked out
+on its own) falls back to the repo root, which is the only sensible reading
+of ``res://`` when the project boundary is not declared.
+
+Unresolved paths are deliberately NOT stem-matched onto a same-named file
+elsewhere in the repo: ``res://`` is exact by construction, so a miss means
+the target genuinely is not indexed, and a wrong edge is worse than none.
+They fall through to ``add_external_node`` so the reference still shows up.
+"""
+
+from __future__ import annotations
+
+from pathlib import PurePosixPath
+
+from repowise.core.fs_walk import iter_glob
+
+from .context import ResolverContext
+
+_RES_PREFIX = "res://"
+
+# Godot 4.4+ writes `uid://` references into scenes and, increasingly, into
+# scripts. Resolving one needs the generated `.uid` sidecar files, which are
+# build-cache artifacts the spec blocks from indexing. Recorded as external
+# rather than guessed at.
+_UID_PREFIX = "uid://"
+
+# `user://` is the per-user writable data directory at runtime. It never
+# points at a repo file.
+_USER_PREFIX = "user://"
+
+
+def _project_roots(ctx: ResolverContext) -> tuple[str, ...]:
+    """Repo-relative POSIX dirs holding a ``project.godot``, longest first.
+
+    Built once per ``GraphBuilder.build()`` and stashed on the context, the
+    same lazy-index pattern the dotnet/PHP/Kotlin resolvers use.
+
+    Scanned from the filesystem rather than ``ctx.path_set``: ``project.godot``
+    is an ini manifest with no language tag of its own, so it is not
+    guaranteed to be among the indexed source files.
+    """
+    cached = getattr(ctx, "_gdscript_project_roots", None)
+    if cached is not None:
+        return cached
+
+    roots: list[str] = []
+    if ctx.repo_path is not None:
+        for manifest in iter_glob(
+            ctx.repo_path, "project.godot", prune_nested_git=ctx.prune_nested_git
+        ):
+            try:
+                rel = manifest.relative_to(ctx.repo_path).parent
+            except ValueError:
+                continue
+            rel_posix = rel.as_posix()
+            roots.append("" if rel_posix == "." else rel_posix)
+
+    # Longest first so the nearest enclosing project wins; the secondary sort
+    # key keeps the order stable across runs (see ResolverContext.sorted_paths
+    # on why resolver iteration order must not vary).
+    result = tuple(sorted(set(roots), key=lambda r: (-len(r), r)))
+    ctx._gdscript_project_roots = result  # type: ignore[attr-defined]
+    return result
+
+
+def _root_for(importer_path: str, ctx: ResolverContext) -> str:
+    """Return the repo-relative project root governing *importer_path*."""
+    for root in _project_roots(ctx):
+        if not root:
+            return ""
+        if importer_path == root or importer_path.startswith(root + "/"):
+            return root
+    # No declared project boundary above this file: res:// is the repo root.
+    return ""
+
+
+def resolve_gdscript_import(
+    module_path: str,
+    importer_path: str,
+    ctx: ResolverContext,
+) -> str | None:
+    """Resolve a GDScript ``res://`` path to a repo-relative file path."""
+    raw = module_path.strip()
+    if not raw:
+        return None
+
+    if raw.startswith(_UID_PREFIX) or raw.startswith(_USER_PREFIX):
+        return ctx.add_external_node(raw)
+
+    if raw.startswith(_RES_PREFIX):
+        relative = raw[len(_RES_PREFIX) :].lstrip("/")
+        root = _root_for(importer_path, ctx)
+        candidate = f"{root}/{relative}" if root else relative
+        if candidate in ctx.path_set:
+            return candidate
+        return ctx.add_external_node(raw)
+
+    # Godot also accepts a path relative to the importing script.
+    candidate = _join_relative(PurePosixPath(importer_path).parent, raw)
+    if candidate in ctx.path_set:
+        return candidate
+
+    return ctx.add_external_node(raw)
+
+
+def _join_relative(base: PurePosixPath, relative: str) -> str:
+    """Join *relative* onto *base*, collapsing ``.``/``..`` textually.
+
+    Not ``Path.resolve()``: resolution must not touch the filesystem (the
+    target is looked up in ``ctx.path_set``, and in tests no such file
+    exists on disk), and ``PurePosixPath`` keeps ``..`` segments literal.
+    """
+    parts: list[str] = [p for p in base.parts if p not in ("", ".")]
+    for segment in relative.split("/"):
+        if segment == "..":
+            if parts:
+                parts.pop()
+        elif segment not in ("", "."):
+            parts.append(segment)
+    return "/".join(parts)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,8 @@ dependencies = [
     "tree-sitter-pascal>=0.11,<1",
     "tree-sitter-luau>=1.2,<2",
     "tree-sitter-bash>=0.23,<1",
+    # GDScript / Godot grammar (not on PyPI — install from upstream git)
+    "tree-sitter-gdscript @ git+https://github.com/PrestonKnopp/tree-sitter-gdscript.git@v6.1.0",
     # Markup grammars for single-file components: these locate <script> blocks
     # and markup expressions only; the JS inside them is parsed with the
     # TypeScript grammar (see sfc_source.py). There is no tree-sitter-vue on

--- a/tests/unit/ingestion/parser/test_gdscript.py
+++ b/tests/unit/ingestion/parser/test_gdscript.py
@@ -1,0 +1,287 @@
+"""Unit tests for the GDScript (Godot) language pipeline.
+
+Tests parse inline byte strings so no filesystem I/O is needed. Covers
+symbols (both GDScript 3 and GDScript 4 spellings), heritage in all three
+positions it can appear, and imports from ``preload`` / ``load`` /
+``extends "res://..."`` -- see docs/architecture/language-support.md's
+"one .scm file + one LanguageConfig" recipe.
+
+Import *resolution* is covered separately in
+tests/unit/ingestion/test_gdscript_resolver.py, which needs no grammar.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from repowise.core.ingestion.parser import ASTParser
+from tests.unit.ingestion.parser._helpers import _make_file_info
+
+# tree-sitter-gdscript is a real dep in pyproject.toml, but it is sometimes
+# absent from a partially-synced developer venv. Skip explicitly so the
+# failure mode is "go run uv sync" rather than confusing AssertionErrors.
+pytest.importorskip("tree_sitter_gdscript", reason="run `uv sync --all-packages`")
+
+
+def _gd(path: str = "actors/player.gd") -> object:
+    return _make_file_info(path, "gdscript")
+
+
+# GDScript 4 spelling: `@export`/`@onready` annotations on a plain `var`.
+PLAYER_SOURCE = b'''\
+extends "res://actors/base_actor.gd"
+class_name Player
+
+signal health_changed(old_value, new_value)
+
+const MAX_HEALTH := 100
+const Bullet = preload("res://weapons/bullet.gd")
+
+enum State { IDLE, RUNNING, JUMPING }
+
+@export var speed: float = 300.0
+@onready var sprite = $Sprite2D
+var health := MAX_HEALTH
+
+class Inventory extends Resource:
+\tvar slots := []
+
+\tfunc add_item(item):
+\t\tslots.append(item)
+
+func _init():
+\thealth = MAX_HEALTH
+
+func _ready():
+\tvar greeting = "hello"
+\tprint(greeting)
+\ttake_damage(0)
+
+func take_damage(amount: int) -> void:
+\thealth -= amount
+\themit_signal("health_changed", health + amount, health)
+
+static func clamp_health(value: int) -> int:
+\treturn clamp(value, 0, MAX_HEALTH)
+'''
+
+
+# GDScript 3 spelling: bare `export`/`onready` keywords, `.method()` super
+# call, and `class_name X extends Y` folded onto one line.
+LEGACY_SOURCE = b'''\
+class_name Enemy extends KinematicBody2D
+
+export var damage = 10
+onready var timer = get_node("Timer")
+
+func _ready():
+\t.ready()
+\tspawn()
+
+func spawn():
+\tpass
+'''
+
+
+class TestGDScriptSymbols:
+    def test_script_level_class_name(self, parser: ASTParser) -> None:
+        result = parser.parse_file(_gd(), PLAYER_SOURCE)
+        assert ("Player", "class") in {(s.name, s.kind) for s in result.symbols}
+
+    def test_inner_class(self, parser: ASTParser) -> None:
+        result = parser.parse_file(_gd(), PLAYER_SOURCE)
+        assert ("Inventory", "class") in {(s.name, s.kind) for s in result.symbols}
+
+    def test_functions_including_static(self, parser: ASTParser) -> None:
+        result = parser.parse_file(_gd(), PLAYER_SOURCE)
+        names = {s.name for s in result.symbols}
+        assert {"_ready", "take_damage", "clamp_health"} <= names
+
+    def test_constructor_is_captured_despite_having_no_name_field(
+        self, parser: ASTParser
+    ) -> None:
+        # `func _init()` parses as `constructor_definition`, which carries no
+        # `name` field at all -- the name is an anonymous "_init" token. If
+        # the .scm ever stops capturing anonymous nodes this is the canary.
+        result = parser.parse_file(_gd(), PLAYER_SOURCE)
+        assert "_init" in {s.name for s in result.symbols}
+
+    def test_constants_variables_signals_and_enums(self, parser: ASTParser) -> None:
+        result = parser.parse_file(_gd(), PLAYER_SOURCE)
+        kinds = {(s.name, s.kind) for s in result.symbols}
+        assert ("MAX_HEALTH", "constant") in kinds
+        assert ("Bullet", "constant") in kinds
+        assert ("State", "enum") in kinds
+        assert ("health", "variable") in kinds
+        # No "signal" member in the SymbolKind literal -- signals share the
+        # "variable" bucket with Pascal properties and C# events.
+        assert ("health_changed", "variable") in kinds
+
+    def test_annotated_export_and_onready_vars(self, parser: ASTParser) -> None:
+        # GDScript 4 `@export var` is an ordinary variable_statement carrying
+        # an `annotations` child, not a distinct node type.
+        result = parser.parse_file(_gd(), PLAYER_SOURCE)
+        names = {s.name for s in result.symbols}
+        assert {"speed", "sprite"} <= names
+
+    def test_gdscript_3_export_and_onready_keywords(self, parser: ASTParser) -> None:
+        # The bare-keyword forms ARE distinct node types
+        # (export_variable_statement / onready_variable_statement).
+        result = parser.parse_file(_gd("actors/enemy.gd"), LEGACY_SOURCE)
+        names = {s.name for s in result.symbols}
+        assert {"damage", "timer"} <= names
+
+    def test_function_local_variables_are_not_top_level_symbols(
+        self, parser: ASTParser
+    ) -> None:
+        # `var greeting` lives inside _ready's body. A `var` is a
+        # variable_statement wherever it appears, so without the source /
+        # class_body anchor in the .scm every loop counter would surface.
+        result = parser.parse_file(_gd(), PLAYER_SOURCE)
+        assert "greeting" not in {s.name for s in result.symbols}
+
+    def test_inner_class_members_attribute_to_the_inner_class(
+        self, parser: ASTParser
+    ) -> None:
+        result = parser.parse_file(_gd(), PLAYER_SOURCE)
+        add_item = next(s for s in result.symbols if s.name == "add_item")
+        assert add_item.parent_name == "Inventory"
+
+    def test_script_level_functions_have_no_parent(self, parser: ASTParser) -> None:
+        # `class_name Player` is a *sibling* of the script's functions, not
+        # their ancestor, so nesting-based parent extraction finds nothing --
+        # which is the honest answer: they belong to the file.
+        result = parser.parse_file(_gd(), PLAYER_SOURCE)
+        take_damage = next(s for s in result.symbols if s.name == "take_damage")
+        assert take_damage.parent_name is None
+
+    def test_underscore_prefixed_names_read_as_private(self, parser: ASTParser) -> None:
+        result = parser.parse_file(_gd(), PLAYER_SOURCE)
+        ready = next(s for s in result.symbols if s.name == "_ready")
+        take_damage = next(s for s in result.symbols if s.name == "take_damage")
+        assert ready.visibility == "private"
+        assert take_damage.visibility == "public"
+
+
+class TestGDScriptHeritage:
+    # A project type, not an engine one: engine roots like Node2D are in the
+    # spec's builtin_parents and are filtered out before heritage is returned
+    # (asserted separately below), which would mask the ordering behaviour.
+    def test_standalone_extends_above_class_name(self, parser: ASTParser) -> None:
+        # `extends X` on its own line is a SIBLING of class_name_statement,
+        # not a child -- the extractor has to walk the file's top level to
+        # find it. This ordering is the common one in real Godot code.
+        result = parser.parse_file(_gd("actors/thing.gd"), b"extends BaseThing\nclass_name Thing\n")
+        rels = {(r.child_name, r.parent_name, r.kind) for r in result.heritage}
+        assert ("Thing", "BaseThing", "extends") in rels
+
+    def test_extends_below_class_name(self, parser: ASTParser) -> None:
+        result = parser.parse_file(_gd("actors/thing.gd"), b"class_name Thing\nextends BaseThing\n")
+        rels = {(r.child_name, r.parent_name, r.kind) for r in result.heritage}
+        assert ("Thing", "BaseThing", "extends") in rels
+
+    def test_engine_root_parents_are_filtered_as_builtins(self, parser: ASTParser) -> None:
+        result = parser.parse_file(_gd("actors/thing.gd"), b"extends Node2D\nclass_name Thing\n")
+        assert result.heritage == []
+
+    def test_inline_class_name_extends(self, parser: ASTParser) -> None:
+        # `class_name Enemy extends KinematicBody2D` -- here the
+        # extends_statement IS a child, via class_name_statement's field.
+        result = parser.parse_file(_gd("actors/enemy.gd"), LEGACY_SOURCE)
+        rels = {(r.child_name, r.parent_name, r.kind) for r in result.heritage}
+        assert ("Enemy", "KinematicBody2D", "extends") in rels
+
+    def test_inner_class_heritage(self, parser: ASTParser) -> None:
+        result = parser.parse_file(_gd(), PLAYER_SOURCE)
+        rels = {(r.child_name, r.parent_name) for r in result.heritage}
+        # `Resource` is in builtin_parents, so the relation is filtered out
+        # rather than left dangling.
+        assert ("Inventory", "Resource") not in rels
+
+    def test_inner_class_heritage_on_a_project_type_survives(
+        self, parser: ASTParser
+    ) -> None:
+        src = b"class_name Outer\n\nclass Inner extends SomeProjectType:\n\tpass\n"
+        result = parser.parse_file(_gd("a.gd"), src)
+        rels = {(r.child_name, r.parent_name, r.kind) for r in result.heritage}
+        assert ("Inner", "SomeProjectType", "extends") in rels
+
+    def test_res_path_extends_is_an_import_not_a_heritage_relation(
+        self, parser: ASTParser
+    ) -> None:
+        # A res:// path is not a type NAME, and HeritageResolver only ever
+        # matches parent_name against symbol names -- emitting one would
+        # create a relation that can never resolve. The dependency is
+        # carried by the import edge instead.
+        result = parser.parse_file(_gd(), PLAYER_SOURCE)
+        assert all("res://" not in r.parent_name for r in result.heritage)
+        assert "res://actors/base_actor.gd" in {i.module_path for i in result.imports}
+
+    def test_script_without_class_name_yields_no_heritage(self, parser: ASTParser) -> None:
+        # Documented ceiling: an anonymous script has no class symbol, so
+        # there is no child name to hang a symbol-level edge on.
+        result = parser.parse_file(_gd("a.gd"), b"extends Node2D\n\nfunc _ready():\n\tpass\n")
+        assert result.heritage == []
+
+
+class TestGDScriptImports:
+    def test_preload_load_and_extends_paths(self, parser: ASTParser) -> None:
+        src = (
+            b'extends "res://actors/base_actor.gd"\n'
+            b'const Bullet = preload("res://weapons/bullet.gd")\n'
+            b'var menu = load("res://ui/menu.tscn")\n'
+        )
+        result = parser.parse_file(_gd(), src)
+        assert {i.module_path for i in result.imports} == {
+            "res://actors/base_actor.gd",
+            "res://weapons/bullet.gd",
+            "res://ui/menu.tscn",
+        }
+
+    def test_quotes_are_stripped_before_the_resolver_sees_the_path(
+        self, parser: ASTParser
+    ) -> None:
+        result = parser.parse_file(_gd(), b'const B = preload("res://b.gd")\n')
+        assert result.imports[0].module_path == "res://b.gd"
+
+    def test_non_literal_load_argument_is_not_an_import(self, parser: ASTParser) -> None:
+        # `load(path_var)` needs dataflow to resolve; emitting the variable
+        # name as a module path would manufacture a wrong edge.
+        result = parser.parse_file(_gd(), b'var path = "res://x.gd"\nvar r = load(path)\n')
+        assert result.imports == []
+
+    def test_preload_is_also_a_constant_symbol(self, parser: ASTParser) -> None:
+        # `const X = preload(...)` is legitimately both a constant and an
+        # import; the two captures are independent.
+        result = parser.parse_file(_gd(), b'const Bullet = preload("res://weapons/bullet.gd")\n')
+        assert ("Bullet", "constant") in {(s.name, s.kind) for s in result.symbols}
+        assert len(result.imports) == 1
+
+
+class TestGDScriptCalls:
+    def test_project_calls_are_recorded(self, parser: ASTParser) -> None:
+        result = parser.parse_file(_gd(), PLAYER_SOURCE)
+        assert "take_damage" in {c.target_name for c in result.calls}
+
+    def test_godot_globals_are_excluded_as_builtins(self, parser: ASTParser) -> None:
+        result = parser.parse_file(_gd(), PLAYER_SOURCE)
+        targets = {c.target_name for c in result.calls}
+        assert "print" not in targets
+        assert "clamp" not in targets
+        # preload is an import, and must not double as a call node.
+        assert "preload" not in targets
+
+    def test_method_call_records_its_receiver(self, parser: ASTParser) -> None:
+        result = parser.parse_file(_gd(), PLAYER_SOURCE)
+        append = next((c for c in result.calls if c.target_name == "append"), None)
+        assert append is not None
+        assert append.receiver_name == "slots"
+
+
+class TestGDScriptParsesCleanly:
+    @pytest.mark.parametrize("source", [PLAYER_SOURCE, LEGACY_SOURCE])
+    def test_no_parse_errors(self, parser: ASTParser, source: bytes) -> None:
+        # The corpus gate in local-stash/gdscript-godot/PLAN.md is "no parse
+        # errors"; this is its unit-level sentinel over both dialects.
+        result = parser.parse_file(_gd(), source)
+        assert result.parse_errors == []

--- a/tests/unit/ingestion/test_gdscript_resolver.py
+++ b/tests/unit/ingestion/test_gdscript_resolver.py
@@ -1,0 +1,155 @@
+"""Unit tests for the GDScript import resolver.
+
+The interesting behaviour is that ``res://`` is absolute from the *Godot
+project* root -- the directory holding ``project.godot`` -- not the repo
+root. A single repo can hold many projects (``godot-demo-projects``, the
+tier-1 validation corpus, is exactly that shape), so these tests pin the
+nearest-enclosing-project rule and the repo-root fallback.
+
+Parser contract
+---------------
+``parser.py`` strips surrounding quotes from the captured ``@import.module``
+text before calling a resolver, so these tests pass unquoted paths --
+``preload("res://a.gd")`` reaches the resolver as ``res://a.gd``.
+
+No grammar dependency here on purpose: this module must run even in a venv
+without ``tree_sitter_gdscript``, so it carries no ``importorskip``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import networkx as nx
+
+from repowise.core.ingestion.resolvers.context import ResolverContext
+from repowise.core.ingestion.resolvers.gdscript import resolve_gdscript_import
+
+
+def _ctx(paths: set[str], repo_path: Path | None = None) -> ResolverContext:
+    stem_map: dict[str, list[str]] = {}
+    for p in paths:
+        stem = p.rsplit("/", 1)[-1].rsplit(".", 1)[0].lower()
+        stem_map.setdefault(stem, []).append(p)
+    return ResolverContext(
+        path_set=paths,
+        stem_map=stem_map,
+        graph=nx.DiGraph(),
+        repo_path=repo_path,
+    )
+
+
+def _write_project(root: Path, *relative_dirs: str) -> None:
+    """Drop a minimal ``project.godot`` into each of *relative_dirs*."""
+    for rel in relative_dirs:
+        target = root / rel if rel else root
+        target.mkdir(parents=True, exist_ok=True)
+        (target / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+
+
+class TestResPaths:
+    def test_resolves_against_repo_root_when_project_is_at_root(self, tmp_path: Path) -> None:
+        _write_project(tmp_path, "")
+        ctx = _ctx({"actors/player.gd", "actors/base.gd"}, repo_path=tmp_path)
+        got = resolve_gdscript_import("res://actors/base.gd", "actors/player.gd", ctx)
+        assert got == "actors/base.gd"
+
+    def test_resolves_against_repo_root_when_no_project_godot_exists(
+        self, tmp_path: Path
+    ) -> None:
+        # A loose bag of scripts with no declared project boundary: the repo
+        # root is the only sensible reading of res://.
+        ctx = _ctx({"actors/player.gd", "actors/base.gd"}, repo_path=tmp_path)
+        got = resolve_gdscript_import("res://actors/base.gd", "actors/player.gd", ctx)
+        assert got == "actors/base.gd"
+
+    def test_leading_slashes_after_the_scheme_are_tolerated(self, tmp_path: Path) -> None:
+        ctx = _ctx({"a.gd", "b.gd"}, repo_path=tmp_path)
+        assert resolve_gdscript_import("res:///b.gd", "a.gd", ctx) == "b.gd"
+
+
+class TestMultiProjectRepo:
+    """The godot-demo-projects shape: many projects, one checkout."""
+
+    def test_nearest_project_root_wins(self, tmp_path: Path) -> None:
+        _write_project(tmp_path, "2d/platformer", "3d/voxel")
+        paths = {
+            "2d/platformer/player.gd",
+            "2d/platformer/enemy.gd",
+            "3d/voxel/player.gd",
+            "3d/voxel/world.gd",
+        }
+        ctx = _ctx(paths, repo_path=tmp_path)
+
+        # Both projects declare a res://player.gd. Each importer must reach
+        # its OWN sibling, never the other project's same-named file.
+        assert (
+            resolve_gdscript_import("res://player.gd", "2d/platformer/enemy.gd", ctx)
+            == "2d/platformer/player.gd"
+        )
+        assert (
+            resolve_gdscript_import("res://player.gd", "3d/voxel/world.gd", ctx)
+            == "3d/voxel/player.gd"
+        )
+
+    def test_deeper_project_shadows_an_outer_one(self, tmp_path: Path) -> None:
+        # A demo project nested inside an outer project: the inner
+        # project.godot is the res:// root for files beneath it.
+        _write_project(tmp_path, "", "demos/inner")
+        paths = {"shared.gd", "demos/inner/shared.gd", "demos/inner/main.gd"}
+        ctx = _ctx(paths, repo_path=tmp_path)
+        got = resolve_gdscript_import("res://shared.gd", "demos/inner/main.gd", ctx)
+        assert got == "demos/inner/shared.gd"
+
+    def test_file_outside_every_project_falls_back_to_repo_root(self, tmp_path: Path) -> None:
+        _write_project(tmp_path, "demos/inner")
+        paths = {"tools/build.gd", "tools/helper.gd"}
+        ctx = _ctx(paths, repo_path=tmp_path)
+        got = resolve_gdscript_import("res://tools/helper.gd", "tools/build.gd", ctx)
+        assert got == "tools/helper.gd"
+
+
+class TestRelativePaths:
+    def test_sibling_relative_path(self, tmp_path: Path) -> None:
+        ctx = _ctx({"actors/player.gd", "actors/base.gd"}, repo_path=tmp_path)
+        assert resolve_gdscript_import("base.gd", "actors/player.gd", ctx) == "actors/base.gd"
+
+    def test_dotdot_walks_up(self, tmp_path: Path) -> None:
+        ctx = _ctx({"actors/player.gd", "lib/util.gd"}, repo_path=tmp_path)
+        got = resolve_gdscript_import("../lib/util.gd", "actors/player.gd", ctx)
+        assert got == "lib/util.gd"
+
+
+class TestUnresolved:
+    def test_missing_target_becomes_external_not_a_stem_guess(self, tmp_path: Path) -> None:
+        # `res://` is exact by construction, so a miss must NOT be rescued by
+        # matching the filename somewhere else in the repo.
+        ctx = _ctx({"a.gd", "somewhere/deep/base.gd"}, repo_path=tmp_path)
+        got = resolve_gdscript_import("res://actors/base.gd", "a.gd", ctx)
+        assert got == "external:res://actors/base.gd"
+
+    def test_uid_paths_are_external(self, tmp_path: Path) -> None:
+        ctx = _ctx({"a.gd"}, repo_path=tmp_path)
+        got = resolve_gdscript_import("uid://cxy8n1e0abcde", "a.gd", ctx)
+        assert got == "external:uid://cxy8n1e0abcde"
+
+    def test_user_paths_are_external(self, tmp_path: Path) -> None:
+        ctx = _ctx({"a.gd"}, repo_path=tmp_path)
+        assert resolve_gdscript_import("user://save.dat", "a.gd", ctx) == "external:user://save.dat"
+
+    def test_empty_module_path_resolves_to_nothing(self, tmp_path: Path) -> None:
+        ctx = _ctx({"a.gd"}, repo_path=tmp_path)
+        assert resolve_gdscript_import("   ", "a.gd", ctx) is None
+
+
+class TestProjectRootScanIsCached:
+    def test_roots_are_scanned_once_per_context(self, tmp_path: Path) -> None:
+        _write_project(tmp_path, "game")
+        ctx = _ctx({"game/a.gd", "game/b.gd"}, repo_path=tmp_path)
+        resolve_gdscript_import("res://b.gd", "game/a.gd", ctx)
+
+        # Deleting the manifest after the first call must not change the
+        # answer -- proof the scan result was cached on the context rather
+        # than repeated per import (this runs once per file per build).
+        (tmp_path / "game" / "project.godot").unlink()
+        assert resolve_gdscript_import("res://b.gd", "game/a.gd", ctx) == "game/b.gd"

--- a/tests/unit/ingestion/test_language_capabilities.py
+++ b/tests/unit/ingestion/test_language_capabilities.py
@@ -143,6 +143,9 @@ _FULL = {
     # dart promoted with the tree-sitter grammar (the regex tier stays as
     # the no-grammar fallback).
     "dart",
+    # res:// is an absolute path from the nearest project.godot, so GDScript
+    # import targets resolve exactly rather than through a stem guess.
+    "gdscript",
     "go",
     "java",
     "javascript",

--- a/uv.lock
+++ b/uv.lock
@@ -3084,6 +3084,7 @@ dependencies = [
     { name = "tree-sitter-c-sharp" },
     { name = "tree-sitter-cpp" },
     { name = "tree-sitter-dart" },
+    { name = "tree-sitter-gdscript" },
     { name = "tree-sitter-go" },
     { name = "tree-sitter-html" },
     { name = "tree-sitter-java" },
@@ -3179,6 +3180,7 @@ requires-dist = [
     { name = "tree-sitter-c-sharp", specifier = ">=0.23,<1" },
     { name = "tree-sitter-cpp", specifier = ">=0.23,<1" },
     { name = "tree-sitter-dart", specifier = ">=0.1,<1" },
+    { name = "tree-sitter-gdscript", git = "https://github.com/PrestonKnopp/tree-sitter-gdscript.git?rev=v6.1.0" },
     { name = "tree-sitter-go", specifier = ">=0.23,<1" },
     { name = "tree-sitter-html", specifier = ">=0.23,<1" },
     { name = "tree-sitter-java", specifier = ">=0.23,<1" },
@@ -4032,6 +4034,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/43/e3/ebee709bdd1e472bfbd1f824e5377993cfcfb7437c9e9fedeac243480ac1/tree_sitter_dart-0.1.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:05906d65a1c8688a0a0358c2e1b65ade0eec2ec7be7364c75de2f5c1e2844e0c", size = 162621, upload-time = "2026-06-21T16:01:56.698Z" },
     { url = "https://files.pythonhosted.org/packages/f7/a7/e8af7fb56dfd0d39df6f96e180d47d822407a7c98edc485b0c18ddd7ee28/tree_sitter_dart-0.1.0-cp38-abi3-win_amd64.whl", hash = "sha256:ee1d5f2109d2a206583227cfc4e2b0890f48700a0796207c2eecb5c3d7f23f63", size = 128126, upload-time = "2026-06-21T16:01:57.878Z" },
 ]
+
+[[package]]
+name = "tree-sitter-gdscript"
+version = "6.1.0"
+source = { git = "https://github.com/PrestonKnopp/tree-sitter-gdscript.git?rev=v6.1.0#d2a0ee914d297b873a40dd4596bd1f7157ebc52b" }
 
 [[package]]
 name = "tree-sitter-go"


### PR DESCRIPTION
## What

Adds GDScript (Godot 4 and 3) as a parsed language at the **Good** tier: symbols, import resolution, a resolved call graph, heritage and named bindings. Fixes #1476.

## What's included

- **`LanguageSpec`** + 201-line **`.scm` query file** (`queries/gdscript.scm`) covering both GDScript 3 (`export var`) and GDScript 4 (`@export var`) spellings
- **Heritage extractor** — `extends`, `class_name`, signals, enums
- **`res://` resolver** scoped to the nearest `project.godot`, so a repo holding many Godot projects keeps each project's namespace separate (`preload`, `load`, `extends "res://..."`)
- Registration in `language_configs.py`, `models.py`, specs/resolvers/heritage `__init__`
- **60 unit tests** (parser + resolver), passing
- Docs: Good tier 5->6, AST count 19->20, GDScript rows + known-gaps section

## Note on the grammar dependency

`tree-sitter-gdscript` is **not on PyPI** (it's GitHub-only). The original work left it undeclared, so the parser tests were silently skipped via `pytest.importorskip`. This PR declares it as a git dependency (`git+...#v6.1.0`) so the tests actually run. If you'd prefer it optional, I can move it to an extra — happy to follow the project's convention here.

## Test status

- GDScript tests: **60 passed**
- Broader `tests/unit/ingestion/`: 2575 passed. One pre-existing failure (`test_repo_totals_churn.py::test_a_rebased_branch_in_the_history_falls_back`) is unrelated — a git-rebase exit-128 in the test sandbox, and that file is untouched by this diff.
