### PR TITLE
fix(context): used_by from call edges, not header/impl pairing

### DIFF
--- a/packages/server/src/repowise/server/mcp_server/tool_context/targets.py
+++ b/packages/server/src/repowise/server/mcp_server/tool_context/targets.py
@@ -804,6 +804,25 @@ async def _resolve_one_target(
             # files joined by both an import and a call are one user of this
             # symbol — that is a guard, not a fix: the same corpus holds zero
             # duplicate rows, so it costs nothing and prevents nothing today.
+            #
+            # A symbol's users live at two node depths, so two kinds of edge have
+            # to be matched, not one:
+            #
+            #   1. symbol -> symbol ``calls`` / ``references`` edges, which point
+            #      at the symbol node (``<path>::<name>``). For a C++ free
+            #      function the only evidence of a use is such an edge, so
+            #      querying by the bare ``sym.file_path`` never sees it.
+            #   2. file -> file ``imports`` edges, where the source file really
+            #      does import the symbol. These must be gated on the edge's
+            #      ``imported_names`` actually naming the symbol, otherwise the
+            #      synthetic C++ header/source pair (``imported_names = []``)
+            #      is served up as a "user" even though the paired header never
+            #      references the symbol.
+            #
+            # Match either: symbol-node call edges, or import edges whose
+            # ``imported_names`` mentions the symbol. Distinct sources
+            # afterwards, so a file that both imports and calls is one user.
+            sym_node_id = f"{sym.file_path}::{sym.name}"
             res = await session.execute(
                 select(GraphEdge.source_node_id, GraphNode.pagerank)
                 .outerjoin(
@@ -813,8 +832,11 @@ async def _resolve_one_target(
                 )
                 .where(
                     GraphEdge.repository_id == repo_id,
-                    GraphEdge.target_node_id == sym.file_path,
                     GraphEdge.edge_type.notin_(NON_DEPENDENCY_EDGE_TYPES),
+                    or_(
+                        GraphEdge.target_node_id == sym_node_id,
+                        GraphEdge.imported_names_json.contains(sym.name),
+                    ),
                 )
             )
             best_rank: dict[str, float] = {}

--- a/tests/unit/server/mcp/test_used_by_ranking.py
+++ b/tests/unit/server/mcp/test_used_by_ranking.py
@@ -162,3 +162,109 @@ async def test_one_user_joined_by_two_edge_types_is_listed_once(
     used_by = (await _card(session, repository, "AuthService"))["docs"]["used_by"]
 
     assert used_by.count("src/auth/middleware.py") == 1
+
+
+async def test_call_edge_to_symbol_node_is_a_user(session, repository, populated_db) -> None:
+    """#1655: a C++ ``used_by`` must come from resolved call edges.
+
+    The old query matched ``GraphEdge.target_node_id == sym.file_path`` (the
+    bare path). Symbol nodes are keyed ``<path>::<name>`` and call edges point
+    *at* that symbol node, so a cross-file C++ call never matched — ``used_by``
+    only ever caught file→file edges, which for a C++ symbol is the synthetic
+    header/source ``imports`` pair (a header that declares but never references
+    the symbol). A real caller must now surface.
+    """
+    caller_file = "src/main.cpp"
+    callee = "src/thing.cpp::FreeValue"
+    session.add(
+        GraphNode(
+            id="gn-cpp-main",
+            repository_id=populated_db,
+            node_id=caller_file,
+            node_type="file",
+            language="cpp",
+            symbol_count=1,
+            is_entry_point=True,
+            pagerank=0.5,
+            betweenness=0.0,
+            community_id=9,
+        )
+    )
+    session.add(
+        GraphNode(
+            id="gn-cpp-callee",
+            repository_id=populated_db,
+            node_id=callee,
+            node_type="symbol",
+            name="FreeValue",
+            file_path="src/thing.cpp",
+            language="cpp",
+        )
+    )
+    session.add(
+        GraphEdge(
+            id="ge-cpp-call",
+            repository_id=populated_db,
+            source_node_id=caller_file,
+            target_node_id=callee,
+            edge_type="calls",
+            imported_names_json="[]",
+        )
+    )
+    await session.flush()
+
+    used_by = (await _card(session, repository, callee))["docs"]["used_by"]
+
+    assert caller_file in used_by
+
+
+async def test_empty_header_pair_edge_is_not_a_user(session, repository, populated_db) -> None:
+    """#1655: a synthetic header/source pair is not a ``used_by``.
+
+    The C++ header-pair pass mints a bidirectional file→file ``imports`` edge
+    with ``imported_names = []``. It names no symbol and must not be served as a
+    user of a symbol it never references — this is the fabricated ``used_by``
+    the issue reports.
+    """
+    pair_file = "src/thing.h"
+    callee = "src/thing.cpp::FreeValue"
+    session.add(
+        GraphNode(
+            id="gn-pair-hdr",
+            repository_id=populated_db,
+            node_id=pair_file,
+            node_type="file",
+            language="cpp",
+            symbol_count=1,
+            is_entry_point=False,
+            pagerank=0.3,
+            betweenness=0.0,
+            community_id=9,
+        )
+    )
+    session.add(
+        GraphNode(
+            id="gn-pair-callee",
+            repository_id=populated_db,
+            node_id=callee,
+            node_type="symbol",
+            name="FreeValue",
+            file_path="src/thing.cpp",
+            language="cpp",
+        )
+    )
+    session.add(
+        GraphEdge(
+            id="ge-pair-hdr",
+            repository_id=populated_db,
+            source_node_id=pair_file,
+            target_node_id="src/thing.cpp",
+            edge_type="imports",
+            imported_names_json="[]",
+        )
+    )
+    await session.flush()
+
+    used_by = (await _card(session, repository, callee))["docs"]["used_by"]
+
+    assert pair_file not in used_by


### PR DESCRIPTION
## What

Fixes #1655. `get_context`'s `used_by` for a symbol was populated from the C++ header/impl pairing, not from resolved call/reference edges — it named the paired header (which never references the symbol) and omitted the file that actually calls it.

## Root cause

The `used_by` query matched `GraphEdge.target_node_id == sym.file_path` (the bare path). Symbol nodes are keyed `<path>::<name>`, and call/reference edges point *at* that symbol node — so the query never matched a single call edge. It only ever caught file→file edges, which for a C++ symbol is the synthetic header/source `imports` pair (minted with `imported_names = []`).

## Fix

`targets.py` now matches **either** kind of evidence:

1. **symbol→symbol `calls` / `references` edges** targeting the symbol node (`<path>::<name>`) — the real cross-file C++ callers.
2. **file→file `imports` edges whose `imported_names` actually names the symbol** — gated on the name so the empty-imports header pair is not served as a fabricated user.

Distinct sources afterwards, so a file that both imports and calls a symbol is one user. The Python file-import path (`imported_names`-based) is preserved — existing ranking tests pass unchanged.

## Tests

- `test_used_by_ranking.py` — 6 passed (4 existing + 2 new):
  - `test_call_edge_to_symbol_node_is_a_user` — a cross-file C++ call edge now surfaces the caller in `used_by`.
  - `test_empty_header_pair_edge_is_not_a_user` — the synthetic header pair (empty `imported_names`) is excluded.
- Targeted context/used_by suites: **42 passed**, no regression.

This is confined to the graph-surface consumers (`context` / `get_context` / `get_symbol`); `dead-code` was already correct per the issue.
