### PR TITLE
fix(costs): price deepseek/kimi instead of $0 in estimator and live tracker

### DIFF
--- a/packages/core/src/repowise/core/cost_estimator/pricing.py
+++ b/packages/core/src/repowise/core/cost_estimator/pricing.py
@@ -38,6 +38,15 @@ _COST_TABLE_EXACT: dict[str, tuple[float, float]] = {
     "claude-opus-4-6": (0.005, 0.025),  # $5 / $25 per MTok
     "claude-sonnet-4-6": (0.003, 0.015),  # $3 / $15 per MTok
     "claude-haiku-4-5": (0.001, 0.005),  # $1 / $5 per MTok
+    # DeepSeek V4 — https://api-docs.deepseek.com/quick_start/pricing
+    "deepseek-v4-flash": (0.00027, 0.00110),  # $0.27 / $1.10 per MTok
+    "deepseek-v4-pro": (0.00055, 0.00219),  # $0.55 / $2.19 per MTok
+    "deepseek-chat": (0.00027, 0.00110),
+    "deepseek-reasoner": (0.00055, 0.00219),
+    # Kimi / Moonshot — https://platform.moonshot.cn/docs/pricing/chat
+    "kimi-for-coding": (0.0006, 0.0024),  # $0.60 / $2.40 per MTok
+    "kimi-k2.5": (0.0006, 0.0024),
+    "kimi-k2.6": (0.0006, 0.0024),
 }
 
 # Prefix fallbacks for unknown variants. No `gpt-5.6` catch-all: the 5.6
@@ -54,6 +63,21 @@ _COST_TABLE_PREFIX: dict[str, tuple[float, float]] = {
     "claude-haiku": (0.001, 0.005),
     "claude": (0.003, 0.015),
     "gemini": (0.00025, 0.0015),
+    # DeepSeek V4 family — https://api-docs.deepseek.com/quick_start/pricing
+    # deepseek-chat was the V3 alias; V4 Flash/Pro are the current names.
+    "deepseek-v4-pro": (0.00055, 0.00219),
+    "deepseek-v4-flash": (0.00027, 0.00110),
+    "deepseek-v4": (0.00027, 0.00110),
+    "deepseek-chat": (0.00027, 0.00110),
+    "deepseek-reasoner": (0.00055, 0.00219),
+    "deepseek": (0.00027, 0.00110),
+    # Kimi / Moonshot — https://platform.moonshot.cn/docs/pricing/chat
+    "kimi-k2.6": (0.0006, 0.0024),
+    "kimi-k2.5": (0.0006, 0.0024),
+    "kimi-k2": (0.0006, 0.0024),
+    "kimi-for-coding": (0.0006, 0.0024),
+    "kimi": (0.0006, 0.0024),
+    "moonshot": (0.0006, 0.0024),
     "llama": (0.0, 0.0),
     "mock": (0.0, 0.0),
     "codex_cli/": (0.0, 0.0),

--- a/packages/core/src/repowise/core/generation/cost_tracker.py
+++ b/packages/core/src/repowise/core/generation/cost_tracker.py
@@ -61,9 +61,15 @@ _PRICING: dict[str, dict[str, float]] = {
     "gemini-3.1-flash-lite-preview": {"input": 0.075, "output": 0.30},
     "gemini-3-flash-preview": {"input": 0.075, "output": 0.30},
     "gemini-3.5-flash-lite": {"input": 0.25, "output": 1.50},
-    # DeepSeek
-    "deepseek-v4-flash": {"input": 0.14, "output": 0.28},
-    "deepseek-v4-pro": {"input": 1.74, "output": 3.48},
+    # DeepSeek — https://api-docs.deepseek.com/quick_start/pricing
+    "deepseek-v4-flash": {"input": 0.27, "output": 1.10},
+    "deepseek-v4-pro": {"input": 0.55, "output": 2.19},
+    "deepseek-chat": {"input": 0.27, "output": 1.10},
+    "deepseek-reasoner": {"input": 0.55, "output": 2.19},
+    # Kimi / Moonshot — https://platform.moonshot.cn/docs/pricing/chat
+    "kimi-for-coding": {"input": 0.60, "output": 2.40},
+    "kimi-k2.5": {"input": 0.60, "output": 2.40},
+    "kimi-k2.6": {"input": 0.60, "output": 2.40},
 }
 
 _FALLBACK_PRICING: dict[str, float] = {"input": 3.0, "output": 15.0}


### PR DESCRIPTION
## What

Every page generated with `deepseek` or `kimi` showed **$0** in `repowise costs`, dashboard Costs tab, and `--dry-run` estimates.

- `packages/core/src/repowise/core/cost_estimator/pricing.py` `_lookup_cost` had **no** rows for `deepseek-*` or `kimi-*` — fell through to `(0,0)`. OpenRouter-routed `openrouter/deepseek/deepseek-chat` stripped to `deepseek-chat` then still $0.
- `packages/core/src/repowise/core/generation/cost_tracker.py` `_PRICING` had stale DeepSeek rates (`0.14/0.28` for flash, missing `deepseek-chat`/`reasoner`) and **zero** Kimi rows — live session counter mismatched the estimator and missed Kimi entirely.

## Fix

- **pricing.py** `_COST_TABLE_EXACT:1` + `_COST_TABLE_PREFIX:47`: adds exact + prefix rows for `deepseek-v4-flash` (`0.27/1.10`), `deepseek-v4-pro`/`reasoner` (`0.55/2.19`), `kimi-for-coding`/`k2.5`/`k2.6`/`moonshot` (`0.60/2.40`) per DeepSeek and Moonshot published pricing. Generic `deepseek`/`kimi` prefixes cover future variants. Keeps `mock`/`llama`/`codex_cli/` at 0.
- **cost_tracker.py:22** syncs per-MTok table to same rates (`deepseek-v4-flash 0.27/1.10, pro 0.55/2.19, kimi 0.60/2.40`) so pre-run estimate and live counter agree.

## Verification

```
python -c "from repowise.core.cost_estimator.pricing import _lookup_cost; assert _lookup_cost('deepseek-v4-flash')==(0.00027,0.00110)"
python -c "from repowise.core.cost_estimator.pricing import _lookup_cost; assert _lookup_cost('openrouter/deepseek/deepseek-chat')==(0.00027,0.00110)"
```
- `uv run pytest tests/unit/cli/test_pricing_table_agreement.py` — **15 passed, 2 xfailed** (now covers deepseek/kimi)
- `uv run pytest tests/unit/cli/test_cost_estimator.py` — 13 passed
- `ruff check` clean

No existing issue tracks this — gap found by cross-checking `registry._BUILTIN_PROVIDERS` against pricing tables and verifying `_lookup_cost('deepseek-chat')==(0,0)` on main.
