### PR TITLE
fix(server): make CORS browser-compliant and configurable via env

### DIFF
--- a/packages/server/src/repowise/server/app.py
+++ b/packages/server/src/repowise/server/app.py
@@ -458,11 +458,31 @@ def create_app() -> FastAPI:
         lifespan=lifespan,
     )
 
-    # CORS — allow all origins for local development
+    # CORS — configurable; default allows local dev but is browser-spec compliant.
+    # Browsers reject `Access-Control-Allow-Origin: *` with `Allow-Credentials: true`
+    # (preflight fails). When REPOWISE_CORS_ORIGINS is unset we allow any origin
+    # without credentials (safe for local dev); when credentials are needed the
+    # operator must set explicit origins via REPOWISE_CORS_ORIGINS.
+    cors_origins_env = os.environ.get("REPOWISE_CORS_ORIGINS", "").strip()
+    if cors_origins_env:
+        cors_origins = [o.strip() for o in cors_origins_env.split(",") if o.strip()]
+        cors_allow_credentials = True
+    else:
+        cors_origins = ["*"]
+        cors_allow_credentials = False
+        # Wildcard with credentials is rejected by browsers — force False and warn
+        # if the old unsafe combination is detected via explicit env.
+        if os.environ.get("REPOWISE_CORS_ALLOW_CREDENTIALS", "").lower() in ("1", "true", "yes"):
+            logger.warning(
+                "cors.wildcard_with_credentials_rejected: "
+                "REPOWISE_CORS_ORIGINS=* cannot be used with credentials; "
+                "set REPOWISE_CORS_ORIGINS to explicit origins"
+            )
+
     app.add_middleware(
         CORSMiddleware,
-        allow_origins=["*"],
-        allow_credentials=True,
+        allow_origins=cors_origins,
+        allow_credentials=cors_allow_credentials,
         allow_methods=["*"],
         allow_headers=["*"],
     )


### PR DESCRIPTION
## What

Every `repowise serve --host` deployment had **broken CORS**:

- `packages/server/src/repowise/server/app.py:445-452` set `CORSMiddleware(allow_origins=["*"], allow_credentials=True, ...)`
- Browsers **reject** `Access-Control-Allow-Origin: *` with `Allow-Credentials: true` (preflight fails) — legitimate browser UI on a team host broke, while `curl`/`fetch(mode:no-cors)` ignored CORS and got cross-site credentialed access from any origin anyway.

Auth via `deps.verify_api_key` already exists per-router (most routers have `dependencies=[Depends(verify_api_key)]`), but CORS misconfig made the browser boundary wrong.

## Fix — `app.py:445-465`

- Default (no env): `allow_origins=["*"]`, `allow_credentials=False` — **browser-spec valid**, safe for `localhost` dev without config.
- When `REPOWISE_CORS_ORIGINS` env is set (comma-separated, e.g. `https://example.com,https://app.example.com`), use explicit origins with `allow_credentials=True` (required for bearer auth from browsers).
- Warns if `REPOWISE_CORS_ALLOW_CREDENTIALS` is set with wildcard (explicit misconfig that browsers reject).

## Verification

```
REPOWISE_CORS_ORIGINS="" -> ["*"] False  # local dev, valid
REPOWISE_CORS_ORIGINS="https://example.com, https://app.example.com" -> explicit origins True
```
- `ruff check/format` clean
- No open issue tracks CORS (searched `CORS`/`allow_credentials` — 0 hits); related #1736 is about host-header 421, not CORS. Gap found by reading `app.py` CORS block and comparing to browser spec.

## Risk

- No behavior change for localhost dev (still `*` but now spec-compliant without credentials — previously credentials with * was rejected anyway).
- Team deployments set `REPOWISE_CORS_ORIGINS` to their actual origins once — no break for those already on loopback.
