### PR TITLE
fix(health): count Python match arms toward cyclomatic complexity

### DIFF
--- a/packages/core/src/repowise/core/analysis/health/complexity/cyclomatic.py
+++ b/packages/core/src/repowise/core/analysis/health/complexity/cyclomatic.py
@@ -197,7 +197,17 @@ def _is_flat_match(node: Node, lmap: LanguageNodeMap) -> bool:
     ``loop``, ``if_let``, ``while_let`` expressions, and no ``block``
     with multiple statements).  Flat matches contribute 1 CCN point for
     the match keyword itself but do NOT count each arm individually.
+
+    Python's ``match_statement`` is excluded: ``match``/``case`` in Python
+    is *pattern matching* — each ``case`` is a distinct branch point,
+    structurally the same decision as ``if``/``elif``. Suppressing its arms
+    like a C-style flat switch would report a ``match`` with N arms as ~N
+    points too low (measured: a 3-arm ``match`` gave CCN 2 while the
+    equivalent ``if``/``elif`` gave 4). Rust ``match_expression`` and other
+    languages' dispatch switches keep the flat behaviour.
     """
+    if node.type == "match_statement":
+        return False
     complex_types = lmap.branch_kinds | lmap.loop_kinds | lmap.switch_kinds
     cases = _collect_case_children(node, lmap)
     if not cases:

--- a/tests/fixtures/lang_samples/python/match.py
+++ b/tests/fixtures/lang_samples/python/match.py
@@ -1,0 +1,27 @@
+# Python match/case is pattern matching — each case is a distinct branch
+# point, structurally the same decision as if/elif. Unlike a flat Rust
+# match (or C-style switch), the arms must count toward CCN.
+#
+# python_match 3 arms -> base 1 + 3 cases = 4
+def python_match(x):
+    match x:
+        case 1:
+            return "one"
+        case 2:
+            return "two"
+        case 3:
+            return "three"
+        case _:
+            return "other"
+
+
+# Equivalent if/elif — must report the same CCN as python_match above.
+def python_if_elif(x):
+    if x == 1:
+        return "one"
+    elif x == 2:
+        return "two"
+    elif x == 3:
+        return "three"
+    else:
+        return "other"

--- a/tests/unit/health/test_complexity_walker.py
+++ b/tests/unit/health/test_complexity_walker.py
@@ -234,6 +234,24 @@ def test_rust_flat_match_complexity():
     )
 
 
+def test_python_match_arms_count_toward_ccn():
+    """Python match/case is pattern matching — each case is a real branch.
+
+    Unlike Rust ``match`` (a flat dispatch that counts once), a Python
+    ``match`` with N ``case`` arms is structurally an ``if``/``elif`` chain
+    and each arm must count toward CCN. Regression for #1774: the flat-match
+    suppression was over-applied to Python, so a 4-arm match reported 2
+    (base 1 + 1 for the match, all arms dropped) instead of counting each arm.
+    """
+    results = _walk("python/match.py", "python")
+    match_fn = _find(results, "python_match")
+    assert match_fn is not None, "python_match not detected"
+    # base 1 + 4 case arms (1, 2, 3, wildcard _) = 5.
+    assert match_fn.ccn == 5, f"python match CCN expected 5, got {match_fn.ccn}"
+    # The arms are genuinely counted, not flattened away.
+    assert match_fn.ccn >= 4, f"match arms must count toward CCN, got {match_fn.ccn}"
+
+
 def test_unsupported_language_returns_empty():
     results = walk_file_complexity("/tmp/x.unknown", "klingon", b"")
     assert results == []

--- a/tests/unit/health/test_ff_track_iljk_structural.py
+++ b/tests/unit/health/test_ff_track_iljk_structural.py
@@ -150,18 +150,29 @@ def test_unbounded_update_still_flagged(dialect):
 
 
 # --------------------------------------------------------------------------
-# large_method: a flat match dispatch is layout, not a size smell
+# large_method: a large Python match dispatch is real branching (each case
+# is an if/elif-equivalent branch), so it is a size + complexity smell
 # --------------------------------------------------------------------------
 
 
-def test_large_method_skips_flat_match_dispatch():
+def test_large_method_fires_on_match_dispatch():
+    """A 31-case Python ``match`` dispatch is real branching, not layout.
+
+    Regression for #1774: Python match/case is pattern matching — each case
+    is a distinct branch, structurally an if/elif chain. The old flat-match
+    suppression reported this dispatch at CCN 2, which let a 65-line
+    dispatcher dodge the large-method detector. It now counts each arm and
+    must be flagged like any other tangled large method.
+    """
     fm = walk_file("m.py", "python", _flat_match_src().encode())
     assert fm.functions, "expected a function to be parsed"
     fn = fm.functions[0]
-    # The flat dispatch trips the NLOC threshold but sits at CCN 2 (layout).
+    # Trips the NLOC threshold and now also the CCN floor (31 arms + base).
     assert fn.nloc >= LargeMethodDetector._NLOC_THRESHOLD
-    assert fn.ccn == 2
-    assert LargeMethodDetector().detect(_fn_ctx([fn])) == []
+    assert fn.ccn >= LargeMethodDetector._CCN_FLOOR
+    out = LargeMethodDetector().detect(_fn_ctx([fn]))
+    assert len(out) == 1, "a large match dispatch must be flagged as large"
+    assert out[0].function_name == "dispatch"
 
 
 def test_large_method_still_fires_on_real_branching():


### PR DESCRIPTION
## What

Fixes #1774. Python `match`/`case` arms are not counted as branches, so `max_ccn` undercounted match-heavy functions — sometimes far lower than independent tools measure.

## Root cause

`_is_flat_match` in `cyclomatic.py` classified Python's `match_statement` as a "flat" switch, and flat-match arms are deliberately counted **once for the dispatch, not per arm** (design note at `languages.py:37-38`). But Python `match`/`case` is *pattern matching* — each `case` is a distinct branch point, structurally the same decision as an `if`/`elif` chain. The suppression that's correct for C `switch`/Rust `match` dispatch was being over-applied to Python.

Measured on `main` before the fix:
```
# match, 3 arms                     # equivalent if/elif
match x:                                if x == 1: return "a"
    case 1: return "a"                  elif x == 2: return "b"
    case 2: return "b"                  elif x == 3: return "c"
    case 3: return "c"                  else: return "z"
    case _: return "z"
match 3 arms   -> ccn = 2        (1 entry + 1 match; all arms dropped)
if/elif 3      -> ccn = 4        (1 + 3 branches, each counted)
```

## Fix

`_is_flat_match` now returns `False` for Python's `match_statement`, so each `case_clause` counts a branch like an `elif`. Rust `match_expression` and other dispatch switches keep the flat behaviour — the existing `flat_match.rs` fixture is unchanged.

## Behavioral note on the large-method detector

This surfaces a deliberate design conflict: the `LargeMethodDetector` had a test asserting a 31-case Python dispatch table sits at CCN 2 and is "layout, not a size smell" (thus dodging the `_CCN_FLOOR = 3` gate). With arms now counted, that same 65-line dispatcher reports CCN 33 and is correctly flagged as a large method. I updated that test to match the corrected behavior — a 31-case dispatch is real branching and should be flagged.

## Tests

- New fixture `python/match.py` + `test_python_match_arms_count_toward_ccn` (4-arm match → CCN 5)
- Updated `test_large_method_fires_on_match_dispatch` (was `..._skips_flat_match_dispatch`)
- Full `tests/unit/health/`: **1187 passed**, no regressions
- Ruff clean

This is a behavior change worth a maintainer's eye — it makes Python match-heavy functions report higher (and more accurate) CCN, which will surface new large-method/brain-method findings on real codebases.
