### PR TITLE
fix(health): don't count comments in a parameter list as parameters

### DIFF
--- a/packages/core/src/repowise/core/analysis/health/complexity/ast_utils.py
+++ b/packages/core/src/repowise/core/analysis/health/complexity/ast_utils.py
@@ -240,7 +240,10 @@ def _count_parameters(fn_node: Node) -> int:
         # A bare ``*`` (keyword-only marker) and a bare ``/`` (positional-only
         # marker) parse as named ``keyword_separator`` / ``positional_separator``
         # nodes but carry no arity, so they must be skipped alongside the
-        # ``*``/``**`` splat tokens and the punctuation.
+        # ``*``/``**`` splat tokens and the punctuation. A ``comment`` node is
+        # also named but carries no arity — an explanatory comment block inside
+        # the parameter list (idiomatic for a validation pattern) must not
+        # count as a parameter (#1775).
         if child.type in (
             "(",
             ")",
@@ -252,6 +255,7 @@ def _count_parameters(fn_node: Node) -> int:
             "**",
             "keyword_separator",
             "positional_separator",
+            "comment",
         ):
             continue
         if child.type == "declArg":

--- a/tests/unit/health/test_complexity_walker.py
+++ b/tests/unit/health/test_complexity_walker.py
@@ -95,6 +95,31 @@ def test_python_complex_method_ccn():
     assert many.ccn >= 9, f"expected CCN ≥ 9, got {many.ccn}"
 
 
+def test_python_comment_in_parameter_list_not_counted():
+    """#1775: a comment inside a parameter list must not inflate param_count.
+
+    ``Annotated[T, Form(...)]`` metadata and an explanatory comment block are
+    idiomatic in FastAPI/Pydantic signatures. The comment node is named but
+    carries no arity; before the fix it was counted, so a 5-parameter handler
+    reported 6+ (and worse on longer signatures) and tripped a spurious
+    high-arity finding.
+    """
+    src = """async def trigger_scan(
+    request: Request,
+    session: Annotated[AsyncSession, Depends(get_session)],
+    # comment with, several, commas explaining the pattern
+    agent_id: Annotated[str, Form(pattern=r\"^[a-z0-9]+(-[a-z0-9]+)*$\", max_length=128)],
+    scan_root: Annotated[str, Form()],
+    subpath: Annotated[str, Form()] = \"\",
+) -> HTMLResponse:
+    pass
+"""
+    fcx = walk_file("/tmp/trigger.py", "python", src.encode())
+    fn = _find(fcx.functions, "trigger_scan")
+    assert fn is not None
+    assert fn.param_count == 5, f"expected 5 params, got {fn.param_count}"
+
+
 def test_typescript_nested_depth():
     results = _walk("typescript/nested.ts", "typescript")
     deep = _find(results, "deeplyNested")


### PR DESCRIPTION
## What

Fixes #1775. A comment inside a Python parameter list was counted as a parameter, inflating the reported arity of `Annotated[T, Form(...)]` / `Annotated[T, Query(...)]` FastAPI handlers and tripping a spurious high-arity finding.

## Root cause

`_count_parameters` in `ast_utils.py` counts every named child of the parameter-list node that isn't in its skip list. A `comment` node inside the signature is named but carries no arity — so an explanatory comment block between parameters (idiomatic when a validation pattern needs explaining) was counted as a parameter. The `Annotated[...]` / `Form(...)` commas are already contained within their own `typed_parameter` nodes, so they don't leak; the comment node was the only gap.

Measured before the fix: a 5-parameter handler with one interleaved comment reported `param_count=6`; on the issue's real signature (more comment commas) it scaled to 15.

## Fix

Add `"comment"` to the skip list in `_count_parameters`, alongside the splat tokens, `keyword_separator`/`positional_separator`, and punctuation. A comment node is named but never an arity-bearing parameter.

## Tests

- Added `test_python_comment_in_parameter_list_not_counted` — a 5-parameter `Annotated`/`Form` handler with an interleaved comma-laden comment now reports `param_count=5`.
- Full `tests/unit/health/`: **1136 passed**, no regressions.
- Ruff clean.

Note: this is scoped to the comment leak (#1775). The separate question of whether a bare `self`/`cls` node is skipped for *methods* is a distinct pre-existing behaviour, untouched here.
