### PR TITLE
fix(risk): emit is_hotspot from the backend, not client re-derivation

### DIFF
--- a/packages/server/src/repowise/server/mcp_server/tool_risk/assessment.py
+++ b/packages/server/src/repowise/server/mcp_server/tool_risk/assessment.py
@@ -413,6 +413,7 @@ async def _assess_one_target(
 
     if meta is None:
         result_data["hotspot_score"] = 0.0
+        result_data["is_hotspot"] = False
         result_data["dependents_count"] = dep_count
         result_data["co_change_partners"] = []
         result_data["primary_owner"] = None
@@ -453,6 +454,12 @@ async def _assess_one_target(
     bus_factor = getattr(meta, "bus_factor", 0) or 0
 
     result_data["hotspot_score"] = hotspot_score
+    # Emit the backend's hotspot classification, not a client re-derivation.
+    # ``is_hotspot`` lives on the stored GitMetadata row and already applies
+    # the absolute activity floors (issue #361); a client that thresholds the
+    # score alone can reproduce the churn half but not the floors, so on a
+    # quiet repo it would badge files the backend does not consider hotspots.
+    result_data["is_hotspot"] = bool(getattr(meta, "is_hotspot", False))
     result_data["dependents_count"] = dep_count
     result_data["co_change_partners"] = co_changes
     result_data["primary_owner"] = owner

--- a/packages/server/src/repowise/server/mcp_server/tool_risk/get_risk.py
+++ b/packages/server/src/repowise/server/mcp_server/tool_risk/get_risk.py
@@ -161,6 +161,7 @@ async def get_risk(
             entry = {
                 "file_path": h.file_path,
                 "hotspot_score": h.churn_percentile,
+                "is_hotspot": True,
                 "primary_owner": h.primary_owner_name,
             }
             # Silent on files with no counted fixes, so a repo without fix

--- a/packages/ui/__tests__/chat/artifacts.test.tsx
+++ b/packages/ui/__tests__/chat/artifacts.test.tsx
@@ -59,7 +59,7 @@ describe("chat artifact renderers", () => {
         data={{
           targets: [
             // Wire scores are 0–1 fractions (rank / total), not 0–100.
-            { file_path: "src/hot.ts", churn_percentile: 0.99 },
+            { file_path: "src/hot.ts", churn_percentile: 0.99, is_hotspot: true },
           ],
           global_hotspots: [{ path: "src/other.ts", churn_percentile: 0.88 }],
         }}
@@ -79,8 +79,10 @@ describe("chat artifact renderers", () => {
           targets: {
             "src/auth.py": {
               target: "src/auth.py",
-              // No is_hotspot on the MCP row — badge comes from score >= 0.75.
+              // Backend now emits is_hotspot directly; the badge trusts it
+              // rather than re-deriving from the score.
               hotspot_score: 0.91,
+              is_hotspot: true,
               risk_type: "churn-heavy",
               trend: "increasing",
             },

--- a/packages/ui/src/chat/artifacts.tsx
+++ b/packages/ui/src/chat/artifacts.tsx
@@ -186,9 +186,6 @@ type NormalizedRiskTarget = {
   risk_summary?: string;
 };
 
-/** Same top-quartile cut `git_indexer/enrich.py` uses for `is_hotspot`. */
-const HOTSPOT_SCORE_THRESHOLD = 0.75;
-
 function formatHotspotPct(score: number): string {
   return `${Math.round(score * 100)}th`;
 }
@@ -227,10 +224,10 @@ function normalizeRiskTargets(data: RiskReportArtifactData): NormalizedRiskTarge
       const out: NormalizedRiskTarget = {
         file_path: t.file_path,
         score,
-        // MCP target rows omit `is_hotspot`; derive from the enrich.py cut.
-        is_hotspot:
-          Boolean(t.is_hotspot) ||
-          (typeof score === "number" && score >= HOTSPOT_SCORE_THRESHOLD),
+        // The backend now emits `is_hotspot` (which already applies the
+        // absolute activity floors); trust it instead of re-deriving from the
+        // score, which can't reproduce the floors and misbadges quiet repos.
+        is_hotspot: Boolean(t.is_hotspot),
       };
       if (typeof t.risk_type === "string") out.risk_type = t.risk_type;
       if (typeof t.trend === "string") out.trend = t.trend;


### PR DESCRIPTION
## What

Fixes #1788. `get_risk` per-target rows carried `hotspot_score` but not `is_hotspot`, so every renderer re-derived the badge by thresholding the score — which can't reproduce the backend's definition and reintroduces the quiet-repo degeneracy #361 was filed to fix.

## Root cause

`is_hotspot` is computed once in `git_indexer/enrich.py` and gated on **two** things: `churn_pct >= 0.75` **and** `meets_hotspot_floors(meta)`. The floors exist because the churn percentile is repo-relative — on a quiet repo the top quartile degenerates to "any file touched recently". A client sees only the score, so it can reproduce the `>= 0.75` half but not the floors, and badged files the backend does not consider hotspots.

## Fix

- **`assessment.py`**: emit `is_hotspot` on the per-target row (and the no-git-metadata fallback) read from the stored `GitMetadata` flag — the single source of truth where the floors already live.
- **`get_risk.py`**: `global_hotspots` entries are hotspots by construction (selected by `is_hotspot == True`), but carry the field for a consistent row shape across both target types.
- **`artifacts.tsx`**: trust the backend flag and **remove** the `score >= 0.75` fallback, so the wrong answer is not left reachable. Dropped the now-unused `HOTSPOT_SCORE_THRESHOLD`.
- Updated the two UI artifacts tests to send `is_hotspot` rather than rely on the derived threshold.

## Tests

- Backend: `tests/unit/server/mcp/test_risk.py` + `test_hotspot_health_surfaces.py` — **21 passed**, no regressions.
- Ruff clean on the backend files.
- UI: changed `artifacts.test.tsx` fixtures to the new contract; type-check runs in CI (Web UI lint + type check).
