### PR TITLE
fix(security): store provider_config 0600 and redact keys in validate response

### DIFF
--- a/packages/server/src/repowise/server/provider_config.py
+++ b/packages/server/src/repowise/server/provider_config.py
@@ -22,6 +22,7 @@ later CLI run in the repo picks it up.
 
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
 import os
@@ -176,14 +177,30 @@ def _load_config() -> dict[str, Any]:
     return {}
 
 
+def _redact_key(text: str) -> str:
+    """Redact API key material from *text* for logging/error responses."""
+    import re
+
+    # Matches common key prefixes: sk-..., sk-ant-..., sk-proj-..., etc.
+    # Keep first 3 chars to indicate presence, redact rest.
+    return re.sub(r"(sk-[A-Za-z0-9\-_]{4,})", "sk-***", text)
+
+
 def _save_config(config: dict[str, Any]) -> None:
     # Write-then-rename so a concurrent reader (or a second writer racing on
     # the read-modify-write) never sees a half-written file or a truncated one.
+    # Keys are sensitive — ensure 0600 permissions (owner read/write only).
+    import os as _os
+
     path = _config_path()
     path.parent.mkdir(parents=True, exist_ok=True)
     tmp = path.with_suffix(f"{path.suffix}.tmp.{os.getpid()}")
     tmp.write_text(json.dumps(config, indent=2), encoding="utf-8")
+    with contextlib.suppress(OSError):
+        _os.chmod(tmp, 0o600)  # best-effort on platforms without chmod (e.g. Windows)
     os.replace(tmp, path)
+    with contextlib.suppress(OSError):
+        _os.chmod(path, 0o600)
 
 
 # ---------------------------------------------------------------------------

--- a/packages/server/src/repowise/server/routers/providers.py
+++ b/packages/server/src/repowise/server/routers/providers.py
@@ -8,6 +8,7 @@ from repowise.core.persistence import crud
 from repowise.core.persistence.database import get_session
 from repowise.server.deps import resolve_session_factory, verify_api_key
 from repowise.server.provider_config import (
+    _redact_key,
     list_provider_status,
     set_active_provider,
     set_api_key,
@@ -129,11 +130,16 @@ async def validate_provider(
         provider_name = getattr(llm_client, "provider_name", None)
         model_name = getattr(llm_client, "model_name", None)
     except Exception as exc:
-        return {"ok": False, "provider": provider_id, "model": None, "error": str(exc)}
+        return {"ok": False, "provider": provider_id, "model": None, "error": _redact_key(str(exc))}
 
     try:
         await llm_client.generate("You are a test.", "Reply with OK.", max_tokens=50)
     except Exception as exc:
-        return {"ok": False, "provider": provider_name, "model": model_name, "error": str(exc)}
+        return {
+            "ok": False,
+            "provider": provider_name,
+            "model": model_name,
+            "error": _redact_key(str(exc)),
+        }
 
     return {"ok": True, "provider": provider_name, "model": model_name, "error": None}


### PR DESCRIPTION
## What

`provider_config.json` (`~/.repowise/provider_config.json`) holds plaintext API keys (openai/anthropic/etc.) but was written **0644** — any user on a shared host can `cat` it. The `/providers/{id}/validate` endpoint also returned raw `str(exc)` which SDKs embed as `Bearer sk-...` on 401, leaking keys to the UI response.

## Fix

- **`provider_config.py:179-196`** `_save_config`: `chmod 0600` on tmp and final path via `contextlib.suppress(OSError)` (best-effort on Windows). Adds `_redact_key` helper (`re.sub(r'sk-[A-Za-z0-9\-_]{4,}', 'sk-***')`)
- **`routers/providers.py:11,132,145`** — import `_redact_key` at top, redact both instantiation and generation errors in `validate_provider`.

## Verification

```python
os.environ['REPOWISE_CONFIG_DIR']=tmp; set_api_key('openai','sk-test-12345'); assert oct(_config_path().stat().st_mode)[-3:] == '600'
_redact_key('Bearer sk-proj-abc123') == 'Bearer sk-***'
```
- `ruff check/format` clean
- `pytest tests/unit/server/test_provider_config.py` — 16 passed
- No open issue tracks perms/scrubbing (searched `chmod`/`scrub` 0 hits)
