### PR TITLE
fix(workspace): diff field-level breaking changes when only current schema exists

### DIFF
--- a/packages/core/src/repowise/core/workspace/breaking_change.py
+++ b/packages/core/src/repowise/core/workspace/breaking_change.py
@@ -531,8 +531,26 @@ def detect_breaking_changes(
         if prev_c is not None and curr_c is not None:
             prev_schema = prev_c.schema
             curr_schema = curr_c.schema
-            if prev_schema is not None and curr_schema is not None:
-                raws.extend(_diff_schemas(prev_schema, curr_schema))
+            if prev_schema is not None or curr_schema is not None:
+                # First schema-bearing run after upgrade: prev has None while curr
+                # carries proto fields. Previous guard required both sides, so the
+                # new required field never fired. Diff against empty when one side
+                # is missing so field additions/removals are surfaced.
+                from repowise.core.workspace.contract_schema import ContractSchema
+
+                if prev_schema is None and curr_schema is not None:
+                    prev_schema = ContractSchema(
+                        source=curr_schema.source, request_fields=[], response_fields=[]
+                    )
+                elif curr_schema is None and prev_schema is not None:
+                    curr_schema = ContractSchema(
+                        source=prev_schema.source, request_fields=[], response_fields=[]
+                    )
+                # Both may still be None only if originals were None, but the outer
+                # or-guard ensures we are here only when at least one existed; the
+                # empty construction above guarantees non-None for diff.
+                if prev_schema is not None and curr_schema is not None:
+                    raws.extend(_diff_schemas(prev_schema, curr_schema))
 
         if not raws:
             continue
@@ -579,9 +597,7 @@ def save_breaking_change_report(report: BreakingChangeReport, workspace_root: Pa
     out_path = data_dir / BREAKING_CHANGES_FILENAME
     # Atomic: the MCP enricher reads these artifacts from a separate
     # process and must never observe a half-written file.
-    atomic_write_text(
-        out_path, json.dumps(report.to_dict(), indent=2, ensure_ascii=False)
-    )
+    atomic_write_text(out_path, json.dumps(report.to_dict(), indent=2, ensure_ascii=False))
     return out_path
 
 


### PR DESCRIPTION
## What

Field-level breaking changes (required field added, type changed, etc.) were **never reported** on the first useful run after schema support landed:

- `breaking_change.py:531-535` gated on `if prev_schema is not None and curr_schema is not None` — so when `previous` had `schema=None` (contracts written before proto schema) and `current` carried `schema=ContractSchema(request_fields=[...])`, the new required field **never fired**.
- Same blind spot for the reverse (schema removed).
- Impact: `breaking_changes.json` showed 0 breaks, `impacted_consumers` empty, dashboard green while consumers actually break — the flagship workspace feature false-negative on its first run.

## Fix — `breaking_change.py:531-550`

When either side carries a schema, diff against an **empty** schema for the missing side (empty request/response fields, same source as the existing side, so source-matched). Both `None` still means no field rules (existing test `test_no_schema_means_no_field_rules` passes). Handles:
- `prev=None, curr=required field` → `field_required breaking`
- `prev=field, curr=None` → removal breaking
- `both present` → existing diff path unchanged.

## Verification

```python
prev=Contract(..., schema=None), curr=Contract(..., schema=required field)
detect_breaking_changes(prev, curr) -> 1 change (field_required) — was 0
```
- `pytest tests/unit/workspace/test_breaking_change.py` — 23 passed
- `ruff check/format` clean
- No open issue/PR covers this guard (searched `breaking_change`/`schema` 0 hits); gap found by reading contract-level vs field-level dispatch.
