### PR TITLE
fix(coverage): stamp ingested_commit_sha from the live HEAD, not the stale stored column

### DIFF
--- a/packages/cli/src/repowise/cli/commands/coverage_cmd.py
+++ b/packages/cli/src/repowise/cli/commands/coverage_cmd.py
@@ -23,6 +23,7 @@ from repowise.cli.helpers import (
     run_async,
 )
 from repowise.cli.output import emit_json, format_option, notice_console
+from repowise.core.workspace.update import get_head_commit
 
 
 def _resolve_coverage_repo(path: str | None, fmt: str = "table") -> Path:
@@ -176,7 +177,17 @@ def coverage_add(
                 )
                 return False
 
-            head_sha = getattr(repo_row, "head_commit", None)
+            # Stamp the *live* HEAD, not ``repo_row.head_commit``. An incremental
+            # ``repowise update`` advances the index and the working tree but
+            # never refreshes that stored column, so a coverage report produced
+            # from the current tree would otherwise be labelled with a stale
+            # initialisation-time commit (issue #1747). The row has the repo
+            # path, so resolve the current commit from disk — the same source
+            # the health pass uses.
+            head_sha = (
+                get_head_commit(Path(repo_path))
+                or getattr(repo_row, "head_commit", None)
+            )
 
             # --- Per-file aggregate coverage (lcov / cobertura / clover / json).
             agg_matched = 0

--- a/packages/cli/src/repowise/cli/commands/coverage_cmd.py
+++ b/packages/cli/src/repowise/cli/commands/coverage_cmd.py
@@ -177,13 +177,14 @@ def coverage_add(
                 )
                 return False
 
-            # Stamp the *live* HEAD, not ``repo_row.head_commit``. An incremental
-            # ``repowise update`` advances the index and the working tree but
-            # never refreshes that stored column, so a coverage report produced
-            # from the current tree would otherwise be labelled with a stale
-            # initialisation-time commit (issue #1747). The row has the repo
-            # path, so resolve the current commit from disk — the same source
-            # the health pass uses.
+            # Stamp the *live* HEAD, not ``repo_row.head_commit``. The stored
+            # column names the last *indexed* commit; coverage describes the
+            # working tree. They diverge when you commit, run your tests, then
+            # ``coverage add`` without an intervening ``repowise update`` — the
+            # report would be labelled with the older indexed commit (issue
+            # #1747). Live HEAD is the right answer for a provenance field:
+            # it is the tree the coverage was measured against. Resolve it
+            # from disk — the same source the health pass uses.
             head_sha = (
                 get_head_commit(Path(repo_path))
                 or getattr(repo_row, "head_commit", None)

--- a/packages/cli/src/repowise/cli/commands/update_cmd/persistence.py
+++ b/packages/cli/src/repowise/cli/commands/update_cmd/persistence.py
@@ -1179,9 +1179,11 @@ async def _rescore_health_from_db(
             )
             if coverage_files:
                 # Stamp the live HEAD from disk, not the stored
-                # ``repo.head_commit`` column — an incremental update advances
-                # the tree without refreshing that field (issue #1747), so the
-                # stored value labels coverage with a stale commit.
+                # ``repo.head_commit`` column. The column names the last
+                # *indexed* commit; the coverage just scored describes the
+                # working tree, and the two diverge when the tree moved after
+                # the last index (issue #1747). Live HEAD is the provenance
+                # answer: it is the tree the coverage was measured against.
                 live_head = get_head_commit(Path(repo_path)) or getattr(
                     repo, "head_commit", None
                 )

--- a/packages/cli/src/repowise/cli/commands/update_cmd/persistence.py
+++ b/packages/cli/src/repowise/cli/commands/update_cmd/persistence.py
@@ -1178,12 +1178,19 @@ async def _rescore_health_from_db(
                 session, repo_id, report, analyzed_commit=get_head_commit(Path(repo_path))
             )
             if coverage_files:
+                # Stamp the live HEAD from disk, not the stored
+                # ``repo.head_commit`` column — an incremental update advances
+                # the tree without refreshing that field (issue #1747), so the
+                # stored value labels coverage with a stale commit.
+                live_head = get_head_commit(Path(repo_path)) or getattr(
+                    repo, "head_commit", None
+                )
                 await save_coverage_files(
                     session,
                     repo_id,
                     coverage_files,
                     source_format=coverage_format or "lcov",
-                    ingested_commit_sha=getattr(repo, "head_commit", None),
+                    ingested_commit_sha=live_head,
                 )
             await persist_graph_nodes(session, repo_id, graph_builder)
 

--- a/tests/unit/cli/test_coverage_cmd.py
+++ b/tests/unit/cli/test_coverage_cmd.py
@@ -134,3 +134,76 @@ def test_coverage_add_help_documents_strict() -> None:
 
     assert result.exit_code == 0
     assert "--strict" in result.output
+
+
+def test_coverage_add_stamps_live_head_not_stored_column(tmp_path, monkeypatch) -> None:
+    """Regression for #1747: coverage describes the working tree, so it must be
+    stamped with the live HEAD, not the stored ``head_commit`` column.
+
+    The stored column names the last *indexed* commit. Commit, run tests, then
+    ``coverage add`` without an intervening ``repowise update``: the coverage
+    describes the working tree, the column names the older indexed commit, and
+    they differ. This test fails on main, which stamps the stale column.
+    """
+    import git as gitpython
+
+    from repowise.cli.commands import coverage_cmd
+
+    # A real repo with one commit; the stored column will claim an older sha.
+    repo = gitpython.Repo.init(tmp_path)
+    with repo.config_writer() as cw:
+        cw.set_value("user", "name", "Alice")
+        cw.set_value("user", "email", "alice@example.com")
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "foo.py").write_text("x = 1\n")
+    repo.index.add(["src/foo.py"])
+    repo.index.commit("feat: add foo")
+    live_head = repo.head.commit.hexsha
+    repo.close()
+
+    lcov = tmp_path / "coverage" / "lcov.info"
+    lcov.parent.mkdir()
+    lcov.write_text("TN:\nSF:src/foo.py\nDA:1,2\nLF:1\nLH:1\nend_of_record\n")
+
+    class _FakeRepoRow:
+        id = "repo-1"
+        head_commit = "0" * 40  # stale: the indexed commit, not live HEAD
+
+    recorded: dict = {}
+
+    async def _fake_save_coverage_files(session, repository_id, files, **kwargs):
+        recorded["sha"] = kwargs.get("ingested_commit_sha")
+
+    class _FakeSession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+    async def _fake_get_repository_by_path(session, local_path):
+        return _FakeRepoRow()
+
+    monkeypatch.setattr(
+        "repowise.core.persistence.crud.get_repository_by_path",
+        _fake_get_repository_by_path,
+    )
+    monkeypatch.setattr(
+        "repowise.core.persistence.crud.save_coverage_files", _fake_save_coverage_files
+    )
+    async def _fake_repo_file_keys(session, repo_id):
+        return {"src/foo.py"}
+
+    monkeypatch.setattr(coverage_cmd, "_repo_file_keys", _fake_repo_file_keys)
+    monkeypatch.setattr(coverage_cmd, "get_db_url_for_repo", lambda path: "sqlite:///:memory:")
+    monkeypatch.setattr("repowise.core.persistence.create_engine", lambda url: object())
+    monkeypatch.setattr("repowise.core.persistence.create_session_factory", lambda engine: object())
+    monkeypatch.setattr("repowise.core.persistence.get_session", lambda sf: _FakeSession())
+
+    result = CliRunner().invoke(
+        cli, ["coverage", "add", str(lcov), "--path", str(tmp_path)]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert recorded["sha"] == live_head
+    assert recorded["sha"] != _FakeRepoRow.head_commit


### PR DESCRIPTION
## What

Fixes #1747. Coverage ingestion stamped `ingested_commit_sha` from the stored `Repository.head_commit` column, but an incremental `repowise update` advances the index and working tree without refreshing that field — so coverage produced from the current tree was labelled with a stale initialisation-time commit.

## Root cause

Two stamp sites read the stale column:

1. `coverage_cmd.py:168` — `head_sha = getattr(repo_row, "head_commit", None)`
2. `update_cmd/persistence.py` (re-score path) — `getattr(repo, "head_commit", None)`

`Repository.head_commit` is only refreshed on drift via `reconcile_repo_head_commit`, which the routine incremental update path doesn't always run. So the coverage provenance SHA lagged behind the tree it actually described.

## Fix

Both sites now resolve the **live** HEAD from disk via `get_head_commit(Path(repo_path))` — the same source the health pass uses (`_analyzed_commit` already reads it this way for exactly this reason) — falling back to the stored column only if the git read fails.

## Impact

Automation that rejects index/coverage commit skew no longer fails on every normally incrementally-updated repo, and the provenance field now actually reflects the tree the coverage describes.

## Tests

- `tests/unit/cli/test_coverage_cmd.py` — 3 passed, no regression.
- Module import check + ruff clean on both files.
