### PR TITLE
fix(costs): price mistral/ministral in estimator and live tracker

### DIFF
--- a/packages/core/src/repowise/core/cost_estimator/pricing.py
+++ b/packages/core/src/repowise/core/cost_estimator/pricing.py
@@ -38,6 +38,11 @@ _COST_TABLE_EXACT: dict[str, tuple[float, float]] = {
     "claude-opus-4-6": (0.005, 0.025),  # $5 / $25 per MTok
     "claude-sonnet-4-6": (0.003, 0.015),  # $3 / $15 per MTok
     "claude-haiku-4-5": (0.001, 0.005),  # $1 / $5 per MTok
+    # Mistral — https://mistral.ai/pricing
+    "mistral-large-latest": (0.002, 0.006),  # $2 / $6 per MTok
+    "mistral-small-latest": (0.0002, 0.0006),
+    "ministral-8b-latest": (0.00015, 0.0004),
+    "ministral-3b-latest": (0.00015, 0.0004),
 }
 
 # Prefix fallbacks for unknown variants. No `gpt-5.6` catch-all: the 5.6
@@ -54,6 +59,11 @@ _COST_TABLE_PREFIX: dict[str, tuple[float, float]] = {
     "claude-haiku": (0.001, 0.005),
     "claude": (0.003, 0.015),
     "gemini": (0.00025, 0.0015),
+    # Mistral AI — https://mistral.ai/pricing
+    "mistral-large": (0.002, 0.006),  # $2 / $6 per MTok
+    "mistral-small": (0.0002, 0.0006),  # $0.20 / $0.60 per MTok
+    "mistral": (0.0002, 0.0006),
+    "ministral": (0.00015, 0.0004),  # $0.15 / $0.40 per MTok (3B/8B edge models)
     "llama": (0.0, 0.0),
     "mock": (0.0, 0.0),
     "codex_cli/": (0.0, 0.0),

--- a/packages/core/src/repowise/core/generation/cost_tracker.py
+++ b/packages/core/src/repowise/core/generation/cost_tracker.py
@@ -64,6 +64,11 @@ _PRICING: dict[str, dict[str, float]] = {
     # DeepSeek
     "deepseek-v4-flash": {"input": 0.14, "output": 0.28},
     "deepseek-v4-pro": {"input": 1.74, "output": 3.48},
+    # Mistral — https://mistral.ai/pricing
+    "mistral-large-latest": {"input": 2.0, "output": 6.0},
+    "mistral-small-latest": {"input": 0.20, "output": 0.60},
+    "ministral-8b-latest": {"input": 0.15, "output": 0.40},
+    "ministral-3b-latest": {"input": 0.15, "output": 0.40},
 }
 
 _FALLBACK_PRICING: dict[str, float] = {"input": 3.0, "output": 15.0}


### PR DESCRIPTION
## What

Same $0 lie as PR1790 but for Mistral's catalog — routed `mistral`/`ministral` models priced at **$0**:

- `pricing.py:47-75` had no `mistral`/`ministral` rows — `openrouter/mistral/mistral-large-latest` stripped to `mistral-large-latest` then `(0,0)`
- `cost_tracker.py:64-67` also missed them — live counter mismatched estimator.

## Fix

- **`pricing.py`** exact `mistral-large/small-latest`, `ministral-8b/3b-latest` (`2/6, 0.20/0.60, 0.15/0.40` per MTok) + prefix `mistral`/`ministral`/`mistral-large`/`mistral-small`
- **`cost_tracker.py`** sync per-MTok entries (`2/6, 0.20/0.60, 0.15/0.40`)

## Verification

```python
_lookup_cost('mistral-large-latest')==(0.002,0.006)
_lookup_cost('openrouter/mistral/mistral-large-latest')==(0.002,0.006)
```
- `pytest test_pricing_table_agreement` — **12 passed, 2 xfailed** (now covers mistral)
- `ruff check/format` clean
- No open issue tracks mistral pricing (searched 0 hits); gap found by checking every `_BUILTIN_PROVIDERS` model against pricing tables.
