### PR TITLE
test(distill): assert the median rewrite time, not a p95 over 12 samples

### DIFF
--- a/tests/unit/distill/test_rewrite_perf.py
+++ b/tests/unit/distill/test_rewrite_perf.py
@@ -74,8 +74,16 @@ def _payload(command: str, cwd: Path) -> str:
     )
 
 
-def _p95(cmd: list[str], payload: str) -> tuple[float, list[str]]:
-    """Wall-clock p95 over 12 invocations, plus every stdout seen."""
+def _p95(cmd: list[str], payload: str) -> tuple[float, list[str], list[float]]:
+    """Wall-clock timings over 12 invocations, plus every stdout seen.
+
+    Returns ``(median_ms, outputs, all_timings_ms)``. The *median* is the
+    quantity the budget is written about: a single slow subprocess spawn on a
+    shared CI runner is a scheduling outlier, not a regression, and must not
+    decide the run. The raw ``all_timings`` list is returned so the failure
+    message can show the whole distribution — one outlier is then obvious at
+    a glance instead of hiding behind a single number (issue #1783).
+    """
     timings: list[float] = []
     outputs: list[str] = []
     for _ in range(12):
@@ -85,7 +93,8 @@ def _p95(cmd: list[str], payload: str) -> tuple[float, list[str]]:
         assert result.returncode == 0
         outputs.append(result.stdout)
     timings.sort()
-    return timings[int(len(timings) * 0.95) - 1], outputs
+    median = timings[len(timings) // 2]
+    return median, outputs, timings
 
 
 #: Command shapes the hook must answer within budget. The pipeline and
@@ -107,9 +116,14 @@ def test_p95_under_150ms(tmp_path: Path) -> None:
     # Warmup: first run pays one-off filesystem cache costs.
     subprocess.run(cmd, input=_payload("pytest -x", tmp_path), capture_output=True, text=True)
 
-    p95, outputs = _p95(cmd, _payload("pytest -x", tmp_path))
+    median, outputs, timings = _p95(cmd, _payload("pytest -x", tmp_path))
     assert all("repowise distill --source hook-bash pytest -x" in out for out in outputs)
-    assert p95 < 150, f"repowise-rewrite p95 {p95:.1f} ms >= 150 ms"
+    _fmt = ", ".join(f"{t:.0f}" for t in timings)
+    assert median < 150, f"repowise-rewrite median {median:.1f} ms >= 150 ms (all: {_fmt})"
+    # A genuine regression is not a single slow spawn — allow one loose ceiling
+    # on the worst sample so a real "sometimes takes a second" failure still
+    # trips while a single scheduling hiccup does not.
+    assert max(timings) < 1000, f"repowise-rewrite max {max(timings):.0f} ms >= 1000 ms"
 
 
 #: Budget for an invocation that also writes its ledger row. Higher than the
@@ -144,14 +158,16 @@ def test_a_ledgered_invocation_stays_under_budget(tmp_path: Path) -> None:
     )
     subprocess.run(cmd, input=payload, capture_output=True, text=True)
 
-    p95, outputs = _p95(cmd, payload)
+    median, outputs, timings = _p95(cmd, payload)
     assert all("repowise distill --source hook-bash pytest -x" in out for out in outputs)
     # Guard the guard: a budget met by not writing the row would pass forever.
     db = tmp_path / ".repowise" / "sessions" / "sessions.db"
     assert db.exists(), "the probe never reached the ledger write it is timing"
-    assert p95 < _LEDGERED_BUDGET_MS, (
-        f"a ledgered rewrite p95 {p95:.1f} ms >= {_LEDGERED_BUDGET_MS} ms"
+    _fmt = ", ".join(f"{t:.0f}" for t in timings)
+    assert median < _LEDGERED_BUDGET_MS, (
+        f"a ledgered rewrite median {median:.1f} ms >= {_LEDGERED_BUDGET_MS} ms (all: {_fmt})"
     )
+    assert max(timings) < 1000, f"ledgered rewrite max {max(timings):.0f} ms >= 1000 ms"
 
 
 @pytest.mark.parametrize("command", _PERF_COMMANDS)
@@ -165,5 +181,7 @@ def test_lexer_shapes_stay_under_budget(tmp_path: Path, command: str) -> None:
     cmd = _hook_invocation()
     subprocess.run(cmd, input=_payload(command, tmp_path), capture_output=True, text=True)
 
-    p95, _ = _p95(cmd, _payload(command, tmp_path))
-    assert p95 < 150, f"{command!r} p95 {p95:.1f} ms >= 150 ms"
+    median, _, timings = _p95(cmd, _payload(command, tmp_path))
+    _fmt = ", ".join(f"{t:.0f}" for t in timings)
+    assert median < 150, f"{command!r} median {median:.1f} ms >= 150 ms (all: {_fmt})"
+    assert max(timings) < 1000, f"{command!r} max {max(timings):.0f} ms >= 1000 ms"


### PR DESCRIPTION
## What

Fixes #1783 — the flaky rewrite-perf timing test that keeps failing unrelated PRs' CI. This is the test that red the build on your #1800 just now, on PR #1568 for five days, and on two of my own PRs today.

## Root cause

`_p95` in `test_rewrite_perf.py` called a 12-sample wall-clock measurement a "p95", but `int(12 * 0.95) - 1` is index 10 — the **eleventh-smallest of 12, one below the maximum**. So a single slow subprocess spawn (exactly where outliers live on a shared CI runner) decided the run. The budget was written as if it measured a typical case, but the instrument measured a near-maximum.

## Fix

- **Measure the median** — the quantity the budget is actually written about. A single scheduling hiccup no longer decides the run.
- **Add a separate, much looser ceiling (1000ms) on the worst sample**, so a genuine "sometimes takes a second" regression still fails while one slow spawn does not — the split the issue leaned toward.
- **The failure message now names the whole timing distribution** (e.g. `median 145 ms >= 150 ms (all: 88, 92, ..., 612)`), so a single outlier is obvious at a glance instead of hiding behind one number — exactly the problem the issue reported: "p95 256.4 ms >= 200 ms gave the contributor nothing to reason about."

## Why this fix

Raising the budget again (done once already, per the comment above `_LEDGERED_BUDGET_MS`) would trade a flaky failure for a guard that no longer catches the regression it exists for. The instrument was wrong, not the threshold.

## Tests

- `tests/unit/distill/test_rewrite_perf.py` — 7 passed locally.
- The median assertion now tolerates a single slow spawn while the 1000ms max ceiling still catches real regressions.
- Ruff clean.

Not in scope (per the issue): the hook's actual cost and the import-graph guard — both unchanged.
