### PR TITLE
fix(hooks): resolve the real hooks dir so worktree installs don't crash init

### DIFF
--- a/packages/cli/src/repowise/cli/hooks.py
+++ b/packages/cli/src/repowise/cli/hooks.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import contextlib
 import re
 import stat
+import subprocess
 from pathlib import Path
 
 _HOOK_MARKER = "# repowise-hook-start"
@@ -94,6 +95,36 @@ def _git_root(path: Path) -> Path | None:
         if (parent / ".git").exists():
             return parent
     return None
+
+
+def _hooks_dir(repo_path: Path) -> Path | None:
+    """Resolve the real hooks directory for *repo_path*.
+
+    A normal repo keeps ``.git/hooks`` under ``.git``, but a git **worktree**
+    stores ``.git`` as a *file* (``gitdir: <path>``) pointing at the shared
+    metadata dir — so ``root / ".git" / "hooks"`` is ``NotADirectoryError``
+    territory. Ask git for the real hooks path so both layouts work, and fall
+    back to the ``.git/hooks`` heuristic when git is unavailable or not a repo.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--git-path", "hooks"],
+            cwd=str(repo_path),
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode == 0:
+            p = Path(result.stdout.strip())
+            if p.is_absolute():
+                return p
+            return repo_path / p
+    except Exception:
+        pass
+    root = _git_root(repo_path)
+    if root is None:
+        return None
+    return root / ".git" / "hooks"
 
 
 def _strip_legacy_block(content: str) -> tuple[str, bool]:
@@ -186,8 +217,10 @@ def install(repo_path: Path) -> str:
     if root is None:
         return "not a git repository"
 
-    hooks_dir = root / ".git" / "hooks"
-    hooks_dir.mkdir(exist_ok=True)
+    hooks_dir = _hooks_dir(repo_path)
+    if hooks_dir is None:
+        return "not a git repository"
+    hooks_dir.mkdir(parents=True, exist_ok=True)
     hook_path = hooks_dir / "post-commit"
 
     migrated_legacy = False
@@ -239,7 +272,10 @@ def uninstall(repo_path: Path) -> str:
     if root is None:
         return "not a git repository"
 
-    hook_path = root / ".git" / "hooks" / "post-commit"
+    hooks_dir = _hooks_dir(repo_path)
+    if hooks_dir is None:
+        return "not a git repository"
+    hook_path = hooks_dir / "post-commit"
     if not hook_path.exists():
         return "no post-commit hook found"
 
@@ -268,7 +304,10 @@ def status(repo_path: Path) -> str:
     if root is None:
         return "not a git repository"
 
-    hook_path = root / ".git" / "hooks" / "post-commit"
+    hooks_dir = _hooks_dir(repo_path)
+    if hooks_dir is None:
+        return "not a git repository"
+    hook_path = hooks_dir / "post-commit"
     if not hook_path.exists():
         return "not installed"
 

--- a/tests/unit/cli/test_hooks_legacy_migration.py
+++ b/tests/unit/cli/test_hooks_legacy_migration.py
@@ -185,6 +185,38 @@ class TestInstallUpgradesMarkerBlock:
         assert result == "already installed"
 
 
+    class TestInstallInWorktree:
+        """Issue #1609: a git worktree stores ``.git`` as a *file*, not a
+        directory, so the naive ``root / \".git\" / \"hooks\"`` path crashed
+        ``install``/``status`` with ``NotADirectoryError`` and took down ``init``.
+        ``_hooks_dir`` resolves the real hooks path via git instead."""
+
+        @pytest.fixture
+        def worktree(self, tmp_path):
+            main = tmp_path / "main"
+            main.mkdir()
+            subprocess.run(["git", "init", "-q"], cwd=main, check=True)
+            (main / "f.txt").write_text("hi\n", encoding="utf-8")
+            subprocess.run(["git", "add", "."], cwd=main, check=True)
+            subprocess.run(
+                ["git", "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-qm", "init"],
+                cwd=main,
+                check=True,
+            )
+            wt = tmp_path / "wt"
+            subprocess.run(["git", "worktree", "add", "-q", str(wt)], cwd=main, check=True)
+            assert (wt / ".git").is_file(), "expected .git to be a file in a worktree"
+            return wt
+
+        def test_install_does_not_crash_in_worktree(self, worktree):
+            result = install(worktree)
+            assert result == "installed"
+            assert status(worktree) == "installed"
+
+        def test_status_in_worktree_is_not_an_error(self, worktree):
+            assert status(worktree) == "not installed"
+
+
 class TestInstalledHookScript:
     """Sanity checks on the shipped hook script so platform-specific
     regressions (e.g. accidentally introducing bash-only syntax) get caught


### PR DESCRIPTION
## What

Fixes #1609. In a git **worktree**, `.git` is a *file* (`gitdir: <path>`), not a directory. The hook installer built `root / ".git" / "hooks"` from `_git_root`'s heuristic, so in a worktree `mkdir` raised `NotADirectoryError` and the crash propagated up to take down the whole `repowise init`.

## Root cause

`_git_root` walks up for any `.git` entry — but in a worktree that entry is a file, not a directory. `install()`/`status()`/`uninstall()` then did `root / ".git" / "hooks"`, which fails on a worktree because `.git` is not a directory.

## Fix

- Add `_hooks_dir(repo_path)` — resolves the real hooks dir via `git rev-parse --git-path hooks`, which returns the correct (shared) hooks dir for **both** normal repos and worktrees. Falls back to the `.git/hooks` heuristic when git is unavailable or not a repo.
- `install`, `status`, and `uninstall` now use `_hooks_dir`.

## Tests

- New `TestInstallInWorktree` in `test_hooks_legacy_migration.py`: creates a real worktree (where `.git` is asserted to be a file), verifies `install` no longer crashes and `status` reports correctly.
- Existing hook tests: **13 passed**, no regression.
- Ruff clean.
