### PR TITLE
fix(pages): pass repo_id to regenerate so Write-with-AI works in workspace mode

### DIFF
--- a/packages/api-client/src/pages.test.ts
+++ b/packages/api-client/src/pages.test.ts
@@ -83,4 +83,12 @@ describe("regeneratePage", () => {
       cascade: "dependents",
     });
   });
+
+  it("includes repo_id when given (workspace routing)", async () => {
+    await regeneratePage("file_page:src/main.py", { repoId: "repo1" });
+    expect(apiPost.mock.calls[0]![3]).toEqual({
+      page_id: "file_page:src/main.py",
+      repo_id: "repo1",
+    });
+  });
 });

--- a/packages/api-client/src/pages.ts
+++ b/packages/api-client/src/pages.ts
@@ -136,7 +136,7 @@ export async function updatePageNotes(
  */
 export async function regeneratePage(
   pageId: string,
-  opts?: { cascade?: GenerateCascade; style?: string },
+  opts?: { cascade?: GenerateCascade; style?: string; repoId?: string },
 ): Promise<JobLaunchResponse> {
   return apiPost<JobLaunchResponse>(
     "/api/pages/lookup/regenerate",
@@ -144,6 +144,7 @@ export async function regeneratePage(
     undefined,
     {
       page_id: pageId,
+      ...(opts?.repoId ? { repo_id: opts.repoId } : {}),
       ...(opts?.cascade ? { cascade: opts.cascade } : {}),
       ...(opts?.style ? { style: opts.style } : {}),
     },

--- a/packages/server/src/repowise/server/routers/pages.py
+++ b/packages/server/src/repowise/server/routers/pages.py
@@ -237,6 +237,11 @@ async def update_page_notes(
 async def regenerate_page_by_query(
     request: Request,
     page_id: str = Query(..., description="Page ID"),
+    repo_id: str | None = Query(
+        None,
+        description="Repository ID. Required in workspace mode to route to the "
+        "correct repository database.",
+    ),
     style: str | None = Query(
         None,
         description="Optional wiki style to regenerate this page in (per-page override).",

--- a/packages/web/src/components/coverage/freshness-table-wrapper.tsx
+++ b/packages/web/src/components/coverage/freshness-table-wrapper.tsx
@@ -29,7 +29,7 @@ export function FreshnessTableWithRegenerate({
         return;
       }
       try {
-        const res = await regeneratePage(pageId, { cascade: "none" });
+        const res = await regeneratePage(pageId, { cascade: "none", repoId });
         setActiveJobId(res.job_id);
         toast.info("Regeneration started");
       } catch (e) {

--- a/packages/web/src/components/docs/page-generate-button.tsx
+++ b/packages/web/src/components/docs/page-generate-button.tsx
@@ -101,7 +101,7 @@ export function PageGenerateButton({
   async function confirm() {
     setLaunching(true);
     try {
-      const res = await regeneratePage(page.id, { cascade });
+      const res = await regeneratePage(page.id, { cascade, repoId });
       setJobId(res.job_id);
       setConfirmOpen(false);
     } catch (e) {


### PR DESCRIPTION
## What

Fixes #1665. The **Write with AI** regenerate request omitted `repo_id`, so in workspace mode `get_db_session` couldn't route to the correct repository database and the page lookup returned **404**. A manual regenerate request with `repo_id` added succeeds (202).

## Root cause

`regeneratePage` (api-client) never sent `repo_id`, and the backend `regenerate_page_by_query` endpoint didn't accept one — so `resolve_request_session_factory` read a `None` repo id and couldn't open the right repo DB.

## Changes

- **`pages.py`**: `regenerate_page_by_query` now accepts an optional `repo_id` query param (workspace routing; single-repo callers unchanged).
- **`api-client/pages.ts`**: `regeneratePage` accepts and forwards `repoId` → `repo_id`.
- **`page-generate-button.tsx` + `freshness-table-wrapper.tsx`**: pass their `repoId` through (both had it available but weren't sending it).

## Tests

- `api-client/src/pages.test.ts`: new test asserting `repo_id` is included when `repoId` is given (workspace routing).
- Backend ruff clean + module import verified.

Note: `test_plugin_content` is red on main itself (v0.47.0 release bug, unrelated to this PR).
