### PR TITLE
fix(server): read the embedder key from the process env so CLI and MCP agree

### DIFF
--- a/packages/server/src/repowise/server/mcp_server/_server.py
+++ b/packages/server/src/repowise/server/mcp_server/_server.py
@@ -98,6 +98,16 @@ def _persisted_embedder_key(name: str) -> str | None:
         return None
     canonical = env_vars[0]
 
+    # The process environment is the highest-precedence source, matching the
+    # CLI's resolver (cli/providers/keys.py): an exported key is an explicit
+    # override. The server used to skip this tier entirely, so on a machine
+    # with an exported credential it and the CLI disagreed about the same
+    # repo in the same shell (issue #1711).
+    for var in env_vars:
+        value = os.environ.get(var)
+        if value:
+            return value
+
     if _state._repo_path:
         try:
             # Reuse the reader get_answer already uses for the LLM credential,

--- a/tests/unit/cli/test_embedder_key_resolution.py
+++ b/tests/unit/cli/test_embedder_key_resolution.py
@@ -313,6 +313,27 @@ def test_cli_and_mcp_resolve_the_same_key_for_the_same_repo(
     assert _server._persisted_embedder_key("openai") == expected
 
 
+def test_env_export_wins_in_both_cli_and_server(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Issue #1711: an exported key is an explicit override on BOTH sides.
+
+    The server previously never consulted the process env, so on a machine with
+    an exported credential it resolved a different key (or none) than the CLI,
+    and the same repo in the same shell disagreed over MCP vs ``repowise
+    search``. The server now reads the env tier first, matching the CLI.
+    """
+    from repowise.server.mcp_server import _server, _state
+
+    _write_env(tmp_path, OPENAI_API_KEY="«redacted:sk-repo»")
+    _write_global_config(embedder="openai", embedder_api_key="«redacted:sk-global»")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-from-env")
+    monkeypatch.setattr(_state, "_repo_path", str(tmp_path), raising=False)
+
+    assert resolve_embedder_api_key("openai", tmp_path).key == "sk-from-env"
+    assert _server._persisted_embedder_key("openai") == "sk-from-env"
+
+
 def test_no_key_search_is_reported_for_a_keyless_backend(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## What

Fixes #1711. The MCP server's `_persisted_embedder_key` never consulted the **process environment**, so on any machine with an exported `OPENAI_API_KEY` (or other provider key) of a different credential than the repo's `.repowise/.env`, the CLI (which reads env first) and the MCP server (which skipped env) resolved **different keys** for the same repo in the same shell. Semantic search degraded/hung through the CLI while the MCP tool answered.

## Root cause

Two resolvers with different precedence:
- **CLI** (`cli/providers/keys.py::resolve_embedder_api_key`): process env → repo `.env` → global config.
- **MCP server** (`_server.py::_persisted_embedder_key`): repo `.env` → global config — **never** the process env.

So on any machine with an exported credential, the two disagreed about the same directory.

## Fix

Unify **the other way** than the issue suggested, to preserve the CLI's deliberate contract that an exported key is an explicit override (`test_env_wins_over_everything`): the **server now reads the process env tier first**, before the repo `.env` and global config — matching `cli/providers/keys.py`. This makes CLI and MCP resolve identically on every machine, and keeps the existing precedence contract intact.

## Tests

- New `test_env_export_wins_in_both_cli_and_server` — asserts an exported `OPENAI_API_KEY` wins on **both** the CLI and the MCP server for the same repo.
- `tests/unit/cli/test_embedder_key_resolution.py` — **20 passed**, no regression (including the existing `test_env_wins_over_everything`).
- Ruff clean.
