### PR TITLE
fix(sql): don't flag SELECT INTO targets as a cartesian join

### DIFF
--- a/packages/core/src/repowise/core/analysis/health/sql_complexity.py
+++ b/packages/core/src/repowise/core/analysis/health/sql_complexity.py
@@ -238,6 +238,13 @@ def _statement_smells(text: str, dialect: str | None) -> list[PerfHit]:
         for sel in stmt.find_all(exp.Select):
             if sel.args.get("where"):
                 continue
+            # ``SELECT ... INTO a, b`` — a multi-target INTO — is parsed with
+            # the trailing target (``b``) as a comma-join FROM item, so a
+            # table-creating statement looks like a cartesian join (issue
+            # #1502). ``into`` is present exactly when the trailing names are
+            # INTO targets, not joins; skip those.
+            if sel.args.get("into"):
+                continue
             for join in sel.args.get("joins") or ():
                 if (
                     not join.args.get("kind")  # CROSS/OUTER etc. are explicit intent

--- a/tests/unit/health/test_sql_markers.py
+++ b/tests/unit/health/test_sql_markers.py
@@ -186,6 +186,21 @@ class TestCartesianJoin:
         assert _smell_kinds("SELECT a.x FROM a JOIN b ON a.id = b.id") == []
         assert _smell_kinds("SELECT a.x FROM a JOIN b USING (id)") == []
 
+    def test_multi_target_select_into_is_silent(self) -> None:
+        """Issue #1502: ``SELECT ... INTO a, b`` parses the trailing target as
+        a comma-join, so it must not be flagged as a cartesian join."""
+        assert _smell_kinds("select a, b into x, y from t where c = 1;") == []
+        assert _smell_kinds("select a, b into x, y from t;") == []
+
+    def test_single_target_select_into_is_silent(self) -> None:
+        assert _smell_kinds("select a into x from t;") == []
+
+    def test_multi_target_into_does_not_mask_real_cartesian(self) -> None:
+        """The INTO escape must not silence a genuine comma-join elsewhere."""
+        assert _smell_kinds(
+            "select a into x from t;\nselect * from orders o, customers c;"
+        ) == ["sql_cartesian_join"]
+
 
 class TestTemplatedFilesSilent:
     def test_dbt_model_yields_no_smells(self) -> None:


### PR DESCRIPTION
## What

Fixes #1502. A multi-target `SELECT ... INTO a, b` is parsed by sqlglot with the **trailing target** (`b`) as a comma-join FROM item, so `sql_cartesian_join` false-fired on table-creating statements. The reporter's reproducer:

```sql
select a, b into x, y from t where c = 1;   -- before: [('sql_cartesian_join', 'y')]
```

## Root cause

For `SELECT ... INTO x, y`, sqlglot sets `into` and lands the trailing target `y` in `joins` — so the detector's "comma-join with no predicate" arm fires on a name that is an INTO target, not a join table. A single-target `INTO x` is silent (no trailing comma), which is why the bug only shows on multi-target INTOs.

## Fix

Skip cartesian detection when the select carries an `into` arg — present exactly when the trailing names are INTO targets, not joins. A genuine comma-join (`FROM a, b` with no `into`) still fires.

## Tests

- `test_multi_target_select_into_is_silent` — the reporter's reproducer + the no-WHERE variant.
- `test_single_target_select_into_is_silent`.
- `test_multi_target_into_does_not_mask_real_cartesian` — a real comma-join elsewhere still fires.
- `tests/unit/health/test_sql_markers.py` — **37 passed**, no regression.
- Ruff clean.
