### PR TITLE
fix(status): surface a broken repository/path mapping as invalid

### DIFF
--- a/packages/cli/src/repowise/cli/commands/status_cmd.py
+++ b/packages/cli/src/repowise/cli/commands/status_cmd.py
@@ -104,6 +104,49 @@ def _query_repo_counts(repo_path: Path) -> tuple[int, int]:
         return 0, 0
 
 
+def _path_mapping_valid(repo_path: Path) -> bool:
+    """True when a ``Repository`` row matches *repo_path*'s ``local_path``.
+
+    ``repowise status`` used to treat ``.repowise/`` existence alone as
+    "indexed", so a store whose repository/path identity no longer resolves
+    the current checkout was presented as healthy — with 0 files — and the
+    downstream coverage ingestion silently lost most of the tree (issue
+    #1748). The repository row is the identity ingestion actually uses; when
+    it does not match, the index and the checkout have diverged.
+    """
+
+    async def _check() -> bool:
+        from sqlalchemy import select as sa_select
+
+        from repowise.core.persistence import (
+            create_engine,
+            create_session_factory,
+            get_session,
+        )
+        from repowise.core.persistence.models import Repository
+
+        url = get_db_url_for_repo(repo_path)
+        await reconcile_schema_best_effort(url)
+        engine = create_engine(url)
+        sf = create_session_factory(engine)
+        try:
+            async with get_session(sf) as session:
+                res = await session.execute(
+                    sa_select(Repository.id).where(Repository.local_path == str(repo_path))
+                )
+                return res.scalar_one_or_none() is not None
+        finally:
+            await engine.dispose()
+
+    db_path = get_repowise_dir(repo_path) / "wiki.db"
+    if not db_path.exists() and not db_configured():
+        return True  # nothing to diverge from
+    try:
+        return run_async(_check())
+    except Exception:
+        return False
+
+
 def _query_page_count(repo_path: Path) -> int:
     """Return the number of generated wiki pages for a repo, or 0."""
 
@@ -341,6 +384,7 @@ def _workspace_rows(target: CommandTarget) -> list[dict]:
             "head": None,
             "stale": None,
             "commits_behind": None,
+            "mapping_valid": None,
         }
         if not row["indexed"]:
             rows.append(row)
@@ -360,6 +404,9 @@ def _workspace_rows(target: CommandTarget) -> list[dict]:
             head=current_head,
             stale=is_stale,
             commits_behind=behind,
+            # False when a Repository row no longer resolves this checkout,
+            # even though .repowise/ exists (issue #1748).
+            mapping_valid=_path_mapping_valid(abs_path),
         )
         rows.append(row)
     return rows

--- a/tests/unit/cli/test_status_storage.py
+++ b/tests/unit/cli/test_status_storage.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from repowise.cli.commands import status_cmd
 
 
@@ -20,3 +22,24 @@ def test_index_storage_bytes_sums_repowise_files(tmp_path: Path) -> None:
 
 def test_index_storage_bytes_missing_dir() -> None:
     assert status_cmd._index_storage_bytes(Path("/no/such/repowise/dir")) == 0
+
+
+def test_path_mapping_valid_with_no_db_is_true(tmp_path: Path) -> None:
+    """Nothing to diverge from: an unindexed dir is not a broken mapping."""
+    assert status_cmd._path_mapping_valid(tmp_path) is True
+
+
+def test_path_mapping_valid_false_when_repo_row_is_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Issue #1748: .repowise/ exists but no Repository row matches the
+    checkout's local_path, so the index/checkout identity has diverged."""
+    # An empty .repowise/wiki.db with no Repository row (identity lost).
+    (tmp_path / ".repowise").mkdir()
+    (tmp_path / ".repowise" / "wiki.db").write_bytes(b"")
+
+    monkeypatch.setenv("REPOWISE_DATA_DIR", str(tmp_path / ".repowise"))
+    monkeypatch.setenv("REPOWISE_DB_PATH", str(tmp_path / ".repowise" / "wiki.db"))
+
+    # No repo was ever upserted -> the mapping must read as invalid.
+    assert status_cmd._path_mapping_valid(tmp_path) is False


### PR DESCRIPTION
## What

Fixes #1748. `repowise status` treated `.repowise/` existence alone as "indexed", so a store whose `Repository` row no longer matches the checkout's `local_path` was presented as **healthy — with 0 files** — while downstream coverage ingestion silently lost most of the tree.

## Root cause

`_query_repo_counts` matches `Repository.local_path == str(repo_path)`. When the stored identity diverges from the current checkout it returns `(0, 0)`, but `indexed` was still `true` (`.repowise/` exists), so a broken mapping read as a healthy index with no signal that anything was wrong.

## Fix

Add `_path_mapping_valid(repo_path)`: checks that a `Repository` row resolves the current `repo_path` (the identity ingestion actually uses), and carry it as **`mapping_valid`** on every workspace status row — so a diverged index is surfaced instead of presented as healthy.

## Tests

- `test_path_mapping_valid_with_no_db_is_true` — an unindexed dir is not a broken mapping.
- `test_path_mapping_valid_false_when_repo_row_is_missing` — `.repowise/` exists but no row matches → invalid.
- `tests/unit/cli/test_status_storage.py` + `test_format_json_rollout.py` + `test_workspace_autodetect_e2e.py` — **51 passed**, no regression.
- Ruff clean.
