### PR TITLE
fix(web): move asFilePageTab to the server-safe module so the file page renders

### DIFF
--- a/packages/ui/src/files/file-page-tabs.ts
+++ b/packages/ui/src/files/file-page-tabs.ts
@@ -112,3 +112,13 @@ export function resolveFileTab(
   const match = tabs.find((t) => t.id === requested);
   return match ? match.id : "overview";
 }
+
+/** Narrow a `?tab=` string to a tab this page actually renders. Exported for
+ *  server components that need it before the shell mounts. Lives here (a
+ *  plain module) rather than in the client component so a server page can
+ *  validate the value without importing client code (issue #1814). */
+export function asFilePageTab(value: string | undefined): FilePageTab | undefined {
+  return value && (FILE_PAGE_TABS as readonly string[]).includes(value)
+    ? (value as FilePageTab)
+    : undefined;
+}

--- a/packages/ui/src/files/file-page.tsx
+++ b/packages/ui/src/files/file-page.tsx
@@ -71,11 +71,3 @@ export function FilePage({ header, tabs, panels, initialTab, onTabChange }: File
     </div>
   );
 }
-
-/** Narrow a `?tab=` string to a tab this page actually renders. Exported for
- *  server components that need it before the shell mounts. */
-export function asFilePageTab(value: string | undefined): FilePageTab | undefined {
-  return value && (FILE_PAGE_TABS as readonly string[]).includes(value)
-    ? (value as FilePageTab)
-    : undefined;
-}


### PR DESCRIPTION
## What

Fixes #1814. The file details page threw:

```
⨯ Error: Attempted to call asFilePageTab() from the server but asFilePageTab is on the client.
```

so opening any file from the Files view failed to render.

## Root cause

`asFilePageTab` — a pure string→tab validator — lived in `file-page.tsx`, which is `"use client"`-marked. The server page (`app/repos/[id]/files/[...path]/page.tsx`) imports it through the `@repowise-dev/ui/files` barrel to validate `?tab=` before the shell mounts, so Next.js rejected the server→client call.

`file-page-tabs.ts` exists precisely so server components can validate tab values without importing client code (its docstring says so). The validator was just misplaced.

## Fix

Move `asFilePageTab` from the client `file-page.tsx` into the server-safe `file-page-tabs.ts`. The barrel re-export keeps the server page's import path unchanged.

## Tests

- Verified `asFilePageTab` now resolves only from the plain module; the server page's import path is unchanged.
- The Web UI lint + type check CI job validates the change.
