### PR TITLE
fix(embedder): make edenai selectable everywhere it is documented

### DIFF
--- a/packages/cli/src/repowise/cli/commands/init_cmd/command.py
+++ b/packages/cli/src/repowise/cli/commands/init_cmd/command.py
@@ -419,8 +419,8 @@ def _run_generation_phase(
     "--embedder",
     "embedder_name",
     default=None,
-    type=click.Choice(["gemini", "openai", "openrouter", "ollama", "mock"]),
-    help="Embedder for RAG: gemini | openai | openrouter | ollama | mock (default: auto-detect).",
+    type=click.Choice(["gemini", "openai", "openrouter", "ollama", "edenai", "mock"]),
+    help="Embedder for RAG: gemini | openai | openrouter | ollama | edenai | mock (default: auto-detect).",
 )
 @click.option("--skip-tests", is_flag=True, default=False, help="Skip test files.")
 @click.option("--skip-infra", is_flag=True, default=False, help="Skip infrastructure files.")

--- a/packages/cli/src/repowise/cli/commands/reindex_cmd.py
+++ b/packages/cli/src/repowise/cli/commands/reindex_cmd.py
@@ -19,7 +19,7 @@ from repowise.cli.ui import BRAND_STYLE, OWL_SPINNER
 @click.argument("path", required=False, default=None)
 @click.option(
     "--embedder",
-    type=click.Choice(["gemini", "openai", "openrouter", "ollama", "mock", "auto"]),
+    type=click.Choice(["gemini", "openai", "openrouter", "ollama", "edenai", "mock", "auto"]),
     default="auto",
     help="Embedder to use. 'auto' detects from env vars / config.",
 )

--- a/packages/cli/src/repowise/cli/ui/mode_selection.py
+++ b/packages/cli/src/repowise/cli/ui/mode_selection.py
@@ -450,7 +450,7 @@ def _prompt_generation(
 
     # Embedder selection
     detected_embedder = _resolve_embedder_from_env()
-    embedder_choices = ["gemini", "openai", "openrouter", "ollama", "mock"]
+    embedder_choices = ["gemini", "openai", "openrouter", "ollama", "edenai", "mock"]
     result["embedder"] = click.prompt(
         "  Embedder for RAG",
         default=detected_embedder,

--- a/packages/server/src/repowise/server/app.py
+++ b/packages/server/src/repowise/server/app.py
@@ -129,8 +129,13 @@ def _build_embedder():
 
         model = os.environ.get("REPOWISE_EMBEDDING_MODEL", "google/gemini-embedding-001")
         return OpenRouterEmbedder(model=model)
+    if name == "edenai":
+        from repowise.core.providers.embedding.edenai import EdenAIEmbedder
+
+        model = os.environ.get("REPOWISE_EMBEDDING_MODEL", "amazon/amazon.titan-embed-text-v2:0")
+        return EdenAIEmbedder(model=model)
     logger.warning(
-        "embedder.mock_active: set REPOWISE_EMBEDDER=gemini, openai, openrouter, or ollama for real RAG"
+        "embedder.mock_active: set REPOWISE_EMBEDDER=gemini, openai, openrouter, ollama, or edenai for real RAG"
     )
     return KeylessEmbedder()
 

--- a/tests/unit/server/mcp/test_embedder_resolution.py
+++ b/tests/unit/server/mcp/test_embedder_resolution.py
@@ -119,6 +119,24 @@ def test_ollama_resolves_without_api_key(monkeypatch):
     }
 
 
+def test_edenai_resolves_with_api_key(monkeypatch):
+    """Issue #1815: edenai is a documented embedder and must resolve, not
+    fall through to the keyless mock."""
+    from repowise.core.providers.embedding.edenai import EdenAIEmbedder
+
+    monkeypatch.setenv("REPOWISE_EMBEDDER", "edenai")
+    monkeypatch.setenv("EDENAI_API_KEY", "dummy")
+
+    embedder = _server._resolve_embedder()
+
+    assert isinstance(embedder, EdenAIEmbedder)
+    assert _state._embedder_status == {
+        "active": "edenai",
+        "requested": "edenai",
+        "degraded": False,
+    }
+
+
 def test_unknown_embedder_name_degrades(monkeypatch):
     """A typo'd / unknown embedder name surfaces as degraded, not silent mock."""
     monkeypatch.setenv("REPOWISE_EMBEDDER", "definitely-not-an-embedder")


### PR DESCRIPTION
## What

Fixes #1815. `edenai` was added as an embedder (#705) and documented, but four lists still carried the older five-backend set — so the flag rejected it, the interactive prompts omitted it, and the HTTP server fell through to the keyless mock.

## Fix

- **`init --embedder`**: add `edenai` to the `click.Choice` + help text.
- **`reindex --embedder`**: add `edenai` to the `click.Choice`.
- **advanced-mode prompt** (`mode_selection.py`): add `edenai` to `embedder_choices`.
- **server `_build_embedder`** (`app.py`): add the `edenai` branch → `EdenAIEmbedder` (default model `amazon/amazon.titan-embed-text-v2:0`), and update the mock-fallback warning.

## Verified

- `--embedder edenai` now accepted by the CLI flag.
- `REPOWISE_EMBEDDER=edenai` + `EDENAI_API_KEY` builds `EdenAIEmbedder` on the server (was `KeylessEmbedder`).

## Tests

- New `test_edenai_resolves_with_api_key` in `test_embedder_resolution.py` — asserts edenai resolves to `EdenAIEmbedder` with `degraded: False`.
- `tests/unit/server/mcp/test_embedder_resolution.py` — **17 passed**, no regression.
- Ruff clean.
