### PR TITLE
fix: make the edenai embedder selectable and honoured by serve

### DIFF
--- a/packages/cli/src/repowise/cli/commands/init_cmd/command.py
+++ b/packages/cli/src/repowise/cli/commands/init_cmd/command.py
@@ -411,7 +411,7 @@ def _run_generation_phase(
     default=None,
     help=(
         "LLM provider name (anthropic, openai, openrouter, gemini, "
-        "deepseek, kimi, ollama, litellm, codex_cli, opencode, mock)."
+        "deepseek, kimi, ollama, litellm, codex_cli, opencode, edenai, mock)."
     ),
 )
 @click.option("--model", default=None, help="Model identifier override.")
@@ -419,8 +419,11 @@ def _run_generation_phase(
     "--embedder",
     "embedder_name",
     default=None,
-    type=click.Choice(["gemini", "openai", "openrouter", "ollama", "mock"]),
-    help="Embedder for RAG: gemini | openai | openrouter | ollama | mock (default: auto-detect).",
+    type=click.Choice(["gemini", "openai", "openrouter", "ollama", "edenai", "mock"]),
+    help=(
+        "Embedder for RAG: gemini | openai | openrouter | ollama | edenai | mock "
+        "(default: auto-detect)."
+    ),
 )
 @click.option("--skip-tests", is_flag=True, default=False, help="Skip test files.")
 @click.option("--skip-infra", is_flag=True, default=False, help="Skip infrastructure files.")

--- a/packages/cli/src/repowise/cli/commands/reindex_cmd.py
+++ b/packages/cli/src/repowise/cli/commands/reindex_cmd.py
@@ -19,7 +19,7 @@ from repowise.cli.ui import BRAND_STYLE, OWL_SPINNER
 @click.argument("path", required=False, default=None)
 @click.option(
     "--embedder",
-    type=click.Choice(["gemini", "openai", "openrouter", "ollama", "mock", "auto"]),
+    type=click.Choice(["gemini", "openai", "openrouter", "ollama", "edenai", "mock", "auto"]),
     default="auto",
     help="Embedder to use. 'auto' detects from env vars / config.",
 )

--- a/packages/cli/src/repowise/cli/ui/mode_selection.py
+++ b/packages/cli/src/repowise/cli/ui/mode_selection.py
@@ -450,7 +450,7 @@ def _prompt_generation(
 
     # Embedder selection
     detected_embedder = _resolve_embedder_from_env()
-    embedder_choices = ["gemini", "openai", "openrouter", "ollama", "mock"]
+    embedder_choices = ["gemini", "openai", "openrouter", "ollama", "edenai", "mock"]
     result["embedder"] = click.prompt(
         "  Embedder for RAG",
         default=detected_embedder,
@@ -644,7 +644,7 @@ def _prompt_index_only_search(console: Console, result: dict[str, Any]) -> None:
     result["embedder"] = click.prompt(
         "  Embedder for semantic search (mock = full-text only)",
         default="mock",
-        type=click.Choice(["mock", "ollama", "gemini", "openai", "openrouter"]),
+        type=click.Choice(["mock", "ollama", "gemini", "openai", "openrouter", "edenai"]),
     )
 
 
@@ -658,6 +658,11 @@ def _resolve_embedder_from_env() -> str:
         return "openrouter"
     if os.environ.get("OLLAMA_EMBEDDING_MODEL"):
         return "ollama"
+    # Last, like the shared resolver in cli/providers/embedders.py: an unrelated
+    # EDENAI_API_KEY in the environment must not outrank a provider the user was
+    # already resolving to.
+    if os.environ.get("EDENAI_API_KEY"):
+        return "edenai"
     return "mock"
 
 

--- a/packages/server/src/repowise/server/app.py
+++ b/packages/server/src/repowise/server/app.py
@@ -103,6 +103,7 @@ def _build_embedder():
         gemini     — GeminiEmbedder via GEMINI_API_KEY / GOOGLE_API_KEY env var
         openai     — OpenAIEmbedder via OPENAI_API_KEY env var
         openrouter — OpenRouterEmbedder via OPENROUTER_API_KEY env var
+        edenai     — EdenAIEmbedder via EDENAI_API_KEY env var
     """
     name = os.environ.get("REPOWISE_EMBEDDER", "mock").lower()
     if name == "ollama":
@@ -129,8 +130,14 @@ def _build_embedder():
 
         model = os.environ.get("REPOWISE_EMBEDDING_MODEL", "google/gemini-embedding-001")
         return OpenRouterEmbedder(model=model)
+    if name == "edenai":
+        from repowise.core.providers.embedding.edenai import EdenAIEmbedder
+
+        model = os.environ.get("REPOWISE_EMBEDDING_MODEL", "amazon/amazon.titan-embed-text-v2:0")
+        return EdenAIEmbedder(model=model)
     logger.warning(
-        "embedder.mock_active: set REPOWISE_EMBEDDER=gemini, openai, openrouter, or ollama for real RAG"
+        "embedder.mock_active: set REPOWISE_EMBEDDER=gemini, openai, openrouter, "
+        "ollama, or edenai for real RAG"
     )
     return KeylessEmbedder()
 

--- a/tests/unit/cli/test_edenai_reachability.py
+++ b/tests/unit/cli/test_edenai_reachability.py
@@ -18,6 +18,7 @@ import click
 import pytest
 
 from repowise.cli.commands.init_cmd.command import init_command
+from repowise.cli.commands.reindex_cmd import reindex_command
 from repowise.cli.ui import mode_selection
 
 _DETECTION_KEYS = (
@@ -43,13 +44,19 @@ class _NullConsole:
 
 
 class TestEmbedderFlag:
-    def test_the_flag_accepts_edenai(self) -> None:
+    def test_init_accepts_edenai(self) -> None:
         ctx = init_command.make_context("init", ["--embedder", "edenai"])
         assert ctx.params["embedder_name"] == "edenai"
 
-    def test_an_unknown_backend_is_still_rejected(self) -> None:
+    def test_reindex_accepts_edenai(self) -> None:
+        """`reindex` documents the same set as `init`, so it has to accept it too."""
+        ctx = reindex_command.make_context("reindex", ["--embedder", "edenai"])
+        assert ctx.params["embedder"] == "edenai"
+
+    @pytest.mark.parametrize("command", [init_command, reindex_command])
+    def test_an_unknown_backend_is_still_rejected(self, command: click.Command) -> None:
         with pytest.raises(click.UsageError):
-            init_command.make_context("init", ["--embedder", "not-a-backend"])
+            command.make_context(command.name or "cmd", ["--embedder", "not-a-backend"])
 
 
 class TestInteractivePickers:

--- a/tests/unit/cli/test_edenai_reachability.py
+++ b/tests/unit/cli/test_edenai_reachability.py
@@ -1,0 +1,126 @@
+"""The Eden AI embedder has to be reachable from `repowise init`, not just registered.
+
+``docs/reference/CLI_REFERENCE.md`` documents ``--embedder edenai``, and the
+embedder itself is in the registry, but the flag's ``click.Choice`` and both
+interactive pickers were left with the older five-backend list. The flag was
+rejected outright, the pickers never offered the option, and a machine whose
+only key is ``EDENAI_API_KEY`` defaulted to the mock, so semantic search ran on
+vectors that cannot match the index.
+
+Precedence matters as much as presence: ``EDENAI_API_KEY`` is read last, so a
+key sitting in the environment for something else cannot outrank a backend the
+user was already resolving to.
+"""
+
+from __future__ import annotations
+
+import click
+import pytest
+
+from repowise.cli.commands.init_cmd.command import init_command
+from repowise.cli.ui import mode_selection
+
+_DETECTION_KEYS = (
+    "GEMINI_API_KEY",
+    "GOOGLE_API_KEY",
+    "OPENAI_API_KEY",
+    "OPENROUTER_API_KEY",
+    "OLLAMA_EMBEDDING_MODEL",
+    "EDENAI_API_KEY",
+)
+
+
+def _clear_detection_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for key in _DETECTION_KEYS:
+        monkeypatch.delenv(key, raising=False)
+
+
+class _NullConsole:
+    """Same stand-in the existing UI tests use: the prompts are what matter."""
+
+    def print(self, *_args: object, **_kwargs: object) -> None:
+        pass
+
+
+class TestEmbedderFlag:
+    def test_the_flag_accepts_edenai(self) -> None:
+        ctx = init_command.make_context("init", ["--embedder", "edenai"])
+        assert ctx.params["embedder_name"] == "edenai"
+
+    def test_an_unknown_backend_is_still_rejected(self) -> None:
+        with pytest.raises(click.UsageError):
+            init_command.make_context("init", ["--embedder", "not-a-backend"])
+
+
+class TestInteractivePickers:
+    """Whichever prompt asks for an embedder must list every real backend.
+
+    The two prompts are written separately, one in advanced config and one in
+    the index-only Search section, which is how they drifted apart.
+    """
+
+    @staticmethod
+    def _offered_choices(monkeypatch: pytest.MonkeyPatch, run) -> list[str]:
+        offered: list[str] = []
+
+        def _capture(_text, *_a, **kwargs):
+            choice_type = kwargs.get("type")
+            if isinstance(choice_type, click.Choice):
+                offered.extend(choice_type.choices)
+            # Answer every prompt with its own default, like the existing UI
+            # tests do: returning a coerced value breaks the numeric prompts.
+            return kwargs.get("default", "")
+
+        monkeypatch.setattr(mode_selection.click, "prompt", _capture)
+        monkeypatch.setattr(
+            mode_selection.click, "confirm", lambda *_a, **k: k.get("default", False)
+        )
+        _clear_detection_env(monkeypatch)
+        run()
+        return offered
+
+    def test_advanced_config_offers_edenai(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        offered = self._offered_choices(
+            monkeypatch,
+            lambda: mode_selection.interactive_advanced_config(_NullConsole()),
+        )
+        assert "edenai" in offered
+
+    def test_index_only_search_offers_edenai(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        offered = self._offered_choices(
+            monkeypatch,
+            lambda: mode_selection._prompt_index_only_search(_NullConsole(), {}),
+        )
+        assert "edenai" in offered
+
+
+class TestEnvDetection:
+    def test_the_key_alone_resolves_to_edenai(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _clear_detection_env(monkeypatch)
+        monkeypatch.setenv("EDENAI_API_KEY", "x")
+        assert mode_selection._resolve_embedder_from_env() == "edenai"
+
+    def test_no_key_still_resolves_to_mock(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _clear_detection_env(monkeypatch)
+        assert mode_selection._resolve_embedder_from_env() == "mock"
+
+    @pytest.mark.parametrize(
+        ("other_key", "other_value", "expected"),
+        [
+            ("GEMINI_API_KEY", "x", "gemini"),
+            ("OPENAI_API_KEY", "x", "openai"),
+            ("OPENROUTER_API_KEY", "x", "openrouter"),
+            ("OLLAMA_EMBEDDING_MODEL", "embeddinggemma", "ollama"),
+        ],
+    )
+    def test_edenai_never_outranks_an_incumbent(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        other_key: str,
+        other_value: str,
+        expected: str,
+    ) -> None:
+        _clear_detection_env(monkeypatch)
+        monkeypatch.setenv("EDENAI_API_KEY", "x")
+        monkeypatch.setenv(other_key, other_value)
+        assert mode_selection._resolve_embedder_from_env() == expected

--- a/tests/unit/cli/test_shared_helpers.py
+++ b/tests/unit/cli/test_shared_helpers.py
@@ -47,6 +47,8 @@ def test_resolve_embedder_explicit_flag_wins(monkeypatch: pytest.MonkeyPatch) ->
         ({"OPENROUTER_API_KEY": "x"}, "openrouter"),
         ({"OLLAMA_BASE_URL": "http://localhost:11434"}, "mock"),
         ({"OLLAMA_EMBEDDING_MODEL": "embeddinggemma"}, "ollama"),
+        ({"EDENAI_API_KEY": "x"}, "edenai"),
+        ({"OLLAMA_EMBEDDING_MODEL": "embeddinggemma", "EDENAI_API_KEY": "x"}, "ollama"),
         ({"REPOWISE_EMBEDDER": "ollama"}, "ollama"),
         ({}, "mock"),
     ],
@@ -61,6 +63,7 @@ def test_resolve_embedder_env_detection(
         "OPENROUTER_API_KEY",
         "OLLAMA_BASE_URL",
         "OLLAMA_EMBEDDING_MODEL",
+        "EDENAI_API_KEY",
         "REPOWISE_EMBEDDER",
     ):
         monkeypatch.delenv(key, raising=False)

--- a/tests/unit/server/test_app_embedder_backends.py
+++ b/tests/unit/server/test_app_embedder_backends.py
@@ -1,0 +1,48 @@
+"""`_build_embedder` must honour every documented `REPOWISE_EMBEDDER` value.
+
+``docs/reference/CONFIG.md`` lists ``edenai`` among the accepted values, but the
+HTTP server resolved backends through a hardcoded chain that stopped at
+``openrouter``, so ``REPOWISE_EMBEDDER=edenai`` fell through to the keyless
+mock with only a warning: the server then reported healthy while semantic
+search ran on vectors that cannot match the index. That is the same failure the
+MCP server fixed in #324 by going through the shared registry; this chain is
+the remaining hardcoded copy.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from repowise.core.providers.embedding.base import KeylessEmbedder
+from repowise.core.providers.embedding.edenai import EdenAIEmbedder
+from repowise.server.app import _build_embedder
+
+
+@pytest.fixture(autouse=True)
+def _clean_embedder_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for key in ("REPOWISE_EMBEDDER", "REPOWISE_EMBEDDING_MODEL", "EDENAI_API_KEY"):
+        monkeypatch.delenv(key, raising=False)
+
+
+def test_edenai_builds_a_real_embedder(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("REPOWISE_EMBEDDER", "edenai")
+    monkeypatch.setenv("EDENAI_API_KEY", "test-key-not-a-real-one")
+    assert isinstance(_build_embedder(), EdenAIEmbedder)
+
+
+def test_edenai_honours_the_indexed_model(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Same guard as the other backends: serve must not silently re-embed at a
+    different width than the one init wrote (issue #426)."""
+    monkeypatch.setenv("REPOWISE_EMBEDDER", "edenai")
+    monkeypatch.setenv("EDENAI_API_KEY", "test-key-not-a-real-one")
+    monkeypatch.setenv("REPOWISE_EMBEDDING_MODEL", "openai/text-embedding-3-large")
+    embedder = _build_embedder()
+    assert isinstance(embedder, EdenAIEmbedder)
+    assert embedder.dimensions == 3072
+
+
+def test_an_unknown_backend_still_degrades_to_the_keyless_mock(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("REPOWISE_EMBEDDER", "not-a-backend")
+    assert isinstance(_build_embedder(), KeylessEmbedder)


### PR DESCRIPTION
## Summary

- Makes the `edenai` embedder selectable: adds it to the `--embedder` `click.Choice` and its help, to both interactive embedder prompts, and to the env detection that supplies the advanced-mode default.
- Fixes the HTTP server falling through to the keyless mock on `REPOWISE_EMBEDDER=edenai`, which made the server report healthy while semantic search ran on vectors that cannot match the index.
- Adds tests for the flag, both prompts, the detection precedence, and the server resolution, and fills the `edenai` gap in the existing `resolve_embedder` parametrize.

## Related Issues

Fixes #1815

Follow-up to #705, which added the embedder and the docs but left four older lists behind. My omission, so this closes it out.

## Test Plan

- [x] Tests pass (`pytest`)
- [x] Lint passes (`ruff check .`)
- [ ] Web build passes (`npm run build`) *(if frontend changes)*

No frontend change, so the web build is untouched.

What I ran:

- `pytest tests/unit/cli/test_edenai_reachability.py tests/unit/server/test_app_embedder_backends.py` gives 13 passed, and `tests/unit/cli/test_shared_helpers.py` 25 passed with the two new parametrize cases.
- `pytest tests/unit/cli tests/unit/server` for regressions, since the change touches prompt construction that other UI tests drive. This branch gives 6 failed, 4500 passed. I then ran the same command on `main` at 9c16233 with nothing of mine applied, and it gives **9 failed, 4482 passed**, so this branch fails strictly fewer tests than the base and every failure on it also fails without the change. They are all in `test_update_e2e.py`, `test_update_persist_reliability.py`, and `test_watch_cmd.py`, none of which this diff touches, and the set varies between runs, which is what flaky looks like.

  One of them I can now explain, and it corrects something I said on #705. The two `test_watch_cmd::TestSingleRepoTrigger` failures are `OSError: [Errno 28] inotify watch limit reached` on my machine, not anything in your code. Sorry for the earlier noise on that.
- `ruff check .` clean across the repo. For formatting I checked against ruff 0.6.9, the version your `.pre-commit-config.yaml` pins, rather than the 0.15.6 the venv resolves under `>=0.6,<1`. Every line this PR adds is already formatted. Two of the files carry one pre-existing line each that 0.6.9 would rewrap, in `mode_selection.py` and `command.py`, both untouched here and both already like that on `main`, so I ran `format --diff` rather than `format --write` and left them alone.

Both failures reproduce before the change and pass after:

```
--embedder edenai      REFUSE -> ACCEPTE
REPOWISE_EMBEDDER=edenai -> KeylessEmbedder -> EdenAIEmbedder
```

## Checklist

- [x] My code follows the project's code style
- [x] I have added tests for new functionality
- [x] All existing tests still pass
- [x] I have updated documentation if needed

Docs needed no change here: `CLI_REFERENCE.md` and `CONFIG.md` already list `edenai`, which is what made this a bug rather than a feature.

## Notes on two judgement calls

`_resolve_embedder_from_env` in `mode_selection.py` reads `EDENAI_API_KEY` **last**, immediately before the mock, mirroring the shared resolver in `cli/providers/embedders.py`. Same reasoning you gave on #705: an unrelated key in the environment must not outrank a backend the user was already resolving to. There is a parametrized test pinning that, so it cannot drift back.

For `server/app.py` I added a branch next to the others rather than routing through `get_embedder`. Your #324 moved the MCP server onto the shared registry, and `_build_embedder` is the last hardcoded copy, so converging it would fix this class of bug for every registered embedder instead of one. I did not do it here because it changes behaviour for the four existing backends and this PR should stay small, but say the word and I will send that separately.

I left the numbered embedder menu in `serve_cmd.py` alone for the same reason, details in the issue.

I do work at Eden AI.
