### PR TITLE
release: v0.45.0 (test intelligence without a coverage report)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "name": "repowise",
       "source": "./plugins/claude-code",
       "description": "Codebase intelligence for Claude Code. Indexes your repo into five layers (Graph, Git, Docs, Decisions, Code Health) and gives Claude deep understanding of architecture, ownership, hotspots, decisions, and defect risk — fewer greps, fewer file reads, lower cost per query.",
-      "version": "0.44.0",
+      "version": "0.45.0",
       "category": "productivity",
       "keywords": [
         "codebase",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,21 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [Unreleased]
+## [0.45.0] — 2026-08-21
+
+The headline this cycle is test intelligence that needs no coverage report. 0.44.0 made the call graph good enough to lead with; this release walks it to answer which tests reach a file, serves that through the API, and turns the Coverage tab into a Tests tab that says something useful on a repository that has never ingested a report. Around it, Code Health's performance findings become bounded opportunities that open the matching refactoring plan, Eden AI joins as an EU-hosted provider and embedder, and pinning BLAS threads before numpy loads halves peak memory on a cold index.
 
 ### Added
-
-- **Code Health performance opportunities now lead into the existing
-  Refactoring workflow.** A dedicated Performance tab groups raw findings into
-  bounded causal opportunities with production/tooling versus test context,
-  affected-call-site totals, confidence, provenance paths, and raw-evidence
-  paging. Exact stable opportunity ids open matching `performance_fix` plans;
-  opportunities without a safe plan say so instead of selecting a nearby one.
-  The Refactoring page adds a Performance filter and shared priority,
-  validation, path, and pagination renderers. Its new server-owned page endpoint
-  bounds initial payloads while preserving the legacy unpaged route. VS Code
-  consumes the same contracts and renders priority and validation without web
-  dependencies; older missing optional fields remain supported.
 
 - **A test-to-code map that needs no coverage report.** The per-test map only
   ever existed if you ingested a coverage report with contexts, so on most
@@ -51,7 +41,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `get_change_risk`'s `impacted_tests`, and a `via` marker on every
   `repowise impacted-tests` candidate saying which tier answered.
 
+- **Code Health performance opportunities now lead into the existing
+  Refactoring workflow.** A dedicated Performance tab groups raw findings into
+  bounded causal opportunities with production/tooling versus test context,
+  affected-call-site totals, confidence, provenance paths, and raw-evidence
+  paging. Exact stable opportunity ids open matching `performance_fix` plans;
+  opportunities without a safe plan say so instead of selecting a nearby one.
+  The Refactoring page adds a Performance filter and shared priority,
+  validation, path, and pagination renderers. Its new server-owned page endpoint
+  bounds initial payloads while preserving the legacy unpaged route. VS Code
+  consumes the same contracts and renders priority and validation without web
+  dependencies; older missing optional fields remain supported.
+
+- **`/health/tests-reaching?file_path=`** answers which tests reach one file,
+  with `via` separating a test whose calls run into it from one that only imports
+  it, and `/health/coverage` falls back to the inferred map under
+  `basis: "inferred"` when no report was ingested. The two bases never share a
+  field, so a consumer cannot render derived data through the measured code path
+  by accident. `include_inferred=false` declines the fallback for a caller that
+  only wants the cheap badge number. (#1757)
+
+- **Eden AI is a first-class LLM provider and embedder.** An EU-headquartered
+  gateway exposing 700+ models behind an OpenAI-compatible endpoint, so it reuses
+  the existing `openai` dependency with a custom base URL and adds no new one.
+  `EDENAI_API_KEY`, `EDENAI_BASE_URL` for the EU endpoint, and an embedder
+  defaulting to a 1024-dimension EU model. It is appended to the autodetect order
+  rather than inserted, so an unrelated key in the environment cannot move anyone
+  off the provider they were already resolving to. (#705)
+
 ### Changed
+
+- **The Coverage tab is now a Tests tab, and it answers without a report.** The
+  URL stays `/coverage` and "coverage" keeps meaning the measured thing inside
+  the tab; what changed is that the empty state no longer tells you to go
+  ingest a report while claiming nothing is inferred. On the inferred basis the
+  chart collapses to two positions rather than a 0-100 continuum, which is the
+  honest statement about the evidence, and nothing is rendered as a percentage
+  or a bar. The file page names the tests that reach it, with `via` separating a
+  test whose calls run into the file from one that only imports it. (#1758)
 
 - **`untested_hotspot` stops accusing files that the tests run.** With no
   coverage ingested it fired on any hotspot without a *paired test file*, which
@@ -77,6 +104,124 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `inferred_tests`.** The bucket no longer holds only filename guesses, so the
   old name described the wrong thing; each entry carries `via` (`call-graph`,
   `import-graph` or `filename-pattern`) to say which tier answered.
+
+- **Refactoring recommendations have one contract.** REST, MCP and the CLI each
+  rebuilt their own ranking and payload shape, and the TypeScript contract was
+  duplicated in the UI package. The wire contract moves to
+  `@repowise-dev/types` and the Python side gets a single read model owning
+  rehydration, enrichment, ranking, validation and serialization for every
+  surface. Blast radius now raises cost and risk rather than benefit, so a wide
+  change ranks as expensive instead of valuable. (#1784)
+
+- **The semantic leg of search gets a budget the cold path can clear.** The first
+  vector query in a process pays for the store open, the first embed and the
+  first ANN probe. That was measured at 6.3s and 13.4s on a cold Windows index
+  where a warm query takes 0.19s, against a hardcoded 8s bound inside a
+  suppressed exception. The budget is now one shared 30s default, capped at 120s and
+  overridable with `REPOWISE_VECTOR_SEARCH_TIMEOUT_S`, and a timeout logs a
+  warning naming the knob instead of silently degrading to full-text with
+  nothing said. (#1678, #1685)
+
+- **Plugin**: `/repowise:impacted-tests` and the `change-review` skill describe
+  the inferred map as the call graph with an import-graph fallback, and `init` /
+  `reindex` list the embedders the CLI actually accepts.
+
+- **Execution-graph analysis is unified** behind one code path in health, with
+  the legacy call fallback restricted rather than left answering alongside it.
+  (#1773)
+
+### Fixed
+
+- **An incremental update stopped erasing ingested coverage.** The incremental
+  pipeline built its analyzer without a coverage map, so every changed file was
+  re-scored as if no report had ever been ingested and the partial-health writer
+  upserted `line_coverage_pct` back to NULL, eroding coverage one file per
+  update, starting with the files under active development. Both callers now load
+  and supply the persisted map. (#1739, #1806)
+- **`repowise init` no longer crashes in a git worktree.** `.git` is a file
+  there, not a directory, so building `.git/hooks` by hand raised
+  `NotADirectoryError` and took the whole command down. The hooks directory is
+  resolved with `git rev-parse --git-path hooks`, which answers correctly for a
+  worktree and a normal clone alike. (#1609, #1808)
+- **The CLI and the MCP server resolve the same embedder key.** The server never
+  consulted the process environment, so on a machine with an exported provider
+  key different from the repository's `.repowise/.env`, semantic search degraded
+  through the CLI while the MCP tool answered. The server now reads the env tier
+  first, matching the CLI's "an exported key is an explicit override" contract.
+  (#1711, #1810)
+- **`edenai` is selectable everywhere it is documented**: `init --embedder`,
+  `reindex --embedder`, both interactive prompts, `EDENAI_API_KEY` autodetection
+  and the server's embedder build, four lists that were left on the older
+  five-backend set. (#1815, #1820)
+- **`repowise reindex` exits non-zero when every embed failed**, so an automated
+  pipeline cannot treat an empty vector index as a successful build. An empty
+  wiki still exits 0. (#1495, #1732)
+- **The file page states how many tests reach a file, not how many it listed.**
+  The list is capped at 50 and the page rendered that cap as the measurement; it
+  now leads with the true count and says what it is showing. (#1764)
+- **A generated-file banner has to be a banner.** The marker is required within
+  the first two lines instead of substring-matched across the whole header, which
+  fixes the class of prose false positives across all six markers. (#1519, #1731)
+- **Python resolution**: `from pkg import submodule` pinned the binding at the
+  package `__init__.py`, so a later `submodule.symbol()` call resolved against a
+  file declaring nothing and dead code called the symbol safe to delete (#1193,
+  #1733); aliased submodule bindings are pinned properly (#1255, #1785).
+- **Go**: a call through a field (`a.b.Method()`) matched no pattern and was
+  missing from the graph entirely rather than present and unresolved (#1727), and
+  an embed of `io.Reader` keeps its package qualifier instead of binding to
+  whatever repo-local `Reader` shares the short name, which made the type
+  inherit from itself when the enclosing type had that name (#1726).
+- **TypeScript**: `#private` class members produce a symbol and a call site
+  (#1715, #1721), a return type no longer renders with a stray colon
+  (`-> : string`) (#1695, #1719), and a relative import probes `index.tsx` and
+  `index.jsx` (#1725).
+- **Java and C# method return types are preserved** in signatures (#1713).
+- **The bare-name tier stops answering for the standard library** (#1708), and
+  barrel-file definitions are aligned with `file_reachability` (#1491, #1557).
+- **The paired-test filename heuristic is shared** rather than reimplemented per
+  surface (#1750).
+- **Security scanning**: `replace_findings` no longer loses rows on a duplicate
+  key (#1523), and a multi-line `subprocess.*(... shell=True)` call is flagged
+  (#1522).
+- **Agent CLIs no longer load the target repository's instruction files** when
+  invoked for generation (#1100).
+- **`workspace init --dry-run` writes nothing** (#1526), and `init --test-run`
+  actually limits generation to the top 10 files (#1525).
+- **`share_of_repo_gap_pct` uses the gross gap as its denominator** (#1452), and
+  history fetches avoid the partial-clone path (#1608).
+- **The `get_risk` artifact renders in chat.** The renderer mapped over a list
+  and read `path` / `churn_percentile`, but the tool returns a path-keyed dict of
+  `hotspot_score` / `file_path`, so opening the artifact threw or showed blank
+  rows. Both shapes are normalized, and the 0-1 score is scaled for display
+  rather than printed as though it were already a percentage. (#1480)
+
+### Performance
+
+- **Peak memory on a cold index is roughly halved.** Importing numpy brings up a
+  BLAS runtime that commits a private per-thread workspace sized to the host's
+  core count: 746 MB on a 32-core machine for the import alone, committed once,
+  never returned, and invisible to `tracemalloc` because no Python object owns
+  it. The pipeline's only numpy work is PageRank over a sparse graph, which runs
+  single-threaded in well under a second, so the thread count is pinned before
+  numpy is imported. A cold `init --no-prose` on an 876-file repository went from
+  1,547 MB to 818 MB at no wall-clock cost. `OMP_NUM_THREADS` is deliberately
+  left alone: igraph community detection really is OpenMP-parallel, and pinning
+  it cost 18% wall clock for no further saving. (#1394, #1776)
+
+### Documentation
+
+- **A roadmap, an enterprise section, and a benchmarks page that leads with its
+  results.** `ROADMAP.md` is new and states plainly that language support is
+  never gated behind the licence; the README gains a real enterprise section
+  covering deployment, data boundary, compliance and contract; `BENCHMARKS.md`
+  goes from 777 visible lines to 456 with every caveat and every losing row
+  preserved behind folds. Language support is now stated the same way in every
+  document: 19 parsed to a full AST, 35 on the ladder. Source control beyond git
+  (Perforce, Subversion, and the mainframe promotion hierarchies) is scoped to
+  the one history-derived layer that actually needs it. (#1766)
+- **The graph precision result is published**, judged by a compiler across five
+  tools (#1738), and `COMMERCIAL.md`'s tool count matches the way the document
+  counts (#1771).
 
 ---
 

--- a/packages/cli/src/repowise/cli/__init__.py
+++ b/packages/cli/src/repowise/cli/__init__.py
@@ -16,4 +16,4 @@ from repowise.cli._stdio import _ensure_utf8_stdio
 # is already UTF-8.
 _ensure_utf8_stdio()
 
-__version__ = "0.44.0"
+__version__ = "0.45.0"

--- a/packages/cli/src/repowise/cli/agent_targets/_data/codex_prompts/repowise-init.md
+++ b/packages/cli/src/repowise/cli/agent_targets/_data/codex_prompts/repowise-init.md
@@ -79,7 +79,8 @@ Core flags:
   --mode fast            Quick first pass on very large repos: no wiki at all.
 
 Embeddings:
-  --embedder NAME        Embedding provider: gemini, openai, mock (default: auto-detect)
+  --embedder NAME        Embedding provider: gemini, openai, openrouter, ollama,
+                         edenai, mock (default: auto-detect)
 
 Cost control:
   --concurrency N        Max parallel LLM calls (default: 10)

--- a/packages/cli/src/repowise/cli/agent_targets/_data/codex_prompts/repowise-reindex.md
+++ b/packages/cli/src/repowise/cli/agent_targets/_data/codex_prompts/repowise-reindex.md
@@ -21,12 +21,12 @@ This is useful when:
 
 ## Available flags
 
-- `--embedder gemini|openai|auto` — embedding provider (default: auto-detect from env vars)
+- `--embedder gemini|openai|openrouter|ollama|edenai|auto` — embedding provider (default: auto-detect from env vars)
 - `--batch-size N` — pages per embedding batch (default: 20)
 
 ## Requirements
 
-Requires either `GEMINI_API_KEY`/`GOOGLE_API_KEY` or `OPENAI_API_KEY` to be set. The mock embedder is not accepted for reindexing. If neither key is available, ask the user to set one before proceeding.
+Requires a key for one of the real embedders — `GEMINI_API_KEY`/`GOOGLE_API_KEY`, `OPENAI_API_KEY`, `OPENROUTER_API_KEY` or `EDENAI_API_KEY` — or a running Ollama. The mock embedder is not accepted for reindexing. If none is available, ask the user to set one before proceeding.
 
 ## Handling $ARGUMENTS
 

--- a/packages/core/src/repowise/core/__init__.py
+++ b/packages/core/src/repowise/core/__init__.py
@@ -6,4 +6,4 @@ generation engine. This is the heart of repowise — all other packages depend o
 Namespace package: repowise.core is part of the repowise namespace.
 """
 
-__version__ = "0.44.0"
+__version__ = "0.45.0"

--- a/packages/core/src/repowise/core/upgrade/_data/CHANGELOG.md
+++ b/packages/core/src/repowise/core/upgrade/_data/CHANGELOG.md
@@ -9,21 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [Unreleased]
+## [0.45.0] — 2026-08-21
+
+The headline this cycle is test intelligence that needs no coverage report. 0.44.0 made the call graph good enough to lead with; this release walks it to answer which tests reach a file, serves that through the API, and turns the Coverage tab into a Tests tab that says something useful on a repository that has never ingested a report. Around it, Code Health's performance findings become bounded opportunities that open the matching refactoring plan, Eden AI joins as an EU-hosted provider and embedder, and pinning BLAS threads before numpy loads halves peak memory on a cold index.
 
 ### Added
-
-- **Code Health performance opportunities now lead into the existing
-  Refactoring workflow.** A dedicated Performance tab groups raw findings into
-  bounded causal opportunities with production/tooling versus test context,
-  affected-call-site totals, confidence, provenance paths, and raw-evidence
-  paging. Exact stable opportunity ids open matching `performance_fix` plans;
-  opportunities without a safe plan say so instead of selecting a nearby one.
-  The Refactoring page adds a Performance filter and shared priority,
-  validation, path, and pagination renderers. Its new server-owned page endpoint
-  bounds initial payloads while preserving the legacy unpaged route. VS Code
-  consumes the same contracts and renders priority and validation without web
-  dependencies; older missing optional fields remain supported.
 
 - **A test-to-code map that needs no coverage report.** The per-test map only
   ever existed if you ingested a coverage report with contexts, so on most
@@ -51,7 +41,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `get_change_risk`'s `impacted_tests`, and a `via` marker on every
   `repowise impacted-tests` candidate saying which tier answered.
 
+- **Code Health performance opportunities now lead into the existing
+  Refactoring workflow.** A dedicated Performance tab groups raw findings into
+  bounded causal opportunities with production/tooling versus test context,
+  affected-call-site totals, confidence, provenance paths, and raw-evidence
+  paging. Exact stable opportunity ids open matching `performance_fix` plans;
+  opportunities without a safe plan say so instead of selecting a nearby one.
+  The Refactoring page adds a Performance filter and shared priority,
+  validation, path, and pagination renderers. Its new server-owned page endpoint
+  bounds initial payloads while preserving the legacy unpaged route. VS Code
+  consumes the same contracts and renders priority and validation without web
+  dependencies; older missing optional fields remain supported.
+
+- **`/health/tests-reaching?file_path=`** answers which tests reach one file,
+  with `via` separating a test whose calls run into it from one that only imports
+  it, and `/health/coverage` falls back to the inferred map under
+  `basis: "inferred"` when no report was ingested. The two bases never share a
+  field, so a consumer cannot render derived data through the measured code path
+  by accident. `include_inferred=false` declines the fallback for a caller that
+  only wants the cheap badge number. (#1757)
+
+- **Eden AI is a first-class LLM provider and embedder.** An EU-headquartered
+  gateway exposing 700+ models behind an OpenAI-compatible endpoint, so it reuses
+  the existing `openai` dependency with a custom base URL and adds no new one.
+  `EDENAI_API_KEY`, `EDENAI_BASE_URL` for the EU endpoint, and an embedder
+  defaulting to a 1024-dimension EU model. It is appended to the autodetect order
+  rather than inserted, so an unrelated key in the environment cannot move anyone
+  off the provider they were already resolving to. (#705)
+
 ### Changed
+
+- **The Coverage tab is now a Tests tab, and it answers without a report.** The
+  URL stays `/coverage` and "coverage" keeps meaning the measured thing inside
+  the tab; what changed is that the empty state no longer tells you to go
+  ingest a report while claiming nothing is inferred. On the inferred basis the
+  chart collapses to two positions rather than a 0-100 continuum, which is the
+  honest statement about the evidence, and nothing is rendered as a percentage
+  or a bar. The file page names the tests that reach it, with `via` separating a
+  test whose calls run into the file from one that only imports it. (#1758)
 
 - **`untested_hotspot` stops accusing files that the tests run.** With no
   coverage ingested it fired on any hotspot without a *paired test file*, which
@@ -77,6 +104,124 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `inferred_tests`.** The bucket no longer holds only filename guesses, so the
   old name described the wrong thing; each entry carries `via` (`call-graph`,
   `import-graph` or `filename-pattern`) to say which tier answered.
+
+- **Refactoring recommendations have one contract.** REST, MCP and the CLI each
+  rebuilt their own ranking and payload shape, and the TypeScript contract was
+  duplicated in the UI package. The wire contract moves to
+  `@repowise-dev/types` and the Python side gets a single read model owning
+  rehydration, enrichment, ranking, validation and serialization for every
+  surface. Blast radius now raises cost and risk rather than benefit, so a wide
+  change ranks as expensive instead of valuable. (#1784)
+
+- **The semantic leg of search gets a budget the cold path can clear.** The first
+  vector query in a process pays for the store open, the first embed and the
+  first ANN probe. That was measured at 6.3s and 13.4s on a cold Windows index
+  where a warm query takes 0.19s, against a hardcoded 8s bound inside a
+  suppressed exception. The budget is now one shared 30s default, capped at 120s and
+  overridable with `REPOWISE_VECTOR_SEARCH_TIMEOUT_S`, and a timeout logs a
+  warning naming the knob instead of silently degrading to full-text with
+  nothing said. (#1678, #1685)
+
+- **Plugin**: `/repowise:impacted-tests` and the `change-review` skill describe
+  the inferred map as the call graph with an import-graph fallback, and `init` /
+  `reindex` list the embedders the CLI actually accepts.
+
+- **Execution-graph analysis is unified** behind one code path in health, with
+  the legacy call fallback restricted rather than left answering alongside it.
+  (#1773)
+
+### Fixed
+
+- **An incremental update stopped erasing ingested coverage.** The incremental
+  pipeline built its analyzer without a coverage map, so every changed file was
+  re-scored as if no report had ever been ingested and the partial-health writer
+  upserted `line_coverage_pct` back to NULL, eroding coverage one file per
+  update, starting with the files under active development. Both callers now load
+  and supply the persisted map. (#1739, #1806)
+- **`repowise init` no longer crashes in a git worktree.** `.git` is a file
+  there, not a directory, so building `.git/hooks` by hand raised
+  `NotADirectoryError` and took the whole command down. The hooks directory is
+  resolved with `git rev-parse --git-path hooks`, which answers correctly for a
+  worktree and a normal clone alike. (#1609, #1808)
+- **The CLI and the MCP server resolve the same embedder key.** The server never
+  consulted the process environment, so on a machine with an exported provider
+  key different from the repository's `.repowise/.env`, semantic search degraded
+  through the CLI while the MCP tool answered. The server now reads the env tier
+  first, matching the CLI's "an exported key is an explicit override" contract.
+  (#1711, #1810)
+- **`edenai` is selectable everywhere it is documented**: `init --embedder`,
+  `reindex --embedder`, both interactive prompts, `EDENAI_API_KEY` autodetection
+  and the server's embedder build, four lists that were left on the older
+  five-backend set. (#1815, #1820)
+- **`repowise reindex` exits non-zero when every embed failed**, so an automated
+  pipeline cannot treat an empty vector index as a successful build. An empty
+  wiki still exits 0. (#1495, #1732)
+- **The file page states how many tests reach a file, not how many it listed.**
+  The list is capped at 50 and the page rendered that cap as the measurement; it
+  now leads with the true count and says what it is showing. (#1764)
+- **A generated-file banner has to be a banner.** The marker is required within
+  the first two lines instead of substring-matched across the whole header, which
+  fixes the class of prose false positives across all six markers. (#1519, #1731)
+- **Python resolution**: `from pkg import submodule` pinned the binding at the
+  package `__init__.py`, so a later `submodule.symbol()` call resolved against a
+  file declaring nothing and dead code called the symbol safe to delete (#1193,
+  #1733); aliased submodule bindings are pinned properly (#1255, #1785).
+- **Go**: a call through a field (`a.b.Method()`) matched no pattern and was
+  missing from the graph entirely rather than present and unresolved (#1727), and
+  an embed of `io.Reader` keeps its package qualifier instead of binding to
+  whatever repo-local `Reader` shares the short name, which made the type
+  inherit from itself when the enclosing type had that name (#1726).
+- **TypeScript**: `#private` class members produce a symbol and a call site
+  (#1715, #1721), a return type no longer renders with a stray colon
+  (`-> : string`) (#1695, #1719), and a relative import probes `index.tsx` and
+  `index.jsx` (#1725).
+- **Java and C# method return types are preserved** in signatures (#1713).
+- **The bare-name tier stops answering for the standard library** (#1708), and
+  barrel-file definitions are aligned with `file_reachability` (#1491, #1557).
+- **The paired-test filename heuristic is shared** rather than reimplemented per
+  surface (#1750).
+- **Security scanning**: `replace_findings` no longer loses rows on a duplicate
+  key (#1523), and a multi-line `subprocess.*(... shell=True)` call is flagged
+  (#1522).
+- **Agent CLIs no longer load the target repository's instruction files** when
+  invoked for generation (#1100).
+- **`workspace init --dry-run` writes nothing** (#1526), and `init --test-run`
+  actually limits generation to the top 10 files (#1525).
+- **`share_of_repo_gap_pct` uses the gross gap as its denominator** (#1452), and
+  history fetches avoid the partial-clone path (#1608).
+- **The `get_risk` artifact renders in chat.** The renderer mapped over a list
+  and read `path` / `churn_percentile`, but the tool returns a path-keyed dict of
+  `hotspot_score` / `file_path`, so opening the artifact threw or showed blank
+  rows. Both shapes are normalized, and the 0-1 score is scaled for display
+  rather than printed as though it were already a percentage. (#1480)
+
+### Performance
+
+- **Peak memory on a cold index is roughly halved.** Importing numpy brings up a
+  BLAS runtime that commits a private per-thread workspace sized to the host's
+  core count: 746 MB on a 32-core machine for the import alone, committed once,
+  never returned, and invisible to `tracemalloc` because no Python object owns
+  it. The pipeline's only numpy work is PageRank over a sparse graph, which runs
+  single-threaded in well under a second, so the thread count is pinned before
+  numpy is imported. A cold `init --no-prose` on an 876-file repository went from
+  1,547 MB to 818 MB at no wall-clock cost. `OMP_NUM_THREADS` is deliberately
+  left alone: igraph community detection really is OpenMP-parallel, and pinning
+  it cost 18% wall clock for no further saving. (#1394, #1776)
+
+### Documentation
+
+- **A roadmap, an enterprise section, and a benchmarks page that leads with its
+  results.** `ROADMAP.md` is new and states plainly that language support is
+  never gated behind the licence; the README gains a real enterprise section
+  covering deployment, data boundary, compliance and contract; `BENCHMARKS.md`
+  goes from 777 visible lines to 456 with every caveat and every losing row
+  preserved behind folds. Language support is now stated the same way in every
+  document: 19 parsed to a full AST, 35 on the ladder. Source control beyond git
+  (Perforce, Subversion, and the mainframe promotion hierarchies) is scoped to
+  the one history-derived layer that actually needs it. (#1766)
+- **The graph precision result is published**, judged by a compiler across five
+  tools (#1738), and `COMMERCIAL.md`'s tool count matches the way the document
+  counts (#1771).
 
 ---
 

--- a/packages/server/src/repowise/server/__init__.py
+++ b/packages/server/src/repowise/server/__init__.py
@@ -7,4 +7,4 @@ Provides:
     - Background job scheduler (APScheduler)
 """
 
-__version__ = "0.44.0"
+__version__ = "0.45.0"

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "repowise",
   "description": "Codebase intelligence for Claude Code. Indexes your codebase into five layers (Graph, Git, Docs, Decisions, Code Health) and exposes them through eleven task-shaped MCP tools — so Claude understands architecture, ownership, hotspots, why code is built the way it is, and where the defect risk lives.",
-  "version": "0.44.0",
+  "version": "0.45.0",
   "author": {
     "name": "Repowise",
     "email": "hello@repowise.dev",

--- a/plugins/claude-code/CHANGELOG.md
+++ b/plugins/claude-code/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to the Repowise Claude Code plugin are documented here.
 
+## 0.45.0
+
+### Changed
+- `/repowise:impacted-tests` and the `change-review` skill describe the map as
+  it now works: with no coverage ingested the candidates come from the call
+  graph, with the import graph filling in only where it is silent, and every
+  candidate carries the `via` marker saying which tier answered. Only
+  `via: coverage` proves a test executed the change (#1749, #1755, #1757).
+- `/repowise:init` and `/repowise:reindex` list the embedders the CLI actually
+  accepts - `gemini`, `openai`, `openrouter`, `ollama`, `edenai` - rather than
+  the three-name set they had drifted to, and name the keys that resolve them
+  (#705, #1820).
+- No hook or MCP tool surface change this cycle: `hooks.json` still mirrors
+  `claude_config.py` and every tool named in a command or skill is one the
+  server lists.
+
 ## 0.44.0
 
 ### Changed

--- a/plugins/claude-code/commands/init.md
+++ b/plugins/claude-code/commands/init.md
@@ -80,7 +80,8 @@ Core flags:
   --mode fast            Quick first pass on very large repos: no wiki at all.
 
 Embeddings:
-  --embedder NAME        Embedding provider: gemini, openai, mock (default: auto-detect)
+  --embedder NAME        Embedding provider: gemini, openai, openrouter, ollama,
+                         edenai, mock (default: auto-detect)
 
 Cost control:
   --concurrency N        Max parallel LLM calls (default: 10)

--- a/plugins/claude-code/commands/reindex.md
+++ b/plugins/claude-code/commands/reindex.md
@@ -22,12 +22,12 @@ This is useful when:
 
 ## Available flags
 
-- `--embedder gemini|openai|auto` — embedding provider (default: auto-detect from env vars)
+- `--embedder gemini|openai|openrouter|ollama|edenai|auto` — embedding provider (default: auto-detect from env vars)
 - `--batch-size N` — pages per embedding batch (default: 20)
 
 ## Requirements
 
-Requires either `GEMINI_API_KEY`/`GOOGLE_API_KEY` or `OPENAI_API_KEY` to be set. The mock embedder is not accepted for reindexing. If neither key is available, ask the user to set one before proceeding.
+Requires a key for one of the real embedders — `GEMINI_API_KEY`/`GOOGLE_API_KEY`, `OPENAI_API_KEY`, `OPENROUTER_API_KEY` or `EDENAI_API_KEY` — or a running Ollama. The mock embedder is not accepted for reindexing. If none is available, ask the user to set one before proceeding.
 
 ## Handling $ARGUMENTS
 

--- a/plugins/claude-code/skills/change-review/SKILL.md
+++ b/plugins/claude-code/skills/change-review/SKILL.md
@@ -65,9 +65,9 @@ The response carries a `directive` block — read it first, it's a few short lis
   exercise the changed files. Recommend running these to validate the change.
   Read **`tests_to_run_basis`** with it: `measured` means a coverage map proves
   those tests execute the changed files (pytest-runnable ids); `inferred` means
-  the import graph shows those test *files* reaching the change, which needs no
-  coverage ingest but is a candidate list, so say so rather than presenting it as
-  proof; `none` with an empty list is "unknown", never "no tests exist".
+  the call graph shows those test *files* reaching the change, with the import
+  graph filling in where it is silent, which needs no coverage ingest but is a
+  candidate list, so say so rather than presenting it as proof; `none` with an empty list is "unknown", never "no tests exist".
 
 `pr_blast_radius` holds the fuller dossier behind those lists (including the
 per-changed-file `guarding_tests` breakdown behind `tests_to_run`).

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Repowise codebase intelligence for Codex.",
   "author": {
     "name": "Repowise",

--- a/plugins/codex/skills/change-review/SKILL.md
+++ b/plugins/codex/skills/change-review/SKILL.md
@@ -60,9 +60,9 @@ The response carries a `directive` block — read it first, it's a few short lis
   exercise the changed files. Recommend running these to validate the change.
   Read **`tests_to_run_basis`** with it: `measured` means a coverage map proves
   those tests execute the changed files (pytest-runnable ids); `inferred` means
-  the import graph shows those test *files* reaching the change, which needs no
-  coverage ingest but is a candidate list, so say so rather than presenting it as
-  proof; `none` with an empty list is "unknown", never "no tests exist".
+  the call graph shows those test *files* reaching the change, with the import
+  graph filling in where it is silent, which needs no coverage ingest but is a
+  candidate list, so say so rather than presenting it as proof; `none` with an empty list is "unknown", never "no tests exist".
 
 `pr_blast_radius` holds the fuller dossier behind those lists (including the
 per-changed-file `guarding_tests` breakdown behind `tests_to_run`).

--- a/plugins/shared/commands/init.md
+++ b/plugins/shared/commands/init.md
@@ -81,7 +81,8 @@ Core flags:
   --mode fast            Quick first pass on very large repos: no wiki at all.
 
 Embeddings:
-  --embedder NAME        Embedding provider: gemini, openai, mock (default: auto-detect)
+  --embedder NAME        Embedding provider: gemini, openai, openrouter, ollama,
+                         edenai, mock (default: auto-detect)
 
 Cost control:
   --concurrency N        Max parallel LLM calls (default: 10)

--- a/plugins/shared/commands/reindex.md
+++ b/plugins/shared/commands/reindex.md
@@ -23,12 +23,12 @@ This is useful when:
 
 ## Available flags
 
-- `--embedder gemini|openai|auto` — embedding provider (default: auto-detect from env vars)
+- `--embedder gemini|openai|openrouter|ollama|edenai|auto` — embedding provider (default: auto-detect from env vars)
 - `--batch-size N` — pages per embedding batch (default: 20)
 
 ## Requirements
 
-Requires either `GEMINI_API_KEY`/`GOOGLE_API_KEY` or `OPENAI_API_KEY` to be set. The mock embedder is not accepted for reindexing. If neither key is available, ask the user to set one before proceeding.
+Requires a key for one of the real embedders — `GEMINI_API_KEY`/`GOOGLE_API_KEY`, `OPENAI_API_KEY`, `OPENROUTER_API_KEY` or `EDENAI_API_KEY` — or a running Ollama. The mock embedder is not accepted for reindexing. If none is available, ask the user to set one before proceeding.
 
 ## Handling $ARGUMENTS
 

--- a/plugins/shared/skills/change-review.md
+++ b/plugins/shared/skills/change-review.md
@@ -73,9 +73,9 @@ The response carries a `directive` block — read it first, it's a few short lis
   exercise the changed files. Recommend running these to validate the change.
   Read **`tests_to_run_basis`** with it: `measured` means a coverage map proves
   those tests execute the changed files (pytest-runnable ids); `inferred` means
-  the import graph shows those test *files* reaching the change, which needs no
-  coverage ingest but is a candidate list, so say so rather than presenting it as
-  proof; `none` with an empty list is "unknown", never "no tests exist".
+  the call graph shows those test *files* reaching the change, with the import
+  graph filling in where it is silent, which needs no coverage ingest but is a
+  candidate list, so say so rather than presenting it as proof; `none` with an empty list is "unknown", never "no tests exist".
 
 `pr_blast_radius` holds the fuller dossier behind those lists (including the
 per-changed-file `guarding_tests` breakdown behind `tests_to_run`).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "repowise"
-version = "0.44.0"
+version = "0.45.0"
 description = "The codebase intelligence layer for your AI coding agent — dependency graph, git history, dead code, decisions, and code health, exposed over MCP"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/server.json
+++ b/server.json
@@ -8,12 +8,12 @@
     "source": "github"
   },
   "websiteUrl": "https://www.repowise.dev",
-  "version": "0.44.0",
+  "version": "0.45.0",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "repowise",
-      "version": "0.44.0",
+      "version": "0.45.0",
       "transport": {
         "type": "stdio"
       },

--- a/uv.lock
+++ b/uv.lock
@@ -3051,7 +3051,7 @@ wheels = [
 
 [[package]]
 name = "repowise"
-version = "0.44.0"
+version = "0.45.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Cuts 0.45.0 from `main` at 3ab320a1, 44 commits since v0.44.0.

The headline is test intelligence that needs no coverage report: the call graph answers which tests reach a file, the API serves it under `basis: "inferred"`, and the Coverage tab becomes a Tests tab that says something useful on a repository that never ingested a report. Around it, Code Health performance findings become bounded opportunities that open the matching refactoring plan, Eden AI joins as an EU-hosted provider and embedder, and pinning BLAS threads before numpy loads roughly halves peak memory on a cold index.

## What is in the commit

- Version bumped in `pyproject.toml`, the three subpackage `__init__.py` files, `uv.lock`, `server.json` (both fields), `.claude-plugin/marketplace.json` and `plugins/claude-code/.claude-plugin/plugin.json`. The Codex plugin goes 0.6.0 to 0.6.1 because its `change-review` skill content moved this cycle.
- `docs/CHANGELOG.md` gains the 0.45.0 section, and the copy the wheel bundles for offline `whats-new` is resynced.
- Plugin parity for this cycle, fixed at the `plugins/shared/` source and regenerated: `/repowise:impacted-tests` and the `change-review` skill described the inferred map as an import walk, which #1755 replaced with a filtered call-graph walk, and `init` / `reindex` listed three embedders when the CLI now accepts five plus `edenai`.
- No hook or MCP tool surface change: `hooks.json` still mirrors `claude_config.py`, and every tool named in a command or skill is one the server lists.

`STORE_FORMAT_VERSION` and `PARSER_SCHEMA_VERSION` are untouched, so no reindex is prompted. `HEALTH_ANALYZER_VERSION` already moved to 3 in #1755, so the first `update` after upgrading re-scores health.

## Test plan

- [x] `ruff check .` clean
- [x] `pytest tests/unit/test_release_manifests.py tests/unit/upgrade/test_bundled_changelog_sync.py` green
- [x] `uv build --wheel` produces `repowise-0.45.0-py3-none-any.whl` with 89 command modules, 19 `.scm` queries and the `.j2` templates
- [x] `npm ci && npm run build --workspace packages/web` green, standalone `server.js` produced
- [x] `repowise serve` against a real index, UI clicked through on overview, health, tests and refactoring
- [x] Full `tests/unit`: 14,067 passed, 19 failed locally. CI is green on the same tree; the Pascal failures need `tree_sitter_pascal`, absent on that machine, and the rest pass in isolation

The VS Code extension is 14 `packages/ui` commits behind `vscode-v0.8.0` and needs its own release. That rides a separate branch and tag after this one.
