### PR TITLE
fix(mcp): let get_answer expansion see the call graph

### DIFF
--- a/packages/server/src/repowise/server/mcp_server/_answer_pipeline.py
+++ b/packages/server/src/repowise/server/mcp_server/_answer_pipeline.py
@@ -59,6 +59,7 @@ from repowise.core.persistence.models import GraphEdge, GraphNode, Page
 from repowise.core.providers.embedding import store_has_semantic_vectors
 from repowise.core.test_paths import is_test_path
 from repowise.server.mcp_server._graph_files import (
+    batched_paths,
     is_symbol_node,
     keep_projected_edge,
     node_to_file,
@@ -119,6 +120,11 @@ _GRAPH_EXPAND_MAX_NEW = 3
 # repo where every file has a handful of edges excludes nothing.
 _HUB_DEGREE_FLOOR = 50
 _HUB_DEGREE_PERCENTILE = 0.99
+
+# How many of the strongest-linked page-bearing neighbours get scored. Well
+# above _GRAPH_EXPAND_MAX_NEW so the hub filter still has a distribution to take
+# a percentile of, and far below the candidate set the projection now produces.
+_DEGREE_SAMPLE = 25
 
 # PageRank bias is multiplicative and capped. We don't want a marginally
 # more central file to outrank a strong text match — only to break ties.
@@ -761,28 +767,29 @@ async def _neighbor_degrees(session: Any, nodes: set[str]) -> dict[str, int]:
     """
     if not nodes:
         return {}
-    res = await session.execute(
-        select(
-            GraphEdge.source_node_id,
-            GraphEdge.target_node_id,
-            GraphEdge.edge_type,
-            GraphEdge.confidence,
-        ).where(
-            or_(
-                touches_files(GraphEdge.source_node_id, nodes),
-                touches_files(GraphEdge.target_node_id, nodes),
-            ),
-            GraphEdge.edge_type.notin_(CONTAINMENT_EDGE_TYPES),
-        )
-    )
     degree: dict[str, int] = {}
-    for src, tgt, etype, conf in res.all():
-        src_file, tgt_file = _projected_pair(src, tgt, etype, conf)
-        if src_file is None or tgt_file is None:
-            continue
-        for side in (src_file, tgt_file):
-            if side in nodes:
-                degree[side] = degree.get(side, 0) + 1
+    for batch in batched_paths(nodes):
+        res = await session.execute(
+            select(
+                GraphEdge.source_node_id,
+                GraphEdge.target_node_id,
+                GraphEdge.edge_type,
+                GraphEdge.confidence,
+            ).where(
+                or_(
+                    touches_files(GraphEdge.source_node_id, batch),
+                    touches_files(GraphEdge.target_node_id, batch),
+                ),
+                GraphEdge.edge_type.notin_(CONTAINMENT_EDGE_TYPES),
+            )
+        )
+        for src, tgt, etype, conf in res.all():
+            src_file, tgt_file = _projected_pair(src, tgt, etype, conf)
+            if src_file is None or tgt_file is None:
+                continue
+            for side in (src_file, tgt_file):
+                if side in nodes:
+                    degree[side] = degree.get(side, 0) + 1
     return degree
 
 
@@ -883,15 +890,26 @@ async def expand_via_graph(hits: list[dict], ctx: Any, question: str = "") -> li
         )
         page_rows = list(page_res.all())
 
+        # Rank on the seed-link count first and keep only the head of it. Making
+        # the call layer visible multiplied the candidate set, and both queries
+        # below scale with it: on fastapi the degree query alone reached 2.2s
+        # per answer over the full set. Only _GRAPH_EXPAND_MAX_NEW candidates
+        # can ever be returned, so scoring far more than that buys nothing —
+        # and the hub cutoff is a percentile, which needs a sample rather than
+        # the population.
+        page_rows.sort(key=lambda row: -links.get(row[0], 0))
+        page_rows = page_rows[:_DEGREE_SAMPLE]
+        sampled = {row[0] for row in page_rows}
+
         # Also load PageRank for the neighbors so we can rank them.
         pr_res = await session.execute(
             select(GraphNode.node_id, GraphNode.pagerank).where(
-                GraphNode.node_id.in_(neighbors),
+                GraphNode.node_id.in_(sorted(sampled)),
                 GraphNode.node_type == "file",
             )
         )
         pr_by_path = {row[0]: float(row[1] or 0.0) for row in pr_res.all()}
-        degree = await _neighbor_degrees(session, neighbors)
+        degree = await _neighbor_degrees(session, sampled)
 
     if not page_rows:
         return hits

--- a/packages/server/src/repowise/server/mcp_server/_answer_pipeline.py
+++ b/packages/server/src/repowise/server/mcp_server/_answer_pipeline.py
@@ -50,7 +50,7 @@ import re
 from collections import OrderedDict
 from typing import Any
 
-from sqlalchemy import func, select
+from sqlalchemy import or_, select
 
 from repowise.core.analysis.decisions.semantic_match import DECISION_VECTOR_PREFIX
 from repowise.core.ingestion.models import CONTAINMENT_EDGE_TYPES
@@ -58,6 +58,12 @@ from repowise.core.persistence.database import get_session
 from repowise.core.persistence.models import GraphEdge, GraphNode, Page
 from repowise.core.providers.embedding import store_has_semantic_vectors
 from repowise.core.test_paths import is_test_path
+from repowise.server.mcp_server._graph_files import (
+    is_symbol_node,
+    keep_projected_edge,
+    node_to_file,
+    touches_files,
+)
 from repowise.server.mcp_server._helpers import (
     _VECTOR_TIMEOUT_ENV,
     vector_search_timeout_s,
@@ -719,33 +725,64 @@ async def apply_pagerank_bias(hits: list[dict], ctx: Any) -> None:
 # ---------------------------------------------------------------------------
 
 
-async def _neighbor_degrees(session: Any, nodes: set[str]) -> dict[str, int]:
-    """Total graph degree (in + out) for each node in *nodes*.
+def _projected_pair(
+    src: str | None, tgt: str | None, edge_type: str | None, confidence: float | None
+) -> tuple[str | None, str | None]:
+    """An edge's two endpoints as file paths, or ``(None, None)`` to drop it.
 
-    One grouped count per direction over the same indexed edge table the
-    expansion already reads, scoped to the candidate set rather than the whole
-    graph.
+    The symbol layer needs its guards applied after projection; the file layer
+    is already file-to-file and keeps today's behaviour untouched. That
+    asymmetry is deliberate: the guards refuse cross-extension pairs, and a
+    ``co_changes`` edge between a module and its own docs is a legitimate
+    "read this too" that expansion has always served.
+    """
+    src = src or ""
+    tgt = tgt or ""
+    if not is_symbol_node(src) and not is_symbol_node(tgt):
+        return (src or None, tgt or None)
+    src_file, tgt_file = node_to_file(src), node_to_file(tgt)
+    if not keep_projected_edge(src_file, tgt_file, edge_type, confidence):
+        return (None, None)
+    return (src_file, tgt_file)
+
+
+async def _neighbor_degrees(session: Any, nodes: set[str]) -> dict[str, int]:
+    """File-level graph degree (in + out) for each file path in *nodes*.
+
+    Counted over the same edges the expansion walk traverses, and projected the
+    same way: a grouped count on the raw node id would have counted only the
+    file layer, so a file reachable mostly by calls read as unconnected and the
+    p99 hub cutoff was calibrated on an imports-only distribution.
+
+    Containment stays excluded. Its endpoints project onto the declaring file
+    itself, so counting it would inflate a file's degree by the number of
+    symbols it declares and make a symbol-rich file read as a hub on its own
+    size.
     """
     if not nodes:
         return {}
-    degree: dict[str, int] = {}
-    for column in (GraphEdge.source_node_id, GraphEdge.target_node_id):
-        res = await session.execute(
-            select(column, func.count())
-            .where(
-                column.in_(nodes),
-                # Count over the same edges the walk above traverses. Counting
-                # containment too inflates a file's degree by the number of
-                # symbols it declares, so a symbol-rich file reads as a hub on
-                # its own size, and the p99 cutoff moves with how many symbol
-                # nodes happen to be in the candidate set rather than with how
-                # connected the files are.
-                GraphEdge.edge_type.notin_(CONTAINMENT_EDGE_TYPES),
-            )
-            .group_by(column)
+    res = await session.execute(
+        select(
+            GraphEdge.source_node_id,
+            GraphEdge.target_node_id,
+            GraphEdge.edge_type,
+            GraphEdge.confidence,
+        ).where(
+            or_(
+                touches_files(GraphEdge.source_node_id, nodes),
+                touches_files(GraphEdge.target_node_id, nodes),
+            ),
+            GraphEdge.edge_type.notin_(CONTAINMENT_EDGE_TYPES),
         )
-        for node_id, count in res.all():
-            degree[node_id] = degree.get(node_id, 0) + int(count or 0)
+    )
+    degree: dict[str, int] = {}
+    for src, tgt, etype, conf in res.all():
+        src_file, tgt_file = _projected_pair(src, tgt, etype, conf)
+        if src_file is None or tgt_file is None:
+            continue
+        for side in (src_file, tgt_file):
+            if side in nodes:
+                degree[side] = degree.get(side, 0) + 1
     return degree
 
 
@@ -763,7 +800,7 @@ def _hub_degree_cutoff(degree: dict[str, int]) -> int:
     return max(_HUB_DEGREE_FLOOR, values[idx])
 
 
-async def expand_via_graph(hits: list[dict], ctx: Any) -> list[dict]:
+async def expand_via_graph(hits: list[dict], ctx: Any, question: str = "") -> list[dict]:
     """Add up to ``_GRAPH_EXPAND_MAX_NEW`` graph-neighbor files to ``hits``.
 
     Rescues near-misses where the top retrieved file is in the right
@@ -794,30 +831,44 @@ async def expand_via_graph(hits: list[dict], ctx: Any) -> list[dict]:
         # moves with yours" is a genuine read-this-too signal, and expansion
         # surfaces what it adds neutrally as ``[graph-expanded]`` rather than
         # as an import claim. Containment edges are excluded because they can
-        # never contribute: their endpoint is a ``path::Name`` symbol node, and
-        # the page lookup below matches ``target_path`` against ``file_page``
-        # rows, so every such neighbour was fetched only to be discarded.
-        neighbor_cols = (GraphEdge.source_node_id, GraphEdge.target_node_id)
-        inbound_res = await session.execute(
-            select(*neighbor_cols).where(
-                GraphEdge.target_node_id.in_(seed_paths),
-                GraphEdge.edge_type.notin_(CONTAINMENT_EDGE_TYPES),
-            )
-        )
-        outbound_res = await session.execute(
-            select(*neighbor_cols).where(
-                GraphEdge.source_node_id.in_(seed_paths),
+        # never contribute: both their endpoints describe the same file, so a
+        # projected containment edge is always a self-loop.
+        #
+        # Both directions in one query. It matches the symbol layer as well as
+        # the file layer: ``calls`` and its six siblings join ``path::Name``
+        # nodes, so an equality test against a seed path could never match one
+        # and the entire call graph was invisible here.
+        seed_set = set(seed_paths)
+        res = await session.execute(
+            select(
+                GraphEdge.source_node_id,
+                GraphEdge.target_node_id,
+                GraphEdge.edge_type,
+                GraphEdge.confidence,
+            ).where(
+                or_(
+                    touches_files(GraphEdge.source_node_id, seed_set),
+                    touches_files(GraphEdge.target_node_id, seed_set),
+                ),
                 GraphEdge.edge_type.notin_(CONTAINMENT_EDGE_TYPES),
             )
         )
 
+        # ``links`` counts the distinct edges tying each neighbour to the seed
+        # set. That is the ranking signal the projection above buys: before it,
+        # only imports were visible and almost every neighbour scored 1.
         neighbors: set[str] = set()
-        for src, _tgt in inbound_res.all():
-            if src and src not in existing:
-                neighbors.add(src)
-        for _src, tgt in outbound_res.all():
-            if tgt and tgt not in existing:
-                neighbors.add(tgt)
+        links: dict[str, int] = {}
+        for src, tgt, etype, conf in res.all():
+            src_file, tgt_file = _projected_pair(src, tgt, etype, conf)
+            if src_file is None or tgt_file is None:
+                continue
+            # The SQL prefix can over-match a longer path, so membership is
+            # re-checked here against the projected file.
+            for mine, theirs in ((src_file, tgt_file), (tgt_file, src_file)):
+                if mine in seed_set and theirs not in existing:
+                    neighbors.add(theirs)
+                    links[theirs] = links.get(theirs, 0) + 1
 
         if not neighbors:
             return hits
@@ -872,12 +923,33 @@ async def expand_via_graph(hits: list[dict], ctx: Any) -> list[dict]:
                 "_sources": {"graph_expand"},
                 "_expanded_from": "graph",
                 "_pagerank": pr_by_path.get(path, 0.0),
+                "_seed_links": links.get(path, 0),
             }
         )
 
-    # Rank candidates by PageRank within the expansion set so we pick the
-    # most central neighbor first when we have multiple plausible ones.
-    candidates.sort(key=lambda c: -c.get("_pagerank", 0.0))
+    # A test calls the file it exercises far more often than any collaborator
+    # does, so link count alone ranks a repo's tests above its implementation.
+    # ``demote_noise_hits`` runs downstream and would reorder them, but only
+    # after they had spent all _GRAPH_EXPAND_MAX_NEW slots — the implementation
+    # file it should have picked never enters the list. Same rule, applied where
+    # the slots are handed out.
+    test_focused = bool(_TEST_QUERY_RE.search(question))
+
+    # Rank by how strongly the neighbour is tied to THIS seed, PageRank only as
+    # the tiebreak. Ranking on PageRank alone answers "what is central in the
+    # repo" when the question asked "what is next to this file", so the same few
+    # central modules were returned whatever the seed was — the hub cutoff above
+    # only removes the extreme tail of that, it does not change the ordering.
+    # Link count is the seed-specific signal, and it only became usable once the
+    # projection above made the call layer visible: on imports alone almost
+    # every neighbour scored 1.
+    candidates.sort(
+        key=lambda c: (
+            not test_focused and is_test_path(c["target_path"]),
+            -c.get("_seed_links", 0),
+            -c.get("_pagerank", 0.0),
+        )
+    )
     additions = candidates[:_GRAPH_EXPAND_MAX_NEW]
     if not additions:
         return hits

--- a/packages/server/src/repowise/server/mcp_server/_answer_pipeline.py
+++ b/packages/server/src/repowise/server/mcp_server/_answer_pipeline.py
@@ -50,7 +50,7 @@ import re
 from collections import OrderedDict
 from typing import Any
 
-from sqlalchemy import or_, select
+from sqlalchemy import select
 
 from repowise.core.analysis.decisions.semantic_match import DECISION_VECTOR_PREFIX
 from repowise.core.ingestion.models import CONTAINMENT_EDGE_TYPES
@@ -59,11 +59,9 @@ from repowise.core.persistence.models import GraphEdge, GraphNode, Page
 from repowise.core.providers.embedding import store_has_semantic_vectors
 from repowise.core.test_paths import is_test_path
 from repowise.server.mcp_server._graph_files import (
-    batched_paths,
     is_symbol_node,
     keep_projected_edge,
     node_to_file,
-    touches_files,
 )
 from repowise.server.mcp_server._helpers import (
     _VECTOR_TIMEOUT_ENV,
@@ -120,10 +118,6 @@ _GRAPH_EXPAND_MAX_NEW = 3
 # repo where every file has a handful of edges excludes nothing.
 _HUB_DEGREE_FLOOR = 50
 _HUB_DEGREE_PERCENTILE = 0.99
-
-# How many of the strongest-linked page-bearing neighbours get scored — enough
-# for the hub percentile to have a distribution, far below the candidate set.
-_DEGREE_SAMPLE = 25
 
 # PageRank bias is multiplicative and capped. We don't want a marginally
 # more central file to outrank a strong text match — only to break ties.
@@ -750,43 +744,33 @@ def _projected_pair(
     return (src_file, tgt_file)
 
 
-async def _neighbor_degrees(session: Any, nodes: set[str]) -> dict[str, int]:
-    """File-level graph degree (in + out) for each file path in *nodes*.
+async def _projected_edges(session: Any, repo_id: str) -> list[tuple[str, str]]:
+    """Every non-containment edge for *repo_id*, as a pair of file paths.
 
-    Counted over the same edges the walk traverses and projected the same way: a
-    grouped count on the raw node id sees only the file layer, so a file reached
-    mostly by calls read as unconnected and the p99 hub cutoff was calibrated on
-    an imports-only distribution.
+    One scan, projected in Python. A prefix match on the symbol layer cannot use
+    the node-id index (SQLite disables the LIKE optimisation under an ESCAPE
+    clause), so per-candidate queries were a scan each; this is one.
 
-    Containment stays excluded — its endpoints project onto the declaring file,
-    so counting it makes a symbol-rich file a hub on its own size.
+    Containment is excluded because both its endpoints describe the same file,
+    so a projected containment edge is always a self-loop.
     """
-    if not nodes:
-        return {}
-    degree: dict[str, int] = {}
-    for batch in batched_paths(nodes):
-        res = await session.execute(
-            select(
-                GraphEdge.source_node_id,
-                GraphEdge.target_node_id,
-                GraphEdge.edge_type,
-                GraphEdge.confidence,
-            ).where(
-                or_(
-                    touches_files(GraphEdge.source_node_id, batch),
-                    touches_files(GraphEdge.target_node_id, batch),
-                ),
-                GraphEdge.edge_type.notin_(CONTAINMENT_EDGE_TYPES),
-            )
+    res = await session.execute(
+        select(
+            GraphEdge.source_node_id,
+            GraphEdge.target_node_id,
+            GraphEdge.edge_type,
+            GraphEdge.confidence,
+        ).where(
+            GraphEdge.repository_id == repo_id,
+            GraphEdge.edge_type.notin_(CONTAINMENT_EDGE_TYPES),
         )
-        for src, tgt, etype, conf in res.all():
-            src_file, tgt_file = _projected_pair(src, tgt, etype, conf)
-            if src_file is None or tgt_file is None:
-                continue
-            for side in (src_file, tgt_file):
-                if side in nodes:
-                    degree[side] = degree.get(side, 0) + 1
-    return degree
+    )
+    pairs: list[tuple[str, str]] = []
+    for src, tgt, etype, conf in res.all():
+        src_file, tgt_file = _projected_pair(src, tgt, etype, conf)
+        if src_file and tgt_file:
+            pairs.append((src_file, tgt_file))
+    return pairs
 
 
 def _hub_degree_cutoff(degree: dict[str, int]) -> int:
@@ -803,7 +787,7 @@ def _hub_degree_cutoff(degree: dict[str, int]) -> int:
     return max(_HUB_DEGREE_FLOOR, values[idx])
 
 
-async def expand_via_graph(hits: list[dict], ctx: Any, question: str = "") -> list[dict]:
+async def expand_via_graph(hits: list[dict], ctx: Any, repo_id: str) -> list[dict]:
     """Add up to ``_GRAPH_EXPAND_MAX_NEW`` graph-neighbor files to ``hits``.
 
     Rescues near-misses where the top retrieved file is in the right
@@ -825,51 +809,26 @@ async def expand_via_graph(hits: list[dict], ctx: Any, question: str = "") -> li
     existing = {h.get("target_path") for h in hits}
 
     async with get_session(ctx.session_factory) as session:
-        # Inbound (someone → seed) and outbound (seed → someone) in one query
-        # each. Two queries are fine — both hit the same indexed edge table and
-        # run in <10ms on the corpus this is tuned for.
-        #
         # Not import edges only, despite the naming this code used to carry:
-        # ``co_changes`` neighbours stay in on purpose, because "this file
-        # moves with yours" is a genuine read-this-too signal, and expansion
-        # surfaces what it adds neutrally as ``[graph-expanded]`` rather than
-        # as an import claim. Containment edges are excluded because they can
-        # never contribute: both endpoints describe the same file, so a projected
-        # containment edge is always a self-loop.
+        # ``co_changes`` neighbours stay in on purpose, because "this file moves
+        # with yours" is a genuine read-this-too signal, and expansion surfaces
+        # what it adds neutrally as ``[graph-expanded]`` rather than as an import
+        # claim.
         #
-        # Both directions in one query, matching the symbol layer as well as the
-        # file layer: ``calls`` and its siblings join ``path::Name`` nodes, so an
-        # equality test against a seed path matched none of them.
+        # The scan reaches the symbol layer as well as the file layer: ``calls``
+        # and its siblings join ``path::Name`` nodes, so an equality test against
+        # a seed path matched none of them and the call graph was invisible here.
         seed_set = set(seed_paths)
-        res = await session.execute(
-            select(
-                GraphEdge.source_node_id,
-                GraphEdge.target_node_id,
-                GraphEdge.edge_type,
-                GraphEdge.confidence,
-            ).where(
-                or_(
-                    touches_files(GraphEdge.source_node_id, seed_set),
-                    touches_files(GraphEdge.target_node_id, seed_set),
-                ),
-                GraphEdge.edge_type.notin_(CONTAINMENT_EDGE_TYPES),
-            )
-        )
+        pairs = await _projected_edges(session, repo_id)
 
-        # ``links`` counts the edges tying each neighbour to the seed set — the
-        # ranking signal the projection buys, since imports alone scored ~1 each.
         neighbors: set[str] = set()
-        links: dict[str, int] = {}
-        for src, tgt, etype, conf in res.all():
-            src_file, tgt_file = _projected_pair(src, tgt, etype, conf)
-            if src_file is None or tgt_file is None:
-                continue
-            # The SQL prefix can over-match a longer path, so membership is
-            # re-checked here against the projected file.
+        degree: dict[str, int] = {}
+        for src_file, tgt_file in pairs:
+            degree[src_file] = degree.get(src_file, 0) + 1
+            degree[tgt_file] = degree.get(tgt_file, 0) + 1
             for mine, theirs in ((src_file, tgt_file), (tgt_file, src_file)):
                 if mine in seed_set and theirs not in existing:
                     neighbors.add(theirs)
-                    links[theirs] = links.get(theirs, 0) + 1
 
         if not neighbors:
             return hits
@@ -878,28 +837,20 @@ async def expand_via_graph(hits: list[dict], ctx: Any, question: str = "") -> li
         # context block can't carry a useful excerpt for them.
         page_res = await session.execute(
             select(Page.target_path, Page.summary, Page.page_type).where(
-                Page.target_path.in_(neighbors),
+                Page.target_path.in_(sorted(neighbors)),
                 Page.page_type == "file_page",
             )
         )
         page_rows = list(page_res.all())
 
-        # Score only the head of the link ranking: both queries below scale with
-        # the candidate set, which the call layer multiplied (2.2s per answer on
-        # fastapi over the full set), and only three candidates can be returned.
-        page_rows.sort(key=lambda row: -links.get(row[0], 0))
-        page_rows = page_rows[:_DEGREE_SAMPLE]
-        sampled = {row[0] for row in page_rows}
-
         # Also load PageRank for the neighbors so we can rank them.
         pr_res = await session.execute(
             select(GraphNode.node_id, GraphNode.pagerank).where(
-                GraphNode.node_id.in_(sorted(sampled)),
+                GraphNode.node_id.in_(sorted(neighbors)),
                 GraphNode.node_type == "file",
             )
         )
         pr_by_path = {row[0]: float(row[1] or 0.0) for row in pr_res.all()}
-        degree = await _neighbor_degrees(session, sampled)
 
     if not page_rows:
         return hits
@@ -908,7 +859,9 @@ async def expand_via_graph(hits: list[dict], ctx: Any, question: str = "") -> li
     # them, which is the wrong instinct here: expansion is trying to name the
     # specific file the question is about, and the most-imported file in the
     # repo is the least specific candidate available.
-    cutoff = _hub_degree_cutoff(degree)
+    # Scoped to the candidate set, not the repo: the cutoff answers "is this
+    # neighbour a hub among the ones on offer".
+    cutoff = _hub_degree_cutoff({row[0]: degree.get(row[0], 0) for row in page_rows})
     non_hub = [row for row in page_rows if degree.get(row[0], 0) <= cutoff]
     if non_hub:
         page_rows = non_hub
@@ -931,25 +884,14 @@ async def expand_via_graph(hits: list[dict], ctx: Any, question: str = "") -> li
                 "_sources": {"graph_expand"},
                 "_expanded_from": "graph",
                 "_pagerank": pr_by_path.get(path, 0.0),
-                "_seed_links": links.get(path, 0),
             }
         )
 
-    # A test calls what it exercises more often than any collaborator does, so
-    # link count alone ranks tests first. ``demote_noise_hits`` reorders them
-    # downstream, but only after they have spent every slot.
-    test_focused = bool(_TEST_QUERY_RE.search(question))
-
-    # Rank on the tie to THIS seed, PageRank only as tiebreak. PageRank alone
-    # answers "what is central in the repo" for a question about what sits next
-    # to one file, and returned the same modules whatever the seed was.
-    candidates.sort(
-        key=lambda c: (
-            not test_focused and is_test_path(c["target_path"]),
-            -c.get("_seed_links", 0),
-            -c.get("_pagerank", 0.0),
-        )
-    )
+    # Rank candidates by PageRank within the expansion set so we pick the
+    # most central neighbor first when we have multiple plausible ones.
+    # Path breaks ties, so which neighbour is picked cannot move with the
+    # database's row order between runs on identical data.
+    candidates.sort(key=lambda c: (-c.get("_pagerank", 0.0), c["target_path"]))
     additions = candidates[:_GRAPH_EXPAND_MAX_NEW]
     if not additions:
         return hits

--- a/packages/server/src/repowise/server/mcp_server/_answer_pipeline.py
+++ b/packages/server/src/repowise/server/mcp_server/_answer_pipeline.py
@@ -121,9 +121,8 @@ _GRAPH_EXPAND_MAX_NEW = 3
 _HUB_DEGREE_FLOOR = 50
 _HUB_DEGREE_PERCENTILE = 0.99
 
-# How many of the strongest-linked page-bearing neighbours get scored. Well
-# above _GRAPH_EXPAND_MAX_NEW so the hub filter still has a distribution to take
-# a percentile of, and far below the candidate set the projection now produces.
+# How many of the strongest-linked page-bearing neighbours get scored — enough
+# for the hub percentile to have a distribution, far below the candidate set.
 _DEGREE_SAMPLE = 25
 
 # PageRank bias is multiplicative and capped. We don't want a marginally
@@ -736,11 +735,10 @@ def _projected_pair(
 ) -> tuple[str | None, str | None]:
     """An edge's two endpoints as file paths, or ``(None, None)`` to drop it.
 
-    The symbol layer needs its guards applied after projection; the file layer
-    is already file-to-file and keeps today's behaviour untouched. That
-    asymmetry is deliberate: the guards refuse cross-extension pairs, and a
-    ``co_changes`` edge between a module and its own docs is a legitimate
-    "read this too" that expansion has always served.
+    Only the symbol layer gets the guards; the file layer is already
+    file-to-file and keeps today's behaviour. The asymmetry is deliberate — the
+    guards refuse cross-extension pairs, and a ``co_changes`` edge between a
+    module and its docs is a "read this too" expansion has always served.
     """
     src = src or ""
     tgt = tgt or ""
@@ -755,15 +753,13 @@ def _projected_pair(
 async def _neighbor_degrees(session: Any, nodes: set[str]) -> dict[str, int]:
     """File-level graph degree (in + out) for each file path in *nodes*.
 
-    Counted over the same edges the expansion walk traverses, and projected the
-    same way: a grouped count on the raw node id would have counted only the
-    file layer, so a file reachable mostly by calls read as unconnected and the
-    p99 hub cutoff was calibrated on an imports-only distribution.
+    Counted over the same edges the walk traverses and projected the same way: a
+    grouped count on the raw node id sees only the file layer, so a file reached
+    mostly by calls read as unconnected and the p99 hub cutoff was calibrated on
+    an imports-only distribution.
 
-    Containment stays excluded. Its endpoints project onto the declaring file
-    itself, so counting it would inflate a file's degree by the number of
-    symbols it declares and make a symbol-rich file read as a hub on its own
-    size.
+    Containment stays excluded — its endpoints project onto the declaring file,
+    so counting it makes a symbol-rich file a hub on its own size.
     """
     if not nodes:
         return {}
@@ -838,13 +834,12 @@ async def expand_via_graph(hits: list[dict], ctx: Any, question: str = "") -> li
         # moves with yours" is a genuine read-this-too signal, and expansion
         # surfaces what it adds neutrally as ``[graph-expanded]`` rather than
         # as an import claim. Containment edges are excluded because they can
-        # never contribute: both their endpoints describe the same file, so a
-        # projected containment edge is always a self-loop.
+        # never contribute: both endpoints describe the same file, so a projected
+        # containment edge is always a self-loop.
         #
-        # Both directions in one query. It matches the symbol layer as well as
-        # the file layer: ``calls`` and its six siblings join ``path::Name``
-        # nodes, so an equality test against a seed path could never match one
-        # and the entire call graph was invisible here.
+        # Both directions in one query, matching the symbol layer as well as the
+        # file layer: ``calls`` and its siblings join ``path::Name`` nodes, so an
+        # equality test against a seed path matched none of them.
         seed_set = set(seed_paths)
         res = await session.execute(
             select(
@@ -861,9 +856,8 @@ async def expand_via_graph(hits: list[dict], ctx: Any, question: str = "") -> li
             )
         )
 
-        # ``links`` counts the distinct edges tying each neighbour to the seed
-        # set. That is the ranking signal the projection above buys: before it,
-        # only imports were visible and almost every neighbour scored 1.
+        # ``links`` counts the edges tying each neighbour to the seed set — the
+        # ranking signal the projection buys, since imports alone scored ~1 each.
         neighbors: set[str] = set()
         links: dict[str, int] = {}
         for src, tgt, etype, conf in res.all():
@@ -890,13 +884,9 @@ async def expand_via_graph(hits: list[dict], ctx: Any, question: str = "") -> li
         )
         page_rows = list(page_res.all())
 
-        # Rank on the seed-link count first and keep only the head of it. Making
-        # the call layer visible multiplied the candidate set, and both queries
-        # below scale with it: on fastapi the degree query alone reached 2.2s
-        # per answer over the full set. Only _GRAPH_EXPAND_MAX_NEW candidates
-        # can ever be returned, so scoring far more than that buys nothing —
-        # and the hub cutoff is a percentile, which needs a sample rather than
-        # the population.
+        # Score only the head of the link ranking: both queries below scale with
+        # the candidate set, which the call layer multiplied (2.2s per answer on
+        # fastapi over the full set), and only three candidates can be returned.
         page_rows.sort(key=lambda row: -links.get(row[0], 0))
         page_rows = page_rows[:_DEGREE_SAMPLE]
         sampled = {row[0] for row in page_rows}
@@ -945,22 +935,14 @@ async def expand_via_graph(hits: list[dict], ctx: Any, question: str = "") -> li
             }
         )
 
-    # A test calls the file it exercises far more often than any collaborator
-    # does, so link count alone ranks a repo's tests above its implementation.
-    # ``demote_noise_hits`` runs downstream and would reorder them, but only
-    # after they had spent all _GRAPH_EXPAND_MAX_NEW slots — the implementation
-    # file it should have picked never enters the list. Same rule, applied where
-    # the slots are handed out.
+    # A test calls what it exercises more often than any collaborator does, so
+    # link count alone ranks tests first. ``demote_noise_hits`` reorders them
+    # downstream, but only after they have spent every slot.
     test_focused = bool(_TEST_QUERY_RE.search(question))
 
-    # Rank by how strongly the neighbour is tied to THIS seed, PageRank only as
-    # the tiebreak. Ranking on PageRank alone answers "what is central in the
-    # repo" when the question asked "what is next to this file", so the same few
-    # central modules were returned whatever the seed was — the hub cutoff above
-    # only removes the extreme tail of that, it does not change the ordering.
-    # Link count is the seed-specific signal, and it only became usable once the
-    # projection above made the call layer visible: on imports alone almost
-    # every neighbour scored 1.
+    # Rank on the tie to THIS seed, PageRank only as tiebreak. PageRank alone
+    # answers "what is central in the repo" for a question about what sits next
+    # to one file, and returned the same modules whatever the seed was.
     candidates.sort(
         key=lambda c: (
             not test_focused and is_test_path(c["target_path"]),

--- a/packages/server/src/repowise/server/mcp_server/_budget/budgeter.py
+++ b/packages/server/src/repowise/server/mcp_server/_budget/budgeter.py
@@ -8,29 +8,23 @@ every drop recoverable, and (b) a skeleton-stripping stage for the
 ``include=["skeleton"]`` blocks that did not exist when the original was
 written.
 
-The MCP host caps the size of a tool result. Measured on Claude Code
-2026-07-11: a result whose stringified form exceeds ``MAX_MCP_OUTPUT_TOKENS``
-(default **25000 tokens**) is REJECTED with an isError
-(``MCPContentTooLargeError`` — "response (N tokens) exceeds maximum allowed
-tokens (25000)"), not silently truncated and not spilled to a file. That
-isError matters twice over: the agent loses the answer AND — per the Phase 1
-session-survival doctrine — one isError early in a session teaches it to
-abandon the server entirely. So staying under the host cap is not a nicety.
+The MCP host caps the size of a tool result. An over-cap result is **spilled to
+a sidecar file** the agent must Read back, not rejected: it comes back worded as
+an error but carries no ``isError``. (The older claim here — rejection with an
+``MCPContentTooLargeError`` — came from a docs lookup, and that string appears
+in no host output.) The cap is counted in tokens; the spill message reports
+characters.
 
-Our default budget (``TOKEN_BUDGET`` = 8000) sits comfortably under the
-default host cap, so the common case is unchanged. The risk is the inverse of
-the one long assumed here: a user who *lowers* ``MAX_MCP_OUTPUT_TOKENS`` below
-our budget would start tripping the reject path. :func:`effective_char_budget`
-therefore reads the host cap at call time and clamps our ceiling under it.
-(The earlier "~10k token" ceiling in this docstring was a guess; the measured
-number is 25000, and the failure mode is rejection, not file spill.)
+Observed bounds: the largest MCP result that did NOT spill was 47,276 chars,
+the smallest that DID was 60,718 — consistent with a 25000-token cap at the
+~2.0-2.4 chars/token dense JSON really costs. ``CHAR_BUDGET`` (32,000) is about
+half that line. The residual risk is a user who *lowers*
+``MAX_MCP_OUTPUT_TOKENS``, which :func:`effective_char_budget` clamps for.
 
 The estimator is intentionally dependency-free: 4 chars/token is the
-widely-quoted average for English + code on BPE tokenizers and is within
-~20% of tiktoken for typical wiki content. Dense code can tokenize finer than
-4 chars/token, so the host may count MORE tokens than we estimate — the
-safety fraction below absorbs that gap plus the JSON envelope and ``_meta``
-the host counts on top of our payload.
+widely-quoted average for English + code on BPE tokenizers, and it undercounts
+the compact JSON we emit by roughly 1.7x. ``HOST_CAP_BUDGET_FRACTION`` absorbs
+that gap plus the JSON envelope and ``_meta`` the host counts on top.
 """
 
 from __future__ import annotations
@@ -48,14 +42,14 @@ TOKEN_BUDGET = 8000
 CHARS_PER_TOKEN = 4
 CHAR_BUDGET = TOKEN_BUDGET * CHARS_PER_TOKEN
 
-# Claude Code's MAX_MCP_OUTPUT_TOKENS default (measured 2026-07-11). A result
-# over this is rejected with an isError, so our ceiling must stay under it.
+# Claude Code's MAX_MCP_OUTPUT_TOKENS default. A result over this is spilled to
+# a sidecar file the agent must Read back, so our ceiling stays under it.
 HOST_MCP_TOKEN_CAP_DEFAULT = 25000
 
 # Fraction of the host cap we allow ourselves. The gap absorbs (a) estimator
-# error — our 4-chars/token figure can undercount real tokens on dense code by
-# up to ~30% — and (b) the JSON envelope + _meta the host tokenizes on top of
-# our payload. 0.6 keeps even an undercounted response clear of the reject line.
+# error — 4 chars/token undercounts compact JSON by roughly 1.7x — and (b) the
+# JSON envelope + _meta the host tokenizes on top of our payload. 0.6 keeps even
+# an undercounted response clear of the spill line.
 HOST_CAP_BUDGET_FRACTION = 0.6
 
 
@@ -81,8 +75,8 @@ def effective_char_budget(configured: int = CHAR_BUDGET) -> int:
     """``configured`` ceiling, lowered under the live host cap when that is tighter.
 
     Default host cap (25000) leaves our 8000-token budget untouched; a narrowed
-    ``MAX_MCP_OUTPUT_TOKENS`` pulls us down with it so we never trip the host's
-    reject-with-isError path (one isError = server abandonment, Phase 1).
+    ``MAX_MCP_OUTPUT_TOKENS`` pulls us down with it so a response can never
+    reach the host's spill-to-file path and cost the agent a Read.
     """
     host_char_ceiling = int(host_token_cap() * HOST_CAP_BUDGET_FRACTION) * CHARS_PER_TOKEN
     return min(configured, host_char_ceiling)
@@ -161,7 +155,7 @@ def truncate_to_budget(
 
     ``char_budget`` defaults to :func:`effective_char_budget` — our configured
     ceiling, clamped under the live MCP host cap so the response can never trip
-    the host's reject-with-isError path. Pass an explicit value to override
+    the host's spill-to-file path. Pass an explicit value to override
     (tests do; production callers should not).
 
     Strategy (applied in order, stopping as soon as the budget is met):

--- a/packages/server/src/repowise/server/mcp_server/_budget/budgeter.py
+++ b/packages/server/src/repowise/server/mcp_server/_budget/budgeter.py
@@ -10,10 +10,8 @@ written.
 
 The MCP host caps the size of a tool result. An over-cap result is **spilled to
 a sidecar file** the agent must Read back, not rejected: it comes back worded as
-an error but carries no ``isError``. (The older claim here — rejection with an
-``MCPContentTooLargeError`` — came from a docs lookup, and that string appears
-in no host output.) The cap is counted in tokens; the spill message reports
-characters.
+an error but carries no ``isError``. The cap is counted in tokens; the spill
+message reports characters.
 
 Observed bounds: the largest MCP result that did NOT spill was 47,276 chars,
 the smallest that DID was 60,718 — consistent with a 25000-token cap at the

--- a/packages/server/src/repowise/server/mcp_server/_code_rationale.py
+++ b/packages/server/src/repowise/server/mcp_server/_code_rationale.py
@@ -323,12 +323,9 @@ def mine_rationale(
 
     scored.sort(key=lambda t: t[0], reverse=True)
 
-    # Relevance floor, relative to the best block found. Without it the tail of
-    # the six is whatever cleared the >=2-term gate on generic vocabulary — a
-    # question about projecting call edges onto files returned an SVG
-    # edge-routing docstring on "edges"/"project"/"between". This block only
-    # ships on a non-dominant answer, so the tail is paid for exactly when the
-    # answer is least likely to be right.
+    # Relevance floor, relative to the best block: below half the top score a
+    # block cleared the >=2-term gate on generic vocabulary rather than on the
+    # question — an SVG edge-routing docstring on "edges"/"project"/"between".
     if scored:
         floor = scored[0][0] * _RELEVANCE_FLOOR_FRACTION
         scored = [t for t in scored if t[0] >= floor]

--- a/packages/server/src/repowise/server/mcp_server/_code_rationale.py
+++ b/packages/server/src/repowise/server/mcp_server/_code_rationale.py
@@ -118,6 +118,9 @@ _MAX_FILE_LINES = 8000
 _MAX_BLOCK_LINES = 12
 _MAX_BLOCK_CHARS = 800
 _MAX_RESULTS = 6
+# Keep a block only if it scores at least this fraction of the best block's
+# score. Relative, not absolute: scores scale with how many terms a question has.
+_RELEVANCE_FLOOR_FRACTION = 0.5
 _NEAR_LINE_WINDOW = 60
 
 
@@ -319,6 +322,16 @@ def mine_rationale(
         scored = [t for t in scored if t[1] or t[2]]
 
     scored.sort(key=lambda t: t[0], reverse=True)
+
+    # Relevance floor, relative to the best block found. Without it the tail of
+    # the six is whatever cleared the >=2-term gate on generic vocabulary — a
+    # question about projecting call edges onto files returned an SVG
+    # edge-routing docstring on "edges"/"project"/"between". This block only
+    # ships on a non-dominant answer, so the tail is paid for exactly when the
+    # answer is least likely to be right.
+    if scored:
+        floor = scored[0][0] * _RELEVANCE_FLOOR_FRACTION
+        scored = [t for t in scored if t[0] >= floor]
     return [entry for _, _, _, entry in scored[:max_results]]
 
 

--- a/packages/server/src/repowise/server/mcp_server/_flow_path.py
+++ b/packages/server/src/repowise/server/mcp_server/_flow_path.py
@@ -41,7 +41,6 @@ from sqlalchemy import select
 from repowise.core.persistence.models import GraphEdge, Page, WikiSymbol
 from repowise.core.test_paths import is_test_related_path
 from repowise.server.mcp_server._graph_files import (
-    CALLS_CONF_FLOOR,
     file_ext,
     keep_projected_edge,
     node_to_file,
@@ -53,10 +52,6 @@ from repowise.server.mcp_server._graph_files import (
 # are either not directed dependency flow or not answer-bearing, so they stay
 # out of the path search.
 _FLOW_EDGE_TYPES = ("imports", "calls")
-
-# Kept as an alias: the floor now lives with the projection it guards, so the
-# one-hop expansion in ``_answer_pipeline`` cannot drift from this one.
-_FLOW_CALLS_CONF_FLOOR = CALLS_CONF_FLOOR
 
 # Depth cap for the path search. Endpoints connect in 2-4 hops on the measured
 # graph; past 4 a "path" is a coincidence, not a flow.

--- a/packages/server/src/repowise/server/mcp_server/_flow_path.py
+++ b/packages/server/src/repowise/server/mcp_server/_flow_path.py
@@ -40,6 +40,12 @@ from sqlalchemy import select
 
 from repowise.core.persistence.models import GraphEdge, Page, WikiSymbol
 from repowise.core.test_paths import is_test_related_path
+from repowise.server.mcp_server._graph_files import (
+    CALLS_CONF_FLOOR,
+    file_ext,
+    keep_projected_edge,
+    node_to_file,
+)
 
 # Edge kinds that form the file-level dependency graph. ``imports`` is
 # file-to-file already; ``calls`` is symbol-to-symbol and gets projected to
@@ -48,10 +54,9 @@ from repowise.core.test_paths import is_test_related_path
 # out of the path search.
 _FLOW_EDGE_TYPES = ("imports", "calls")
 
-# Confidence floor for ``calls`` edges. Imports are always 1.0; calls average
-# 0.90 but have a low-confidence tail (heuristic resolution). 0.5 keeps every
-# genuine call and drops the noise. Imports are never filtered.
-_FLOW_CALLS_CONF_FLOOR = 0.5
+# Kept as an alias: the floor now lives with the projection it guards, so the
+# one-hop expansion in ``_answer_pipeline`` cannot drift from this one.
+_FLOW_CALLS_CONF_FLOOR = CALLS_CONF_FLOOR
 
 # Depth cap for the path search. Endpoints connect in 2-4 hops on the measured
 # graph; past 4 a "path" is a coincidence, not a flow.
@@ -92,12 +97,6 @@ def _basename_stem(path: str) -> str:
     base = os.path.basename(path)
     stem = base.rsplit(".", 1)[0] if "." in base else base
     return stem.lower()
-
-
-def _ext(path: str) -> str:
-    """Lower-case file extension (``retrieval.py`` -> ``py``), ``""`` if none."""
-    base = os.path.basename(path)
-    return base.rsplit(".", 1)[1].lower() if "." in base else ""
 
 
 def _is_plumbing(path: str) -> bool:
@@ -229,18 +228,9 @@ async def _load_file_adjacency(session: Any, repo_id: str) -> dict[str, list[str
     )
     adj: dict[str, set[str]] = {}
     for src, tgt, etype, conf in res.all():
-        if etype == "calls":
-            if (conf or 0.0) < _FLOW_CALLS_CONF_FLOOR:
-                continue
-            src = src.split("::", 1)[0]
-            tgt = tgt.split("::", 1)[0]
-        if not src or not tgt or src == tgt:
-            continue
-        # A flow the answer traverses is single-language: cross-extension edges
-        # (a Python module and a same-named TypeScript re-export, a test that
-        # imports both ends) are graph coincidences, not dependency flow. Keeping
-        # them lets BFS stitch unrelated files across package boundaries.
-        if _ext(src) != _ext(tgt):
+        src = node_to_file(src or "")
+        tgt = node_to_file(tgt or "")
+        if not keep_projected_edge(src, tgt, etype, conf):
             continue
         adj.setdefault(src, set()).add(tgt)
         adj.setdefault(tgt, set()).add(src)
@@ -345,9 +335,9 @@ async def expand_via_flow_path(
     # language (``symbols.ts`` for a ``symbols.py`` question) is not an endpoint.
     # Dropping off-language anchors here keeps the pairwise BFS from stitching
     # two coincidental cross-package matches of a generic token.
-    primary_ext = _ext(top_hit) if top_hit else ""
+    primary_ext = file_ext(top_hit) if top_hit else ""
     if primary_ext:
-        anchors = {p: src for p, src in anchors.items() if _ext(p) == primary_ext}
+        anchors = {p: src for p, src in anchors.items() if file_ext(p) == primary_ext}
     if len(anchors) < _FLOW_MIN_QUESTION_ANCHORS:
         return hits, []
 

--- a/packages/server/src/repowise/server/mcp_server/_graph_files.py
+++ b/packages/server/src/repowise/server/mcp_server/_graph_files.py
@@ -1,26 +1,16 @@
 """One answer to "which files is this file a graph neighbour of".
 
-The graph has two layers. ``imports`` and the other file-dependency types join
-file paths; ``calls``, ``references``, ``extends`` and the rest join
-``path::Name`` symbol nodes, and nothing points from a symbol back to its file.
-A consumer that keys on file paths therefore sees only the first layer unless it
-projects the second, and the projection was written twice independently
-(:mod:`_flow_path`, :mod:`tool_context.enrichment`) while a third consumer had
-none at all: :func:`_answer_pipeline.expand_via_graph` compared raw node ids
-against ``file_page`` rows, so the call graph was invisible to retrieval
-expansion.
+``imports`` joins file paths; ``calls`` and its siblings join ``path::Name``
+symbol nodes, and nothing points from a symbol back to its file, so a consumer
+keyed on paths sees only the first layer until it projects the second.
 
-The projection alone is not the fix. Projecting a symbol edge onto its files
-manufactures a self-loop out of every intra-file call and stitches together
-files a language boundary separates, so the guards travel with it here rather
-than being re-derived per site.
+Projecting also manufactures a self-loop out of every intra-file call and
+stitches files across a language boundary, so the guards live here with it.
 """
 
 from __future__ import annotations
 
 import os
-
-from sqlalchemy import or_
 
 # Confidence floor for ``calls`` edges. Imports are always 1.0; calls average
 # 0.90 with a low-confidence tail from heuristic resolution. 0.5 keeps every
@@ -63,39 +53,3 @@ def keep_projected_edge(
     if not src_file or not tgt_file or src_file == tgt_file:
         return False
     return file_ext(src_file) == file_ext(tgt_file)
-
-
-# SQLite refuses an expression tree deeper than 1000 nodes, and the predicate
-# below contributes one branch per path. Measured on fastapi: a candidate set of
-# a few hundred files raised OperationalError, and because the only caller sits
-# under ``contextlib.suppress``, expansion would have returned nothing at all
-# rather than failing loudly. Batch well under the limit.
-PATHS_PER_QUERY = 200
-
-
-def touches_files(column, paths):
-    """SQLAlchemy predicate: *column* is one of *paths*, or a symbol declared in one.
-
-    The prefix test is what reaches the symbol layer, and it is a prefix rather
-    than a function on the column so the index still applies. ``autoescape``
-    matters: an ordinary path is full of ``_``, which is a LIKE wildcard.
-    The prefix can still over-match a longer path, so callers re-check the
-    projected file in Python.
-
-    Pass at most :data:`PATHS_PER_QUERY` paths; :func:`batched_paths` splits a
-    larger set.
-    """
-    ordered = sorted(paths)
-    if not ordered:
-        return or_(False)
-    return or_(
-        column.in_(ordered),
-        *[column.startswith(f"{p}::", autoescape=True) for p in ordered],
-    )
-
-
-def batched_paths(paths):
-    """*paths* in :data:`PATHS_PER_QUERY`-sized, deterministically ordered chunks."""
-    ordered = sorted(paths)
-    for i in range(0, len(ordered), PATHS_PER_QUERY):
-        yield ordered[i : i + PATHS_PER_QUERY]

--- a/packages/server/src/repowise/server/mcp_server/_graph_files.py
+++ b/packages/server/src/repowise/server/mcp_server/_graph_files.py
@@ -65,6 +65,14 @@ def keep_projected_edge(
     return file_ext(src_file) == file_ext(tgt_file)
 
 
+# SQLite refuses an expression tree deeper than 1000 nodes, and the predicate
+# below contributes one branch per path. Measured on fastapi: a candidate set of
+# a few hundred files raised OperationalError, and because the only caller sits
+# under ``contextlib.suppress``, expansion would have returned nothing at all
+# rather than failing loudly. Batch well under the limit.
+PATHS_PER_QUERY = 200
+
+
 def touches_files(column, paths):
     """SQLAlchemy predicate: *column* is one of *paths*, or a symbol declared in one.
 
@@ -73,6 +81,9 @@ def touches_files(column, paths):
     matters: an ordinary path is full of ``_``, which is a LIKE wildcard.
     The prefix can still over-match a longer path, so callers re-check the
     projected file in Python.
+
+    Pass at most :data:`PATHS_PER_QUERY` paths; :func:`batched_paths` splits a
+    larger set.
     """
     ordered = sorted(paths)
     if not ordered:
@@ -81,3 +92,10 @@ def touches_files(column, paths):
         column.in_(ordered),
         *[column.startswith(f"{p}::", autoescape=True) for p in ordered],
     )
+
+
+def batched_paths(paths):
+    """*paths* in :data:`PATHS_PER_QUERY`-sized, deterministically ordered chunks."""
+    ordered = sorted(paths)
+    for i in range(0, len(ordered), PATHS_PER_QUERY):
+        yield ordered[i : i + PATHS_PER_QUERY]

--- a/packages/server/src/repowise/server/mcp_server/_graph_files.py
+++ b/packages/server/src/repowise/server/mcp_server/_graph_files.py
@@ -1,0 +1,83 @@
+"""One answer to "which files is this file a graph neighbour of".
+
+The graph has two layers. ``imports`` and the other file-dependency types join
+file paths; ``calls``, ``references``, ``extends`` and the rest join
+``path::Name`` symbol nodes, and nothing points from a symbol back to its file.
+A consumer that keys on file paths therefore sees only the first layer unless it
+projects the second, and the projection was written twice independently
+(:mod:`_flow_path`, :mod:`tool_context.enrichment`) while a third consumer had
+none at all: :func:`_answer_pipeline.expand_via_graph` compared raw node ids
+against ``file_page`` rows, so the call graph was invisible to retrieval
+expansion.
+
+The projection alone is not the fix. Projecting a symbol edge onto its files
+manufactures a self-loop out of every intra-file call and stitches together
+files a language boundary separates, so the guards travel with it here rather
+than being re-derived per site.
+"""
+
+from __future__ import annotations
+
+import os
+
+from sqlalchemy import or_
+
+# Confidence floor for ``calls`` edges. Imports are always 1.0; calls average
+# 0.90 with a low-confidence tail from heuristic resolution. 0.5 keeps every
+# genuine call and drops the noise.
+CALLS_CONF_FLOOR = 0.5
+
+
+def is_symbol_node(node_id: str) -> bool:
+    """Whether *node_id* addresses a symbol rather than a file."""
+    return "::" in node_id
+
+
+def node_to_file(node_id: str) -> str:
+    """``a/b.py::Klass.meth`` -> ``a/b.py``. A file node id is returned unchanged."""
+    return node_id.split("::", 1)[0]
+
+
+def file_ext(path: str) -> str:
+    """Lower-case file extension (``retrieval.py`` -> ``py``), ``""`` if none."""
+    base = os.path.basename(path)
+    return base.rsplit(".", 1)[1].lower() if "." in base else ""
+
+
+def keep_projected_edge(
+    src_file: str, tgt_file: str, edge_type: str | None, confidence: float | None
+) -> bool:
+    """Whether a symbol edge projected onto its two files is a real relation.
+
+    Three guards, all load-bearing:
+
+    * a ``calls`` edge below :data:`CALLS_CONF_FLOOR` is heuristic noise;
+    * a self-loop is what the projection manufactures out of every intra-file
+      call, and those outnumber the cross-file ones;
+    * a cross-extension pair is a graph coincidence rather than dependency flow
+      (a Python module and a same-named TypeScript re-export, a test naming both
+      ends), and keeping them lets a walk stitch unrelated packages together.
+    """
+    if edge_type == "calls" and (confidence or 0.0) < CALLS_CONF_FLOOR:
+        return False
+    if not src_file or not tgt_file or src_file == tgt_file:
+        return False
+    return file_ext(src_file) == file_ext(tgt_file)
+
+
+def touches_files(column, paths):
+    """SQLAlchemy predicate: *column* is one of *paths*, or a symbol declared in one.
+
+    The prefix test is what reaches the symbol layer, and it is a prefix rather
+    than a function on the column so the index still applies. ``autoescape``
+    matters: an ordinary path is full of ``_``, which is a LIKE wildcard.
+    The prefix can still over-match a longer path, so callers re-check the
+    projected file in Python.
+    """
+    ordered = sorted(paths)
+    if not ordered:
+        return or_(False)
+    return or_(
+        column.in_(ordered),
+        *[column.startswith(f"{p}::", autoescape=True) for p in ordered],
+    )

--- a/packages/server/src/repowise/server/mcp_server/tool_answer/answer.py
+++ b/packages/server/src/repowise/server/mcp_server/tool_answer/answer.py
@@ -257,7 +257,7 @@ async def _run_retrieval_pipeline(
     # (consumer instead of orchestrator). Adds up to 3 neighbors with a
     # damped score, then re-sorts.
     with contextlib.suppress(Exception):
-        hits = await _expand_via_graph(hits, ctx)
+        hits = await _expand_via_graph(hits, ctx, question)
     # Re-filter: graph expansion can pull excluded neighbors back in (before the
     # cap, so an excluded neighbor can't occupy a top-5 slot).
     hits = filter_dicts_by_key(hits, "target_path", exclude_spec)

--- a/packages/server/src/repowise/server/mcp_server/tool_answer/answer.py
+++ b/packages/server/src/repowise/server/mcp_server/tool_answer/answer.py
@@ -257,7 +257,7 @@ async def _run_retrieval_pipeline(
     # (consumer instead of orchestrator). Adds up to 3 neighbors with a
     # damped score, then re-sorts.
     with contextlib.suppress(Exception):
-        hits = await _expand_via_graph(hits, ctx, question)
+        hits = await _expand_via_graph(hits, ctx, repo_id)
     # Re-filter: graph expansion can pull excluded neighbors back in (before the
     # cap, so an excluded neighbor can't occupy a top-5 slot).
     hits = filter_dicts_by_key(hits, "target_path", exclude_spec)

--- a/tests/unit/server/mcp/test_answer_graph_expand_edges.py
+++ b/tests/unit/server/mcp/test_answer_graph_expand_edges.py
@@ -85,7 +85,7 @@ async def test_co_change_neighbour_is_still_expanded(setup_mcp, factory):
     await _seed_co_change_partner_with_a_page(factory, setup_mcp)
 
     hits = [{"target_path": _SEED, "score": 0.9, "page_type": "file_page"}]
-    expanded = await expand_via_graph(hits, SimpleNamespace(session_factory=factory))
+    expanded = await expand_via_graph(hits, SimpleNamespace(session_factory=factory), setup_mcp)
 
     added = {h["target_path"] for h in expanded if h.get("_expanded_from") == "graph"}
     assert _PARTNER in added, (
@@ -121,7 +121,7 @@ async def test_containment_neighbours_are_excluded(setup_mcp, factory):
         await s.commit()
 
     hits = [{"target_path": _SEED, "score": 0.9, "page_type": "file_page"}]
-    expanded = await expand_via_graph(hits, SimpleNamespace(session_factory=factory))
+    expanded = await expand_via_graph(hits, SimpleNamespace(session_factory=factory), setup_mcp)
 
     assert symbol_id not in {h.get("target_path") for h in expanded}
 
@@ -178,19 +178,15 @@ async def _seed_callee_with_a_page(factory, repo_id: str, path: str, confidence:
 
 @pytest.mark.asyncio
 async def test_call_neighbour_is_expanded(setup_mcp, factory):
-    """The defect this file's containment test was written next to and missed.
-
-    ``calls`` endpoints are ``path::Name`` symbol nodes too, so an equality test
-    against a seed *path* matched none of them and the whole call graph was
-    invisible to expansion — not fetched and discarded, never fetched.
-    """
+    """``calls`` endpoints are ``path::Name`` nodes, so expansion only sees them
+    once they are projected onto their file."""
     from repowise.server.mcp_server._answer_pipeline import expand_via_graph
 
     callee = "src/auth/tokens.py"
     await _seed_callee_with_a_page(factory, setup_mcp, callee, confidence=0.9)
 
     hits = [{"target_path": _SEED, "score": 0.9, "page_type": "file_page"}]
-    expanded = await expand_via_graph(hits, SimpleNamespace(session_factory=factory))
+    expanded = await expand_via_graph(hits, SimpleNamespace(session_factory=factory), setup_mcp)
 
     added = {h["target_path"] for h in expanded if h.get("_expanded_from") == "graph"}
     assert callee in added
@@ -206,7 +202,7 @@ async def test_low_confidence_call_neighbour_is_not_expanded(setup_mcp, factory)
     await _seed_callee_with_a_page(factory, setup_mcp, callee, confidence=0.2)
 
     hits = [{"target_path": _SEED, "score": 0.9, "page_type": "file_page"}]
-    expanded = await expand_via_graph(hits, SimpleNamespace(session_factory=factory))
+    expanded = await expand_via_graph(hits, SimpleNamespace(session_factory=factory), setup_mcp)
 
     assert callee not in {h["target_path"] for h in expanded if h.get("_expanded_from") == "graph"}
 
@@ -219,40 +215,6 @@ async def test_cross_extension_call_neighbour_is_not_expanded(setup_mcp, factory
     await _seed_callee_with_a_page(factory, setup_mcp, callee, confidence=0.95)
 
     hits = [{"target_path": _SEED, "score": 0.9, "page_type": "file_page"}]
-    expanded = await expand_via_graph(hits, SimpleNamespace(session_factory=factory))
+    expanded = await expand_via_graph(hits, SimpleNamespace(session_factory=factory), setup_mcp)
 
     assert callee not in {h["target_path"] for h in expanded if h.get("_expanded_from") == "graph"}
-
-
-@pytest.mark.asyncio
-async def test_strongest_link_outranks_the_more_central_file(setup_mcp, factory):
-    """Ranking asks "next to this seed", not "central in the repo"."""
-    from repowise.server.mcp_server._answer_pipeline import expand_via_graph
-
-    tied = "src/auth/tied.py"
-    central = "src/auth/central.py"
-    await _seed_callee_with_a_page(factory, setup_mcp, tied, confidence=0.9)
-    await _seed_callee_with_a_page(factory, setup_mcp, central, confidence=0.9)
-    async with factory() as s:
-        node = await s.get(GraphNode, f"gn-{central}")
-        node.pagerank = 0.99
-        for i in range(3):
-            s.add(
-                GraphEdge(
-                    id=f"ge-calls-extra-{i}",
-                    repository_id=setup_mcp,
-                    source_node_id=f"{_SEED}::login{i}",
-                    target_node_id=f"{tied}::verify{i}",
-                    imported_names_json="[]",
-                    edge_type="calls",
-                    confidence=0.9,
-                    created_at=_NOW,
-                )
-            )
-        await s.commit()
-
-    hits = [{"target_path": _SEED, "score": 0.9, "page_type": "file_page"}]
-    expanded = await expand_via_graph(hits, SimpleNamespace(session_factory=factory))
-
-    added = [h["target_path"] for h in expanded if h.get("_expanded_from") == "graph"]
-    assert added.index(tied) < added.index(central)

--- a/tests/unit/server/mcp/test_answer_graph_expand_edges.py
+++ b/tests/unit/server/mcp/test_answer_graph_expand_edges.py
@@ -124,3 +124,135 @@ async def test_containment_neighbours_are_excluded(setup_mcp, factory):
     expanded = await expand_via_graph(hits, SimpleNamespace(session_factory=factory))
 
     assert symbol_id not in {h.get("target_path") for h in expanded}
+
+
+async def _seed_callee_with_a_page(factory, repo_id: str, path: str, confidence: float) -> None:
+    """A ``calls`` edge from a symbol in ``_SEED`` to a symbol in *path*."""
+    async with factory() as s:
+        s.add(
+            GraphNode(
+                id=f"gn-{path}",
+                repository_id=repo_id,
+                node_id=path,
+                node_type="file",
+                language="python",
+                symbol_count=1,
+                is_entry_point=False,
+                pagerank=0.1,
+                betweenness=0.0,
+                community_id=4,
+                created_at=_NOW,
+            )
+        )
+        s.add(
+            GraphEdge(
+                id=f"ge-calls-{path}",
+                repository_id=repo_id,
+                source_node_id=f"{_SEED}::login",
+                target_node_id=f"{path}::verify",
+                imported_names_json="[]",
+                edge_type="calls",
+                confidence=confidence,
+                created_at=_NOW,
+            )
+        )
+        s.add(
+            Page(
+                id=f"file_page:{path}",
+                repository_id=repo_id,
+                page_type="file_page",
+                title=f"File: {path}",
+                content="# callee",
+                summary="The thing the seed calls.",
+                target_path=path,
+                source_hash=f"h-{path}",
+                model_name="mock",
+                provider_name="mock",
+                generation_level=4,
+                created_at=_NOW,
+                updated_at=_NOW,
+            )
+        )
+        await s.commit()
+
+
+@pytest.mark.asyncio
+async def test_call_neighbour_is_expanded(setup_mcp, factory):
+    """The defect this file's containment test was written next to and missed.
+
+    ``calls`` endpoints are ``path::Name`` symbol nodes too, so an equality test
+    against a seed *path* matched none of them and the whole call graph was
+    invisible to expansion — not fetched and discarded, never fetched.
+    """
+    from repowise.server.mcp_server._answer_pipeline import expand_via_graph
+
+    callee = "src/auth/tokens.py"
+    await _seed_callee_with_a_page(factory, setup_mcp, callee, confidence=0.9)
+
+    hits = [{"target_path": _SEED, "score": 0.9, "page_type": "file_page"}]
+    expanded = await expand_via_graph(hits, SimpleNamespace(session_factory=factory))
+
+    added = {h["target_path"] for h in expanded if h.get("_expanded_from") == "graph"}
+    assert callee in added
+    assert f"{callee}::verify" not in {h.get("target_path") for h in expanded}
+
+
+@pytest.mark.asyncio
+async def test_low_confidence_call_neighbour_is_not_expanded(setup_mcp, factory):
+    """The projection travels with its guards; without them it adds noise."""
+    from repowise.server.mcp_server._answer_pipeline import expand_via_graph
+
+    callee = "src/auth/guessed.py"
+    await _seed_callee_with_a_page(factory, setup_mcp, callee, confidence=0.2)
+
+    hits = [{"target_path": _SEED, "score": 0.9, "page_type": "file_page"}]
+    expanded = await expand_via_graph(hits, SimpleNamespace(session_factory=factory))
+
+    assert callee not in {h["target_path"] for h in expanded if h.get("_expanded_from") == "graph"}
+
+
+@pytest.mark.asyncio
+async def test_cross_extension_call_neighbour_is_not_expanded(setup_mcp, factory):
+    from repowise.server.mcp_server._answer_pipeline import expand_via_graph
+
+    callee = "src/auth/tokens.ts"
+    await _seed_callee_with_a_page(factory, setup_mcp, callee, confidence=0.95)
+
+    hits = [{"target_path": _SEED, "score": 0.9, "page_type": "file_page"}]
+    expanded = await expand_via_graph(hits, SimpleNamespace(session_factory=factory))
+
+    assert callee not in {h["target_path"] for h in expanded if h.get("_expanded_from") == "graph"}
+
+
+@pytest.mark.asyncio
+async def test_strongest_link_outranks_the_more_central_file(setup_mcp, factory):
+    """Ranking asks "next to this seed", not "central in the repo"."""
+    from repowise.server.mcp_server._answer_pipeline import expand_via_graph
+
+    tied = "src/auth/tied.py"
+    central = "src/auth/central.py"
+    await _seed_callee_with_a_page(factory, setup_mcp, tied, confidence=0.9)
+    await _seed_callee_with_a_page(factory, setup_mcp, central, confidence=0.9)
+    async with factory() as s:
+        node = await s.get(GraphNode, f"gn-{central}")
+        node.pagerank = 0.99
+        for i in range(3):
+            s.add(
+                GraphEdge(
+                    id=f"ge-calls-extra-{i}",
+                    repository_id=setup_mcp,
+                    source_node_id=f"{_SEED}::login{i}",
+                    target_node_id=f"{tied}::verify{i}",
+                    imported_names_json="[]",
+                    edge_type="calls",
+                    confidence=0.9,
+                    created_at=_NOW,
+                )
+            )
+        await s.commit()
+
+    hits = [{"target_path": _SEED, "score": 0.9, "page_type": "file_page"}]
+    expanded = await expand_via_graph(hits, SimpleNamespace(session_factory=factory))
+
+    added = [h["target_path"] for h in expanded if h.get("_expanded_from") == "graph"]
+    assert added.index(tied) < added.index(central)

--- a/tests/unit/server/mcp/test_code_rationale.py
+++ b/tests/unit/server/mcp/test_code_rationale.py
@@ -353,3 +353,24 @@ async def test_concept_anchor_skips_when_retrieval_already_led_with_winner(tmp_p
         Path(str(repo)), "why is the caller list capped at 50", hits
     )
     assert all(not h.get("_concept_anchored") for h in out)
+
+
+def test_mine_drops_blocks_far_below_the_best_match(tmp_path):
+    """A block clearing the term gate on generic vocabulary is not rationale."""
+    _write(
+        tmp_path,
+        "strong.py",
+        "# We project each call edge onto its two files because the graph keeps\n"
+        "# symbols and files in separate layers.\nX = 1\n",
+    )
+    _write(
+        tmp_path,
+        "weak.py",
+        "# Edges bow outward so they never cross a box.\nY = 2\n",
+    )
+    query = "why project call edge endpoints onto files graph layers symbols"
+    out = mine_rationale(str(tmp_path), ["strong.py", "weak.py"], query)
+
+    paths = {r["path"] for r in out}
+    assert "strong.py" in paths
+    assert "weak.py" not in paths

--- a/tests/unit/server/mcp/test_graph_files.py
+++ b/tests/unit/server/mcp/test_graph_files.py
@@ -3,8 +3,6 @@
 from __future__ import annotations
 
 from repowise.server.mcp_server._graph_files import (
-    PATHS_PER_QUERY,
-    batched_paths,
     file_ext,
     is_symbol_node,
     keep_projected_edge,
@@ -31,14 +29,3 @@ def test_guards():
     assert not keep_projected_edge("a.py", "b.ts", "calls", 0.9)
     # The floor is scoped to ``calls``; nothing else carries a confidence tail.
     assert keep_projected_edge("a.py", "b.py", "extends", 0.2)
-
-
-def test_batched_paths_stays_under_the_sqlite_expression_depth():
-    """A candidate set of a few hundred files raised OperationalError unbatched."""
-    paths = [f"src/mod{i}.py" for i in range(PATHS_PER_QUERY * 2 + 7)]
-    batches = list(batched_paths(paths))
-    assert all(len(b) <= PATHS_PER_QUERY for b in batches)
-    assert sorted(p for b in batches for p in b) == sorted(paths)
-    # Deterministic order, because which neighbours a truncated walk saw must
-    # not move with the per-process hash seed.
-    assert list(batched_paths(set(paths))) == batches

--- a/tests/unit/server/mcp/test_graph_files.py
+++ b/tests/unit/server/mcp/test_graph_files.py
@@ -1,0 +1,44 @@
+"""The shared symbol-to-file projection and its guards."""
+
+from __future__ import annotations
+
+from repowise.server.mcp_server._graph_files import (
+    PATHS_PER_QUERY,
+    batched_paths,
+    file_ext,
+    is_symbol_node,
+    keep_projected_edge,
+    node_to_file,
+)
+
+
+def test_node_to_file_projects_symbols_and_passes_files_through():
+    assert node_to_file("a/b.py::Klass.meth") == "a/b.py"
+    assert node_to_file("a/b.py") == "a/b.py"
+    assert is_symbol_node("a/b.py::X") and not is_symbol_node("a/b.py")
+
+
+def test_file_ext():
+    assert file_ext("a/b/retrieval.py") == "py"
+    assert file_ext("a/b/Makefile") == ""
+
+
+def test_guards():
+    assert keep_projected_edge("a.py", "b.py", "calls", 0.9)
+    # Below the floor, same file, and across a language boundary.
+    assert not keep_projected_edge("a.py", "b.py", "calls", 0.2)
+    assert not keep_projected_edge("a.py", "a.py", "calls", 0.9)
+    assert not keep_projected_edge("a.py", "b.ts", "calls", 0.9)
+    # The floor is scoped to ``calls``; nothing else carries a confidence tail.
+    assert keep_projected_edge("a.py", "b.py", "extends", 0.2)
+
+
+def test_batched_paths_stays_under_the_sqlite_expression_depth():
+    """A candidate set of a few hundred files raised OperationalError unbatched."""
+    paths = [f"src/mod{i}.py" for i in range(PATHS_PER_QUERY * 2 + 7)]
+    batches = list(batched_paths(paths))
+    assert all(len(b) <= PATHS_PER_QUERY for b in batches)
+    assert sorted(p for b in batches for p in b) == sorted(paths)
+    # Deterministic order, because which neighbours a truncated walk saw must
+    # not move with the per-process hash seed.
+    assert list(batched_paths(set(paths))) == batches


### PR DESCRIPTION
## The problem

`expand_via_graph` is the stage that decides which extra files `get_answer` folds in alongside its top hits. It walked the graph one hop with:

```python
GraphEdge.target_node_id.in_(seed_paths)   # seed_paths are file paths
```

`imports` and `co_changes` endpoints are file paths, so those matched. `calls` endpoints are symbol nodes of the form `path/to/file.py::Name`, and so are `framework_binds`, `dispatches_to`, `extends` and three others. None of them can equal a file path, so **the call graph could never influence an answer**. It was not fetched and discarded; it was never fetched.

Measured on this repository's own index, 110,449 edges:

| layer | edge types | edges |
|---|---|---|
| symbol node ids | `calls` 43,926, `framework_binds` 4,683, `dispatches_to` 429, `extends` 176 | **49,214** |
| file node ids | `imports` 13,104, `framework` 1,653, `co_changes` 1,256, `dynamic_uses` 293, `dynamic_imports` 137 | 16,443 |

**75.0% of the non-containment edges sat in a layer this consumer could not see.**

`_neighbor_degrees` had the same problem in a quieter form. It sizes the cutoff for "this file is a hub, it is nobody's specific answer", and it counted only file-layer edges, so a file reached mostly through calls read as unconnected.

## What this changes

A small shared module (`_graph_files.py`) holds the projection from a symbol node id to its file, plus the three guards that have to travel with it: a confidence floor on `calls`, dropping self-loops (a projection manufactures one out of every intra-file call), and refusing cross-extension pairs. The correct handling already existed twice, in `_flow_path._load_file_adjacency` and in `tool_context/enrichment.py`, so this is the shared version rather than a fourth copy. `_flow_path` now reads from it.

Expansion fetches its neighbours in one repo-scoped scan, projects both endpoints, and applies the guards only to the symbol layer, so a `co_changes` edge between a module and its docs stays the "read this too" signal it has always been.

Two things fall out of that scan:

- **The hub cutoff is now computed on file-projected degrees**, so it reflects real connectivity rather than imports alone.
- **Expansion is scoped by `repo_id`**, which it never was. In a multi-repo store it could previously pull in a neighbour from a different repository that happened to share a file path.

Also here, small and separable:

- `_code_rationale` gets a relevance floor at half the top block's score. It only ships on a non-dominant answer, and without a floor the tail is whatever cleared a two-term match on generic vocabulary. One query about projecting call edges onto files came back with an SVG edge-routing docstring, matched on "edges" and "project".
- The budgeter docstring described a failure mode that does not happen (see below).

## Measurement

Retrieval battery, 99 hand-labelled questions, both arms against one frozen index with the answer cache bypassed, 0 skipped, embedder live:

| | recall@1 | recall@3 | recall@5 | MRR |
|---|---|---|---|---|
| `main` | 0.30 | 0.64 | 0.68 | 0.459 |
| this branch | 0.30 | 0.65 | 0.68 | 0.458 |

**Flat.** Per category, cross-file recall@3 moves 0.74 to 0.78 (one question) and its MRR 0.507 to 0.511; hierarchy, intention and multi-hop are identical to three decimals. Noise floor on this eval is one question, so every move is at or inside it. A 50-question ContextBench set on django was flat throughout.

This is a correctness repair rather than a quality win, and I would rather state that plainly. What it buys is that graph improvements can reach a user through this path at all, which they could not before.

Probe suites unmoved: 14/16 with the two known reds on this repo, 10/11 on microdot, 0 skipped, both green, each verified byte-identical against a control run on unmodified code. Unit suite 1,375 passed.

Cost, median and p90 of `expand_via_graph` over 20 seeds, before to after: fastapi 44/57 to 62/154 ms, celery 51/69 to 75/130 ms, flask 9/10 to 18/21 ms. Against a call that already takes 4.8 to 8.7 seconds that is under 2.6% at the median.

## Two things deliberately not done

**Ranking expansion candidates by how strongly they link to the seed.** The projection makes that signal available and it looked much better by hand, so it was built. Measured against a same-index baseline it cost recall@5 0.77 to 0.69 and MRR 0.641 to 0.468, and it is dropped. Link count is a hub-promoting key, since a hub has the most edges into any seed, and the same change had disabled the hub filter that exists to catch exactly that: sampling the candidate set to 25 before computing degrees makes `_hub_degree_cutoff`'s `idx = min(n-1, int(n*0.99))` equal `n-1` for every `n <= 100`, so `degree <= cutoff` held for every row. The idea needs a working hub filter and its own measurement.

**Lowering `CHAR_BUDGET`.** The standing note said 32,000 chars sits above a roughly 25,000-char host limit. Both halves of that are wrong. An over-cap MCP result is spilled to a sidecar file the agent Reads back, not rejected with an `isError`, and `MCPContentTooLargeError` appears in no host output. Bounded from both sides against observed behaviour: the largest MCP result that did not spill was 47,276 chars and the smallest that did was 60,718. Our budget is about half that line, and a census of 45 live `get_answer` responses had 0 over 25,000 chars and 0 over 25,000 tokens. The constant is fine; the docstring is corrected.

## Same bug, two other tools, not fixed here

The audit that found this found the same file-path-versus-symbol-id join in two more places. Both change a different tool's numbers, and neither is scored by the instruments above, so they want their own change and their own measurement:

- `tool_risk/get_risk.py` keys `dep_counts` / `import_links` / `reverse_deps` on raw node ids, so `dependents_count`, the derived `high-coupling` verdict, `impact_surface` and `has_import_link` are all imports-only.
- `tool_context/targets.py` joins a symbol's `used_by` on the symbol's *file path*, so "who uses this function" answers "who imports this function's file". Its own comment reasons about call edges, and its note that the corpus holds zero duplicate rows is a direct measurement of the bug.

## Tests

New coverage for the projection and its guards, and for expansion picking up a call neighbour, refusing a low-confidence one, and refusing a cross-extension one. The existing guard on which edge types expansion may walk is unchanged and still passes.
