### PR TITLE
perf(cli): cut the per-call startup floor

### DIFF
--- a/packages/cli/src/repowise/cli/ui/__init__.py
+++ b/packages/cli/src/repowise/cli/ui/__init__.py
@@ -3,109 +3,88 @@
 This package was split out of the former single ``ui.py`` module. The submodules
 group the helpers by concern; this façade re-exports every previously-public name
 so existing ``from repowise.cli.ui import ...`` call sites are unchanged.
+
+The façade is lazy: each public name is resolved on first access via
+:func:`__getattr__` rather than imported eagerly at package import time. That
+matters for CLI startup — importing *any* submodule (e.g. ``ui.brand``, the one
+cheap ``status``/``coverage`` commands need) used to run this package's
+``__init__``, which eagerly pulled in the heavy interactive modules
+(``mode_selection`` -> ``repo_scanner`` -> ``core.ingestion`` -> networkx +
+tree-sitter, ~1.1s on a cold process). Issue #1712. ``import repowise.cli.ui``
+still resolves ``__all__`` cheaply because the name -> submodule mapping lives in
+this module; only the bodies are imported when actually accessed.
 """
 
 from __future__ import annotations
 
-from repowise.cli.ui.brand import (
-    BRAND,
-    BRAND_STYLE,
-    DIM,
-    ERR,
-    OK,
-    VALUE,
-    WARN,
-    format_bytes,
-    format_elapsed,
-    key_value_table,
-    print_banner,
-    print_phase_header,
-    print_section,
-)
-from repowise.cli.ui.env_persistence import load_dotenv
-from repowise.cli.ui.mascot import (
-    OWL_SPINNER,
-    THINKING_FRAMES,
-    banner_text,
-    mini,
-)
-from repowise.cli.ui.mode_selection import (
-    LARGE_REPO_FILE_THRESHOLD,
-    interactive_advanced_config,
-    interactive_customize_offer,
-    interactive_fast_mode_offer,
-    interactive_generate_docs_toggle,
-    interactive_mode_select,
-    print_index_only_intro,
-    prompt_file_page_volume,
-    prompt_wiki_style,
-    should_offer_fast_mode,
-)
-from repowise.cli.ui.progress import MaybeCountColumn, RichProgressCallback
-from repowise.cli.ui.provider_selection import (
-    ProviderSelection,
-    interactive_provider_config_select,
-    interactive_provider_select,
-)
-from repowise.cli.ui.repo_scanner import (
-    RepoScanInfo,
-    print_scan_summary,
-    quick_repo_scan,
-)
-from repowise.cli.ui.result_panels import (
-    build_completion_panel,
-    build_contextual_next_steps,
-    build_status_notes,
-    print_analysis_summary,
-    print_files_written,
-)
-from repowise.cli.ui.workspace_selection import (
-    interactive_primary_select,
-    interactive_repo_select,
-)
+from importlib import import_module
+from typing import Any
 
-__all__ = [
-    "BRAND",
-    "BRAND_STYLE",
-    "DIM",
-    "ERR",
-    "LARGE_REPO_FILE_THRESHOLD",
-    "OK",
-    "OWL_SPINNER",
-    "THINKING_FRAMES",
-    "VALUE",
-    "WARN",
-    "MaybeCountColumn",
-    "ProviderSelection",
-    "RepoScanInfo",
-    "RichProgressCallback",
-    "banner_text",
-    "build_completion_panel",
-    "build_contextual_next_steps",
-    "build_status_notes",
-    "format_bytes",
-    "format_elapsed",
-    "interactive_advanced_config",
-    "interactive_customize_offer",
-    "interactive_fast_mode_offer",
-    "interactive_generate_docs_toggle",
-    "interactive_mode_select",
-    "interactive_primary_select",
-    "interactive_provider_config_select",
-    "interactive_provider_select",
-    "interactive_repo_select",
-    "key_value_table",
-    "load_dotenv",
-    "mini",
-    "print_analysis_summary",
-    "print_banner",
-    "print_files_written",
-    "print_index_only_intro",
-    "print_phase_header",
-    "print_scan_summary",
-    "print_section",
-    "prompt_file_page_volume",
-    "prompt_wiki_style",
-    "quick_repo_scan",
-    "should_offer_fast_mode",
-]
+#: Public name -> submodule that owns it, mirroring the eager re-exports below.
+#: ``import *`` and ``hasattr`` stay cheap because only this dict is built.
+_LAZY: dict[str, str] = {
+    "BRAND": "brand",
+    "BRAND_STYLE": "brand",
+    "DIM": "brand",
+    "ERR": "brand",
+    "LARGE_REPO_FILE_THRESHOLD": "mode_selection",
+    "OK": "brand",
+    "OWL_SPINNER": "mascot",
+    "THINKING_FRAMES": "mascot",
+    "VALUE": "brand",
+    "WARN": "brand",
+    "MaybeCountColumn": "progress",
+    "ProviderSelection": "provider_selection",
+    "RepoScanInfo": "repo_scanner",
+    "RichProgressCallback": "progress",
+    "banner_text": "mascot",
+    "build_completion_panel": "result_panels",
+    "build_contextual_next_steps": "result_panels",
+    "build_status_notes": "result_panels",
+    "format_bytes": "brand",
+    "format_elapsed": "brand",
+    "interactive_advanced_config": "mode_selection",
+    "interactive_customize_offer": "mode_selection",
+    "interactive_fast_mode_offer": "mode_selection",
+    "interactive_generate_docs_toggle": "mode_selection",
+    "interactive_mode_select": "mode_selection",
+    "interactive_primary_select": "workspace_selection",
+    "interactive_provider_config_select": "provider_selection",
+    "interactive_provider_select": "provider_selection",
+    "interactive_repo_select": "workspace_selection",
+    "key_value_table": "brand",
+    "load_dotenv": "env_persistence",
+    "mini": "mascot",
+    "print_analysis_summary": "result_panels",
+    "print_banner": "brand",
+    "print_files_written": "result_panels",
+    "print_index_only_intro": "mode_selection",
+    "print_phase_header": "brand",
+    "print_scan_summary": "repo_scanner",
+    "print_section": "brand",
+    "prompt_file_page_volume": "mode_selection",
+    "prompt_wiki_style": "mode_selection",
+    "quick_repo_scan": "repo_scanner",
+    "should_offer_fast_mode": "mode_selection",
+}
+
+__all__ = sorted(_LAZY)
+
+#: Cached fully-imported submodules, so repeated attribute access in a long-lived
+#: process (the MCP/server path) does not re-import each time.
+_loaded: dict[str, Any] = {}
+
+
+def __getattr__(name: str) -> Any:
+    submodule = _LAZY.get(name)
+    if submodule is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    module = _loaded.get(submodule)
+    if module is None:
+        module = import_module(f"{__name__}.{submodule}")
+        _loaded[submodule] = module
+    return getattr(module, name)
+
+
+def __dir__() -> list[str]:
+    return sorted({*globals(), *_LAZY})

--- a/tests/unit/cli/test_ui_package.py
+++ b/tests/unit/cli/test_ui_package.py
@@ -7,6 +7,9 @@ the façade must still expose every public name, and the decomposed
 
 from __future__ import annotations
 
+import subprocess
+import sys
+
 import pytest
 
 import repowise.cli.ui as ui
@@ -158,3 +161,30 @@ def test_advanced_config_allow_fast_small_repo(monkeypatch: pytest.MonkeyPatch) 
     assert result["run_mode"] == "standard"
     assert result["commit_limit"] == 1000  # <500 files -> deeper history default
     assert result["concurrency"] == 12  # <200 files -> higher concurrency default
+
+
+def test_lazy_facade_imports_no_heavy_modules() -> None:
+    """Importing the façade (or a cheap submodule) must not pull core.ingestion.
+
+    Importing ``ui.brand`` used to run the package ``__init__``, which eagerly
+    imported every interactive submodule -> ``core.ingestion`` -> networkx +
+    tree-sitter (~1.1s on a cold process), the dominant startup floor for cheap
+    commands like ``status``/``coverage`` (issue #1712). The façade is now lazy,
+    so a fresh interpreter that touches the cheap surface must not load those.
+    """
+    probe = (
+        "import sys; "
+        "from repowise.cli.ui.brand import format_bytes; "
+        "print(format_bytes(1536)); "
+        "heavy = sorted(m for m in sys.modules "
+        "if m.startswith(('repowise.core.ingestion', 'networkx', 'tree_sitter', "
+        "'lancedb', 'scipy'))); "
+        "print(heavy)"
+    )
+    out = subprocess.run(
+        [sys.executable, "-c", probe], capture_output=True, text=True, check=True
+    )
+    lines = out.stdout.strip().splitlines()
+    assert lines[-2] == "1.5 KB"
+    assert lines[-1] == "[]", f"facade import pulled heavy modules: {lines[-1]}"
+


### PR DESCRIPTION
Fixes #1712

## Problem
Every `repowise` CLI invocation pays a ~1.1s fixed import floor on top of actual work, making one-shot calls (`status`, `coverage status`, hooks, editor integrations) uneconomical.

Root cause: `repowise.cli.ui/__init__.py` is an **eager facade**. Importing *any* submodule — even the cheap `ui.brand.format_bytes` that `status` needs — runs the package `__init__`, which eagerly imports every interactive UI submodule (`mode_selection` → `repo_scanner` → `core.ingestion` → `networkx` + `tree-sitter`). Measured with `python -X importtime`: importing `status_cmd` pulled `networkx` (0.045s) + `tree_sitter` (0.19s) + `core.ingestion` (~1.1s cumulative).

## Fix
Convert `ui/__init__.py` to a **lazy facade** (PEP 562 `__getattr__`). Each public name maps to its owning submodule and is imported only on first access. Cheap commands no longer pay for the interactive UI's heavy graph deps.

## Measured
Cold `repowise status`:
- Before: **~1.9s**
- After: **~0.5s** (~4x)

Import profile of `status_cmd`: `core.ingestion`/`networkx`/`tree_sitter` → **0** modules loaded.

## Tests
- Added regression test asserting a fresh interpreter importing `ui.brand` loads no `core.ingestion`/`networkx`/`tree_sitter`/`lancedb`/`scipy`.
- Existing facade-parity test (all 44 public names resolve) and interactive-UI tests all pass.
- `ruff` clean.