### PR TITLE
fix(web): render API timestamps as UTC

### DIFF
--- a/packages/ui/__tests__/lib/format.test.ts
+++ b/packages/ui/__tests__/lib/format.test.ts
@@ -3,7 +3,10 @@ import {
   formatAgeDays,
   formatBytes,
   formatCompact,
+  formatDate,
+  formatDateTime,
   formatPercent,
+  parseDate,
 } from "../../src/lib/format";
 
 describe("formatCompact", () => {
@@ -73,5 +76,44 @@ describe("formatBytes", () => {
   it("returns an em dash for invalid input", () => {
     expect(formatBytes(-1)).toBe("—");
     expect(formatBytes(Number.NaN)).toBe("—");
+  });
+});
+
+describe("parseDate", () => {
+  it("treats a bare ISO string (no tz suffix) as UTC", () => {
+    // "2026-08-21T13:23:33" must mean 13:23 UTC, not local time.
+    expect(parseDate("2026-08-21T13:23:33").toISOString()).toBe(
+      "2026-08-21T13:23:33.000Z",
+    );
+  });
+
+  it("keeps an explicit Z or offset as-is", () => {
+    expect(parseDate("2026-08-21T13:23:33Z").toISOString()).toBe(
+      "2026-08-21T13:23:33.000Z",
+    );
+    expect(parseDate("2026-08-21T21:23:33+08:00").toISOString()).toBe(
+      "2026-08-21T13:23:33.000Z",
+    );
+  });
+
+  it("passes Date instances through unchanged", () => {
+    const d = new Date("2026-08-21T13:23:33Z");
+    expect(parseDate(d)).toBe(d);
+  });
+});
+
+describe("formatDate / formatDateTime render UTC, not the local zone", () => {
+  it("renders the bare API string as the same wall-clock in UTC", () => {
+    // With a plain `new Date("2026-08-21T13:23:33")`, a UTC+8 browser would
+    // render 21:23 on the 21st as the local reading of 13:23 UTC. Parsing as
+    // UTC and pinning timeZone: "UTC" keeps the shown wall-clock fixed at the
+    // value the API returned.
+    expect(formatDate("2026-08-21T13:23:33")).toBe("Aug 21, 2026");
+    expect(formatDateTime("2026-08-21T13:23:33")).toBe("Aug 21, 2026, 1:23 PM");
+  });
+
+  it("renders an explicit Z timestamp at the same UTC wall-clock", () => {
+    expect(formatDate("2026-08-21T13:23:33Z")).toBe("Aug 21, 2026");
+    expect(formatDateTime("2026-08-21T13:23:33Z")).toBe("Aug 21, 2026, 1:23 PM");
   });
 });

--- a/packages/ui/src/commits/code-evolution-chart.tsx
+++ b/packages/ui/src/commits/code-evolution-chart.tsx
@@ -22,6 +22,7 @@ import {
   TooltipTrigger,
 } from "../ui/tooltip";
 import { cn } from "../lib/cn";
+import { parseDate } from "../lib/format";
 
 /**
  * The repo's development "story arc" — a stacked-area timeline of how the
@@ -81,13 +82,13 @@ const STACK_ORDER: CommitCategory[] = [
 type Mode = "share" | "volume";
 
 function formatBucketLabel(startIso: string, granularity: string): string {
-  const d = new Date(startIso);
+  const d = parseDate(startIso);
   if (Number.isNaN(d.getTime())) return startIso;
-  const month = d.toLocaleString("en-US", { month: "short" });
+  const month = d.toLocaleString("en-US", { month: "short", timeZone: "UTC" });
   if (granularity === "week") {
-    return `${month} ${d.getDate()}`;
+    return `${month} ${d.getUTCDate()}`;
   }
-  return `${month} ${String(d.getFullYear()).slice(2)}`;
+  return `${month} ${String(d.getUTCFullYear()).slice(2)}`;
 }
 
 /** Dominant category across a slice of buckets (by summed count). */

--- a/packages/ui/src/coupling/coupling-table.tsx
+++ b/packages/ui/src/coupling/coupling-table.tsx
@@ -8,6 +8,7 @@ import { VirtualizedTable } from "../shared/virtualized-table";
 import { clickableRowProps, CLICKABLE_ROW_CLS } from "../shared/responsive-table";
 import { AiPromptButton } from "../health/ai-prompt-button";
 import { cn } from "../lib/cn";
+import { formatDate, formatDateTime } from "../lib/format";
 import type { CouplingEdge } from "@repowise-dev/types/coupling";
 
 /**
@@ -256,8 +257,8 @@ export function CouplingTable({
           </div>
         </td>
         <td className={`px-3 py-2 text-left text-xs text-[var(--color-text-tertiary)] ${HIDE_BELOW_LG}`}>
-          <span title={e.last_co_change ? new Date(e.last_co_change).toLocaleString() : undefined}>
-            {e.last_co_change ? new Date(e.last_co_change).toLocaleDateString() : "—"}
+          <span title={e.last_co_change ? formatDateTime(e.last_co_change) : undefined}>
+            {e.last_co_change ? formatDate(e.last_co_change) : "—"}
           </span>
         </td>
         {onGeneratePrompt ? (

--- a/packages/ui/src/coverage/freshness-table.tsx
+++ b/packages/ui/src/coverage/freshness-table.tsx
@@ -12,6 +12,7 @@ import {
 } from "../lib/confidence";
 import {
   formatConfidence,
+  formatDateTime,
   formatRelativeTime,
 } from "../lib/format";
 import { getPageTypeIcon, getPageTypeLabel } from "../lib/page-types";
@@ -183,7 +184,7 @@ export function FreshnessTable({
                 </td>
                 <td
                   className="px-4 py-2.5 text-xs text-[var(--color-text-tertiary)] hidden md:table-cell"
-                  title={new Date(page.updated_at).toLocaleString()}
+                  title={formatDateTime(page.updated_at)}
                 >
                   {formatRelativeTime(page.updated_at)}
                 </td>

--- a/packages/ui/src/dead-code/findings-table.tsx
+++ b/packages/ui/src/dead-code/findings-table.tsx
@@ -14,7 +14,7 @@ import { EmptyState } from "../shared/empty-state";
 import { ResponsiveTable, type ResponsiveColumn } from "../shared/responsive-table";
 import { toFriendlyMessage } from "../lib/errors";
 import { AiPromptButton } from "../health/ai-prompt-button";
-import { formatRelativeTimeOrNull } from "../lib/format";
+import { formatDateTime, formatRelativeTimeOrNull } from "../lib/format";
 import {
   FindingIdentity,
   FindingConfidence,
@@ -339,7 +339,7 @@ export function FindingsTable({
         render: (f) => (
           <span
             className="block text-xs tabular-nums text-[var(--color-text-tertiary)]"
-            title={f.last_commit_at ? new Date(f.last_commit_at).toLocaleString() : undefined}
+            title={f.last_commit_at ? formatDateTime(f.last_commit_at) : undefined}
           >
             {formatRelativeTimeOrNull(f.last_commit_at)}
             {/* Recent churn is why a finding scores low; saying so makes the

--- a/packages/ui/src/files/file-doc-tab.tsx
+++ b/packages/ui/src/files/file-doc-tab.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from "react";
 import { BookOpen } from "lucide-react";
 import { EmptyState } from "../shared/empty-state";
-import { formatRelativeTime } from "../lib/format";
+import { formatDateTime, formatRelativeTime } from "../lib/format";
 import type { FileWikiPageRef } from "@repowise-dev/types/files";
 
 interface FileDocTabProps {
@@ -37,7 +37,7 @@ export function FileDocTab({ wikiPage, docSlot }: FileDocTabProps) {
       {wikiPage.updated_at && (
         <p
           className="font-mono text-[10px] uppercase tracking-[0.12em] text-[var(--color-text-tertiary)]"
-          title={new Date(wikiPage.updated_at).toLocaleString()}
+          title={formatDateTime(wikiPage.updated_at)}
         >
           Written {formatRelativeTime(wikiPage.updated_at)}
         </p>

--- a/packages/ui/src/health/coverage-lede.tsx
+++ b/packages/ui/src/health/coverage-lede.tsx
@@ -18,7 +18,7 @@ import type { CoverageFileRow, CoverageSummary } from "@repowise-dev/types/healt
 
 import { PageLede } from "../shared/page-lede";
 import { StatRibbon, type RibbonStat } from "../stats/stat-ribbon";
-import { formatNumber } from "../lib/format";
+import { formatDate, formatDateTime, formatNumber } from "../lib/format";
 import { coverageBand } from "./tokens";
 
 export interface CoverageLedeProps {
@@ -96,7 +96,7 @@ export function CoverageLede({
       label: "Report format",
       value: (summary.source_format ?? "").toUpperCase(),
       ...(summary.ingested_at
-        ? { sub: `ingested ${new Date(summary.ingested_at).toLocaleDateString()}` }
+        ? { sub: `ingested ${formatDate(summary.ingested_at)}` }
         : {}),
     },
   ];
@@ -144,7 +144,7 @@ export function CoverageLede({
             </span>{" "}
             output
             {summary.ingested_at
-              ? `, ingested ${new Date(summary.ingested_at).toLocaleString()}`
+              ? `, ingested ${formatDateTime(summary.ingested_at)}`
               : ""}
             {summary.ingested_commit_sha
               ? ` at ${summary.ingested_commit_sha.slice(0, 8)}`

--- a/packages/ui/src/health/file-trend-chart.tsx
+++ b/packages/ui/src/health/file-trend-chart.tsx
@@ -2,6 +2,7 @@
 
 import { TrendingDown } from "lucide-react";
 import type { FileHealthTrend } from "@repowise-dev/types/health";
+import { formatDate } from "../lib/format";
 import { deltaColor, formatDelta, scoreTextColor } from "./tokens";
 
 export interface FileTrendChartProps {
@@ -129,7 +130,7 @@ function Chart({
   // so the end dot's colour matches the file's stated score.
   const endColor = scoreTextColor(last.score);
 
-  const fmtDate = (iso: string | null) => (iso ? new Date(iso).toLocaleDateString() : "");
+  const fmtDate = (iso: string | null) => (iso ? formatDate(iso) : "");
 
   return (
     <div className="rounded-md border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-2">

--- a/packages/ui/src/health/page-chrome.tsx
+++ b/packages/ui/src/health/page-chrome.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { HealthTabs, type HealthTabKey, type HealthTabsProps } from "./health-tabs";
+import { formatDate, parseDate } from "../lib/format";
 
 export interface HealthPageChromeProps {
   repoId: string;
@@ -24,7 +25,7 @@ export interface HealthPageChromeProps {
 
 function formatIndexedAt(iso: string | null): string {
   if (!iso) return "never";
-  const d = new Date(iso);
+  const d = parseDate(iso);
   const diff = Date.now() - d.getTime();
   const minutes = Math.round(diff / 60_000);
   if (minutes < 1) return "just now";
@@ -33,7 +34,7 @@ function formatIndexedAt(iso: string | null): string {
   if (hours < 24) return `${hours}h ago`;
   const days = Math.round(hours / 24);
   if (days < 30) return `${days}d ago`;
-  return d.toLocaleDateString();
+  return formatDate(d);
 }
 
 export function HealthPageChrome({

--- a/packages/ui/src/health/trend-chart.tsx
+++ b/packages/ui/src/health/trend-chart.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { formatDate } from "../lib/format";
+
 export interface TrendSeriesPoint {
   taken_at: string | null;
   hotspot_health: number;
@@ -85,11 +87,11 @@ export function TrendChart({ history, height = 220 }: TrendChartProps) {
         {history.length > 1 ? (
           <>
             <text x={padL} y={H - 8} fontSize={10} fill="currentColor" opacity={0.5}>
-              {history[0]?.taken_at ? new Date(history[0]!.taken_at!).toLocaleDateString() : ""}
+              {history[0]?.taken_at ? formatDate(history[0]!.taken_at!) : ""}
             </text>
             <text x={W - padR} y={H - 8} fontSize={10} textAnchor="end" fill="currentColor" opacity={0.5}>
               {history[history.length - 1]?.taken_at
-                ? new Date(history[history.length - 1]!.taken_at!).toLocaleDateString()
+                ? formatDate(history[history.length - 1]!.taken_at!)
                 : ""}
             </text>
           </>

--- a/packages/ui/src/lib/format.ts
+++ b/packages/ui/src/lib/format.ts
@@ -2,6 +2,25 @@
  * Number, date, token, and other formatters for repowise UI.
  */
 
+/** A timestamp we can render. */
+type Timestamp = string | Date;
+
+/**
+ * Parse an API timestamp into a `Date`, treating a bare ISO string without an
+ * explicit timezone suffix (e.g. `"2026-08-21T13:23:33"`) as UTC. The repowise
+ * API returns UTC wall-clock strings with no trailing `Z`, so a plain
+ * `new Date("...")` would interpret them as *local* time and shift every
+ * displayed timestamp by the viewer's UTC offset.
+ */
+export function parseDate(date: Timestamp): Date {
+  if (date instanceof Date) return date;
+  // No timezone suffix (`Z`/`z` or `+HH:MM`)? Treat the wall-clock as UTC.
+  if (!/[zZ]|[+-]\d\d?:\d\d$/.test(date.trim())) {
+    return new Date(`${date.trim()}Z`);
+  }
+  return new Date(date);
+}
+
 /** Format a number with commas: 1234567 → "1,234,567" */
 export function formatNumber(n: number): string {
   return new Intl.NumberFormat().format(n);
@@ -37,7 +56,7 @@ export function formatCost(usd: number): string {
 
 /** Format a datetime to a relative string: "2h ago", "3d ago", "just now" */
 export function formatRelativeTime(date: string | Date): string {
-  const d = typeof date === "string" ? new Date(date) : date;
+  const d = parseDate(date);
   const now = Date.now();
   const diff = now - d.getTime();
   const seconds = Math.floor(diff / 1000);
@@ -64,30 +83,32 @@ export function formatRelativeTimeOrNull(
   fallback = "—",
 ): string {
   if (!iso) return fallback;
-  const d = new Date(iso);
+  const d = parseDate(iso);
   if (Number.isNaN(d.getTime()) || d.getTime() > Date.now()) return fallback;
   return formatRelativeTime(d);
 }
 
-/** Format a datetime to an absolute string: "Mar 19, 2026" */
+/** Format a datetime to an absolute string: "Mar 19, 2026" (in UTC) */
 export function formatDate(date: string | Date): string {
-  const d = typeof date === "string" ? new Date(date) : date;
+  const d = parseDate(date);
   return new Intl.DateTimeFormat("en-US", {
     month: "short",
     day: "numeric",
     year: "numeric",
+    timeZone: "UTC",
   }).format(d);
 }
 
-/** Format a datetime to full: "Mar 19, 2026 at 10:30 AM" */
+/** Format a datetime to full: "Mar 19, 2026 at 10:30 AM" (in UTC) */
 export function formatDateTime(date: string | Date): string {
-  const d = typeof date === "string" ? new Date(date) : date;
+  const d = parseDate(date);
   return new Intl.DateTimeFormat("en-US", {
     month: "short",
     day: "numeric",
     year: "numeric",
     hour: "numeric",
     minute: "2-digit",
+    timeZone: "UTC",
   }).format(d);
 }
 

--- a/packages/ui/src/overview/activity-lists.tsx
+++ b/packages/ui/src/overview/activity-lists.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { formatRelativeTime, stripMarkdown } from "../lib/format";
+import { formatDateTime, formatRelativeTime, stripMarkdown } from "../lib/format";
 
 export interface CommitRow {
   sha: string;
@@ -63,7 +63,7 @@ export function CommitRows({
             {c.committed_at && (
               <span
                 className="shrink-0 font-mono text-[10px] text-[var(--color-text-tertiary)]"
-                title={`${c.author_name} · ${new Date(c.committed_at).toLocaleString()}`}
+                title={`${c.author_name} · ${formatDateTime(c.committed_at)}`}
               >
                 {formatRelativeTime(c.committed_at)}
               </span>

--- a/packages/ui/src/overview/change-line.tsx
+++ b/packages/ui/src/overview/change-line.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { formatRelativeTime } from "../lib/format";
+import { formatDateTime, formatRelativeTime } from "../lib/format";
 
 export interface ChangeStat {
   /** Pre-formatted figure, e.g. "8" or "10+". */
@@ -42,7 +42,7 @@ export function ChangeLine({ since, stats }: ChangeLineProps) {
     <div className="flex flex-wrap items-baseline gap-x-4 gap-y-1 border-y border-[var(--color-border-default)] py-2.5 text-xs text-[var(--color-text-secondary)]">
       <span
         className="font-mono text-[10px] uppercase tracking-[0.12em] text-[var(--color-text-tertiary)]"
-        title={new Date(since).toLocaleString()}
+        title={formatDateTime(since)}
       >
         Since the previous index, {formatRelativeTime(since)}
       </span>

--- a/packages/ui/src/security/findings-table.tsx
+++ b/packages/ui/src/security/findings-table.tsx
@@ -7,7 +7,7 @@ import { Input } from "../ui/input";
 import { EmptyState } from "../shared/empty-state";
 import { ResponsiveTable, type ResponsiveColumn } from "../shared/responsive-table";
 import { AiPromptButton } from "../health/ai-prompt-button";
-import { formatRelativeTimeOrNull } from "../lib/format";
+import { formatDate, formatDateTime, formatRelativeTimeOrNull } from "../lib/format";
 import type { SecurityFinding } from "@repowise-dev/types";
 
 // One declaration of the wire shape, not a third hand-kept copy: this file's
@@ -146,7 +146,7 @@ export function SecurityFindingsTable({ findings, onSelect, onGeneratePrompt }: 
         render: (f) => (
           <span
             className="text-xs tabular-nums text-[var(--color-text-tertiary)]"
-            title={f.commit_at ? new Date(f.commit_at).toLocaleString() : undefined}
+            title={f.commit_at ? formatDateTime(f.commit_at) : undefined}
           >
             {formatRelativeTimeOrNull(f.commit_at)}
           </span>
@@ -159,7 +159,7 @@ export function SecurityFindingsTable({ findings, onSelect, onGeneratePrompt }: 
         priority: 3,
         render: (f) => (
           <span className="text-xs tabular-nums text-[var(--color-text-tertiary)]">
-            {new Date(f.detected_at).toLocaleDateString()}
+            {formatDate(f.detected_at)}
           </span>
         ),
       },

--- a/packages/ui/src/stats/origin-block.tsx
+++ b/packages/ui/src/stats/origin-block.tsx
@@ -1,5 +1,5 @@
 import type { StatsOrigin } from "@repowise-dev/types/stats";
-import { formatAgeDays, formatNumber } from "../lib/format";
+import { formatAgeDays, formatNumber, parseDate } from "../lib/format";
 
 /** Absolute date in UTC.
  *
@@ -8,7 +8,7 @@ import { formatAgeDays, formatNumber } from "../lib/format";
  *  it locally would show two different birthdays to two people looking at the
  *  same repo (and slip a day for anyone far enough east or west). */
 function foundingDate(iso: string): string {
-  return new Date(iso).toLocaleDateString(undefined, {
+  return parseDate(iso).toLocaleDateString(undefined, {
     day: "numeric",
     month: "short",
     year: "numeric",

--- a/packages/ui/src/stats/punch-card.tsx
+++ b/packages/ui/src/stats/punch-card.tsx
@@ -4,6 +4,7 @@ import * as React from "react";
 import type { StatsPunchCard } from "@repowise-dev/types/stats";
 import { DEFAULT_WEEKEND_PRESET, weekendShare } from "./weekend";
 import { repoArchetype } from "./archetype";
+import { parseDate } from "../lib/format";
 
 const WEEKDAYS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"] as const;
 /** One gap value on both axes, so the cells read as an even lattice. */
@@ -34,7 +35,7 @@ function weekdayLong(i: number): string {
 function spanLabel(first: string | null, last: string | null): string | null {
   if (!first || !last) return null;
   const fmt = (iso: string) => {
-    const d = new Date(iso);
+    const d = parseDate(iso);
     return Number.isNaN(d.getTime())
       ? null
       : // UTC deliberately: this is a coarse month label on an absolute instant,

--- a/packages/ui/src/wiki/confidence-badge.tsx
+++ b/packages/ui/src/wiki/confidence-badge.tsx
@@ -8,7 +8,7 @@ import {
   statusLabel,
   type FreshnessStatus,
 } from "../lib/confidence";
-import { formatConfidence } from "../lib/format";
+import { formatConfidence, formatDate } from "../lib/format";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../ui/tooltip";
 
 interface ConfidenceBadgeProps {
@@ -74,7 +74,7 @@ export function ConfidenceBadge({
       <Tooltip>
         <TooltipTrigger asChild>{badge}</TooltipTrigger>
         <TooltipContent>
-          <p>Stale since {new Date(staleSince).toLocaleDateString()}</p>
+          <p>Stale since {formatDate(staleSince)}</p>
           <p className="text-[var(--color-text-tertiary)]">
             Confidence: {formatConfidence(score)}
           </p>

--- a/packages/web/src/app/repos/[id]/code-health/page.tsx
+++ b/packages/web/src/app/repos/[id]/code-health/page.tsx
@@ -31,6 +31,7 @@ import { PageShell } from "@repowise-dev/ui/shared/page-shell";
 import { ViewTabs } from "@repowise-dev/ui/shared/view-tabs";
 import { OverviewSection } from "@repowise-dev/ui/overview";
 import { Button } from "@repowise-dev/ui/ui/button";
+import { formatDateTime } from "@repowise-dev/ui/lib/format";
 import type { CodeHealthOverlay } from "@repowise-dev/ui/health";
 import type { DeadCodeSummary } from "@repowise-dev/types/dead-code";
 import { TriageTab } from "@/components/code-health/triage-tab";
@@ -283,7 +284,7 @@ export default function CodeHealthPage() {
       {meta ? (
         <p className="-mt-3 font-mono text-[10px] uppercase tracking-[0.12em] text-[var(--color-text-tertiary)]">
           {meta.last_indexed_at
-            ? `Indexed ${new Date(meta.last_indexed_at).toLocaleString()}`
+            ? `Indexed ${formatDateTime(meta.last_indexed_at)}`
             : "Not indexed yet"}
           {meta.head_commit ? ` · ${meta.head_commit.slice(0, 8)}` : ""}
           {` · ${meta.snapshot_count} snapshot${meta.snapshot_count === 1 ? "" : "s"}`}

--- a/packages/web/src/app/repos/[id]/overview/page.tsx
+++ b/packages/web/src/app/repos/[id]/overview/page.tsx
@@ -35,6 +35,7 @@ import { fileEntityPath } from "@repowise-dev/ui/shared/entity";
 import {
   formatBytes,
   formatCost,
+  formatDateTime,
   formatLOC,
   formatNumber,
   formatRelativeTime,
@@ -92,7 +93,7 @@ export default async function OverviewPage({ params }: Props) {
   if (lastActivityAt) {
     meta.push({
       label: `synced ${formatRelativeTime(lastActivityAt)}`,
-      title: new Date(lastActivityAt).toLocaleString(),
+      title: formatDateTime(lastActivityAt),
     });
   }
 


### PR DESCRIPTION
## Summary

Fixes #1821. The repowise API returns UTC wall-clock strings with no trailing `Z` (e.g. `"2026-08-21T13:23:33"`). The web UI parsed these with `new Date()` — which interprets a timezone-less ISO string as *local* time — and then formatted them in the browser's local timezone. On a non-UTC client (e.g. `Asia/Shanghai`, UTC+8) every API-supplied timestamp rendered **8 hours behind** the real UTC value.

### Root cause
```js
new Date("2026-08-21T13:23:33").toLocaleString()  // 1:23 PM in UTC+8 — 8h late
new Date("2026-08-21T13:23:33Z").toLocaleString() // 9:23 PM — correct
```

### Fix
- **`packages/ui/src/lib/format.ts`** — added a `parseDate` helper that treats a bare ISO string (no timezone suffix) as UTC and appends `Z`. `formatDate`, `formatDateTime`, `formatRelativeTime`, and `formatRelativeTimeOrNull` now parse via `parseDate` and render with `timeZone: 'UTC'`, so the displayed wall-clock always matches the value the API returned.
- Replaced all raw `new Date(...).toLocaleString()/toLocaleDateString()` calls across the UI and web surface with the UTC-aware formatters — including the **Committed** column (security findings) and **Last touched** column (dead-code findings) called out in the issue, plus coupling, coverage, health, overview, code-health, commits timeline, and chart bucket labels.
- **Tests** — added unit tests in `packages/ui/__tests__/lib/format.test.ts` covering `parseDate` (bare ISO as UTC, explicit `Z`/offset preserved, `Date` pass-through) and `formatDate`/`formatDateTime` rendering in UTC.

### Test plan
- `packages/ui`: `npx vitest run __tests__/lib/format.test.ts` — **16 passed**.
- `packages/ui` & `packages/web`: `tsc --noEmit` — **0 errors**.

Closes #1821
