### PR TITLE
fix(ingestion): make the per-file git-index timeout generous and configurable

### DIFF
--- a/packages/core/src/repowise/core/ingestion/git_indexer/_constants.py
+++ b/packages/core/src/repowise/core/ingestion/git_indexer/_constants.py
@@ -7,6 +7,8 @@ the commit-depth defaults, decay half-lives, and skip heuristics.
 from __future__ import annotations
 
 import contextlib
+import math
+import os
 import re
 from typing import Any
 
@@ -383,4 +385,37 @@ _MAX_BLAME_SIZE_BYTES: int = 100 * 1024  # 100 KB
 # Maximum seconds to wait for a single file's git indexing.  If exceeded the
 # file is recorded with whatever data was collected before the timeout and the
 # semaphore slot is released so other files can proceed.
-_FILE_INDEX_TIMEOUT_SECS: float = 45.0
+#
+# The default is deliberately generous: a first full index of a large
+# repository can run several slow git subprocesses per file (log, blame,
+# renames), and a premature fire here would silently record partial data for
+# files that were simply still working — the same premature-timeout failure
+# mode reported for long-running build/compile commands. Override per-repo or
+# per-machine with ``REPOWISE_GIT_INDEX_TIMEOUT_S`` (a positive float, seconds).
+_FILE_INDEX_TIMEOUT_SECS_ENV = "REPOWISE_GIT_INDEX_TIMEOUT_S"
+_FILE_INDEX_TIMEOUT_SECS_DEFAULT: float = 120.0
+
+
+def _resolve_file_index_timeout() -> float:
+    """Seconds one file's git indexing may take, from env or the default.
+
+    An unparseable or non-positive value keeps the default rather than
+    silently dropping the budget (matching the other ``REPOWISE_*_TIMEOUT_S``
+    resolvers in the codebase).
+    """
+    raw = os.environ.get(_FILE_INDEX_TIMEOUT_SECS_ENV, "").strip()
+    if not raw:
+        return _FILE_INDEX_TIMEOUT_SECS_DEFAULT
+    try:
+        seconds = float(raw)
+    except ValueError:
+        seconds = float("nan")
+    # NaN and inf both fail ``isfinite``/``> 0``, so they land on the default
+    # rather than on a budget asyncio.wait_for would treat as already expired
+    # (or one it would never fire at all).
+    if not math.isfinite(seconds) or not seconds > 0:
+        return _FILE_INDEX_TIMEOUT_SECS_DEFAULT
+    return seconds
+
+
+_FILE_INDEX_TIMEOUT_SECS: float = _resolve_file_index_timeout()

--- a/tests/unit/ingestion/test_git_index_timeout.py
+++ b/tests/unit/ingestion/test_git_index_timeout.py
@@ -1,0 +1,43 @@
+"""Unit tests for the git-index file timeout resolver.
+
+The per-file git indexing timeout must not fire early on legitimately
+long first-time indexes of large repositories (the same premature-timeout
+failure mode as long build/compile commands — issue #1781). It is therefore
+configurable via ``REPOWISE_GIT_INDEX_TIMEOUT_S`` and defaults generously.
+"""
+
+from __future__ import annotations
+
+import importlib
+from collections.abc import Iterator
+
+import pytest
+
+import repowise.core.ingestion.git_indexer._constants as constants
+
+
+@pytest.fixture(autouse=True)
+def _reset_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Clear the override between tests and reload the module constants."""
+    monkeypatch.delenv("REPOWISE_GIT_INDEX_TIMEOUT_S", raising=False)
+    yield
+    importlib.reload(constants)
+
+
+def test_default_timeout_is_generous() -> None:
+    assert constants._FILE_INDEX_TIMEOUT_SECS == 120.0
+
+
+def test_env_override_is_honoured(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("REPOWISE_GIT_INDEX_TIMEOUT_S", "300")
+    importlib.reload(constants)
+    assert constants._FILE_INDEX_TIMEOUT_SECS == 300.0
+
+
+@pytest.mark.parametrize("bad", ["abc", "0", "-5", "  ", "nan", "inf"])
+def test_bad_env_value_falls_back_to_default(
+    monkeypatch: pytest.MonkeyPatch, bad: str
+) -> None:
+    monkeypatch.setenv("REPOWISE_GIT_INDEX_TIMEOUT_S", bad)
+    importlib.reload(constants)
+    assert constants._FILE_INDEX_TIMEOUT_SECS == 120.0


### PR DESCRIPTION
## Summary

The per-file git-indexing timeout was a hardcoded 45s, so a file whose log/blame/rename subprocess was legitimately still working got recorded as partial data. That budget is thin for a first-time full index of a large repository.

## Changes
- Raise the per-file git-index timeout default 45s → 120s.
- Make it configurable via `REPOWISE_GIT_INDEX_TIMEOUT_S` (positive float seconds), matching the existing `REPOWISE_*_TIMEOUT_S` resolver pattern; invalid values fall back to the default.
- Regression tests for the default, the env override, and malformed values.

## Scope
This changes `_FILE_INDEX_TIMEOUT_SECS` in the git indexer. It does not touch `distill`, which has no timeout of its own; #1781 stays open as the design question for what `distill` should emit while a long build runs.

## Test Plan
- `ruff check` passes on changed files.
- New tests pass; related git-indexer tests pass (no regression).
