### PR TITLE
feat(providers): add Devin CLI provider

### DIFF
--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -1629,7 +1629,7 @@ Two things worth knowing before you start:
 Full configuration with defaults (`.repowise/config.yaml`):
 
 ```yaml
-provider: anthropic          # anthropic | openai | openrouter | gemini | deepseek | kimi | ollama | litellm | codex_cli | opencode | edenai | mock
+provider: anthropic          # anthropic | openai | openrouter | gemini | deepseek | kimi | ollama | litellm | codex_cli | opencode | devin | edenai | mock
 model: claude-sonnet-4-5    # passed through to the provider
 embedding_provider: anthropic
 embedding_model: voyage-3

--- a/docs/reference/CLI_REFERENCE.md
+++ b/docs/reference/CLI_REFERENCE.md
@@ -145,7 +145,7 @@ All three reach the indexing knobs; the LLM-only knobs appear only when model-wr
 
 | Flag | Description |
 |------|-------------|
-| `--provider` | LLM provider: `anthropic`, `openai`, `openrouter`, `gemini`, `deepseek`, `kimi`, `ollama`, `litellm`, `codex_cli`, `opencode`, `edenai`, `mock` |
+| `--provider` | LLM provider: `anthropic`, `openai`, `openrouter`, `gemini`, `deepseek`, `kimi`, `ollama`, `litellm`, `codex_cli`, `opencode`, `devin`, `edenai`, `mock` |
 | `--model` | Model name override (e.g., `claude-sonnet-4-6`) |
 | `--embedder` | Embedder for semantic search: `gemini`, `openai`, `openrouter`, `ollama`, `edenai`, `mock` (default: auto-detect) |
 | `--prose` / `--no-prose` | The single knob over LLM spend. The file, symbol, cycle (SCC), API and infra pages are rendered from structure either way, with no key and no cost. The model-written set is the subsystem (concept) tree plus the repo overview, the architecture diagram, and the onboarding collection: `--prose` writes those as model prose and needs a key; `--no-prose` leaves them as structural stubs, so the whole wiki is keyless and free. Default: prose when a key is available. Full-text search works either way; semantic search needs an embedder. Fill or refill that prose later with [`repowise generate`](#repowise-generate-path). |

--- a/packages/cli/src/repowise/cli/commands/init_cmd/command.py
+++ b/packages/cli/src/repowise/cli/commands/init_cmd/command.py
@@ -335,7 +335,7 @@ def _run_generation_phase(
         console.print(f"  Languages: {', '.join(lang_parts)}")
 
     # Warn when a local provider runs with default concurrency
-    if provider.provider_name in ("ollama", "codex_cli", "opencode") and concurrency > 4:
+    if provider.provider_name in ("ollama", "codex_cli", "opencode", "devin") and concurrency > 4:
         console.print(
             f"  [{WARN}]Warning:[/] {provider.provider_name} is a local provider "
             f"running with concurrency={concurrency}. "
@@ -411,7 +411,7 @@ def _run_generation_phase(
     default=None,
     help=(
         "LLM provider name (anthropic, openai, openrouter, gemini, "
-        "deepseek, kimi, ollama, litellm, codex_cli, opencode, edenai, mock)."
+        "deepseek, kimi, ollama, litellm, codex_cli, opencode, devin, edenai, mock)."
     ),
 )
 @click.option("--model", default=None, help="Model identifier override.")

--- a/packages/cli/src/repowise/cli/ui/provider_selection.py
+++ b/packages/cli/src/repowise/cli/ui/provider_selection.py
@@ -33,6 +33,7 @@ _PROVIDER_DEFAULTS: dict[str, str] = {
     "edenai": "mistral/mistral-small-latest",
     "codex_cli": "codex_cli/default",
     "opencode": "opencode/default",
+    "devin": "devin/adaptive",
     "ollama": "qwen3.5:4b",
     "openrouter": "google/gemini-3.5-flash-lite",
     "litellm": "groq/llama-3.1-70b-versatile",
@@ -47,6 +48,7 @@ _PROVIDER_ENV: dict[str, str] = {
     "edenai": "EDENAI_API_KEY",
     "codex_cli": "__CODEX_CLI__",
     "opencode": "__OPENCODE_CLI__",
+    "devin": "__DEVIN_CLI__",
     "ollama": "OLLAMA_BASE_URL",
     "openrouter": "OPENROUTER_API_KEY",
     # The picker iterates this map, so a provider missing here never renders a
@@ -64,6 +66,7 @@ _PROVIDER_SIGNUP: dict[str, str] = {
     "edenai": "https://app.edenai.run/user/register",
     "codex_cli": "https://developers.openai.com/codex/cli",
     "opencode": "https://opencode.ai",
+    "devin": "https://docs.devin.ai/cli",
     "ollama": "https://ollama.com/download",
     "openrouter": "https://openrouter.ai/keys",
     "litellm": "https://docs.litellm.ai/docs/providers",
@@ -77,6 +80,7 @@ _PROVIDER_NOTES: dict[str, str] = {
     "gemini": "recommended",
     "codex_cli": "uses your Codex CLI login",
     "opencode": "uses your opencode CLI setup",
+    "devin": "uses your Devin CLI setup",
     "ollama": "runs on your machine, no key",
     "litellm": "proxy in front of another provider",
 }
@@ -109,6 +113,13 @@ def _detect_opencode_status() -> bool:
     import shutil
 
     return shutil.which("opencode") is not None
+
+
+def _detect_devin_status() -> bool:
+    """Return ``True`` if the Devin CLI is installed on PATH."""
+    import shutil
+
+    return shutil.which("devin") is not None
 
 
 def ollama_base_url() -> str:
@@ -181,6 +192,9 @@ def _detect_provider_status() -> dict[str, str]:
         elif prov == "opencode":
             if _detect_opencode_status():
                 status[prov] = "opencode CLI"
+        elif prov == "devin":
+            if _detect_devin_status():
+                status[prov] = "devin CLI"
         elif prov == "ollama":
             if _detect_ollama_status():
                 status[prov] = ollama_base_url()
@@ -219,6 +233,22 @@ def _opencode_setup_lines() -> list[str]:
     ]
 
 
+def _devin_setup_lines() -> list[str]:
+    return [
+        "  [bold]devin[/bold] is a local AI coding agent that manages its own "
+        "models and authentication. No API key here.",
+        f"  Install: [{BRAND}]curl -fsSL https://cli.devin.ai/install.sh | bash[/]",
+        f"  Log in:  [{BRAND}]devin auth login[/]",
+        f"  Models:  [{BRAND}]devin --model adaptive -- your prompt[/]",
+        "",
+        f"  To pick a specific model: [{BRAND}]repowise init --provider devin "
+        "--model devin/opus[/]",
+        "",
+        f"  [{WARN}]devin CLI not found on PATH.[/] Install it and retry, "
+        "or select another provider.",
+    ]
+
+
 def _ollama_setup_lines() -> list[str]:
     base_url = ollama_base_url()
     lines = ["  [bold]ollama[/bold] runs models on your machine. No key needed.", ""]
@@ -248,6 +278,7 @@ def _ollama_setup_lines() -> list[str]:
 _LOCAL_PROVIDER_SETUP: dict[str, Callable[[], list[str]]] = {
     "codex_cli": _codex_cli_setup_lines,
     "opencode": _opencode_setup_lines,
+    "devin": _devin_setup_lines,
     "ollama": _ollama_setup_lines,
 }
 

--- a/packages/core/src/repowise/core/cost_estimator/pricing.py
+++ b/packages/core/src/repowise/core/cost_estimator/pricing.py
@@ -58,6 +58,7 @@ _COST_TABLE_PREFIX: dict[str, tuple[float, float]] = {
     "mock": (0.0, 0.0),
     "codex_cli/": (0.0, 0.0),
     "opencode/": (0.0, 0.0),
+    "devin/": (0.0, 0.0),
 }
 
 
@@ -67,7 +68,7 @@ def _lookup_cost(model_name: str) -> tuple[float, float]:
     # OpenRouter/LiteLLM slugs carry a routing prefix (`google/gemini-3.5-flash-lite`)
     # that hides the model from every entry below, which priced them at zero.
     # `codex_cli/` and `opencode/` are genuinely free, so they keep their prefixes.
-    if "/" in lower and not lower.startswith(("codex_cli/", "opencode/")):
+    if "/" in lower and not lower.startswith(("codex_cli/", "opencode/", "devin/")):
         lower = lower.rsplit("/", 1)[-1]
     if lower in _COST_TABLE_EXACT:
         return _COST_TABLE_EXACT[lower]

--- a/packages/core/src/repowise/core/generation/cost_tracker.py
+++ b/packages/core/src/repowise/core/generation/cost_tracker.py
@@ -90,12 +90,12 @@ def is_local_model(model: str) -> bool:
 
     Both the cost ledger and the savings estimate price these at $0: no dollars
     change hands per token. Covers Ollama/LM Studio/llama.cpp model strings and
-    the agent-CLI passthrough prefixes (``codex_cli/``, ``opencode/``).
+    the agent-CLI passthrough prefixes (``codex_cli/``, ``opencode/``, ``devin/``).
     """
     return (
         model == "mock"
         or model.startswith(_LOCAL_MODEL_PREFIXES)
-        or model.startswith(("codex_cli/", "opencode/"))
+        or model.startswith(("codex_cli/", "opencode/", "devin/"))
         # Bare Ollama tags carry no prefix — the default is plain `qwen3.5:4b`,
         # and a `family:size` tag is not a shape any hosted vendor uses.
         or (":" in model and "/" not in model)

--- a/packages/core/src/repowise/core/providers/llm/__init__.py
+++ b/packages/core/src/repowise/core/providers/llm/__init__.py
@@ -20,6 +20,7 @@ Built-in providers:
     litellm    — 100+ providers via LiteLLM proxy
     codex_cli  — local authenticated Codex CLI via codex exec
     opencode   — local opencode CLI via opencode run
+    devin      — local Devin CLI via devin -p
     mock       — deterministic test provider
 """
 

--- a/packages/core/src/repowise/core/providers/llm/devin.py
+++ b/packages/core/src/repowise/core/providers/llm/devin.py
@@ -1,0 +1,340 @@
+"""Devin CLI provider for repowise.
+
+This provider delegates generation to the local Devin CLI via ``devin -p``
+(single-turn, non-interactive mode). It uses the user's existing Devin CLI
+installation and authentication (``devin auth login``) without requiring a
+separate API key managed by repowise.
+
+Security: uses ``asyncio.create_subprocess_exec`` (no shell), validates model
+names against a safe character set, resolves all paths before passing them to
+the subprocess, and runs the CLI against a read-only permission profile
+(``normal`` is the Devin default, which auto-approves read-only tools within
+the working directory and prompts for write/execute operations). The ``cwd``
+is pinned to the target repo so the CLI reasons about the right directory even
+when repowise is launched from elsewhere.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import os
+import re
+import shutil
+from pathlib import Path
+from typing import Any
+
+import structlog
+
+from repowise.core.providers.llm.base import (
+    BaseProvider,
+    CacheHint,
+    GeneratedResponse,
+    ProviderError,
+    ProviderModelOption,
+)
+from repowise.core.rate_limiter import RateLimiter
+from repowise.core.reasoning import ReasoningMode
+
+log = structlog.get_logger(__name__)
+
+_DEFAULT_MODEL_LABEL = "devin/adaptive"
+_EXEC_TIMEOUT_SECONDS = 600
+_MAX_STDERR_CHARS = 1_000
+
+# Devin CLI supports a short list of model-family aliases plus "adaptive", its
+# intelligent model router. These are stable, cross-version short names that
+# always resolve to the latest version in their family (docs.devin.ai/cli/models).
+_KNOWN_MODELS: tuple[str, ...] = (
+    "adaptive",
+    "opus",
+    "sonnet",
+    "gpt",
+    "swe",
+    "codex",
+    "gemini",
+)
+
+# Anything other than an alpha-numeric, dot, hyphen, underscore or forward
+# slash is rejected before it can reach the subprocess argv.
+_MODEL_NAME_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._/\-]*$")
+
+
+def _resolve_devin_executable() -> str | None:
+    return shutil.which("devin")
+
+
+def _validate_model_name(model: str) -> None:
+    if not _MODEL_NAME_RE.match(model):
+        raise ProviderError(
+            "devin",
+            f"Invalid model name {model!r}. Model names may only contain "
+            "alphanumeric characters, dots, hyphens, underscores, and forward slashes.",
+        )
+
+
+def _normalize_model(model: str | None) -> str | None:
+    if not model:
+        return None
+    if model == _DEFAULT_MODEL_LABEL:
+        return None
+    if model.startswith("devin/"):
+        suffix = model.removeprefix("devin/")
+        return suffix or None
+    return model
+
+
+def _model_label(model: str | None) -> str:
+    native = _normalize_model(model)
+    return f"devin/{native}" if native else _DEFAULT_MODEL_LABEL
+
+
+def _combine_prompt(system_prompt: str, user_prompt: str) -> str:
+    return (
+        "System instructions for this task:\n\n"
+        f"{system_prompt.strip()}\n\n"
+        "---\n\n"
+        "User request and context:\n\n"
+        f"{user_prompt.strip()}"
+    )
+
+
+def _tail(text: str, max_chars: int = _MAX_STDERR_CHARS) -> str:
+    text = text.strip()
+    if len(text) <= max_chars:
+        return text
+    return text[-max_chars:]
+
+
+def _error_message(stderr: str, stdout: str, returncode: int) -> str:
+    for candidate in (_tail(stderr), _tail(stdout)):
+        if not candidate:
+            continue
+        if candidate.lstrip().startswith(("{", "[")):
+            continue
+        return candidate
+    return f"devin -p exited with {returncode}"
+
+
+def _devin_model_options() -> tuple[ProviderModelOption, ...]:
+    """Return the built-in Devin model options.
+
+    Devin CLI does not expose a stable ``models list`` machine-readable
+    subcommand for the models a logged-in user may actually select (the docs
+    tell users to run ``/model`` interactively), so repowise ships the
+    documented model-family aliases. The user can always type a custom model
+    id in the interactive picker.
+    """
+    options: list[ProviderModelOption] = [
+        ProviderModelOption(
+            model=_DEFAULT_MODEL_LABEL,
+            label="Devin Adaptive",
+            reasoning_modes=("auto",),
+            recommended=True,
+            source="builtin",
+            notes="intelligent model router (recommended)",
+        )
+    ]
+    for native in _KNOWN_MODELS:
+        if native == "adaptive":
+            continue
+        options.append(
+            ProviderModelOption(
+                model=_model_label(native),
+                label=native,
+                reasoning_modes=("auto",),
+                recommended=False,
+                source="local",
+                notes="model family alias",
+            )
+        )
+    return tuple(options)
+
+
+class DevinProvider(BaseProvider):
+    """LLM provider backed by ``devin -p``.
+
+    Uses the local Devin CLI for generation. Does not require an API key —
+    Devin manages its own authentication via ``devin auth login``.
+
+    Args:
+        model:     Optional Devin model-family alias (e.g. ``adaptive``,
+                   ``opus``, ``sonnet``). If omitted or ``devin/adaptive``,
+                   Devin uses its default (Adaptive router).
+        repo_path: Working directory the CLI runs in (passed as ``cwd``).
+        rate_limiter: Serializes subprocess calls by default.
+    """
+
+    # ``devin -p`` spawns a process and drives a whole agent turn. Minutes,
+    # not seconds. Stays under _EXEC_TIMEOUT_SECONDS so the caller gives up
+    # before the subprocess does and the error names the real cause.
+    interactive_timeout_s: float = 180.0
+
+    def __init__(
+        self,
+        model: str | None = None,
+        repo_path: str | Path | None = None,
+        rate_limiter: RateLimiter | None = None,
+    ) -> None:
+        devin_cmd = _resolve_devin_executable()
+        if not devin_cmd:
+            raise ProviderError(
+                "devin",
+                "Devin CLI is not installed.\n\n"
+                "Installation:\n"
+                "  curl -fsSL https://cli.devin.ai/install.sh | bash\n\n"
+                "After installing, run 'devin' once to log in (or 'devin auth "
+                "login'). No API keys are managed by repowise — Devin handles "
+                "all authentication.",
+            )
+        self._devin_cmd = devin_cmd
+        native = _normalize_model(model)
+        if native is not None:
+            _validate_model_name(native)
+        self._model = native
+        self._repo_path = (
+            Path(repo_path).resolve() if repo_path is not None else Path.cwd().resolve()
+        )
+        self._rate_limiter = rate_limiter
+        self._subprocess_semaphore: asyncio.Semaphore | None = None
+        self._semaphore_loop: asyncio.AbstractEventLoop | None = None
+
+    @property
+    def provider_name(self) -> str:
+        return "devin"
+
+    @property
+    def model_name(self) -> str:
+        return _model_label(self._model)
+
+    def supported_reasoning_modes(self) -> tuple[ReasoningMode, ...]:
+        return ("auto",)
+
+    def available_model_options(self) -> tuple[ProviderModelOption, ...]:
+        return _devin_model_options()
+
+    def _get_semaphore(self) -> asyncio.Semaphore:
+        loop = asyncio.get_running_loop()
+        if self._semaphore_loop is not loop:
+            self._subprocess_semaphore = asyncio.Semaphore(1)
+            self._semaphore_loop = loop
+        return self._subprocess_semaphore  # type: ignore[return-value]
+
+    def _build_command(self) -> list[str]:
+        # --respect-workspace-trust false: non-interactive mode cannot show the
+        # workspace trust prompt, so this skips the check for scripts/CI.
+        cmd = [
+            self._devin_cmd,
+            "-p",
+            "--permission-mode",
+            "normal",
+            "--respect-workspace-trust",
+            "false",
+        ]
+        if self._model:
+            cmd.extend(["--model", self._model])
+        return cmd
+
+    async def generate(
+        self,
+        system_prompt: str,
+        user_prompt: str,
+        max_tokens: int = 4096,
+        temperature: float = 0.3,
+        request_id: str | None = None,
+        reasoning: ReasoningMode = "auto",
+        cache_hints: tuple[CacheHint, ...] = (),
+    ) -> GeneratedResponse:
+        if self._rate_limiter:
+            await self._rate_limiter.acquire(estimated_tokens=max_tokens)
+
+        prompt = _combine_prompt(system_prompt, user_prompt)
+        # The prompt is passed as the trailing positional argument to `devin -p`.
+        cmd = [*self._build_command(), prompt]
+        log.debug(
+            "devin.generate.start",
+            model=self.model_name,
+            repo_path=str(self._repo_path),
+            request_id=request_id,
+        )
+
+        async with self._get_semaphore():
+            try:
+                proc = await asyncio.create_subprocess_exec(
+                    *cmd,
+                    cwd=str(self._repo_path),
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                    env=os.environ.copy(),
+                )
+            except FileNotFoundError as exc:
+                raise ProviderError(
+                    "devin",
+                    "Devin CLI not found. Install it with: "
+                    "curl -fsSL https://cli.devin.ai/install.sh | bash",
+                ) from exc
+
+            try:
+                stdout_bytes, stderr_bytes = await asyncio.wait_for(
+                    proc.communicate(),
+                    timeout=_EXEC_TIMEOUT_SECONDS,
+                )
+            except TimeoutError as exc:
+                proc.kill()
+                with contextlib.suppress(ProcessLookupError):
+                    await proc.wait()
+                raise ProviderError(
+                    "devin",
+                    f"devin -p timed out after {_EXEC_TIMEOUT_SECONDS} seconds.",
+                ) from exc
+            finally:
+                await _close_subprocess_transport(proc)
+
+        stdout = stdout_bytes.decode("utf-8", errors="replace") if stdout_bytes else ""
+        stderr = stderr_bytes.decode("utf-8", errors="replace") if stderr_bytes else ""
+
+        if proc.returncode != 0:
+            raise ProviderError(
+                "devin",
+                _error_message(stderr, stdout, proc.returncode),
+                status_code=proc.returncode,
+            )
+
+        content = stdout.strip()
+        if not content:
+            raise ProviderError(
+                "devin",
+                "devin -p completed but produced no output on stdout.",
+            )
+
+        log.debug(
+            "devin.generate.done",
+            request_id=request_id,
+        )
+
+        # Devin's plain-text single-turn output carries no token accounting, so
+        # usage is marked estimated (repowise prices the model at $0 locally).
+        usage_payload: dict[str, Any] = {
+            "source": "devin_p",
+            "model": self.model_name,
+            "stderr": _tail(stderr) if stderr.strip() else "",
+            "estimated": True,
+        }
+
+        return GeneratedResponse(
+            content=content,
+            input_tokens=0,
+            output_tokens=0,
+            cached_tokens=0,
+            usage=usage_payload,
+        )
+
+
+async def _close_subprocess_transport(proc: asyncio.subprocess.Process) -> None:
+    transport = getattr(proc, "_transport", None)
+    close = getattr(transport, "close", None)
+    if not callable(close):
+        return
+    with contextlib.suppress(Exception):
+        close()
+    await asyncio.sleep(0)

--- a/packages/core/src/repowise/core/providers/llm/registry.py
+++ b/packages/core/src/repowise/core/providers/llm/registry.py
@@ -15,6 +15,7 @@ Built-in providers:
     - litellm     → LiteLLMProvider
     - codex_cli   → CodexCliProvider
     - opencode    → OpenCodeProvider
+    - devin       → DevinProvider
     - mock        → MockProvider (testing only)
 
 Custom provider registration:
@@ -53,6 +54,7 @@ _BUILTIN_PROVIDERS: dict[str, tuple[str, str]] = {
     "edenai": ("repowise.core.providers.llm.edenai", "EdenAIProvider"),
     "codex_cli": ("repowise.core.providers.llm.codex_cli", "CodexCliProvider"),
     "opencode": ("repowise.core.providers.llm.opencode", "OpenCodeProvider"),
+    "devin": ("repowise.core.providers.llm.devin", "DevinProvider"),
     "mock": ("repowise.core.providers.llm.mock", "MockProvider"),
 }
 
@@ -93,13 +95,13 @@ PROVIDER_BASE_URL_ENVS: dict[str, tuple[str, ...]] = {
 # proxy the user secured elsewhere). Resolution must never reject one of these
 # for a "missing" key, and must never fall through to a different provider
 # because it could not find one.
-KEYLESS_PROVIDERS = frozenset({"codex_cli", "opencode", "ollama", "litellm", "mock"})
+KEYLESS_PROVIDERS = frozenset({"codex_cli", "opencode", "devin", "ollama", "litellm", "mock"})
 
 # Providers that shell out to a CLI and therefore need to be told which repo
 # they are reasoning about: they pass it as the subprocess working directory.
 # Omitting it silently runs the CLI against whatever cwd the host process had,
 # which for an MCP server launched by an editor is not the user's repo.
-REPO_PATH_PROVIDERS = frozenset({"codex_cli", "opencode"})
+REPO_PATH_PROVIDERS = frozenset({"codex_cli", "opencode", "devin"})
 
 # Order to try providers in when nothing was configured and we are guessing
 # from whatever credentials the environment happens to carry. This is the CLI's
@@ -284,7 +286,7 @@ def get_provider(
         raise ValueError(f"Unknown provider: {name!r}. Available providers: {available}")
 
     # Attach rate limiter (skip for mock — tests should run without limits)
-    if with_rate_limiter and name not in ("mock", "codex_cli", "opencode"):
+    if with_rate_limiter and name not in ("mock", "codex_cli", "opencode", "devin"):
         config = rate_limit_config or PROVIDER_DEFAULTS.get(name)
         if config and "rate_limiter" not in kwargs:
             kwargs["rate_limiter"] = RateLimiter(config)
@@ -306,6 +308,7 @@ def get_provider(
             "litellm": "litellm",
             "codex_cli": "@openai/codex",
             "opencode": "opencode",
+            "devin": "devin",
         }
         package = _missing.get(name, name)
         raise ImportError(

--- a/packages/server/src/repowise/server/provider_config.py
+++ b/packages/server/src/repowise/server/provider_config.py
@@ -141,6 +141,22 @@ PROVIDER_CATALOG: list[dict[str, Any]] = [
         "env_keys": [],
         "requires_key": False,
     },
+    {
+        "id": "devin",
+        "name": "Devin CLI",
+        "default_model": "devin/adaptive",
+        "models": [
+            "devin/adaptive",
+            "devin/opus",
+            "devin/sonnet",
+            "devin/gpt",
+            "devin/swe",
+            "devin/codex",
+            "devin/gemini",
+        ],
+        "env_keys": [],
+        "requires_key": False,
+    },
 ]
 
 _CATALOG_BY_ID = {p["id"]: p for p in PROVIDER_CATALOG}

--- a/tests/providers/test_registry.py
+++ b/tests/providers/test_registry.py
@@ -117,5 +117,5 @@ class TestCustomProviderRegistration:
         assert received.get("api_key") == "key-123"
 
     def test_builtin_count(self) -> None:
-        """Sanity check: we have exactly 11 built-in providers."""
-        assert len(_BUILTIN_PROVIDERS) == 12
+        """Sanity check: we have exactly 13 built-in providers."""
+        assert len(_BUILTIN_PROVIDERS) == 13

--- a/tests/unit/cli/test_init_ux.py
+++ b/tests/unit/cli/test_init_ux.py
@@ -241,7 +241,12 @@ def test_an_unusable_ollama_url_says_so_instead_of_blaming_the_daemon(
 def test_the_keyless_providers_get_setup_help_instead_of_a_key_prompt() -> None:
     """Ollama used to be registered like a hosted provider, so selecting it
     asked for an API key it does not have and bounced forever on Enter."""
-    assert set(provider_selection._LOCAL_PROVIDER_SETUP) == {"codex_cli", "opencode", "ollama"}
+    assert set(provider_selection._LOCAL_PROVIDER_SETUP) == {
+        "codex_cli",
+        "opencode",
+        "devin",
+        "ollama",
+    }
     for name, lines in provider_selection._LOCAL_PROVIDER_SETUP.items():
         rendered = "\n".join(lines()).lower()
         assert rendered.strip(), f"{name} has no setup help"

--- a/tests/unit/server/mcp/test_answer_synthesis_timeout.py
+++ b/tests/unit/server/mcp/test_answer_synthesis_timeout.py
@@ -137,6 +137,7 @@ def test_every_builtin_provider_has_a_deliberate_budget():
         "litellm": 120.0,
         "codex_cli": 180.0,
         "opencode": 180.0,
+        "devin": 180.0,
     }
     assert set(expected) == set(_BUILTIN_PROVIDERS), (
         "a provider was added or removed; decide its interactive budget here"

--- a/tests/unit/test_providers/test_devin_provider.py
+++ b/tests/unit/test_providers/test_devin_provider.py
@@ -1,0 +1,341 @@
+"""Unit tests for DevinProvider.
+
+All tests mock the devin subprocess; no real Devin CLI calls are made.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from repowise.core.providers.llm.base import GeneratedResponse, ProviderError
+from repowise.core.providers.llm.devin import (
+    DevinProvider,
+    _normalize_model,
+    _validate_model_name,
+)
+from repowise.core.providers.llm.registry import (
+    _BUILTIN_PROVIDERS,
+    get_provider,
+    list_providers,
+)
+
+
+class FakeProcess:
+    def __init__(
+        self,
+        *,
+        returncode: int = 0,
+        stdout: str = "",
+        stderr: str = "",
+        on_communicate: Any | None = None,
+        transport: Any | None = None,
+    ) -> None:
+        self.returncode = returncode
+        self._stdout = stdout
+        self._stderr = stderr
+        self._on_communicate = on_communicate
+        self._transport = transport
+        self.killed = False
+
+    async def communicate(self) -> tuple[bytes, bytes]:
+        if self._on_communicate is not None:
+            await self._on_communicate()
+        return self._stdout.encode("utf-8"), self._stderr.encode("utf-8")
+
+    def kill(self) -> None:
+        self.killed = True
+
+    async def wait(self) -> int:
+        return self.returncode
+
+
+class FakeTransport:
+    def __init__(self) -> None:
+        self.closed = False
+
+    def close(self) -> None:
+        self.closed = True
+
+
+# ---------------------------------------------------------------------------
+# Model name normalization / validation
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_model():
+    assert _normalize_model(None) is None
+    assert _normalize_model("") is None
+    assert _normalize_model("devin/adaptive") is None
+    assert _normalize_model("devin/opus") == "opus"
+    assert _normalize_model("opus") == "opus"
+
+
+def test_validate_model_name_accepts_valid_names():
+    for name in ["adaptive", "opus", "sonnet", "swe-1-6-fast", "gpt-5.5"]:
+        _validate_model_name(name)
+
+
+def test_validate_model_name_rejects_shell_metacharacters():
+    for name in ["bad; ls", "name$(whoami)", "name|cat", "`evil`"]:
+        with pytest.raises(ProviderError, match="Invalid model name"):
+            _validate_model_name(name)
+
+
+def test_validate_model_name_rejects_empty():
+    with pytest.raises(ProviderError, match="Invalid model name"):
+        _validate_model_name("")
+
+
+# ---------------------------------------------------------------------------
+# Provider metadata
+# ---------------------------------------------------------------------------
+
+
+def test_provider_name_and_default_model(monkeypatch, tmp_path):
+    monkeypatch.setattr("shutil.which", lambda _cmd: "devin")
+
+    provider = DevinProvider(repo_path=tmp_path)
+
+    assert provider.provider_name == "devin"
+    assert provider.model_name == "devin/adaptive"
+
+
+def test_custom_model_is_normalized(monkeypatch, tmp_path):
+    monkeypatch.setattr("shutil.which", lambda _cmd: "devin")
+
+    assert DevinProvider(model="devin/opus", repo_path=tmp_path).model_name == "devin/opus"
+    assert DevinProvider(model="devin/adaptive", repo_path=tmp_path).model_name == "devin/adaptive"
+    assert DevinProvider(model="opus", repo_path=tmp_path).model_name == "devin/opus"
+
+
+def test_invalid_model_name_raises(monkeypatch, tmp_path):
+    monkeypatch.setattr("shutil.which", lambda _cmd: "devin")
+
+    with pytest.raises(ProviderError, match="Invalid model name"):
+        DevinProvider(model="bad;name", repo_path=tmp_path)
+
+
+def test_missing_cli_raises(monkeypatch, tmp_path):
+    monkeypatch.setattr("shutil.which", lambda _cmd: None)
+
+    with pytest.raises(ProviderError, match="Devin CLI is not installed"):
+        DevinProvider(repo_path=tmp_path)
+
+
+def test_available_model_options(monkeypatch, tmp_path):
+    monkeypatch.setattr("shutil.which", lambda _cmd: "devin")
+
+    options = DevinProvider(repo_path=tmp_path).available_model_options()
+
+    models = [o.model for o in options]
+    assert models[0] == "devin/adaptive"
+    assert options[0].recommended is True
+    assert "devin/opus" in models
+    assert "devin/sonnet" in models
+    assert "devin/gpt" in models
+    assert "devin/swe" in models
+    assert "devin/codex" in models
+    assert "devin/gemini" in models
+
+
+def test_supported_reasoning_modes(monkeypatch, tmp_path):
+    monkeypatch.setattr("shutil.which", lambda _cmd: "devin")
+
+    assert DevinProvider(repo_path=tmp_path).supported_reasoning_modes() == ("auto",)
+
+
+# ---------------------------------------------------------------------------
+# Registry integration
+# ---------------------------------------------------------------------------
+
+
+def test_devin_is_registered_as_a_builtin_provider():
+    assert "devin" in _BUILTIN_PROVIDERS
+    assert "devin" in list_providers()
+    assert _BUILTIN_PROVIDERS["devin"] == (
+        "repowise.core.providers.llm.devin",
+        "DevinProvider",
+    )
+
+
+def test_get_provider_resolves_devin(monkeypatch, tmp_path):
+    monkeypatch.setattr("shutil.which", lambda _cmd: "devin")
+
+    provider = get_provider("devin", model="devin/opus", repo_path=tmp_path)
+
+    assert isinstance(provider, DevinProvider)
+    assert provider.provider_name == "devin"
+    assert provider.model_name == "devin/opus"
+
+
+# ---------------------------------------------------------------------------
+# Generation
+# ---------------------------------------------------------------------------
+
+
+async def test_generate_invokes_devin_with_prompt(monkeypatch, tmp_path):
+    devin_cmd = str(tmp_path / "bin" / "devin")
+    monkeypatch.setattr("shutil.which", lambda _cmd: devin_cmd)
+    captured: dict[str, Any] = {}
+    proc = FakeProcess(stdout="Hello from Devin")
+
+    async def fake_exec(*args: str, **kwargs: Any) -> FakeProcess:
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return proc
+
+    monkeypatch.setattr("asyncio.create_subprocess_exec", fake_exec)
+
+    provider = DevinProvider(model="devin/opus", repo_path=tmp_path)
+    result = await provider.generate("system rules", "user context")
+
+    assert isinstance(result, GeneratedResponse)
+    assert result.content == "Hello from Devin"
+    args = list(captured["args"])
+    assert args[0] == devin_cmd
+    assert args[1] == "-p"
+    assert "--permission-mode" in args
+    assert args[args.index("--permission-mode") + 1] == "normal"
+    assert "--respect-workspace-trust" in args
+    assert args[args.index("--model") + 1] == "opus"
+    # The combined prompt is the trailing positional arg.
+    combined = args[-1]
+    assert "system rules" in combined
+    assert "user context" in combined
+    assert captured["kwargs"]["cwd"] == str(tmp_path.resolve())
+
+
+async def test_generate_default_model_omits_model_flag(monkeypatch, tmp_path):
+    monkeypatch.setattr("shutil.which", lambda _cmd: "devin")
+    captured: dict[str, Any] = {}
+
+    async def fake_exec(*args: str, **kwargs: Any) -> FakeProcess:
+        captured["args"] = args
+        return FakeProcess(stdout="OK")
+
+    monkeypatch.setattr("asyncio.create_subprocess_exec", fake_exec)
+
+    await DevinProvider(repo_path=tmp_path).generate("sys", "user")
+
+    args = list(captured["args"])
+    assert "--model" not in args
+
+
+async def test_generate_marks_usage_as_estimated(monkeypatch, tmp_path):
+    monkeypatch.setattr("shutil.which", lambda _cmd: "devin")
+
+    async def fake_exec(*_args: str, **_kwargs: Any) -> FakeProcess:
+        return FakeProcess(stdout="OK")
+
+    monkeypatch.setattr("asyncio.create_subprocess_exec", fake_exec)
+
+    result = await DevinProvider(repo_path=tmp_path).generate("sys", "user")
+
+    assert result.content == "OK"
+    assert result.input_tokens == 0
+    assert result.output_tokens == 0
+    assert result.usage["source"] == "devin_p"
+    assert result.usage["estimated"] is True
+    assert result.usage["model"] == "devin/adaptive"
+
+
+async def test_generate_raises_on_nonzero_exit(monkeypatch, tmp_path):
+    monkeypatch.setattr("shutil.which", lambda _cmd: "devin")
+
+    async def fake_exec(*_args: str, **_kwargs: Any) -> FakeProcess:
+        return FakeProcess(returncode=1, stdout="", stderr="not authenticated")
+
+    monkeypatch.setattr("asyncio.create_subprocess_exec", fake_exec)
+
+    with pytest.raises(ProviderError, match="not authenticated"):
+        await DevinProvider(repo_path=tmp_path).generate("sys", "user")
+
+
+async def test_generate_raises_when_no_stdout(monkeypatch, tmp_path):
+    monkeypatch.setattr("shutil.which", lambda _cmd: "devin")
+
+    async def fake_exec(*_args: str, **_kwargs: Any) -> FakeProcess:
+        return FakeProcess(stdout="", stderr="")
+
+    monkeypatch.setattr("asyncio.create_subprocess_exec", fake_exec)
+
+    with pytest.raises(ProviderError, match="no output"):
+        await DevinProvider(repo_path=tmp_path).generate("sys", "user")
+
+
+async def test_generate_serializes_subprocess_calls(monkeypatch, tmp_path):
+    monkeypatch.setattr("shutil.which", lambda _cmd: "devin")
+    active = 0
+    max_active = 0
+
+    async def on_communicate() -> None:
+        nonlocal active, max_active
+        active += 1
+        max_active = max(max_active, active)
+        await asyncio.sleep(0.01)
+        active -= 1
+
+    async def fake_exec(*_args: str, **_kwargs: Any) -> FakeProcess:
+        return FakeProcess(stdout="OK", on_communicate=on_communicate)
+
+    monkeypatch.setattr("asyncio.create_subprocess_exec", fake_exec)
+    provider = DevinProvider(repo_path=tmp_path)
+
+    await asyncio.gather(
+        provider.generate("sys", "user 1"),
+        provider.generate("sys", "user 2"),
+    )
+
+    assert max_active == 1
+
+
+async def test_generate_times_out_and_kills_process(monkeypatch, tmp_path):
+    monkeypatch.setattr("shutil.which", lambda _cmd: "devin")
+    monkeypatch.setattr(
+        "repowise.core.providers.llm.devin._EXEC_TIMEOUT_SECONDS",
+        0.01,
+    )
+
+    async def on_communicate() -> None:
+        await asyncio.sleep(1)
+
+    proc = FakeProcess(stdout="", on_communicate=on_communicate)
+
+    async def fake_exec(*_a: str, **_k: Any) -> FakeProcess:
+        return proc
+
+    monkeypatch.setattr("asyncio.create_subprocess_exec", fake_exec)
+
+    with pytest.raises(ProviderError, match="timed out"):
+        await DevinProvider(repo_path=tmp_path).generate("sys", "user")
+
+    assert proc.killed
+
+
+async def test_generate_closes_subprocess_transport(monkeypatch, tmp_path):
+    monkeypatch.setattr("shutil.which", lambda _cmd: "devin")
+    transport = FakeTransport()
+
+    async def fake_exec(*_a: str, **_k: Any) -> FakeProcess:
+        return FakeProcess(stdout="OK", transport=transport)
+
+    monkeypatch.setattr("asyncio.create_subprocess_exec", fake_exec)
+
+    await DevinProvider(repo_path=tmp_path).generate("sys", "user")
+
+    assert transport.closed is True
+
+
+async def test_generate_handles_file_not_found(monkeypatch, tmp_path):
+    monkeypatch.setattr("shutil.which", lambda _cmd: "devin")
+
+    async def fake_exec(*_a: str, **_k: Any) -> FakeProcess:
+        raise FileNotFoundError("No such file")
+
+    monkeypatch.setattr("asyncio.create_subprocess_exec", fake_exec)
+
+    with pytest.raises(ProviderError, match=r"cli\.devin\.ai"):
+        await DevinProvider(repo_path=tmp_path).generate("sys", "user")

--- a/tests/unit/test_providers/test_provider_env_registry.py
+++ b/tests/unit/test_providers/test_provider_env_registry.py
@@ -143,6 +143,7 @@ def test_required_envs_is_the_endpoint_for_ollama():
 def test_required_envs_is_empty_for_the_agent_clis():
     assert provider_required_envs("codex_cli") == ()
     assert provider_required_envs("opencode") == ()
+    assert provider_required_envs("devin") == ()
 
 
 # --- provider_is_usable vs provider_credentials_present --------------------
@@ -153,6 +154,8 @@ def test_keyless_provider_is_usable_with_an_empty_environment():
     empty = {}.get
     assert provider_is_usable("codex_cli", empty) is True
     assert provider_credentials_present("codex_cli", empty) is False
+    assert provider_is_usable("devin", empty) is True
+    assert provider_credentials_present("devin", empty) is False
 
 
 def test_keyed_provider_needs_its_key_to_be_usable():
@@ -212,7 +215,7 @@ def test_litellm_prefers_base_url_over_api_base():
 
 def test_agent_cli_providers_are_told_which_repo_to_run_in():
     """#1119: without this the CLI runs against the host process cwd."""
-    for name in ("codex_cli", "opencode"):
+    for name in ("codex_cli", "opencode", "devin"):
         kwargs = provider_kwargs(name, repo_path="/repo", getenv={}.get)
         assert kwargs["repo_path"] == "/repo"
 


### PR DESCRIPTION
Closes #1761

Adds the Devin CLI as an LLM/agent provider, mirroring the existing `opencode` / `codex_cli` local-CLI provider pattern.

## What's added

- **`repowise.core.providers.llm.devin`** — a new `DevinProvider` that shells out to the local Devin CLI via `devin -p` (single-turn, non-interactive mode). No API key is managed by repowise: Devin authenticates out-of-band via `devin auth login`.
  - Runs with `cwd` pinned to the target repo, `--permission-mode normal` (read-only auto-approve, prompts on write/execute), and `--respect-workspace-trust false` (the non-interactive `-p` mode cannot show the workspace-trust prompt).
  - Model selection via `devin/adaptive` (default, the Adaptive router), `devin/opus`, `devin/sonnet`, `devin/gpt`, `devin/swe`, `devin/codex`, `devin/gemini`.
  - Validates model names against a safe character set, serializes subprocess calls, times out after 600s, and closes the asyncio subprocess transport.
- **Registry wiring** — registered as a built-in, keyless, repo-path provider; skipped by the rate limiter; added to the ImportError mapping and the `__init__.py` docstring.
- **CLI picker** — added to `_PROVIDER_DEFAULTS`, `_PROVIDER_ENV`, `_PROVIDER_SIGNUP`, `_PROVIDER_NOTES`, readiness detection, and install/setup help lines.
- **Server catalog** — added a `devin` entry to `PROVIDER_CATALOG`.
- **Cost** — `devin/*` treated as local/free in `cost_estimator/pricing.py` and `generation/cost_tracker.py`.
- **Tests** — `test_devin_provider.py` (unit tests incl. registry registration + resolution), plus updates to the registry/env drift tests and the keyless-provider picker test.

## Assumptions

- Uses the documented `devin -p "prompt"` single-turn print mode (docs.devin.ai/cli). Devin's CLI output is plain text with no structured token accounting, so usage is marked `estimated` and the local model is priced at `$0`.
- Model list is the documented model-family aliases; there is no stable machine-readable `models list` subcommand to discover available models, so the built-in list is static.
- `DEVIN_BEARER_TOKEN` / `DEVIN_API_TOKEN` env vars are not required — Devin CLI authenticates via its own stored credentials (`devin auth login`), matching the keyless design of `opencode`/`codex_cli`.

## Quality

- `ruff` clean on all touched files.
- Targeted test suites pass (296 provider tests + init UX, cost estimator, generation, server provider config).
