### PR TITLE
fix(generation): give e2e spec files a wiki page

### DIFF
--- a/packages/core/src/repowise/core/ingestion/traverser.py
+++ b/packages/core/src/repowise/core/ingestion/traverser.py
@@ -223,10 +223,20 @@ _BLOCKED_DIRS: frozenset[str] = frozenset(
         # is_test_related_path() so downstream consumers can filter them
         # when appropriate.
         #
+        # e2e/ used to sit here because Playwright/Cypress rigs were
+        # treated as browser-driven test scaffolding whose content rarely
+        # answers code questions. But end-to-end specs are exactly where a
+        # codebase's hard-won conventions live -- the hydration gate every
+        # console e2e test depends on, the fixtures everyone must use -- and
+        # silently dropping them left the wiki unable to answer any
+        # test-infrastructure question with no signal a whole area was
+        # missing. e2e files are now indexed like other tests and tagged
+        # is_test=True via is_test_related_path(), so they get a file_page
+        # and stay filterable when a consumer wants to exclude them.
+        #
         # The following ARE still blocked because they typically hold
-        # binary fixtures, generated artifacts, or browser-driven test
-        # rigs whose content rarely answers code questions:
-        "e2e",
+        # binary fixtures, generated artifacts, or scaffolding whose content
+        # rarely answers code questions:
         "fixtures",
         "conftest",
     }

--- a/tests/unit/ingestion/test_traverser.py
+++ b/tests/unit/ingestion/test_traverser.py
@@ -154,6 +154,35 @@ class TestFileTraverser:
         assert not any(p.startswith("Library/") for p in paths)
         assert not any(p.startswith("Temp/") for p in paths)
 
+    def test_traverses_e2e_specs(self, tmp_path: Path) -> None:
+        """e2e spec files are indexed so they can get a file_page (#1497).
+
+        They used to be silently dropped via ``_BLOCKED_DIRS``, which left
+        the wiki unable to answer any test-infrastructure question with no
+        signal a whole area was missing. They are now indexed like other
+        tests and tagged ``is_test=True`` so they stay filterable.
+        """
+        (tmp_path / "apps" / "console" / "e2e" / "helpers").mkdir(parents=True)
+        (tmp_path / "apps" / "console" / "e2e" / "helpers" / "hydration.ts").write_text(
+            "export function hydrate() {}\n"
+        )
+        (tmp_path / "apps" / "console" / "e2e" / "fixtures.ts").write_text(
+            "export const fixtures = {};\n"
+        )
+        (tmp_path / "apps" / "console" / "e2e" / "login.spec.ts").write_text(
+            "it('works', () => {});\n"
+        )
+
+        traverser = FileTraverser(tmp_path)
+        infos = {f.path: f for f in traverser.traverse()}
+
+        assert "apps/console/e2e/helpers/hydration.ts" in infos
+        assert "apps/console/e2e/fixtures.ts" in infos
+        assert "apps/console/e2e/login.spec.ts" in infos
+        # Tagged as test material so consumers (skip_tests, scoring) can
+        # filter them without dropping them silently.
+        assert all(info.is_test for info in infos.values())
+
     def test_skips_unity_asset_extensions_before_binary_detection(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
## What

End-to-end test spec files (`apps/*/e2e/**`, `*.spec.ts` under an `e2e/` tree, etc.) are **silently dropped from ingestion entirely**, so they never get a `file_page`. Because `get_answer` searches wiki pages, any question about test infrastructure comes back as five confident, unrelated files — with no signal a whole area is missing.

## Root cause

The `e2e` directory is in `_BLOCKED_DIRS` in `packages/core/src/repowise/core/ingestion/traverser.py`. It was grouped with `fixtures/` and `conftest/` as "browser-driven test rigs whose content rarely answers code questions", but unlike those it silently excludes **every file** under an `e2e/` directory before parsing — before a `file_page` could ever be selected. This is why the init summary reported only `2 by .gitignore, 1 by filename pattern, 18 oversized, 11 binary, 4 generated, 79 unknown type` as exclusions: the `e2e/` drop happened in the walker's blocklist, which the summary doesn't count.

## Fix

Remove `e2e` from `_BLOCKED_DIRS` so e2e specs are traversed and parsed like any other test file. They are stamped `is_test=True` via `is_test_related_path()` (the `e2e` token was already in `_TEST_DIR_TOKENS`), so:

- they get a `file_page` and are retrievable by `get_answer`, and
- every existing downstream filter (`skip_tests`, scoring's test penalty, test-dilution handling) still works exactly as before.

This matches how `tests/`, `spec/` and `__tests__/` are already treated — the traverser comment already documented that those directories are indexed and tagged `is_test=True`.

## Tests

- Added `test_traverses_e2e_specs` to `tests/unit/ingestion/test_traverser.py`: an `apps/console/e2e/**` tree is traversed and every file is tagged `is_test=True`.
- `uv run ruff check .` — all checks passed.
- `uv run pytest tests/unit/ingestion/ tests/unit/generation/ tests/unit/test_test_paths.py tests/unit/test_no_test_path_copies.py -q` — all pass (one unrelated pre-existing git-rebase sandbox failure excluded).

## Notes

The issue offered two acceptable resolutions: surface the skip (`--include-tests` flag / overview note) or just give e2e specs a page. Since these files are small, high-signal, and already meant to be indexed as tests (the `#`-comment above `_BLOCKED_DIRS` explicitly says test dirs are not blocked and are tagged `is_test=True`), making them actually indexed is the cleaner fix — no flag needed, and nothing is silently hidden.
