### PR TITLE
feat(kg): say how many files the map is not showing

### DIFF
--- a/packages/server/src/repowise/server/routers/c4.py
+++ b/packages/server/src/repowise/server/routers/c4.py
@@ -275,6 +275,7 @@ def _zoom_response(zoom: ZoomMap) -> ZoomMapResponse:
         root_id=zoom.root_id,
         project_name=zoom.project_name,
         total_files=zoom.total_files,
+        unclaimed_files=zoom.unclaimed_files,
         max_depth=zoom.max_depth,
         truncated=zoom.truncated,
         nodes=[

--- a/packages/server/src/repowise/server/schemas/zoom.py
+++ b/packages/server/src/repowise/server/schemas/zoom.py
@@ -61,6 +61,10 @@ class ZoomMapResponse(BaseModel):
     root_id: str
     project_name: str
     total_files: int
+    # Files in the repository view that curation put in no layer, so they are on
+    # no tree. Additive and defaulted: an older consumer reading ``total_files``
+    # gets the same number it always did.
+    unclaimed_files: int = 0
     max_depth: int
     truncated: bool = False
     nodes: list[ZoomNodeResponse]

--- a/packages/server/src/repowise/server/services/zoom_builder/__init__.py
+++ b/packages/server/src/repowise/server/services/zoom_builder/__init__.py
@@ -155,6 +155,8 @@ def assemble_zoom_map(
     # about but that curation assigned to no layer is not in the tree, so
     # counting file_stats would over-report). Taken before depth/focus pruning.
     total_files = sum(1 for n in nodes.values() if n.kind == "file")
+    # ...and the rest of that denominator, so the map can say how much it omits.
+    unclaimed_files = max(len(file_stats) - total_files, 0)
 
     root_id, nodes, relations, truncated = _prune(
         root_id, nodes, relations, max_depth=max_depth, focus=focus
@@ -169,6 +171,7 @@ def assemble_zoom_map(
         total_files=total_files,
         max_depth=present_depth,
         truncated=truncated,
+        unclaimed_files=unclaimed_files,
     )
 
 

--- a/packages/server/src/repowise/server/services/zoom_builder/models.py
+++ b/packages/server/src/repowise/server/services/zoom_builder/models.py
@@ -97,3 +97,7 @@ class ZoomMap:
     total_files: int
     max_depth: int                # deepest level present in this (possibly pruned) map
     truncated: bool = False       # True when depth/focus pruning dropped deeper nodes
+    # Files the view knows about that curation assigned to no layer, so they are
+    # in no tree at all. ``total_files`` stays the count actually placed; this is
+    # the rest of the denominator, so a map can say what it is not showing.
+    unclaimed_files: int = 0

--- a/packages/ui/src/zoom/types.ts
+++ b/packages/ui/src/zoom/types.ts
@@ -64,6 +64,9 @@ export interface ZoomMap {
   root_id: string;
   project_name: string;
   total_files: number;
+  /** Files curation placed in no layer, so they are on no tree. Optional: an
+   *  older server does not send it. */
+  unclaimed_files?: number;
   max_depth: number;
   truncated: boolean;
   nodes: ZoomNode[];

--- a/packages/web/src/app/repos/[id]/knowledge-graph/page.tsx
+++ b/packages/web/src/app/repos/[id]/knowledge-graph/page.tsx
@@ -166,6 +166,8 @@ export default function KnowledgeGraphPage({ params }: { params: Promise<{ id: s
 
           <ZoomMapKey
             verbs={verbs}
+            totalFiles={zoomMap.total_files}
+            unclaimedFiles={zoomMap.unclaimed_files ?? 0}
             selected={relationVerbs}
             onSelectedChange={setRelationVerbs}
           />

--- a/packages/web/src/components/zoom/zoom-map-key.tsx
+++ b/packages/web/src/components/zoom/zoom-map-key.tsx
@@ -35,6 +35,11 @@ import { HEALTH_BAND_LABEL } from "@repowise-dev/types/health";
 interface ZoomMapKeyProps {
   /** Every verb present in the loaded map, descending by count. */
   verbs: VerbCount[];
+  /** Files placed in the tree, and files curation left in no layer. The second
+   *  is the map's missing denominator: without it, a map short one file in
+   *  seven reads as complete. */
+  totalFiles: number;
+  unclaimedFiles: number;
   /** Null = every relation draws; otherwise only these verbs do. */
   selected: ReadonlySet<string> | null;
   onSelectedChange: (verbs: ReadonlySet<string> | null) => void;
@@ -44,7 +49,13 @@ function Dot({ className }: { className: string }) {
   return <span aria-hidden className={`inline-block h-2 w-2 shrink-0 rounded-full ${className}`} />;
 }
 
-export function ZoomMapKey({ verbs, selected, onSelectedChange }: ZoomMapKeyProps) {
+export function ZoomMapKey({
+  verbs,
+  totalFiles,
+  unclaimedFiles,
+  selected,
+  onSelectedChange,
+}: ZoomMapKeyProps) {
   const filtered = selected !== null;
 
   return (
@@ -63,6 +74,15 @@ export function ZoomMapKey({ verbs, selected, onSelectedChange }: ZoomMapKeyProp
             <>
               Hover a card to see what it depends on. Arrow weight is how many file pairs the
               dependency covers.
+            </>
+          )}
+          {unclaimedFiles > 0 && (
+            /* Silence when nothing is missing: "0 not shown" is noise. */
+            <>
+              {" "}
+              {unclaimedFiles.toLocaleString()} of{" "}
+              {(totalFiles + unclaimedFiles).toLocaleString()} files are not on the map; they
+              belong to no layer.
             </>
           )}
         </p>

--- a/tests/unit/server/services/test_zoom_builder.py
+++ b/tests/unit/server/services/test_zoom_builder.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
+
 from repowise.server.services.c4_builder.models import (
     ArchEdge,
     ArchitectureView,
@@ -537,6 +539,23 @@ def test_assemble_zoom_map_full():
     main = zoom.nodes[file_id("pkg/main.py")]
     assert main.is_entry_point and main.sibling_rank == 1
     assert not zoom.truncated
+    # every file the view knows about landed in a layer, so nothing is hidden
+    assert zoom.unclaimed_files == 0
+
+
+def test_assemble_zoom_map_counts_files_no_layer_claimed():
+    # A file the view knows about but that curation assigned to no layer is on
+    # no tree at all, so total_files cannot see it. Report it separately rather
+    # than letting an incomplete map read as complete.
+    view = _view()
+    orphan = _node("pkg/core/orphan.py", pagerank_percentile=5.0)
+    view = replace(view, nodes=[*view.nodes, orphan], total_files=4)
+
+    zoom = assemble_zoom_map(view)
+
+    assert zoom.total_files == 3
+    assert zoom.unclaimed_files == 1
+    assert file_id("pkg/core/orphan.py") not in zoom.nodes
 
 
 def test_assemble_zoom_map_health_rolls_up():


### PR DESCRIPTION
`assemble_zoom_map` counts `total_files` as the files actually placed in the tree. That is the honest numerator, deliberately: a file that curation assigned to no layer is absent from the tree entirely, so counting `file_stats` would over-report. The problem is that the denominator was never shown, so a map missing one file in seven read as complete.

Measured on real single-repo indexes (files in tree / files in view):

| repo | in tree | in view | unclaimed |
|---|---|---|---|
| Ocelot | 876 | 1,018 | 142 (13.9%) |
| repowise | 3,655 | 3,776 | 121 (3.2%) |
| flask | 130 | 131 | 1 |
| celery | 470 | 471 | 1 |
| aider | 358 | 358 | 0 |

Ocelot is the case that justifies the work.

## The number

`unclaimed_files` is a subtraction against `file_stats`, which the assembler already has, not a new query. It is additive and defaulted at every rung, and `total_files` keeps its meaning exactly, so a consumer reading it today gets the same number tomorrow. That matters because hosted mirrors this schema in `backend/app/models/schemas/zoom.py` and calls OSS `assemble_zoom_map` directly; additive leaves it working untouched.

Four rungs: the `ZoomMap` dataclass, the response schema, the router serialization, and the TS mirror in `packages/ui/src/zoom/types.ts` (optional there, since an older server does not send it).

## The surface

The web KG page never rendered `total_files` at all — it was on the wire and unused. So this adds a surface, not just a number. It goes in the map key row under the canvas, which already carries the "what the marks mean" copy, as one line of text. No new chrome.

Nothing renders when nothing is missing: a fully-claimed tree says nothing rather than printing "0 hidden".

## Testing

New: a tree where one file is in no curated layer reports it, and the existing full-assembly test now asserts zero on a tree where every file landed.

Gates: `ruff check .`; 118 tests across `tests/unit/server/services`, `test_c4.py`, `test_architecture_api.py`; 90 tests in `packages/ui __tests__/zoom`; ui + web type-check, web lint, web build.

The measured numbers above come from separate single-repo stores under `test-repos/*/.repowise/wiki.db`, opened on a copy, never the root dev index.
