### PR TITLE
fix(mcp): one confidence floor for the calls-to-files rollup

### DIFF
--- a/packages/server/src/repowise/server/mcp_server/tool_context/enrichment.py
+++ b/packages/server/src/repowise/server/mcp_server/tool_context/enrichment.py
@@ -38,10 +38,17 @@ from repowise.core.persistence.models import (
     HealthFinding,
     Repository,
 )
+from repowise.server.mcp_server._graph_files import keep_projected_edge, node_to_file
 from repowise.server.mcp_server._helpers import filter_dicts_by_key, filter_path_list
 from repowise.server.schemas.intelligence import SYMBOL_RELATION_GROUP_OF
 
-# Minimum confidence for call edges to filter false positives
+# Minimum confidence for call edges to filter false positives.
+#
+# Symbol-level only. The file-level rollup below defers to the shared
+# ``_graph_files`` floor (0.5) that every other file-pair surface uses; this
+# one stays at 0.7 because the two sites that read it -- the totals query and
+# the symbol rows -- have to be cut by the same rule as each other, and that
+# rule is documented at ``_count_neighbors_by_edge_type``.
 _MIN_CALL_CONFIDENCE = 0.7
 
 # Every edge type meaning "something reaches this symbol". Sorted so the
@@ -411,12 +418,18 @@ async def _resolve_file_level_callers(
                 GraphEdge.edge_type == "calls",
             )
         )
+        # One rule for every calls-projected-onto-files surface. This rollup
+        # used to hand-roll a 0.7 floor and the self-loop drop and had no
+        # cross-extension guard at all, so the same edge was kept by the zoom
+        # map and dropped here (1,436 of 45,755 reliable execution edges, 3.1%,
+        # across 8 indexed repos; 24.8% on eShopOnWeb). The shared helper
+        # replaces all three checks. Its same-extension guard does drop genuine
+        # cross-language calls -- that is the known ceiling on the shared
+        # helper, not debt introduced here.
         for src_id, confidence in edge_res.all():
-            if (confidence or 0) < _MIN_CALL_CONFIDENCE:
+            src_file = node_to_file(src_id)
+            if not keep_projected_edge(src_file, target_file, "calls", confidence):
                 continue
-            src_file = src_id.split("::")[0] if "::" in src_id else src_id
-            if src_file == target_file:
-                continue  # intra-file calls are not "callers" of the file
             calls_by_file[src_file] = calls_by_file.get(src_file, 0) + 1
 
     entries: list[dict[str, Any]] = []

--- a/tests/unit/server/mcp/test_context_call_floor.py
+++ b/tests/unit/server/mcp/test_context_call_floor.py
@@ -1,0 +1,134 @@
+"""The file-level caller rollup cuts calls edges by the shared rule.
+
+``tool_context/enrichment.py`` kept a private calls-to-files rollup with its own
+0.7 floor while every other file-pair surface (the zoom map, ``_flow_path``)
+uses the 0.5 floor in ``_graph_files``. The same call edge was therefore kept by
+one surface and dropped by another: 1,436 of 45,755 reliable execution edges
+(3.1%) across 8 indexed repos, 24.8% of them on eShopOnWeb. The rollup also had
+no cross-extension guard, so a projection could stitch two languages together.
+
+The two symbol-level sites keep the 0.7 floor deliberately. The totals query and
+the displayed rows have to be cut by the same rule as each other, because two
+symbols can be joined by more than one edge and a mismatched total re-arms a
+previous truncation bug. The last test here is that invariant.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from repowise.core.persistence.models import GraphEdge, GraphNode
+
+_NOW = datetime(2026, 3, 19, 12, 0, 0, tzinfo=UTC)
+_TARGET = "src/auth/service.py"
+_TARGET_SYM = "src/auth/service.py::login"
+
+_WEAK = "src/reports/exporter.py"        # 0.6: over the shared floor, under 0.7
+_CROSS_LANG = "web/dashboard.ts"         # 0.95 but a different extension
+_NOISE = "src/legacy/old_auth.py"        # 0.4: under every floor
+_STRONG = "src/db/models.py"             # 0.95, same extension
+
+
+def _sym(node_id: str, sid: str) -> GraphNode:
+    file_path, name = node_id.split("::", 1)
+    return GraphNode(
+        id=sid,
+        repository_id=None,  # set by the caller
+        node_id=node_id,
+        node_type="symbol",
+        name=name,
+        file_path=file_path,
+        kind="function",
+        start_line=10,
+        end_line=20,
+        created_at=_NOW,
+    )
+
+
+async def _seed(session, repo_id: str) -> None:
+    """One symbol in the target file, called from four different places."""
+    callers = {
+        _WEAK: 0.6,
+        _CROSS_LANG: 0.95,
+        _NOISE: 0.4,
+        _STRONG: 0.95,
+        _TARGET: 0.95,  # intra-file: a self-loop once projected onto files
+    }
+    rows: list[object] = []
+    target = _sym(_TARGET_SYM, "cf_target")
+    target.repository_id = repo_id
+    rows.append(target)
+    for i, (path, confidence) in enumerate(callers.items()):
+        caller = _sym(f"{path}::caller_{i}", f"cf_src_{i}")
+        caller.repository_id = repo_id
+        rows.append(caller)
+        rows.append(
+            GraphEdge(
+                id=f"cf_edge_{i}",
+                repository_id=repo_id,
+                source_node_id=caller.node_id,
+                target_node_id=_TARGET_SYM,
+                edge_type="calls",
+                confidence=confidence,
+                created_at=_NOW,
+            )
+        )
+    session.add_all(rows)
+    await session.flush()
+
+
+@pytest.mark.asyncio
+async def test_file_rollup_keeps_edges_above_the_shared_floor(setup_mcp, session):
+    """A 0.6 call edge is a caller here, as it already is on every other surface."""
+    from repowise.server.mcp_server import get_context
+
+    await _seed(session, setup_mcp)
+
+    t = (await get_context([_TARGET], include=["callers"], compact=False))["targets"][_TARGET]
+    by_file = {c["file"]: c for c in t["callers"]}
+
+    assert by_file[_WEAK]["inbound_calls"] == 1
+    assert by_file[_STRONG]["inbound_calls"] == 1
+
+
+@pytest.mark.asyncio
+async def test_file_rollup_drops_noise_self_loops_and_cross_language(setup_mcp, session):
+    """The other two guards the shared helper brings, and the one it already had."""
+    from repowise.server.mcp_server import get_context
+
+    await _seed(session, setup_mcp)
+
+    t = (await get_context([_TARGET], include=["callers"], compact=False))["targets"][_TARGET]
+    calls_by_file = {c["file"] for c in t["callers"] if c.get("inbound_calls")}
+
+    assert _CROSS_LANG not in calls_by_file, "a .ts caller of a .py symbol is a coincidence"
+    assert _NOISE not in calls_by_file, "0.4 is under the shared floor too"
+    assert _TARGET not in calls_by_file, "an intra-file call is not a caller of the file"
+
+
+@pytest.mark.asyncio
+async def test_symbol_level_floor_and_totals_are_unchanged(setup_mcp, session):
+    """INVARIANT: the symbol rows and the symbol totals still cut at 0.7 together.
+
+    If either site drifted, the total and the row count would disagree and
+    `callers_truncated` would appear (or wrongly stay absent) on a set that is
+    in fact complete.
+    """
+    from repowise.server.mcp_server import get_context
+
+    await _seed(session, setup_mcp)
+
+    t = (await get_context([_TARGET_SYM], include=["callers"], compact=False))["targets"][
+        _TARGET_SYM
+    ]
+    files = {c["file"] for c in t["callers"]}
+
+    # Only the three edges at >= 0.7 survive; the self-loop is a caller at the
+    # symbol layer, where it is a real recursive relation.
+    assert files == {_CROSS_LANG, _STRONG, _TARGET}
+    assert _WEAK not in files, "the symbol layer must still cut at 0.7"
+    # Total == rows, so nothing reports as truncated.
+    assert "callers_total" not in t
+    assert not t.get("callers_truncated")


### PR DESCRIPTION
`tool_context/enrichment.py` kept a private calls-to-files rollup with its own floor, `_MIN_CALL_CONFIDENCE = 0.7`, where every other file-pair surface uses the shared 0.5 in `_graph_files`. So the same call edge was kept by one surface and dropped by another.

Quantified across 8 indexed repos: 1,436 of 45,755 reliable execution edges (3.1%) are kept by the zoom map and `_flow_path` and dropped by enrichment.

| repo | share dropped |
|---|---|
| eShopOnWeb | 24.8% |
| gin-vue-admin | 6.0% |
| jhipster | 5.2% |
| Ocelot | 4.7% |
| celery | 4.0% |
| flask | 2.9% |
| PowerToys | 2.2% |
| aider | 0.0% |

## Only one of the three sites changes

`_MIN_CALL_CONFIDENCE` is read at three places, and two of them are bound by an invariant the code already documents:

- `_count_neighbors_by_edge_type` — the totals query, counting distinct symbols
- `_resolve_call_graph` — the symbol-level rows
- `_resolve_file_level_callers` — the file-level rollup, **the only one this touches**

The comment above the totals query spells out why the first two must be cut by the same rule as each other: two symbols can be joined by more than one edge, so mismatching them makes the total exceed what the rows can ever show, and that re-arms a truncation bug that already landed once. Those two stay at 0.7 and stay identical. The constant's comment now records that they are a coupled pair, so the next reader does not have to rediscover it.

## What the shared helper brings

`keep_projected_edge(src_file, tgt_file, edge_type, confidence)` applies all three guards at once: the 0.5 floor, the self-loop drop, and the same-extension guard. The rollup hand-rolled the first two and had no cross-extension guard at all, so the helper replaces that code and closes the third gap in the same move.

Worth naming: **the same-extension guard drops genuine cross-language calls.** That is the known ceiling on the shared helper, not new debt introduced here. It is also the one way this change removes a row rather than adding one.

This makes enrichment the third caller of `_graph_files`, after `_flow_path.py` and `_answer_pipeline.py`, rather than a fourth private copy — which is the whole point.

## Testing

Three new tests in `tests/unit/server/mcp/test_context_call_floor.py`:

1. an edge at confidence 0.6 now appears in the file-level callers;
2. a cross-extension pair is dropped where it was not, alongside the sub-0.5 noise and the intra-file self-loop;
3. **the invariant** — the symbol rows and symbol totals still cut at 0.7 together, the 0.6 caller is still absent there, and nothing reports as truncated.

Checked against `main` before committing: tests 1 and 2 fail on baseline and test 3 passes on both sides, so the change is what makes them pass and it demonstrably does not move the symbol layer.

Gates: `ruff check .`; 1,383 tests in `tests/unit/server/mcp`; 117 in `tests/unit/server/services` + `test_c4.py` + `test_architecture_api.py`. The diff is Python-only, so the JS gates are byte-identical to main.
