### PR TITLE
fix(risk): normalize the git_metadata target path in get_risk

### DIFF
--- a/packages/server/src/repowise/server/mcp_server/tool_risk/assessment.py
+++ b/packages/server/src/repowise/server/mcp_server/tool_risk/assessment.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import contextlib
 import json
 from datetime import UTC, datetime
+from pathlib import Path
 from typing import Any
 
 from sqlalchemy import select, text
@@ -34,6 +35,37 @@ _TOP_FIX_SYMBOLS = 3
 # Relationship rows are deliberately bounded independently.  Their totals are
 # computed after repository exclusions and before this presentation cap.
 _RELATIONSHIP_LIMIT = 5
+
+
+def normalize_target_path(target: str, repo_root: str | None = None) -> str:
+    """Normalize a caller-supplied file path to the POSIX-relative form stored
+    in ``git_metadata.file_path``.
+
+    ``get_risk`` matches ``file_path`` by exact string equality, but callers
+    reach it through git tools, shell completion, or editors that hand over a
+    backslash form (Windows), a leading ``./``, an absolute path, or a trailing
+    separator. Any of those makes the row lookup miss, and ``_assess_one_target``
+    then reports the indistinguishable ``no git metadata available`` card
+    (hotspot_score=0, primary_owner=None, empty co_change_partners) even though
+    the row exists — issue #1279. Normalizing the caller's side closes that gap.
+    """
+    normalized = target.replace("\\", "/")
+    # Make a repo-absolute path (``/abs/repo/src/x.py``) relative to the repo
+    # root when we know it. Uses a prefix check on the normalized forms, so a
+    # path that is already repo-relative is left untouched.
+    if repo_root:
+        root_norm = str(Path(repo_root).resolve()).replace("\\", "/")
+        try:
+            resolved = Path(normalized).resolve()
+            if str(resolved).startswith(root_norm.rstrip("/") + "/"):
+                normalized = str(resolved).replace("\\", "/")[len(root_norm.rstrip("/")) + 1 :]
+        except OSError:
+            pass
+    # Strip a leading cwd-relative prefix and any leading slash left over.
+    normalized = normalized.lstrip("/").lstrip(".")
+    # Collapse duplicate slashes and any trailing separator.
+    parts = [p for p in normalized.split("/") if p]
+    return "/".join(parts)
 
 
 def _derive_change_pattern(categories: dict[str, int]) -> str:
@@ -559,11 +591,22 @@ async def _assess_one_target(
         preserve_counts=True,
     )
 
+    # Callers reach get_risk with the file path in many forms — backslashes
+    # (Windows), a leading ``./``, a trailing separator, or a repo-absolute
+    # path — while git_metadata.file_path (and the graph node/edge ids) are
+    # stored POSIX-relative. Exact-string equality against the raw target made
+    # a row that exists look absent, and _assess_one_target then reported the
+    # indistinguishable "no git metadata available" card (hotspot_score=0,
+    # primary_owner=None, empty co_change_partners) — issue #1279. Normalize
+    # once and key every file-path lookup on it, but keep the response keyed by
+    # what the caller asked for.
+    lookup_path = normalize_target_path(target, repo_root=repository.local_path)
+
     # Git metadata
     res = await session.execute(
         select(GitMetadata).where(
             GitMetadata.repository_id == repo_id,
-            GitMetadata.file_path == target,
+            GitMetadata.file_path == lookup_path,
         )
     )
     meta = res.scalar_one_or_none()
@@ -584,15 +627,15 @@ async def _assess_one_target(
         result_data["owner_pct"] = None
         result_data["trend"] = "unknown"
         result_data["risk_type"] = "high-coupling" if dep_count >= 5 else "unknown"
-        result_data["test_gap"] = await _check_test_gap(session, repo_id, target)
-        result_data["security_signals"] = await _get_security_signals(session, repo_id, target)
+        result_data["test_gap"] = await _check_test_gap(session, repo_id, lookup_path)
+        result_data["security_signals"] = await _get_security_signals(session, repo_id, lookup_path)
         result_data["risk_summary"] = f"{target} — no git metadata available"
         return result_data
 
     hotspot_score = meta.churn_percentile or 0.0
 
     co_change_population, co_changes_total = _build_co_changes(
-        meta, import_links.get(target, {}), exclude_spec
+        meta, import_links.get(lookup_path, {}), exclude_spec
     )
     co_changes = co_change_population[:_RELATIONSHIP_LIMIT]
 
@@ -663,8 +706,8 @@ async def _assess_one_target(
         result_data["defect_profile"] = defect_profile
 
     # C. Test gaps + security signals
-    result_data["test_gap"] = await _check_test_gap(session, repo_id, target)
-    result_data["security_signals"] = await _get_security_signals(session, repo_id, target)
+    result_data["test_gap"] = await _check_test_gap(session, repo_id, lookup_path)
+    result_data["security_signals"] = await _get_security_signals(session, repo_id, lookup_path)
 
     capped = getattr(meta, "commit_count_capped", False)
     capped_note = " (history truncated — actual count may be higher)" if capped else ""

--- a/packages/server/src/repowise/server/mcp_server/tool_risk/assessment.py
+++ b/packages/server/src/repowise/server/mcp_server/tool_risk/assessment.py
@@ -56,13 +56,21 @@ def normalize_target_path(target: str, repo_root: str | None = None) -> str:
     if repo_root:
         root_norm = str(Path(repo_root).resolve()).replace("\\", "/")
         try:
-            resolved = Path(normalized).resolve()
+            # Resolve against the repo root, not the process cwd: the MCP
+            # server's cwd is not the repo, so a relative path that happens
+            # to exist there could resolve somewhere unrelated.
+            resolved = Path(repo_root, normalized).resolve()
             if str(resolved).startswith(root_norm.rstrip("/") + "/"):
                 normalized = str(resolved).replace("\\", "/")[len(root_norm.rstrip("/")) + 1 :]
-        except OSError:
+        except (OSError, ValueError):
+            # resolve() can raise ValueError on a malformed Windows path.
             pass
     # Strip a leading cwd-relative prefix and any leading slash left over.
-    normalized = normalized.lstrip("/").lstrip(".")
+    # A prefix strip, not lstrip: lstrip takes a character set, so it would
+    # eat every leading dot (``.github/...`` -> ``github/...``).
+    if normalized.startswith("./"):
+        normalized = normalized[2:]
+    normalized = normalized.lstrip("/")
     # Collapse duplicate slashes and any trailing separator.
     parts = [p for p in normalized.split("/") if p]
     return "/".join(parts)

--- a/tests/unit/server/mcp/test_risk.py
+++ b/tests/unit/server/mcp/test_risk.py
@@ -124,6 +124,9 @@ async def test_get_risk_no_git_metadata(setup_mcp):
         ("./src/auth/service.py", None, "src/auth/service.py"),
         ("src/auth/service.py/", None, "src/auth/service.py"),
         ("src//auth//service.py", None, "src/auth/service.py"),
+        (".github/workflows/ci.yml", None, ".github/workflows/ci.yml"),
+        ("./.github/workflows/ci.yml", None, ".github/workflows/ci.yml"),
+        (".claude/TRIAGE.md", None, ".claude/TRIAGE.md"),
         ("/tmp/test-repo/src/auth/service.py", "/tmp/test-repo", "src/auth/service.py"),
     ],
 )

--- a/tests/unit/server/mcp/test_risk.py
+++ b/tests/unit/server/mcp/test_risk.py
@@ -66,6 +66,43 @@ async def test_get_risk_global_hotspots_exclude_targets(setup_mcp):
 
 
 @pytest.mark.asyncio
+async def test_get_risk_normalizes_target_path(setup_mcp):
+    """#1279: git_metadata row lookup must survive non-POSIX target forms.
+
+    Callers hand paths over with backslashes, a leading ``./``, or a trailing
+    separator. get_risk matches git_metadata.file_path by exact equality, so
+    each of these previously missed the row and reported the "no git metadata
+    available" card (hotspot_score=0 / primary_owner=None / empty partners)
+    even though the row exists.
+    """
+    from repowise.server.mcp_server import get_risk
+
+    for target in ("src\\auth\\service.py", "./src/auth/service.py", "src/auth/service.py/"):
+        result = await get_risk([target])
+        # Response stays keyed by the caller's exact string.
+        t = result["targets"][target]
+        assert t["hotspot_score"] == 0.92, target
+        assert t["primary_owner"] == "Alice", target
+        assert len(t["co_change_partners"]) == 2, target
+        assert "no git metadata available" not in t["risk_summary"], target
+        # Trend: 30d=3, 90d=8 → stable.
+        assert t["trend"] == "stable", target
+
+
+@pytest.mark.asyncio
+async def test_get_risk_repo_absolute_target_path(setup_mcp):
+    """A repo-absolute target is made repo-relative before the lookup (#1279)."""
+    from repowise.server.mcp_server import get_risk
+
+    abs_target = "/tmp/test-repo/src/auth/service.py"
+    result = await get_risk([abs_target])
+    t = result["targets"][abs_target]
+    assert t["hotspot_score"] == 0.92
+    assert t["primary_owner"] == "Alice"
+    assert len(t["co_change_partners"]) == 2
+
+
+@pytest.mark.asyncio
 async def test_get_risk_no_git_metadata(setup_mcp):
     from repowise.server.mcp_server import get_risk
 
@@ -77,6 +114,23 @@ async def test_get_risk_no_git_metadata(setup_mcp):
     # Impact surface and risk_type still computed from graph data
     assert "risk_type" in t
     assert "impact_surface" in t
+
+
+@pytest.mark.parametrize(
+    ("raw", "repo_root", "expected"),
+    [
+        ("src/auth/service.py", None, "src/auth/service.py"),
+        ("src\\auth\\service.py", None, "src/auth/service.py"),
+        ("./src/auth/service.py", None, "src/auth/service.py"),
+        ("src/auth/service.py/", None, "src/auth/service.py"),
+        ("src//auth//service.py", None, "src/auth/service.py"),
+        ("/tmp/test-repo/src/auth/service.py", "/tmp/test-repo", "src/auth/service.py"),
+    ],
+)
+def test_normalize_target_path(raw, repo_root, expected):
+    from repowise.server.mcp_server.tool_risk.assessment import normalize_target_path
+
+    assert normalize_target_path(raw, repo_root=repo_root) == expected
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
Fixes #1279: `get_risk` returned `hotspot_score=0`, `primary_owner=null`, `co_change_partners=[]`, and a `"no git metadata available"` summary for files that do have rich `git_metadata` rows.

## Root cause
`_assess_one_target` looked up the `GitMetadata` row by **exact string equality** on `file_path` against the caller's raw target. The index stores `file_path` POSIX-relative (`src/auth/service.py`), but callers reach `get_risk` through git tools, shell completion, or editors that hand over:
- backslash form (`src\auth\service.py`, common on Windows),
- a leading `./`,
- a trailing separator,
- or a repo-absolute path (`/abs/repo/src/auth/service.py`).

Any of these made the lookup miss, so `meta` was `None` and `_assess_one_target` emitted the indistinguishable "no git metadata available" card — the exact payload the reporter saw. (The v0.37 column names were already correct; the lookup simply never found the row.)

## Change
- Add `normalize_target_path(target, repo_root)` in `assessment.py`: converts backslashes to `/`, strips a leading `./` and any leading slash, collapses duplicate/trailing separators, and makes a repo-absolute path relative to `repository.local_path`.
- In `_assess_one_target`, normalize the target once and key every file-path lookup (git_metadata, graph edges/nodes, test gap, security signals) on the normalized form, while keeping the response keyed by the caller's exact string.

## Tests
Added regression tests in `tests/unit/server/mcp/test_risk.py`:
- `test_get_risk_normalizes_target_path` — backslash, `./`, trailing-slash forms now populate `hotspot_score`/`primary_owner`/`co_change_partners`.
- `test_get_risk_repo_absolute_target_path` — repo-absolute form resolves.
- `test_normalize_target_path` — parametrized unit coverage of the helper.

Ruff + all `test_risk.py` / `test_risk_dependency_edges.py` tests pass.