### PR TITLE
fix(cli): don't promise retry for config errors that cannot self-heal

### DIFF
--- a/packages/cli/src/repowise/cli/commands/update_cmd/reporting.py
+++ b/packages/cli/src/repowise/cli/commands/update_cmd/reporting.py
@@ -163,19 +163,67 @@ def render_degraded(degraded: list[str] | None) -> None:
 
     These used to be swallowed (``except Exception: pass``), so the update
     claimed clean success while, say, git metadata or graph nodes silently
-    stayed at the previous commit. The run still exits 0 — every listed step
-    is retried by the next update — but the panel must not say "complete"
-    without this block when something was skipped.
+    stayed at the previous commit. The run still exits 0, but the panel must
+    not say "complete" without this block when something was skipped.
+
+    Not every degraded step heals on the next update. A transient failure
+    (lock contention, a server that recovered, a network blip) re-runs and
+    fixes itself, so promising a retry is honest. A step that failed because
+    the *config* is broken — the canonical case is the embedder: a bad
+    ``REPOWISE_EMBEDDER`` value, a missing/bad API key, or an unreachable
+    endpoint the user configured — reads the same config on the next run and
+    fails identically, so telling the user "will retry on the next update" is
+    a promise nothing will keep. Those steps are surfaced as a config error
+    with the way to fix them instead.
     """
     if not degraded:
         return
-    console.print()
-    console.print(
-        f"[yellow]Update completed with {len(degraded)} degraded step(s) "
-        "(will retry on the next update):[/yellow]"
-    )
+    config, retryable = _split_degraded(degraded)
+    if retryable:
+        console.print()
+        console.print(
+            f"[yellow]Update completed with {len(retryable)} degraded step(s) "
+            "(will retry on the next update):[/yellow]"
+        )
+        for entry in retryable:
+            console.print(f"  [yellow]-[/yellow] {entry}")
+    if config:
+        console.print()
+        console.print(
+            "[yellow]Update degraded on config-dependent steps a retry cannot heal. "
+            "Fix the config, then run [cyan]repowise reindex[/cyan]:[/yellow]"
+        )
+        for entry in config:
+            console.print(f"  [yellow]-[/yellow] {entry}")
+
+
+def _split_degraded(
+    degraded: list[str],
+) -> tuple[list[str], list[str]]:
+    """Split degraded entries into ``(config_cannot_self_heal, retryable)``.
+
+    Entries are ``"Step: message"`` strings. The step name before the first
+    colon decides the class.  The embedder step is config-driven: a bad env
+    value or unreachable endpoint is identical on the next run, so no retry
+    can heal it and the panel must say how to fix the config instead of
+    promising a retry.  Every other step is a transient/range-scoped failure
+    that genuinely re-runs on the next update.
+    """
+    config: list[str] = []
+    retryable: list[str] = []
     for entry in degraded:
-        console.print(f"  [yellow]-[/yellow] {entry}")
+        step = entry.split(":", 1)[0].strip()
+        if step in _CONFIG_CANNOT_SELF_HEAL_STEPS:
+            config.append(entry)
+        else:
+            retryable.append(entry)
+    return config, retryable
+
+
+# Degraded steps whose failure is a config value that is unchanged on the
+# next run, so "will retry on the next update" would be a promise retry cannot
+# keep. Promoted here so the panel can say how to fix them instead.
+_CONFIG_CANNOT_SELF_HEAL_STEPS = frozenset({"Page embedding"})
 
 
 def _dead_code_counts(

--- a/tests/unit/cli/test_update_reporting.py
+++ b/tests/unit/cli/test_update_reporting.py
@@ -84,6 +84,90 @@ class TestRenderChangedFiles:
         assert "1 deleted" in summary
 
 
+class TestDegradedPanelRetryPromise:
+    """The degraded panel must only promise a retry when retry can actually help.
+
+    Transient failures (a lock, a server that recovered) re-run and heal on
+    the next update, so "(will retry on the next update)" is honest. A config
+    error — the canonical case is the embedder with a bad env value or an
+    unreachable endpoint the user configured — reads the same config next run
+    and fails identically, so promising a retry is a promise nothing will keep.
+    Those steps surface with the fix (reindex) instead.
+    """
+
+    def _entries(self, *entries: str) -> list[str]:
+        return list(entries)
+
+    def test_retryable_step_still_promises_retry(self, monkeypatch):
+        printed = _capture(monkeypatch)
+        reporting.render_degraded(["Graph nodes persist: lock timeout"])
+        text = "\n".join(printed.lines)
+        assert "degraded step(s)" in text
+        assert "(will retry on the next update)" in text
+        assert "Graph nodes persist" in text
+        assert "a retry cannot heal" not in text
+
+    def test_config_embedder_error_says_fix_config_not_retry(self, monkeypatch):
+        printed = _capture(monkeypatch)
+        reporting.render_degraded(
+            [
+                "Page embedding: OpenAI API key required. Pass api_key= or set OPENAI_API_KEY env var."
+            ]
+        )
+        text = "\n".join(printed.lines)
+        # It must not promise something a retry cannot deliver.
+        assert "will retry on the next update" not in text
+        # It must say how to actually fix the config.
+        assert "a retry cannot heal" in text
+        assert "repowise reindex" in text
+        assert "Page embedding" in text
+
+    def test_mixed_entries_are_split_into_both_channels(self, monkeypatch):
+        printed = _capture(monkeypatch)
+        reporting.render_degraded(
+            [
+                "Page embedding: Gemini API key required",
+                "Graph nodes persist: lock timeout",
+            ]
+        )
+        text = "\n".join(printed.lines)
+        assert "degraded step(s)" in text
+        assert "(will retry on the next update)" in text
+        assert "a retry cannot heal" in text
+        assert "Graph nodes persist" in text
+        assert "Page embedding" in text
+
+    def test_only_config_error_omits_the_retry_block(self, monkeypatch):
+        printed = _capture(monkeypatch)
+        reporting.render_degraded(["Page embedding: bad REPOWISE_EMBEDDER"])
+        text = "\n".join(printed.lines)
+        assert "degraded step(s)" not in text
+        assert "a retry cannot heal" in text
+
+    def test_empty_list_renders_nothing(self, monkeypatch):
+        printed = _capture(monkeypatch)
+        reporting.render_degraded([])
+        assert printed.lines == []
+
+    def test_none_renders_nothing(self, monkeypatch):
+        printed = _capture(monkeypatch)
+        reporting.render_degraded(None)
+        assert printed.lines == []
+
+    def test_split_degraded_classifies_embedder_as_config(self):
+        config, retryable = reporting._split_degraded(
+            [
+                "Page embedding: bad env",
+                "Graph nodes persist: lock timeout",
+                "Page embedding: unreachable endpoint",
+            ]
+        )
+        assert len(config) == 2
+        assert all(e.startswith("Page embedding") for e in config)
+        assert len(retryable) == 1
+        assert retryable[0].startswith("Graph nodes persist")
+
+
 class TestCompletionPanels:
     def test_full_completion_renders(self, monkeypatch):
         printed = _capture(monkeypatch)


### PR DESCRIPTION
Closes #1372

## Summary
The degraded panel promised '(will retry on the next update)' for every best-effort step that failed during `repowise update`. That promise is only honest for transient failures (lock contention, a recovered server, a network blip) that genuinely re-run and heal on the next update. A config-driven step — the canonical case is the embedder with a bad `REPOWISE_EMBEDDER` value, a missing/bad API key, or an unreachable configured endpoint — reads the same config on the next run and fails identically, so promising a retry is a promise nothing will keep.

## Change

`render_degraded` in `update_cmd/reporting.py` now splits degraded entries into two channels:

- **Retryable** (transient) steps keep the honest '(will retry on the next update)' message.
- **Config-cannot-self-heal** steps (currently the embedder) surface with the actual remedy instead: *'Fix the config, then run `repowise reindex`'*.

A helper (`_split_degraded`) and a step-name allowlist (`_CONFIG_CANNOT_SELF_HEAL_STEPS`) keep the classification explicit and easy to extend.

## Test Plan

- `tests/unit/cli/test_update_reporting.py` — new `TestDegradedPanelRetryPromise` covering: retryable step still promises retry, a config embedder error says fix-config/reindex (and does *not* say 'will retry'), mixed entries split across both channels, and empty/None render nothing.
- `uv run pytest tests/unit/cli/test_update*.py` — 146 passed.
- `ruff check` + `ruff format --check` — clean.