### PR TITLE
fix(mcp): stop grading a derived value as a fabrication

### DIFF
--- a/packages/server/src/repowise/server/mcp_server/tool_answer/confidence.py
+++ b/packages/server/src/repowise/server/mcp_server/tool_answer/confidence.py
@@ -89,6 +89,15 @@ def _numbers_in(text: str) -> set[str]:
     return set(_NUMBER_RE.findall(_THOUSANDS_SEP_RE.sub("", text or "")))
 
 
+def _asserted_numbers(answer_text: str) -> set[str]:
+    """Standalone numbers the answer asserts, citation line refs removed.
+
+    Shared by :func:`_ungrounded_numbers` and the value-grounding gate so the
+    two never disagree about what counts as an asserted value.
+    """
+    return _numbers_in(_FILE_LINE_REF_RE.sub(" ", answer_text or ""))
+
+
 def _is_value_question(question: str) -> bool:
     """True when the question asks for a concrete value."""
     return bool(_VALUE_QUESTION_RE.search(question or ""))
@@ -142,8 +151,7 @@ def _ungrounded_numbers(answer_text: str, hits: list[dict]) -> list[str]:
     everything the LLM was shown for the hits — titles, summaries, snippets,
     and hydrated symbols (signatures, docstrings, source excerpts).
     """
-    text = _FILE_LINE_REF_RE.sub(" ", answer_text or "")
-    asserted = _numbers_in(text)
+    asserted = _asserted_numbers(answer_text)
     if not asserted:
         return []
 
@@ -756,12 +764,23 @@ def _grade_answer(
     # appear somewhere in the material retrieval actually contained. A
     # number synthesis produced from thin air is a factual error delivered
     # with authority — the single worst calibration failure, because the
-    # consumer was told not to verify. Cap at low and say why.
+    # consumer was told not to verify. Cap and say why.
     ungrounded_values: list[str] = []
     if not hedged and _is_value_question(question):
         ungrounded_values = _ungrounded_numbers(answer_text, hits)
         if ungrounded_values:
-            confidence = "low"
+            # A value derived from grounded operands is not a fabrication, so
+            # soften one notch instead of capping — but only on a clean high over
+            # dominant retrieval (earn_high on weak retrieval stays capped), and
+            # only when some OTHER asserted number is grounded. Without that
+            # second clause a lone invented value would soften too, which is the
+            # case this gate exists to catch. The note and next_action_hint fire
+            # on ungrounded_values regardless of tier.
+            grounded_sibling = len(_asserted_numbers(answer_text)) > len(ungrounded_values)
+            if grounded_sibling and confidence == "high" and dominant:
+                confidence = "medium"
+            else:
+                confidence = "low"
 
     # Fifth gate — citation-source gate: a high-confidence answer must cite
     # at least one page that contributed actual source material (hydrated

--- a/tests/unit/server/mcp/test_answer_calibration.py
+++ b/tests/unit/server/mcp/test_answer_calibration.py
@@ -358,6 +358,31 @@ async def test_grounded_value_keeps_high_confidence(setup_mcp, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_derived_value_softens_to_medium_not_low(setup_mcp, monkeypatch):
+    """Grounded 2 plus a computed 6 softens to medium.
+
+    ``test_ungrounded_value_caps_confidence_low`` is the negative control: a
+    lone invented value with no grounded sibling still caps at low.
+    """
+    import repowise.server.mcp_server.tool_answer.answer as answer_mod
+    from repowise.server.mcp_server import get_answer
+
+    _patch_pipeline(monkeypatch, answer_mod, with_symbols=True, symbol=_FN_SYMBOL)
+    _patch_provider(
+        monkeypatch,
+        answer_mod,
+        "min_count_policy returns 2, and the three retry tiers "
+        "multiply it to 6 (pkg/alpha/one.py).",
+    )
+
+    result = await get_answer("What is the default value of min_count_policy?")
+    assert result["confidence"] == "medium"
+    # Still told to verify: the note and hint key off ungrounded_values, not tier.
+    assert "6" in result["note"]
+    assert "next_action_hint" in result
+
+
+@pytest.mark.asyncio
 async def test_high_confidence_requires_source_backed_citation(setup_mcp, monkeypatch):
     """No cited page contributed symbols → high is downgraded to medium."""
     import repowise.server.mcp_server.tool_answer.answer as answer_mod


### PR DESCRIPTION
The value-grounding gate caps an answer at `low` when it asserts a number absent from retrieval. It cannot tell a fabrication from arithmetic over operands the answer quoted verbatim, so an answer that shows its working is graded exactly like one that invents a figure.

## The reply that prompted this

Asked where the MCP response character budget is enforced and what the limit is, `get_answer` quoted `TOKEN_BUDGET`, `HOST_MCP_TOKEN_CAP_DEFAULT` and `HOST_CAP_BUDGET_FRACTION` from `_budget/budgeter.py` — all three in its own `quotes` block — and asserted their product, 60000. Every number grounded except the one it had just derived.

`retrieval_quality` read `high`. The answer was correct in every particular, verified by hand against the source. It came back:

```
confidence: "low"
note: "Value-grounding gate: the answer asserts ['60000'] but none of these
       appear in any retrieved excerpt — the value(s) may be synthesised."
next_action_hint: "Read .../budgeter.py and verify the asserted value(s)..."
```

## Why it is worth fixing

#1840 measured median estimated response tokens as **high 282, medium 1,918, low 4,061**. A false downgrade costs about **14x** to read, and it fires a `next_action_hint` sending the caller to Read a file — the exact work the tool exists to prevent. A gate that misfires on correct answers is paying that toll for nothing.

## The change

Soften one notch instead of capping, under two conditions that both have to hold:

- **The answer is otherwise a clean high** — dominant retrieval that cleared the score floor and survived the hedge and citation gates. Requiring `dominant` deliberately excludes the `earn_high`-on-weak-retrieval path, where the ranking itself is what is in doubt.
- **Some other asserted number is grounded.** This clause is load-bearing, not decorative. Without it a lone invented value ("the minimum count is 3", nothing else numeric) softens too — the fabrication this gate exists to catch hardest.

`_asserted_numbers` factors out the extraction the gate and `_ungrounded_numbers` both need, so the two cannot drift on what counts as an assertion.

## This is a deliberate loosening, not a bug fix

The gate carries its own rationale in-line and that rationale is right:

> A number synthesis produced from thin air is a factual error delivered with authority — the single worst calibration failure, because the consumer was told not to verify.

Agreed. The gap is only that "from thin air" and "product of three operands quoted in this same response" were indistinguishable to it. The header comment moves from "Cap at low and say why" to "Cap and say why" so it no longer contradicts the code.

## The caller is not told less

`payload.py` attaches the note and `next_action_hint` on `ungrounded_values` alone, independent of tier. A derived figure is still flagged for verification and still names the file — it just arrives in a cheaper payload.

**Honest cost:** an answer that quotes `25000` and `0.6` correctly but botches the product to `62000` now reads `medium` rather than `low`. It stays flagged, with the same note and the same pointer.

## Tests

`test_derived_value_softens_to_medium_not_low` is new. `test_ungrounded_value_caps_confidence_low` is unchanged and is the negative control — a lone invented number with no grounded sibling still caps at `low`.

517 answer-path tests pass (`-k answer` across `tests/unit/server/mcp/`). `ruff check` clean.

Not covered, and worth knowing: the branch where a grounded sibling exists but the citation gate already pulled confidence to `medium` falls through to `low`. That is correct behaviour but has no test of its own.
