### PR TITLE
fix(risk): rank tests_to_run by files reached, not alphabetically

### DIFF
--- a/packages/core/src/repowise/core/analysis/pr_blast.py
+++ b/packages/core/src/repowise/core/analysis/pr_blast.py
@@ -17,7 +17,8 @@ from __future__ import annotations
 import json
 import math
 import os
-from collections import defaultdict
+from collections import Counter, defaultdict
+from collections.abc import Iterable, Mapping
 from typing import Any
 
 from sqlalchemy import select, text
@@ -25,6 +26,18 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from repowise.core.ingestion.models import NON_DEPENDENCY_EDGE_TYPES
 from repowise.core.persistence.models import GitMetadata, GraphNode
+
+
+def rank_tests_by_reach(by_file: Mapping[str, Iterable[str]]) -> list[str]:
+    """Test ids ordered by how many changed files each one reaches.
+
+    Callers cap this list and tell the agent to run the head of it first, so a
+    flat alphabetical sort hands over the head of the alphabet rather than the
+    tests that cover most of the change. Ties keep alphabetical order, which
+    leaves a single-file change ordered exactly as before.
+    """
+    reach = Counter(test_id for tests in by_file.values() for test_id in tests)
+    return sorted(reach, key=lambda t: (-reach[t], t))
 
 
 class PRBlastRadiusAnalyzer:
@@ -409,7 +422,7 @@ class PRBlastRadiusAnalyzer:
         return {
             "map_present": True,
             "basis": "measured",
-            "tests_to_run": sorted(all_ids),
+            "tests_to_run": rank_tests_by_reach(by_file),
             "by_file": by_file,
         }
 
@@ -431,11 +444,10 @@ class PRBlastRadiusAnalyzer:
         if not reaching:
             return empty
         by_file = {path: sorted(tests) for path, tests in reaching.items() if tests}
-        all_tests = sorted({t for tests in by_file.values() for t in tests})
         return {
             "map_present": empty["map_present"],
             "basis": "inferred",
-            "tests_to_run": all_tests,
+            "tests_to_run": rank_tests_by_reach(by_file),
             "by_file": by_file,
         }
 

--- a/packages/server/src/repowise/server/mcp_server/tool_change_risk.py
+++ b/packages/server/src/repowise/server/mcp_server/tool_change_risk.py
@@ -19,6 +19,7 @@ from repowise.core.analysis.change_risk import (
     normalize_extensions,
     score_live_change,
 )
+from repowise.core.analysis.pr_blast import rank_tests_by_reach
 from repowise.core.registry import mcp_tool_registry as mcp
 from repowise.server.mcp_server._helpers import (
     _get_repo,
@@ -447,7 +448,7 @@ async def _inferred_impacted(
         reaching = await tests_reaching(session, repo_id, changed_files)
     except Exception:
         reaching = {}
-    tests = sorted({t for group in reaching.values() for t in group})
+    tests = rank_tests_by_reach(reaching)
     if not tests:
         return _empty_impacted(
             "no_map",
@@ -510,14 +511,16 @@ async def _impacted_tests_block(
             report = await detect_missing_tests(session, repo_id, changed)
             if report.map_empty:
                 return await _inferred_impacted(session, repo_id, sorted(changed))
-            all_ids: set[str] = set()
+            by_file: dict[str, list[str]] = {}
             for source_file, lines in changed.items():
-                for row in await tests_covering(session, repo_id, source_file, lines=lines):
-                    all_ids.add(row["test_id"])
+                rows = await tests_covering(session, repo_id, source_file, lines=lines)
+                ids = sorted({row["test_id"] for row in rows})
+                if ids:
+                    by_file[source_file] = ids
     except LookupError:
         return _empty_impacted("no_index", "No indexed repository; run `repowise init`.")
 
-    tests = sorted(all_ids)
+    tests = rank_tests_by_reach(by_file)
     total = len(tests)
     return {
         "status": "map_present",

--- a/tests/unit/server/mcp/test_risk.py
+++ b/tests/unit/server/mcp/test_risk.py
@@ -156,6 +156,67 @@ async def test_get_risk_pr_directive_surfaces_coverage_backed_tests_to_run(setup
 
 
 @pytest.mark.asyncio
+async def test_get_risk_tests_to_run_ranks_by_files_reached(setup_mcp, session):
+    """The test covering both changed files leads, despite sorting last."""
+    from repowise.core.analysis.health.coverage import TestCoverage
+    from repowise.core.persistence.crud import save_test_coverage
+    from repowise.server.mcp_server import get_risk
+
+    def _cov(test_id: str, path: str) -> TestCoverage:
+        return TestCoverage(
+            test_id=test_id,
+            file_path=path,
+            covered_lines=[1, 2],
+            source_format="coverage.py",
+            test_file=test_id.split("::")[0],
+        )
+
+    await save_test_coverage(
+        session,
+        "repo1",
+        [
+            # Sorts last alphabetically, reaches both changed files.
+            _cov("tests/test_zeta.py::test_both", "src/auth/service.py"),
+            _cov("tests/test_zeta.py::test_both", "src/auth/token.py"),
+            # Sorts first alphabetically, reaches one.
+            _cov("tests/test_alpha.py::test_one", "src/auth/service.py"),
+        ],
+        source_format="coverage.py",
+    )
+    await session.flush()
+
+    result = await get_risk(
+        ["src/auth/service.py"],
+        changed_files=["src/auth/service.py", "src/auth/token.py"],
+    )
+
+    assert result["directive"]["tests_to_run"] == [
+        "tests/test_zeta.py::test_both",
+        "tests/test_alpha.py::test_one",
+    ]
+
+
+class TestRankTestsByReach:
+    def test_more_files_reached_wins_over_alphabetical(self) -> None:
+        from repowise.core.analysis.pr_blast import rank_tests_by_reach
+
+        ranked = rank_tests_by_reach({"a.py": ["t_z", "t_both"], "b.py": ["t_a", "t_both"]})
+        assert ranked == ["t_both", "t_a", "t_z"]
+
+    def test_single_file_keeps_alphabetical_order(self) -> None:
+        # Every test ties at one file reached, so the pre-existing ordering
+        # of a single-file change is unchanged.
+        from repowise.core.analysis.pr_blast import rank_tests_by_reach
+
+        assert rank_tests_by_reach({"a.py": ["t_c", "t_a", "t_b"]}) == ["t_a", "t_b", "t_c"]
+
+    def test_empty_mapping_is_empty(self) -> None:
+        from repowise.core.analysis.pr_blast import rank_tests_by_reach
+
+        assert rank_tests_by_reach({}) == []
+
+
+@pytest.mark.asyncio
 async def test_get_risk_pr_directive_falls_back_to_the_graph_without_a_map(setup_mcp):
     """No per-test map -> the import graph answers, labelled as inferred.
 


### PR DESCRIPTION
Both run-list builders group tests per changed file, then flatten with a bare `sorted()` and drop the grouping one line later. Callers cap the result and tell the agent to run the head of it first — so what they actually hand over is the head of the alphabet.

## How it shows up

Two `get_change_risk` calls on different revspecs, touching different files, returned an **identical** first ten:

```
tests/integration/test_cli.py
tests/unit/cli/test_command_target.py
tests/unit/cli/test_distill_verdict_fingerprint.py
tests/unit/cli/test_doctor_workspace.py
tests/unit/cli/test_editor_setup.py
tests/unit/cli/test_mcp_command_resolution.py
tests/unit/cli/test_mcp_config.py
tests/unit/cli/test_mcp_transport.py
tests/unit/cli/test_workspace_add_defaults.py
tests/unit/cli/test_workspace_cmd.py
```

Alongside: *"53 test file(s) reach the changed files; showing first 10 ... run these first."* Handing over the alphabetical head of 53 is worse than handing over nothing, because the ordering gets trusted.

## The fix

`rank_tests_by_reach` orders by how many changed files each test reaches, alphabetical as tiebreak. The data was already built and discarded — both builders construct `by_file` immediately before flattening it away.

Rejected alternatives:
- **Graph distance** — `tests_reaching` / `tests_covering` return direct file→test edges, not depth-ranked walks. There is no distance to read.
- **Historical co-change** — a new query per test file. Disproportionate for a run-list.
- **Inverse test-file size** — penalises exactly the broad integration suites that are often most worth running first. They are broad *because* they exercise more of the change.

## Four sites, two of them a copy

`pr_blast.py` has it in `_guarding_tests` (measured) and `_inferred_guarding_tests` (graph). `tool_change_risk.py` has the same bug independently in `_inferred_impacted` and `_impacted_tests_block` — copy-paste, not a shared helper. They share one now, so the pair cannot drift again.

`_impacted_tests_block`'s measured path was accumulating into a flat `set`, so it now keeps the per-file grouping it needs in order to rank at all.

## Backward compatibility

On a single-file change every test ties at one file reached and the order falls back to alphabetical — exactly what it was. `test_get_risk_pr_directive_surfaces_coverage_backed_tests_to_run` is unchanged and covers that case.

## Tests

`test_get_risk_tests_to_run_ranks_by_files_reached` seeds two changed files where the test covering **both** sorts *last* alphabetically, so it only passes if reach beats the alphabet. Plus three pure-function tests for the helper: ranking, the single-file alphabetical fallback, and the empty mapping.

638 tests in `tests/unit/analysis/` and 30 in `tests/unit/server/mcp/{test_risk,test_change_risk}.py` pass. `ruff check` clean.
