### PR TITLE
fix(tests): exempt the ASP.NET handler head from the bare-name guard

### DIFF
--- a/tests/unit/test_no_bare_type_name_copies.py
+++ b/tests/unit/test_no_bare_type_name_copies.py
@@ -90,6 +90,11 @@ _KNOWN: dict[str, int] = {
     # prefix to resolve the package it came from. Neither wants a type.
     _PREFIX + "framework_edges/rust.py": 1,
     _PREFIX + "framework_edges/go.py": 1,
+    # Takes the qualifier HEAD of `OrderHandlers.GetOrder` to reach the
+    # declaring type. It does want a type, but the shared helper returns the
+    # trailing segment, which is the member — the opposite end, the same reason
+    # `receiver_types.py` is exempt.
+    _PREFIX + "framework_edges/aspnet.py": 1,
     # Real copies, each held by a consumer no gate here measures: converting
     # them moves framework edges, C++ symbol parent names and Go
     # `method_implements` edges respectively. Removable once those are covered.


### PR DESCRIPTION
**Main is red.** `test_no_bare_type_name_copies` fails on Python 3.11, 3.12 and 3.13 at `350f6a3a` (#1860). `7cd722c0` before it was green.

```
AssertionError: New qualifier-splitting expression(s) outside
repowise.core.ingestion.type_names:
assert not {'.../ingestion/framework_edges/aspnet.py': ["line 122: split('.')"]}
```

## Why this is an exemption and not a conversion

The guard matches on shape rather than meaning, and its docstring says so — the same expression takes apart a file extension or a URL, which is why the scan is confined to the type-resolving modules in the first place.

This site is not a second implementation of `bare_type_name`. It takes the qualifier **head**:

```python
# The leading segment of `OrderHandlers.GetOrder` is the declaring
# type; the contract consumer reads the trailing one instead.
target = type_decl_to_file.get(route.handler.split(".")[0])
```

`bare_type_name` returns the **trailing** segment (`ns.Qual` → `Qual`). Here the trailing segment is `GetOrder`, the member — so calling the shared helper would hand back the wrong half and the `type_decl_to_file` lookup would silently miss. There is no canonical helper for the head, and inventing one is a design change, not a hotfix.

That is exactly the reason `languages/receiver_types.py` already carries: *"Reads the head to decide whether taking a bare name is safe at all… it asks the opposite question."* The sibling route-handler splits in `framework_edges/rust.py` and `framework_edges/go.py` are in the table for the same shape.

## Recorded with a count

Per the table's own rule — a count rather than a bare path, so a second copy cannot hide behind this entry, and the companion exact-count test fails if this site is ever converted and the exemption goes stale.

## Verification

- `tests/unit/test_no_bare_type_name_copies.py` — 7 passed, including the exact-count test.
- `tests/unit/ingestion/` framework-edge tests — 92 passed, 1 skipped, C# included. The behaviour #1860 shipped is correct; only the architectural guard needed telling.
- `ruff check` clean.
