### PR TITLE
fix(mcp): prefer most-specific workspace repo

### DIFF
--- a/packages/server/src/repowise/server/mcp_server/_server.py
+++ b/packages/server/src/repowise/server/mcp_server/_server.py
@@ -346,14 +346,18 @@ def _detect_workspace(repo_path: str | None):
         # Determine which repo the given path belongs to
         resolved = _Path(repo_path).resolve()
         repo_alias = None
+        best_match_depth = -1
         for entry in ws_config.repos:
             entry_abs = (ws_root / entry.path).resolve()
             try:
                 resolved.relative_to(entry_abs)
-                repo_alias = entry.alias
-                break
             except ValueError:
                 continue
+
+            match_depth = len(entry_abs.parts)
+            if match_depth > best_match_depth:
+                repo_alias = entry.alias
+                best_match_depth = match_depth
 
         if repo_alias is None:
             # Path is inside workspace but doesn't match a repo — use default

--- a/tests/unit/server/test_mcp_workspace_detection.py
+++ b/tests/unit/server/test_mcp_workspace_detection.py
@@ -1,0 +1,61 @@
+"""Tests for MCP workspace member detection."""
+
+from pathlib import Path
+
+import pytest
+
+from repowise.server.mcp_server._server import _detect_workspace
+
+
+@pytest.fixture
+def workspace(tmp_path: Path) -> Path:
+    """Create a workspace with a root repo and two declared members."""
+    (tmp_path / "backend").mkdir()
+    (tmp_path / "frontend").mkdir()
+    (tmp_path / "test-repos" / "microdot").mkdir(parents=True)
+
+    (tmp_path / ".repowise-workspace.yaml").write_text(
+        "version: 1\n"
+        "default_repo: repowise\n"
+        "repos:\n"
+        "- path: .\n"
+        "  alias: repowise\n"
+        "  is_primary: true\n"
+        "- path: backend\n"
+        "  alias: backend\n"
+        "- path: frontend\n"
+        "  alias: frontend\n",
+        encoding="utf-8",
+    )
+    return tmp_path
+
+
+@pytest.mark.parametrize(
+    ("member_path", "expected_alias"),
+    [
+        ("backend", "backend"),
+        ("frontend", "frontend"),
+    ],
+)
+def test_detect_workspace_prefers_most_specific_member(
+    workspace: Path,
+    member_path: str,
+    expected_alias: str,
+) -> None:
+    ws_root, ws_config, repo_alias = _detect_workspace(str(workspace / member_path))
+
+    assert ws_root == workspace.resolve()
+    assert ws_config is not None
+    assert repo_alias == expected_alias
+
+
+def test_detect_workspace_root_uses_primary(workspace: Path) -> None:
+    _, _, repo_alias = _detect_workspace(str(workspace))
+
+    assert repo_alias == "repowise"
+
+
+def test_detect_workspace_non_member_uses_primary(workspace: Path) -> None:
+    _, _, repo_alias = _detect_workspace(str(workspace / "test-repos" / "microdot"))
+
+    assert repo_alias == "repowise"


### PR DESCRIPTION
## Summary

- Make MCP workspace detection consider all containing repo paths and prefer the deepest match, so a declared member such as `backend` is not shadowed by the workspace root (`.`).
- Add real temporary-workspace regression tests covering declared members, the workspace root, and the current non-member fallback to the primary repo.

## Related Issues

Fixes #1818

## Test Plan

- [x] `uv run pytest tests/unit/server/test_mcp_workspace_detection.py tests/unit/server/test_mcp_workspace.py -q` — 33 passed
- [x] `uv run pytest tests/unit/server/ -q` — 2,359 passed
- [x] `uv run ruff check packages/server/src/repowise/server/mcp_server/_server.py tests/unit/server/test_mcp_workspace_detection.py`
- [x] Web build not applicable — no frontend changes

## Checklist

- [x] My code follows the project's code style
- [x] I have added tests for new functionality
- [x] All relevant existing tests pass
- [x] Documentation is not required for this internal bug fix