### PR TITLE
fix(mcp): give get_change_risk's truncated test list a way back

### DIFF
--- a/docs/agent/MCP_TOOLS.md
+++ b/docs/agent/MCP_TOOLS.md
@@ -482,10 +482,13 @@ subject. `baseline_sample_size` reports how many filtered commits informed the
 percentile; `features`, `drivers`, and combined `exclude_patterns` make the
 result auditable.
 
-It also returns `impacted_tests`: the tests the per-test coverage map proves
-execute the change's changed *lines* (line-precise, so a narrower set than
-`get_risk`'s file-level `tests_to_run`), capped at ten with `total` and
-`truncated` reporting any overflow. Its `missing_tests` buckets flag
+It also returns `impacted_tests`, whose `tests_to_run` names the tests the
+per-test coverage map proves execute the change's changed *lines* (line-precise,
+so a narrower set than `get_risk`'s file-level `tests_to_run` — same field name,
+because it is the same concern). It is capped at ten, with `total` and
+`truncated` reporting the overflow and the tail written to the omission store:
+on `truncated: true` the response carries an `omission_marker`, and
+`repowise expand <ref>` returns the rest. Its `missing_tests` buckets flag
 `untested_changes` (covered file, uncovered change), `stale_test_candidates`
 (covered lines whose guarding test file is absent from the diff), `covered`, and
 `no_coverage_data` (files absent from the map). When no map is ingested the
@@ -496,6 +499,9 @@ to lines), and `no_map` ("run the full suite") when it cannot. `basis` carries
 the same distinction in one word: `measured`, `inferred`, or absent. Build the
 measured map with `coverage run --contexts=test` followed by
 `repowise coverage add`.
+
+> **Output-schema change.** `impacted_tests.tests` is now
+> `impacted_tests.tests_to_run`, matching `get_risk`'s directive.
 
 When the changed files carry counted bug fixes, the response also holds
 `prior_fixes`: per file, how many past bug-fix commits touched it

--- a/packages/server/src/repowise/server/mcp_server/tool_change_risk.py
+++ b/packages/server/src/repowise/server/mcp_server/tool_change_risk.py
@@ -21,6 +21,7 @@ from repowise.core.analysis.change_risk import (
 )
 from repowise.core.analysis.pr_blast import rank_tests_by_reach
 from repowise.core.registry import mcp_tool_registry as mcp
+from repowise.server.mcp_server._budget import OmissionCollector
 from repowise.server.mcp_server._helpers import (
     _get_repo,
     _resolve_repo_context,
@@ -29,8 +30,8 @@ from repowise.server.mcp_server._helpers import (
 from repowise.server.mcp_server._meta import build_meta as _build_meta
 
 #: Cap on the line-precise impacted-test list, matching the get_risk directive's
-#: ``tests_to_run`` cap so both surfaces stay glanceable. ``total`` and
-#: ``truncated`` report the overflow rather than silently dropping it.
+#: ``tests_to_run`` cap so both surfaces stay glanceable. The tail goes to the
+#: omission store, so ``truncated: true`` is recoverable rather than a dead end.
 _IMPACTED_TESTS_LIMIT = 10
 
 #: Cap on the per-file prior-fix list, matching ``_IMPACTED_TESTS_LIMIT`` so both
@@ -49,22 +50,22 @@ async def get_change_risk(
     """Score a live commit, ``base..head`` range, or uncommitted work.
 
     Use this for a pre-merge read on a commit or PR range. Distinct from
-    ``get_risk``, which assesses indexed files and PR blast radius. The filters
-    below also apply to the baseline behind the repository percentile.
+    ``get_risk``, which scores indexed files and PR blast radius. The filters
+    below also apply to the percentile baseline.
 
     Lead with ``fix_history``: the recency-weighted bug-fix record of the files
     touched, ``files`` naming where the pressure sits. It separates a surgical
-    edit to a file that keeps breaking from a bulk rename of files that never
-    have. ``score`` measures diff size and spread, not where the change lands
+    edit to a bug magnet from a bulk rename of files that never break. ``score`` measures diff size and spread, not where the change lands
     (see ``score_measures``); calibrated per commit, so a PR-sized change reads
     high by construction. ``risk_percentile`` ranks that shape against recent
     commits.
 
-    ``impacted_tests`` names the tests for this change; ``missing_tests`` the
-    uncovered lines. ``basis``: ``measured`` = a coverage map proves those tests
-    run the changed *lines*; ``inferred`` = test files the graph shows
-    reaching it (candidates, file-level, no ingest needed). No map is never
-    "untested": ``status`` ``no_map`` means run the suite. ``prior_fixes``
+    ``impacted_tests.tests_to_run`` names the tests for this change;
+    ``missing_tests`` the uncovered lines. ``basis``: ``measured`` = a coverage
+    map proves those tests run the changed *lines*; ``inferred`` = test files
+    the graph shows reaching it (candidates, file-level). No map is never
+    "untested": ``no_map`` means run the suite. On ``truncated``, expand
+    ``omission_marker`` for the tail. ``prior_fixes``
     counts past fixes whose lines overlap this diff.
 
     Args:
@@ -117,7 +118,10 @@ async def get_change_risk(
             result.riskignore_excludes + result.request_excludes,
             working_tree=result.working_tree,
         )
-    payload["impacted_tests"] = await _impacted_tests_block(ctx, changed, changed_error)
+    collector = OmissionCollector("get_change_risk", repo_root=ctx.path)
+    payload["impacted_tests"] = await _impacted_tests_block(
+        ctx, changed, changed_error, collector
+    )
     prior_fixes = await _prior_fixes_block(ctx, changed)
     if prior_fixes is not None:
         payload["prior_fixes"] = prior_fixes
@@ -132,6 +136,7 @@ async def get_change_risk(
         targets=sorted(changed) or None,
         extra={"source": "live_git"},
     )
+    collector.attach(payload)
     return payload
 
 
@@ -197,7 +202,7 @@ def _empty_impacted(status: str, summary: str) -> dict[str, Any]:
     return {
         "status": status,
         "map_present": False,
-        "tests": [],
+        "tests_to_run": [],
         "total": 0,
         "truncated": False,
         "missing_tests": {
@@ -420,8 +425,19 @@ def _overlap_count(changed_lines_now: set[int], old_ranges_json: str) -> int:
     return hits
 
 
+def _cap_tests(tests: list[str], collector: OmissionCollector, label: str) -> list[str]:
+    """First _IMPACTED_TESTS_LIMIT ids; the tail goes to the omission store."""
+    if len(tests) > _IMPACTED_TESTS_LIMIT:
+        collector.add(
+            f"impacted_tests.tests_to_run ({label}) beyond cap={_IMPACTED_TESTS_LIMIT} "
+            f"({len(tests) - _IMPACTED_TESTS_LIMIT} dropped)",
+            tests[_IMPACTED_TESTS_LIMIT:],
+        )
+    return tests[:_IMPACTED_TESTS_LIMIT]
+
+
 async def _inferred_impacted(
-    session: Any, repo_id: str, changed_files: list[str]
+    session: Any, repo_id: str, changed_files: list[str], collector: OmissionCollector
 ) -> dict[str, Any]:
     """Graph-inferred candidates for a repo with no coverage map.
 
@@ -460,7 +476,7 @@ async def _inferred_impacted(
     block.update(
         {
             "basis": "inferred",
-            "tests": tests[:_IMPACTED_TESTS_LIMIT],
+            "tests_to_run": _cap_tests(tests, collector, "inferred"),
             "total": total,
             "truncated": total > _IMPACTED_TESTS_LIMIT,
             "summary": (
@@ -482,6 +498,7 @@ async def _impacted_tests_block(
     ctx: Any,
     changed: dict[str, set[int]],
     changed_error: tuple[str, str] | None,
+    collector: OmissionCollector,
 ) -> dict[str, Any]:
     """Line-precise impacted tests + honest missing-test buckets for the change.
 
@@ -510,7 +527,7 @@ async def _impacted_tests_block(
             repo_id = (await _get_repo(session)).id
             report = await detect_missing_tests(session, repo_id, changed)
             if report.map_empty:
-                return await _inferred_impacted(session, repo_id, sorted(changed))
+                return await _inferred_impacted(session, repo_id, sorted(changed), collector)
             by_file: dict[str, list[str]] = {}
             for source_file, lines in changed.items():
                 rows = await tests_covering(session, repo_id, source_file, lines=lines)
@@ -526,7 +543,7 @@ async def _impacted_tests_block(
         "status": "map_present",
         "basis": "measured",
         "map_present": True,
-        "tests": tests[:_IMPACTED_TESTS_LIMIT],
+        "tests_to_run": _cap_tests(tests, collector, "measured"),
         "total": total,
         "truncated": total > _IMPACTED_TESTS_LIMIT,
         "missing_tests": _serialize_missing(report),

--- a/tests/unit/server/mcp/test_change_risk.py
+++ b/tests/unit/server/mcp/test_change_risk.py
@@ -217,7 +217,7 @@ async def test_impacted_tests_line_precise_hit_and_miss(tmp_path, monkeypatch) -
     assert it["basis"] == "measured"
     assert it["map_present"] is True
     # app.py line 3 is covered -> its test is named; other/new are not covering.
-    assert it["tests"] == ["tests/test_app.py::test_app"]
+    assert it["tests_to_run"] == ["tests/test_app.py::test_app"]
     assert it["total"] == 1
     assert it["truncated"] is False
 
@@ -254,7 +254,7 @@ async def test_impacted_tests_no_map_is_unknown_not_untested(tmp_path, monkeypat
     # Nothing is seeded in the graph either, so neither tier can speak.
     assert it["status"] == "no_map"
     assert it["map_present"] is False
-    assert it["tests"] == []
+    assert it["tests_to_run"] == []
     # Honest degradation: no untested claim, a "run the suite" summary instead.
     assert it["missing_tests"]["untested_changes"] == []
     assert "run the full suite" in it["summary"]
@@ -304,7 +304,7 @@ async def test_impacted_tests_falls_back_to_the_graph_without_a_map(tmp_path, mo
     assert it["status"] == "inferred"
     assert it["basis"] == "inferred"
     assert it["map_present"] is False
-    assert it["tests"] == ["tests/test_round_trips.py"]
+    assert it["tests_to_run"] == ["tests/test_round_trips.py"]
     assert it["missing_tests"]["untested_changes"] == []
     # Answered by the import tier: there is no call edge here, which is exactly
     # when the weaker tier is allowed to speak.
@@ -337,8 +337,11 @@ async def test_impacted_tests_overflow_cap_is_honest(tmp_path, monkeypatch) -> N
 
     it = result["impacted_tests"]
     assert it["total"] == 12
-    assert len(it["tests"]) == 10
+    assert len(it["tests_to_run"]) == 10
     assert it["truncated"] is True
+    # The 2 over the cap are recoverable, not dropped.
+    assert "omission_marker" in result
+    assert result["_meta"]["omitted"]["refs"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

`get_change_risk` capped `impacted_tests` at 10, reported `total` and
`truncated: true`, and dropped the rest on the floor. Observed on a real
change: `total: 53, truncated: true`, with 43 test ids unreachable by any
follow-up call. The block's own summary then points at building a coverage map,
which does not retrieve them either.

`get_risk` has the same cap on the same concern and loses nothing: the full list
survives in `pr_blast_radius.guarding_tests.tests_to_run`, and the directive's
tail is banked to the omission store. `get_change_risk` was the only MCP tool of
the eight with no `OmissionCollector` at all.

## Change

Give it one, and route both overflow sites through it: the measured block
(`_impacted_tests_block`) and the graph-inferred one (`_inferred_impacted`),
which each did a bare `tests[:_IMPACTED_TESTS_LIMIT]`.

`truncated: true` now comes with an `omission_marker` and a
`_meta.omitted.refs` entry, so `repowise expand <ref>` returns the tail. That is
the same recovery every other capped list in the MCP surface already had, using
the mechanism that already exists rather than a new concept.

The cap itself does not move. Ten is the right glanceable number; the problem
was that the other 43 had nowhere to go.

## Field rename

`impacted_tests.tests` -> `impacted_tests.tests_to_run`.

`get_risk`'s directive already called this exact concern `tests_to_run`. Two
names for one thing made the two risk tools read as though they answered
different questions, which is the opposite of what their docstrings are trying
to establish. Documented as an output-schema change in `MCP_TOOLS.md`.

## Docstring

Names the field, and says the tail is recoverable so an agent does not re-derive
what it can expand. Refit to 1,591 chars against the 1,600 cap by tightening
three existing clauses.

## Tests

`test_impacted_tests_overflow_cap_is_honest` now also asserts the response
carries an `omission_marker` and a ref, so "truncated" and "recoverable" are
tested together. The four `it["tests"]` assertions follow the rename.

1,388 passed in `tests/unit/server/mcp/`.