### PR TITLE
fix(ingestion): refuse java's package tier when two siblings declare the name

### DIFF
--- a/packages/core/src/repowise/core/ingestion/call_resolver.py
+++ b/packages/core/src/repowise/core/ingestion/call_resolver.py
@@ -150,7 +150,13 @@ _LANGUAGE_CALL_STRATEGIES: dict[str, _LanguageCallStrategies] = {
     # the typed-receiver fallback too. One `name: Type` shape reaches its
     # typed vals, vars and parameters alike, so the language gate no longer
     # declines the moment the fallback asks.
-    "java": replace(_JVM_STRATEGIES, member_fallback=_TYPED_RECEIVER),
+    # Java takes the uniqueness-gated package tier, Kotlin the open one; see
+    # ``_resolve_java_same_package_unique`` for why that is a language rule.
+    "java": replace(
+        _JVM_STRATEGIES,
+        free=("_resolve_java_same_package_unique",),
+        member_fallback=_TYPED_RECEIVER,
+    ),
     "kotlin": replace(_JVM_STRATEGIES, member_fallback=_TYPED_RECEIVER),
     "csharp": _LanguageCallStrategies(member_fallback=_TYPED_RECEIVER),
     "python": _LanguageCallStrategies(member_fallback=_TYPED_RECEIVER),
@@ -578,16 +584,53 @@ class CallResolver:
         identifier ``Helper`` may be a class or method defined in any sibling
         file of the same package, with no import statement.
         """
+        return self._jvm_same_package(file_path, call, caller_id, unique_only=False)
+
+    def _resolve_java_same_package_unique(
+        self,
+        file_path: str,
+        call: CallSite,
+        caller_id: str,
+    ) -> ResolvedCall | None:
+        """Same tier as ``_resolve_jvm_same_package``, refusing on ambiguity.
+
+        Java-only because Kotlin has package-scope top-level and extension
+        functions, so a bare name there really is a package lookup; Java has
+        none, so it is a static import, an inherited member, or a member call
+        whose receiver the grammar dropped. Hand-read, the removals agree:
+        20 of 20 wrong on caffeine, 16 of 20 right on exposed and ktor.
+
+        Refusing is not deleting. The chain continues into the import tiers,
+        which answer 14,307 of caffeine's 18,390 refused sites.
+        """
+        return self._jvm_same_package(file_path, call, caller_id, unique_only=True)
+
+    def _jvm_same_package(
+        self,
+        file_path: str,
+        call: CallSite,
+        caller_id: str,
+        *,
+        unique_only: bool,
+    ) -> ResolvedCall | None:
         index = self._get_jvm_index()
         if index is None:
             return None
-        siblings = index.same_package_files(file_path)
-        for sibling in siblings:
-            syms = self._file_symbols.get(sibling, {})
-            sym_id = syms.get(call.target_name)
+        found: str | None = None
+        for sibling in index.same_package_files(file_path):
+            sym_id = self._file_symbols.get(sibling, {}).get(call.target_name)
             if sym_id is not None and sym_id != caller_id:
-                return ResolvedCall(caller_id, sym_id, 0.90, call.line, "same_package")
-        return None
+                if not unique_only:
+                    return ResolvedCall(caller_id, sym_id, 0.90, call.line, "same_package")
+                if found is not None:
+                    # Two siblings declare it and nothing here can tell them
+                    # apart; this used to answer with whichever the index
+                    # walked first.
+                    return None
+                found = sym_id
+        if found is None:
+            return None
+        return ResolvedCall(caller_id, found, 0.90, call.line, "same_package")
 
     def _resolve_jvm_receiver_same_package(
         self,

--- a/packages/core/src/repowise/core/ingestion/languages/specs/swift.py
+++ b/packages/core/src/repowise/core/ingestion/languages/specs/swift.py
@@ -50,5 +50,35 @@ SPEC = LanguageSpec(
             "Sendable",
         }
     ),
+    # Standard-library and Foundation type names, read only by the bare-name
+    # fallback: an `extension Data` adds members to Foundation's type but does
+    # not own the initializer `Data(contentsOf:)` names.
+    #
+    # Rust's rule, a name a repository plausibly declares itself stays off, is
+    # why `Result`, `Error`, `Task`, `Operation`, `Request` and `Response` are
+    # absent. `OperationQueue` came off on measurement: Alamofire declares a
+    # real `convenience init` on it and the call site invokes that one. A name
+    # match cannot see that, which is this guard's ceiling.
+    builtin_methods=frozenset(
+        {
+            # Foundation value types
+            "Data", "URL", "URLRequest", "URLResponse", "HTTPURLResponse",
+            "URLComponents", "URLQueryItem", "URLSession", "URLSessionConfiguration",
+            "UUID", "Date", "DateComponents", "DateFormatter", "ISO8601DateFormatter",
+            "NumberFormatter", "IndexPath", "IndexSet", "CharacterSet",
+            "Bundle", "Locale", "TimeZone", "Calendar", "FileManager",
+            "JSONDecoder", "JSONEncoder", "JSONSerialization",
+            "PropertyListDecoder", "PropertyListEncoder",
+            "NotificationCenter", "ProcessInfo", "RunLoop", "Thread",
+            "DispatchQueue", "DispatchGroup", "DispatchSemaphore", "DispatchTime",
+            "InputStream", "OutputStream", "Pipe",
+            "NSNumber", "NSString", "NSError", "NSNull", "NSLock", "NSRecursiveLock",
+            # Stdlib containers and scalars
+            "Array", "Dictionary", "Set", "String", "Substring", "Character",
+            "Int", "Int8", "Int16", "Int32", "Int64",
+            "UInt", "UInt8", "UInt16", "UInt32", "UInt64",
+            "Double", "Float", "Bool", "Range", "ClosedRange",
+        }
+    ),
     color_hex="#F05138",
 )

--- a/tests/unit/ingestion/test_call_resolver_strategies.py
+++ b/tests/unit/ingestion/test_call_resolver_strategies.py
@@ -207,6 +207,7 @@ _LANGUAGE_STRATEGIES = (
     "_resolve_go_same_package",
     "_resolve_go_package_call",
     "_resolve_jvm_same_package",
+    "_resolve_java_same_package_unique",
     "_resolve_jvm_receiver_same_package",
     "_resolve_cpp_same_target",
 )
@@ -250,7 +251,8 @@ class TestLanguageDispatch:
                 "Main.java",
                 "java",
                 "class Main {\n    void run() {\n        elsewhere();\n    }\n}\n",
-                ["_resolve_jvm_same_package"],
+                # java gates the package tier on uniqueness, kotlin does not.
+                ["_resolve_java_same_package_unique"],
             ),
             (
                 "main.cc",


### PR DESCRIPTION
The JVM package-scope call tier returned the first file in the caller's package
declaring the target name and never asked whether a second one did. On a large
Java codebase, 58% of the sites it answers have more than one candidate, so it
was picking one by index iteration order and stamping it 0.90 confidence.

## What changed

**Java takes a uniqueness-gated form of the tier and refuses ambiguous sites.
Kotlin keeps the open one.** The split is a language rule, not a tuning knob:
Kotlin puts top-level and extension functions in package scope, so a bare name
there genuinely is a package lookup, while Java has no top-level functions at
all. Reading what the gate removes says the same thing from the other end.

**A refusal is not a deletion.** The free-call chain continues into the import
tiers, which answer 14,307 of the 18,390 refused sites from the caller's own
import list, evidence this tier never consulted.

**Swift gets a standard-library name list.** The bare-name fallback already
refuses to answer for the standard library, but the guard reads a spec field
only the Rust spec populated, so it never fired for Swift and
`Data(contentsOf:)` bound to a repository's `extension Data`.

## Measured

Per language, per repository, on the resolved call-site population:

| repo | language | call sites | removed | retargeted | removals read wrong |
|---|---|---:|---:|---:|---|
| caffeine | java | 52,054 | 4,083 | 7,042 | 20 of 20 |
| javalin | java | 1,108 | 20 | 21 | not sampled |
| spring-petclinic | java | 295 | 0 | 6 | n/a |
| Alamofire | swift | 2,610 | 198 | 0 | 11 of 11 |

Removed and retargeted edges were sampled stratified and read from source on
both sides, rather than re-drawing a precision cell: a seeded 30-row sample
reshuffles wholesale when the population changes at all and cannot see a change
of this size. On the retargeted sample, correct answers go from 2 of 20 to 9 of
20, with two regressions.

`OperationQueue` was on the Swift list and came off for the twelfth removal:
Alamofire declares a real convenience initializer on it in an extension and the
call site invokes exactly that, so the name would have deleted a correct edge.
The comment records that ceiling.

**Controls.** Byte-identical resolved-call populations on gitleaks (go), zod
(typescript), Ocelot (csharp), celery (python), ripgrep (rust) and leveldb
(cpp), on both the graded and the broad basis. Kotlin is byte-identical on
exposed, ktor and javalin. The zeros were checked by perturbing the resolver and
confirming the same instrument catches 85 rows on gitleaks and 1,787 on celery.

**Cost**, best of three builds in one process: caffeine 5.183 to 5.255 ms/file,
Alamofire 1.066 to 1.018 ms/file. Dead-code findings unchanged both ways,
caffeine 71 and Alamofire 53, with none newly reported and none dropped.

`tests/unit/ingestion` passes, 2,557 tests. The one expectation change is the
language-dispatch test, which pins which strategy each language reaches.
