### PR TITLE
fix(generation): stamp editor files with the indexed commit, not live HEAD

### DIFF
--- a/packages/core/src/repowise/core/generation/editor_files/fetcher.py
+++ b/packages/core/src/repowise/core/generation/editor_files/fetcher.py
@@ -67,10 +67,18 @@ class EditorFileDataFetcher:
 
         kg_layers, kg_tour = await self._get_kg_data()
 
+        # The stamp must report the commit the index was built against, not
+        # the live HEAD: a rebase fires the regeneration hook per replayed
+        # commit while the index underneath is unchanged, so a live-HEAD
+        # stamp walks forward on its own and silently misdates everything
+        # below it. Fall back to the shell-out only when the column is empty
+        # (pre-backfill indexes).
+        stored_commit = ((repo.head_commit or "")[:7]) if repo else ""
+
         return EditorFileData(
             repo_name=repo_name,
             indexed_at=datetime.now(UTC).strftime("%Y-%m-%d"),
-            indexed_commit=_get_head_short_sha(self._repo_path),
+            indexed_commit=stored_commit or _get_head_short_sha(self._repo_path),
             architecture_summary=await self._get_architecture_summary(),
             key_modules=await self._get_key_modules(),
             entry_points=await self._get_entry_points(),

--- a/tests/unit/generation/test_editor_file_fetcher.py
+++ b/tests/unit/generation/test_editor_file_fetcher.py
@@ -372,3 +372,45 @@ async def test_fetch_indexed_at_is_date_string(session, repo, tmp_path):
     import re
 
     assert re.match(r"^\d{4}-\d{2}-\d{2}$", data.indexed_at)
+
+
+async def test_fetch_indexed_commit_reports_stored_head_commit(session, tmp_path):
+    """The stamp must report the commit the index was built against.
+
+    Regression test for #1874: the stamp used to shell out for the live HEAD,
+    which drifts from the indexed commit (e.g. a rebase rewrites CLAUDE.md
+    with the then-current HEAD while the index underneath is unchanged).
+    """
+    stored_commit = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
+    repo = await upsert_repository(
+        session,
+        name="test-repo",
+        local_path="/tmp/test-repo",
+        url="",
+        head_commit=stored_commit,
+    )
+    await session.commit()
+
+    # tmp_path is not a git checkout, so any shell-out for live HEAD would
+    # return "" — the stamp must still carry the stored commit's short form.
+    fetcher = EditorFileDataFetcher(session, repo.id, tmp_path)
+    data = await fetcher.fetch()
+
+    assert data.indexed_commit == stored_commit[:7]
+
+
+async def test_fetch_indexed_commit_falls_back_to_live_head_when_stored_is_empty(session, tmp_path):
+    """Pre-backfill indexes (head_commit NULL) keep the legacy shell-out path."""
+    repo = await upsert_repository(
+        session,
+        name="test-repo",
+        local_path="/tmp/test-repo",
+        url="",
+    )
+    await session.commit()
+
+    fetcher = EditorFileDataFetcher(session, repo.id, tmp_path)
+    data = await fetcher.fetch()
+
+    # tmp_path is not a git checkout, so the fallback resolves to "".
+    assert data.indexed_commit == ""


### PR DESCRIPTION
## Summary

- The "Last indexed" stamp in generated `CLAUDE.md` / `AGENTS.md` shelled out for the live `git HEAD` at write time instead of using `Repository.head_commit` — the commit the index was actually built against. A rebase fires the regeneration hook once per replayed commit, so the stamp walked forward on its own while the index underneath stayed unchanged, silently misdating every fact rendered below it.
- The stamp now reads the stored `head_commit` (shortened to 7 chars to match the width of `git rev-parse --short`) and falls back to the shell-out only when the column is empty (pre-backfill indexes).

## Related Issues

Fixes #1874

## Test Plan

- New regression test sets `head_commit` to a known full SHA, points the fetcher at a non-git directory (so any live-HEAD shell-out would resolve to `""`), and asserts the stamp reports the stored commit's short form.
- Companion test covers the fallback: with `head_commit` NULL the legacy shell-out path is preserved unchanged.
- Confirmed RED before the fix (`assert '' == 'a1b2c3d'`), GREEN after.

- [x] Tests pass (`pytest`) — full unit suite: 14,339 passed. One pre-existing failure in `tests/unit/cli/test_agent_target_baseline.py::test_integration_writes_match_baseline` reproduces identically on clean `main` (platform-dependent baseline: expects the Windows `AppData` path, gets macOS `Library/Application Support`); unrelated to this change.
- [x] Lint passes (`ruff check .`)
- [ ] Web build passes (`npm run build`) *(if frontend changes)* — N/A, no frontend changes

## Checklist

- [x] My code follows the project's code style
- [x] I have added tests for new functionality
- [x] All existing tests still pass
- [x] I have updated documentation if needed
