### PR TITLE
Handle corrupt LanceDB reads during resume

### DIFF
--- a/packages/core/src/repowise/core/persistence/vector_store/lancedb_store.py
+++ b/packages/core/src/repowise/core/persistence/vector_store/lancedb_store.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+
 from repowise.core.providers.embedding.base import Embedder
 
 from ..search import _SNIPPET_LEN, SearchResult, snippet_around
@@ -9,10 +11,12 @@ from ._base import STORED_SNIPPET_CHARS, VectorStore, iter_embed_chunks
 
 __all__ = ["STORED_SNIPPET_CHARS", "LanceDBVectorStore"]
 
-# DataFusion expands every literal in a large ``IN`` filter into native query
+# DataFusion expands every literal in a large `IN` filter into native query
 # state. A several-thousand-path generation level can otherwise commit
 # gigabytes before returning even though the selected result is small.
 _SUMMARY_PATH_BATCH_SIZE = 100
+
+logger = logging.getLogger(__name__)
 
 # ``STORED_SNIPPET_CHARS`` — how much of a page's content each row keeps — is
 # defined with the embed recipe and re-exported here so the historical import
@@ -326,8 +330,20 @@ class LanceDBVectorStore(VectorStore):
         await self._ensure_connected()
         if self._table is None:
             return set()
-        rows = await self._table.query().select(["page_id"]).to_list()  # type: ignore[union-attr]
-        return {r["page_id"] for r in rows}
+
+        try:
+            rows = await self._table.query().select(["page_id"]).to_list()  # type: ignore[union-attr]
+            return {r["page_id"] for r in rows}
+        except Exception as exc:
+            logger.warning(
+                "Failed to read page IDs from LanceDB vector store at %s. "
+                "The vector store may be damaged. Repowise will regenerate "
+                "pages instead. Run 'repowise reindex' to rebuild the vector store. "
+                "Error: %s",
+                self._db_path,
+                exc,
+            )
+            return set()
 
     async def get_page_summary_by_path(self, path: str) -> dict | None:
         """Return {'summary': str, 'key_exports': list[str]} for a previously-indexed page, or None.

--- a/tests/unit/persistence/test_vector_store.py
+++ b/tests/unit/persistence/test_vector_store.py
@@ -479,3 +479,46 @@ async def test_lancedb_embed_batch_isolates_failed_chunk(tmp_path):
         assert len(ids) == EMBED_BATCH_MAX_ITEMS * 2
     finally:
         await store.close()
+
+@pytest.mark.asyncio
+async def test_lancedb_list_page_ids_handles_corrupt_store(tmp_path, mock_embedder, caplog):
+    """A damaged LanceDB table must not crash resume generation."""
+    pytest.importorskip("lancedb")
+    from repowise.core.persistence.vector_store import LanceDBVectorStore
+
+    db_path = tmp_path / "lance"
+
+    store = LanceDBVectorStore(str(db_path), mock_embedder)
+
+    try:
+        await store.embed_and_upsert(
+            "p1",
+            "test content",
+            {"target_path": "a.py"},
+        )
+
+        # Healthy store still returns its page IDs.
+        assert await store.list_page_ids() == {"p1"}
+
+        # Simulate a corrupted LanceDB read.
+        class BrokenQuery:
+            def select(self, columns):
+                return self
+
+            async def to_list(self):
+                raise RuntimeError("simulated LanceDB corruption")
+
+        class BrokenTable:
+            def query(self):
+                return BrokenQuery()
+
+        store._table = BrokenTable()
+
+        # Corruption must degrade safely instead of crashing.
+        assert await store.list_page_ids() == set()
+
+        assert "vector store may be damaged" in caplog.text.lower()
+        assert "repowise reindex" in caplog.text.lower()
+
+    finally:
+        await store.close()

--- a/tests/unit/persistence/test_vector_store.py
+++ b/tests/unit/persistence/test_vector_store.py
@@ -7,6 +7,8 @@ LanceDB-specific tests are skipped if lancedb is not installed.
 
 from __future__ import annotations
 
+import logging
+
 import math
 
 import pytest
@@ -483,6 +485,7 @@ async def test_lancedb_embed_batch_isolates_failed_chunk(tmp_path):
 @pytest.mark.asyncio
 async def test_lancedb_list_page_ids_handles_corrupt_store(tmp_path, mock_embedder, caplog):
     """A damaged LanceDB table must not crash resume generation."""
+    caplog.set_level(logging.WARNING, logger="repowise.core.persistence.vector_store.lancedb_store")
     pytest.importorskip("lancedb")
     from repowise.core.persistence.vector_store import LanceDBVectorStore
 


### PR DESCRIPTION
## Summary

Handle corrupted or incomplete LanceDB vector-store reads during resume generation instead of crashing.

## Changes

- Guard `LanceDBVectorStore.list_page_ids()` against LanceDB read failures.
- Log a warning with the vector-store path and recommend `repowise reindex`.
- Return an empty set so generation can continue and regenerate resume state.
- Add a regression test covering a failed LanceDB read and the warning behavior.

## Verification

- `uv run pytest tests/unit/persistence/test_vector_store.py -v`
- Result: 28 passed

Closes #1765