### PR TITLE
fix(mcp): stop get_change_risk sharing a key name with a different question

### DIFF
--- a/docs/agent/MCP_TOOLS.md
+++ b/docs/agent/MCP_TOOLS.md
@@ -507,13 +507,13 @@ so a narrower set than `get_risk`'s file-level `tests_to_run` — same field nam
 because it is the same concern). It is capped at ten, with `total` and
 `truncated` reporting the overflow and the tail written to the omission store:
 on `truncated: true` the response carries an `omission_marker`, and
-`repowise expand <ref>` returns the rest. Its `missing_tests` buckets flag
+`repowise expand <ref>` returns the rest. Its `line_coverage` buckets flag
 `untested_changes` (covered file, uncovered change), `stale_test_candidates`
 (covered lines whose guarding test file is absent from the diff), `covered`, and
 `no_coverage_data` (files absent from the map). When no map is ingested the
 change is never reported as untested: `status` becomes `inferred` when the
 import graph can name test files reaching the change (candidates, file-level, no
-line attribution, and `missing_tests` stays empty because reaching cannot speak
+line attribution, and `line_coverage` stays empty because reaching cannot speak
 to lines), and `no_map` ("run the full suite") when it cannot. `basis` carries
 the same distinction in one word: `measured`, `inferred`, or absent. Build the
 measured map with `coverage run --contexts=test` followed by

--- a/docs/layers/TEST_INTELLIGENCE.md
+++ b/docs/layers/TEST_INTELLIGENCE.md
@@ -213,7 +213,7 @@ changed *lines*, so it is a strictly narrower and more useful set:
   "tests": ["tests/test_auth.py::test_login", "..."],
   "total": 23,
   "truncated": true,
-  "missing_tests": {
+  "line_coverage": {
     "untested_changes": [{"source_file": "...", "uncovered_lines": [...]}],
     "stale_test_candidates": [...],
     "covered": [...],
@@ -223,7 +223,7 @@ changed *lines*, so it is a strictly narrower and more useful set:
 }
 ```
 
-The `missing_tests` buckets are the honest breakdown: `untested_changes` is the
+The `line_coverage` buckets are the honest breakdown: `untested_changes` is the
 strong signal (the file *is* in the map, but nothing covers the lines you
 touched), `stale_test_candidates` flags covered lines whose guarding test file is
 absent from the diff, and `no_coverage_data` means the file is simply not in the

--- a/packages/core/src/repowise/core/analysis/change_risk/model.py
+++ b/packages/core/src/repowise/core/analysis/change_risk/model.py
@@ -138,7 +138,10 @@ SCORE_UNIT = "per-commit"
 #: blamed by a later fix. Ranking changes by lines-added alone beats the fitted
 #: model on that benchmark. So the score is reported as what it demonstrably is —
 #: a diff-size statistic — and ``fix_history`` carries the part that is not.
-SCORE_MEASURES = "diff size and spread; not where the change lands"
+SCORE_MEASURES = (
+    "diff size and spread; not where the change lands - overall_risk_score "
+    "is the separate 0-10 for that"
+)
 
 
 def _level(score: float) -> str:

--- a/packages/server/src/repowise/server/mcp_server/tool_change_risk.py
+++ b/packages/server/src/repowise/server/mcp_server/tool_change_risk.py
@@ -77,7 +77,7 @@ async def get_change_risk(
     calibrated per commit; ``risk_percentile`` ranks that shape against recent
     commits.
 
-    ``impacted_tests.tests_to_run`` names the tests to run; ``missing_tests``
+    ``impacted_tests.tests_to_run`` names the tests to run; ``line_coverage``
     the uncovered lines. ``basis``: ``measured`` = a coverage map proves those
     tests run the changed *lines*; ``inferred`` = test files the graph shows
     reaching it (file-level candidates). No map is never "untested":
@@ -366,7 +366,7 @@ def _empty_impacted(status: str, summary: str) -> dict[str, Any]:
         "tests_to_run": [],
         "total": 0,
         "truncated": False,
-        "missing_tests": {
+        "line_coverage": {
             "untested_changes": [],
             "stale_test_candidates": [],
             "covered": [],
@@ -610,7 +610,7 @@ async def _inferred_impacted(
     measured answer.
 
     Deliberately file-level and line-blind. Reaching carries no line
-    attribution, so ``missing_tests`` stays empty rather than being filled from
+    attribution, so ``line_coverage`` stays empty rather than being filled from
     a signal that cannot speak to lines - the distinction this whole block
     exists to keep.
     """
@@ -707,7 +707,7 @@ async def _impacted_tests_block(
         "tests_to_run": _cap_tests(tests, collector, "measured"),
         "total": total,
         "truncated": total > _IMPACTED_TESTS_LIMIT,
-        "missing_tests": _serialize_missing(report),
+        "line_coverage": _serialize_missing(report),
         "summary": (
             f"{total} test(s) cover the changed lines"
             + (f"; showing first {_IMPACTED_TESTS_LIMIT}" if total > _IMPACTED_TESTS_LIMIT else "")

--- a/tests/unit/server/mcp/test_change_risk.py
+++ b/tests/unit/server/mcp/test_change_risk.py
@@ -221,7 +221,7 @@ async def test_impacted_tests_line_precise_hit_and_miss(tmp_path, monkeypatch) -
     assert it["total"] == 1
     assert it["truncated"] is False
 
-    mt = it["missing_tests"]
+    mt = it["line_coverage"]
     # other.py is in the map but its changed lines (1,2,3) are uncovered.
     assert mt["untested_changes"] == [
         {"source_file": "src/other.py", "uncovered_lines": [1, 2, 3], "changed_line_count": 3}
@@ -256,7 +256,7 @@ async def test_impacted_tests_no_map_is_unknown_not_untested(tmp_path, monkeypat
     assert it["map_present"] is False
     assert it["tests_to_run"] == []
     # Honest degradation: no untested claim, a "run the suite" summary instead.
-    assert it["missing_tests"]["untested_changes"] == []
+    assert it["line_coverage"]["untested_changes"] == []
     assert "run the full suite" in it["summary"]
 
 
@@ -266,7 +266,7 @@ async def test_impacted_tests_falls_back_to_the_graph_without_a_map(tmp_path, mo
 
     Replaces a bare "run the full suite" with a candidate list on every repo
     that never ingested a report. Labelled ``inferred`` and file-level: reaching
-    carries no line attribution, so ``missing_tests`` stays empty rather than
+    carries no line attribution, so ``line_coverage`` stays empty rather than
     being filled from a signal that cannot speak to lines.
     """
     from repowise.core.persistence.models import GraphEdge, GraphNode
@@ -305,7 +305,7 @@ async def test_impacted_tests_falls_back_to_the_graph_without_a_map(tmp_path, mo
     assert it["basis"] == "inferred"
     assert it["map_present"] is False
     assert it["tests_to_run"] == ["tests/test_round_trips.py"]
-    assert it["missing_tests"]["untested_changes"] == []
+    assert it["line_coverage"]["untested_changes"] == []
     # Answered by the import tier: there is no call edge here, which is exactly
     # when the weaker tier is allowed to speak.
     assert "reach the changed files in the graph" in it["summary"]
@@ -362,3 +362,32 @@ async def test_impacted_tests_no_session_factory_degrades_to_no_index(tmp_path, 
 
     assert result["impacted_tests"]["status"] == "no_index"
     assert result["impacted_tests"]["map_present"] is False
+
+
+@pytest.mark.asyncio
+async def test_the_two_risk_tools_do_not_share_a_key_for_different_questions() -> None:
+    """``missing_tests`` asked two different questions under one name.
+
+    get_risk's is a list of file paths with no test; this one bucketed changed
+    files by line coverage. An agent that learned one misread the other.
+    """
+    import importlib
+
+    module = importlib.import_module("repowise.server.mcp_server.tool_change_risk")
+    empty = module._empty_impacted("no_map", "run the suite")
+
+    assert "missing_tests" not in empty
+    assert set(empty["line_coverage"]) == {
+        "untested_changes",
+        "stale_test_candidates",
+        "covered",
+        "no_coverage_data",
+    }
+
+
+def test_score_measures_names_the_other_zero_to_ten() -> None:
+    """Whichever risk tool an agent calls first, it learns the other is not it."""
+    from repowise.core.analysis.change_risk import SCORE_MEASURES
+
+    assert "diff size and spread" in SCORE_MEASURES
+    assert "overall_risk_score" in SCORE_MEASURES


### PR DESCRIPTION
Companion to the `get_risk` payload PR, from the same dogfood of both risk tools.

## One key name, two different questions

`get_risk.directive.missing_tests` is a list of file paths that have no test.

`get_change_risk.impacted_tests.missing_tests` was an object bucketing the changed files by line coverage: `untested_changes`, `stale_test_candidates`, `covered`, `no_coverage_data`.

Same name, different shape, different question. An agent that learns one misreads the other, and both were confirmed from live responses. The `get_change_risk` one is renamed to **`line_coverage`** — the more specific concept and the easier rename. Not `uncovered_lines`, which its own `untested_changes` entries already use for the line numbers, so that name would have nested inside itself.

## `score` did not say what it was not

`get_risk.overall_risk_score` and `get_change_risk.score` both render 0-10 and measure unrelated things. Measured on the same commit at the same moment they read **2.1** and **8.7**. `score_measures` already said what this score measures; it now also names the other one, so whichever tool an agent calls first it learns the two are not comparable.

The clause went into `SCORE_MEASURES` itself rather than a second string. It is shared with the REST git router, whose response carries an `overall_risk_score` too, so the pointer holds on that surface as well. The `get_change_risk` docstring is at the 1,600-char schema budget and stays untouched: a one-clause cross-reference in it measured 1,628. Rebasing onto #1880 conflicted here, since that PR had just tightened the same docstring for the same reason; its wording is kept and only the `line_coverage` rename is reapplied. The scale note lives in the payload, where a machine-readable note belongs anyway.

## Two things checked and left alone

**The truncated `impacted_tests` list is fine.** A response captured before #1869 merged showed `total: 21, truncated: true` with no omission ref, which would have been a regression of exactly what #1869 fixed. Re-verified against a restarted server: the ref is there and `repowise expand <ref>` returns all 11 dropped tests. The earlier reading came from a long-lived server process that had imported the modules before the merge.

**The payload does not need gating.** Re-measured properly on a live 8-file range — the CLI path emits neither `prior_fixes` nor `impacted_tests`, so the previous figure was an estimate. It is **4,342 chars**: `prior_fixes` 1,602, `impacted_tests` 933, `fix_history` 561, `drivers` 392, `_meta` 330, `features` 76, and the two static score strings 90 together. `prior_fixes` is the standout field of either tool, past bug fixes overlapping these exact changed lines being a signal nothing else in the product provides. The only gating candidates came to about 130 chars, which is not worth an `include=` parameter, so none was added.
