### PR TITLE
fix(graph): a rust macro invocation is not a function call

### DIFF
--- a/packages/core/src/repowise/core/ingestion/call_resolver.py
+++ b/packages/core/src/repowise/core/ingestion/call_resolver.py
@@ -46,6 +46,7 @@ from .languages.receiver_types import (
 )
 from .models import (
     CallSite,
+    CallSiteEdgeType,
     NamedBinding,
     ParsedFile,
     ResolutionOrigin,
@@ -185,6 +186,7 @@ class ResolvedCall:
     confidence: float  # 0.0–1.0
     line: int  # call site line number (for diagnostics)
     origin: ResolutionOrigin  # which strategy below produced it
+    edge_type: CallSiteEdgeType = "calls"  # carried through from the CallSite
 
 
 class CallResolver:
@@ -884,7 +886,14 @@ class CallResolver:
 
             resolved = self._resolve_one(file_path, call)
             if resolved:
-                results.append(self._redirect_to_definition(resolved))
+                resolved = self._redirect_to_definition(resolved)
+                # Stamped once here rather than in each tier: what a site
+                # produces is a property of the syntax, not of the strategy
+                # that answered it. No tier sets it, so this compares against
+                # the default rather than against a tier's opinion.
+                if call.edge_type != "calls":
+                    resolved = replace(resolved, edge_type=call.edge_type)
+                results.append(resolved)
 
         return results
 

--- a/packages/core/src/repowise/core/ingestion/graph/_resolvers.py
+++ b/packages/core/src/repowise/core/ingestion/graph/_resolvers.py
@@ -558,6 +558,7 @@ class ResolveMixin:
                 self._graph.nodes[decl_id]["defined_by"] = def_id
 
         total_resolved = 0
+        total_referenced = 0
 
         files_with_calls = [
             (p, pf) for p, pf in self._parsed_files.items() if pf.calls
@@ -567,29 +568,46 @@ class ResolveMixin:
         for path, parsed in files_with_calls:
             resolved = resolver.resolve_file(path, parsed.calls)
             for rc in resolved:
-                if rc.caller_id in self._graph and rc.callee_id in self._graph:
-                    if not self._graph.has_edge(rc.caller_id, rc.callee_id):
-                        self._graph.add_edge(
-                            rc.caller_id,
-                            rc.callee_id,
-                            edge_type="calls",
-                            confidence=rc.confidence,
-                            resolution_origin=rc.origin,
-                            call_lines=[rc.line],
-                        )
+                if rc.caller_id not in self._graph or rc.callee_id not in self._graph:
+                    continue
+                if not self._graph.has_edge(rc.caller_id, rc.callee_id):
+                    attrs = (
+                        {"edge_type": "calls", "call_lines": [rc.line]}
+                        if rc.edge_type == "calls"
+                        else {"edge_type": "references"}
+                    )
+                    self._graph.add_edge(
+                        rc.caller_id,
+                        rc.callee_id,
+                        confidence=rc.confidence,
+                        resolution_origin=rc.origin,
+                        **attrs,
+                    )
+                    if rc.edge_type == "calls":
                         total_resolved += 1
                     else:
-                        # Several call sites collapse onto one edge; the
-                        # strongest wins, and the origin has to follow the
-                        # confidence it explains.
-                        existing = self._graph[rc.caller_id][rc.callee_id]
-                        lines = existing.setdefault("call_lines", [])
-                        if rc.line not in lines:
-                            lines.append(rc.line)
-                            lines.sort()
-                        if rc.confidence > existing.get("confidence", 0):
-                            existing["confidence"] = rc.confidence
-                            existing["resolution_origin"] = rc.origin
+                        total_referenced += 1
+                    continue
+                existing = self._graph[rc.caller_id][rc.callee_id]
+                if rc.edge_type != "calls":
+                    # A pair reached by both an invocation and a non-invoking
+                    # site keeps the call: it is the stronger claim, and the
+                    # same rule ``_add_reference_edges`` applies.
+                    continue
+                if existing.get("edge_type") == "references":
+                    existing["edge_type"] = "calls"
+                    total_referenced -= 1
+                    total_resolved += 1
+                # Several call sites collapse onto one edge; the strongest
+                # wins, and the origin has to follow the confidence it
+                # explains.
+                lines = existing.setdefault("call_lines", [])
+                if rc.line not in lines:
+                    lines.append(rc.line)
+                    lines.sort()
+                if rc.confidence > existing.get("confidence", 0):
+                    existing["confidence"] = rc.confidence
+                    existing["resolution_origin"] = rc.origin
             if progress:
                 progress.on_item_done("graph.calls")
 
@@ -597,7 +615,11 @@ class ResolveMixin:
             _phase_done = getattr(progress, "on_phase_done", None)
             if _phase_done is not None:
                 _phase_done("graph.calls")
-        log.info("Call edges resolved", total=total_resolved)
+        log.info(
+            "Call edges resolved",
+            total=total_resolved,
+            non_invoking=total_referenced,
+        )
 
         self._add_reference_edges(resolver)
 

--- a/packages/core/src/repowise/core/ingestion/language_configs.py
+++ b/packages/core/src/repowise/core/ingestion/language_configs.py
@@ -63,6 +63,12 @@ class LanguageConfig:
     # what tells them apart downstream (see ``Symbol.is_declaration``).
     declaration_node_types: frozenset[str] = field(default_factory=frozenset)
 
+    # Call-site node types that name a symbol without invoking it. Rust's
+    # ``foo!(..)`` expands a ``macro_rules! foo``; which symbol the name means
+    # is the same question a call asks, so these still run the call tiers, but
+    # the edge they produce is ``references`` rather than ``calls``.
+    reference_call_node_types: frozenset[str] = field(default_factory=frozenset)
+
 
 LANGUAGE_CONFIGS: dict[str, LanguageConfig] = {
     "python": LanguageConfig(
@@ -152,6 +158,7 @@ LANGUAGE_CONFIGS: dict[str, LanguageConfig] = {
         visibility_fn=rust_visibility,
         parent_extraction="impl",
         parent_class_types=frozenset({"impl_item", "mod_item"}),
+        reference_call_node_types=frozenset({"macro_invocation"}),
     ),
     "java": LanguageConfig(
         symbol_node_types={

--- a/packages/core/src/repowise/core/ingestion/models.py
+++ b/packages/core/src/repowise/core/ingestion/models.py
@@ -261,6 +261,14 @@ class CallReceiver:
     argument_count: int | None
 
 
+#: What a resolved call site becomes in the graph. A syntactic form that names
+#: a symbol without invoking it still runs the call tiers -- deciding which
+#: symbol a name means is the same problem -- but must not reach the graph as
+#: ``calls``. Both members are ``EdgeType`` members; this is the subset a call
+#: site may produce.
+CallSiteEdgeType = Literal["calls", "references"]
+
+
 @dataclass
 class CallSite:
     """A function or method call extracted from a source file.
@@ -274,6 +282,7 @@ class CallSite:
     line: int  # 1-indexed line number of the call
     argument_count: int | None  # number of arguments (None if unknown)
     receiver_call: CallReceiver | None = None  # set only for a captured chained call
+    edge_type: CallSiteEdgeType = "calls"  # see ``CallSiteEdgeType``
 
 
 HeritageKind = Literal["extends", "implements", "trait_impl", "mixin"]

--- a/packages/core/src/repowise/core/ingestion/parser.py
+++ b/packages/core/src/repowise/core/ingestion/parser.py
@@ -1249,6 +1249,11 @@ class ASTParser:
                     line=line,
                     argument_count=arg_count,
                     receiver_call=receiver_call,
+                    edge_type=(
+                        "references"
+                        if site_node.type in config.reference_call_node_types
+                        else "calls"
+                    ),
                 )
             )
 

--- a/packages/ui/src/graph/symbol-relations.ts
+++ b/packages/ui/src/graph/symbol-relations.ts
@@ -50,7 +50,8 @@ const RELATION_LABELS: Record<string, Record<SymbolRelationDirection, string>> =
 const GROUP_HINTS: Record<SymbolRelationGroup["group"], string> = {
   heritage: "Inherits or implements. Not a call site.",
   wiring: "Connected by a framework, so no call site exists in the source.",
-  reference: "Named without being called, such as a handler in a dispatch table.",
+  reference:
+    "Reached without a function call: a handler named in a dispatch table, or a Rust macro invocation.",
 };
 
 export function relationLabel(

--- a/tests/unit/ingestion/test_value_reference_edges.py
+++ b/tests/unit/ingestion/test_value_reference_edges.py
@@ -170,13 +170,27 @@ class TestRustFunctionValues:
         graph = _build(tmp_path)
         assert _inbound(graph, "main.rs::on_tick", "references")
 
-    def test_a_macro_invocation_is_still_a_call(self, tmp_path: Path) -> None:
-        """Macros carry no argument capture either, and are not value references.
 
-        The two are separated by the pattern, not by the absence of an argument
-        list — reading that absence as "this is a value" would reclassify every
-        ``println!`` in the corpus.
-        """
+class TestRustMacroInvocations:
+    """``foo!(..)`` names a ``macro_rules! foo``; a macro is not a function.
+
+    Hand-read across ripgrep, serde and bevy, four of the eight wrong rows in
+    the rust precision cell were this one shape, and every one had the *right*
+    target: the resolver found the correct ``macro_rules!`` at the correct site
+    and filed it under the wrong edge type.
+
+    So the site keeps its resolution and changes only its type. That is a
+    deliberate divergence from the value-reference shapes above, which route
+    through the ``@reference.name`` capture and so inherit
+    ``_add_reference_edges``'s 0.85 confidence floor. That floor was bought by
+    a *bare identifier* in argument position, where an ordinary local looks
+    exactly like a function name; ``foo!`` is unambiguous. Applying it here
+    would delete every macro edge the repo-wide unique-name tier answers -
+    160 of 669 across the three repositories - rather than retype them,
+    discarding a real dependency to move a precision number.
+    """
+
+    def test_a_macro_invocation_is_a_reference_not_a_call(self, tmp_path: Path) -> None:
         (tmp_path / "main.rs").write_text(
             "macro_rules! shout { () => {} }\n"
             "fn run() {\n"
@@ -184,6 +198,62 @@ class TestRustFunctionValues:
             "}\n"
         )
         graph = _build(tmp_path)
+        assert _inbound(graph, "main.rs::shout", "references")
+        assert not _inbound(graph, "main.rs::shout", "calls")
+
+    def test_an_ordinary_call_beside_it_is_still_a_call(self, tmp_path: Path) -> None:
+        """The macro node type decides it, not the absence of an argument capture.
+
+        Reading that absence as "not an invocation" would reclassify every
+        ordinary call the argument capture happens to miss.
+        """
+        (tmp_path / "main.rs").write_text(
+            "macro_rules! shout { () => {} }\n"
+            "fn helper() {}\n"
+            "fn run() {\n"
+            "    shout!();\n"
+            "    helper();\n"
+            "}\n"
+        )
+        graph = _build(tmp_path)
+        assert _inbound(graph, "main.rs::helper", "calls")
+        assert _inbound(graph, "main.rs::shout", "references")
+
+    def test_a_macro_edge_below_the_reference_floor_survives(
+        self, tmp_path: Path
+    ) -> None:
+        """The retype must not inherit ``_add_reference_edges``'s 0.85 floor.
+
+        A macro defined in another file resolves on a lower tier than a
+        same-file one. That population is the majority of macro invocations in
+        the corpus, so a floor here would read as a removal rather than a
+        retype.
+        """
+        (tmp_path / "mac.rs").write_text("macro_rules! only_here { () => {} }\n")
+        (tmp_path / "main.rs").write_text("fn run() {\n    only_here!();\n}\n")
+        graph = _build(tmp_path)
+        assert _inbound(graph, "mac.rs::only_here", "references")
+
+    def test_a_reclassified_edge_carries_no_call_lines(self, tmp_path: Path) -> None:
+        """``call_lines`` is what a call site contributes, and this is not one.
+
+        Every other ``references`` producer omits it, and the persistence layer
+        writes the attribute through unconditionally, so setting it here would
+        put a shape in the store that no consumer has ever seen.
+        """
+        (tmp_path / "main.rs").write_text(
+            "macro_rules! shout { () => {} }\nfn run() {\n    shout!();\n}\n"
+        )
+        graph = _build(tmp_path)
+        assert "call_lines" not in graph["main.rs::run"]["main.rs::shout"]
+
+    def test_other_languages_keep_their_call_edges(self, tmp_path: Path) -> None:
+        """The node-type list is per language and empty everywhere but rust."""
+        (tmp_path / "app.py").write_text(
+            "def helper():\n    return 1\n\n\ndef run():\n    return helper()\n"
+        )
+        graph = _build(tmp_path)
+        assert _inbound(graph, "app.py::helper", "calls")
         assert not _edges_of_type(graph, "references")
 
 


### PR DESCRIPTION
`foo!(..)` names a `macro_rules! foo` and expands it. The resolver found the right definition at the right site and filed the edge as `calls`, which asserts an invocation of a function that does not exist. Hand-read across ripgrep, serde and bevy, this was four of the eight wrong rows in the rust precision cell, and every one of them had the correct target.

So the site keeps its resolution and changes only its type.

## The mechanism

`LanguageConfig.reference_call_node_types` lists the call-site node types that are not invocations. Rust holds `macro_invocation`; every other language's is empty, so this is a no-op elsewhere by construction. The parser stamps `CallSite.edge_type` from it, `resolve_file` carries the stamp through in one place rather than in each of its tiers, and the emitter writes `references` instead of `calls`. A pair reached by both a macro invocation and a real call keeps the call, which is the rule the existing reference emitter already applies.

**Deliberately not routed through the `@reference.name` capture** that #1661 used for the same class of problem. That path applies a 0.85 confidence floor, bought by bare identifiers in argument position where an ordinary local is spelled exactly like a function name. `foo!` carries no such ambiguity, and 160 of the 669 edges resolve on the repo-wide unique-name tier at 0.50, so the floor would have deleted them rather than retyping them.

## Measured on ripgrep, serde and bevy

**669 edges retyped, 0 added and 0 deleted.** Same caller, same callee, same confidence, same resolution origin. Total graph edges identical either side (11,250 / 5,814 / 101,784) and every other edge type byte-identical.

Predicted before it was measured, by a source-text regex sharing no code with the change (the change reads a tree-sitter node type; the instrument reads the line and asks whether it spells `target!`):

| repo | sites predicted | sites moved | edges predicted | edges moved |
|---|---:|---:|---:|---:|
| ripgrep | 1,047 | 1,047 | 20 | 20 |
| serde | 709 | 709 | 131 | 131 |
| bevy | 3,935 | 3,935 | 518 | 518 |

Exact on both bases on all three repositories, and the site agreement is at the level of sets rather than counts: the two instruments identify the same 5,691 sites, not merely the same number of them. The two bases are not interchangeable — ripgrep's 349 module-level `rgtest!` invocations are 349 sites and one edge.

**30 removed rows hand-read from source**, 10 per repository, drawn from the production population diff and stratified by resolution origin: 30/30 genuine macro invocations, 30/30 wrong as a `calls` edge, 29/30 with a correct target. The single wrong target is a pre-existing same-name collision that this change does not fix and does not introduce.

**Five non-rust controls byte-identical.** Dead-code findings 0 moved on all three rust repos. Cost free and slightly cheaper per file, since the emitter does less work on a retyped edge.

## What it costs, stated rather than discovered

`references` sits outside `EXECUTION_EDGE_TYPES` on the stated ground that it records a mention rather than a transfer of control. **A macro invocation does transfer control** — it expands, and the expansion runs — so the vocabulary understates these edges, and everything asking "would running this test execute that code" loses them: test reachability, `get_risk`'s `tests_to_run`, execution flows, MCP call tracing, the System Map adjacency, move-method and split-file blast radius. `get_context` and `get_symbol` key on a literal `"calls"`, so these rows move from `callers`/`callees` into `relations`.

Measured: **23 files across the three repositories lose their only cross-file `calls` edge; none lose their only dependency edge.**

A third bucket, for a form that expands rather than dispatches, is what would actually be right here. That is a separate change with its own gate, not something to fold into this one. Filing a macro as a function call is worse than filing it as a reference, which is why this ships as it stands.

## Also in this diff

The symbol-page hint copy read "Named without being called, such as a handler in a dispatch table", which this change makes false for a macro invocation.

## Re-indexing

Adding a field to `CallSite` moves the parse-cache fingerprint, so an already-indexed rust repository picks this up on its next `update` through a full reparse and a widened `graph_edges` rewrite. No manual re-index needed.
