### PR TITLE
fix(search): strip trailing glob wildcards in path-mode queries

### DIFF
--- a/packages/server/src/repowise/server/mcp_server/tool_search_symbols.py
+++ b/packages/server/src/repowise/server/mcp_server/tool_search_symbols.py
@@ -271,7 +271,14 @@ def _path_score(target_path: str, qnorm: str) -> float:
 
 async def search_paths_single(ctx: Any, query: str, limit: int) -> list[dict]:
     """Path search against one repo context. Returns ranked file result dicts."""
-    qnorm = query.strip().lower().replace("\\", "/")
+    # Strip leading/trailing glob chars: the match below is a substring search
+    # (``%...%`` on both sides), so a trailing/leading ``*`` or ``?`` carries no
+    # extra information. Without this, ``foo*`` survives into the LIKE pattern
+    # as a literal asterisk (``*`` is not a LIKE metacharacter) and matches
+    # nothing, silently. Mid-string globs (``src/*/main.py``) are left alone —
+    # a substring match cannot honour them, so stripping there would answer a
+    # different question than the one asked.
+    qnorm = query.strip().lower().replace("\\", "/").strip("*?")
     if not qnorm:
         return []
 

--- a/tests/unit/server/mcp/test_search.py
+++ b/tests/unit/server/mcp/test_search.py
@@ -665,6 +665,31 @@ class TestPathSearch:
         assert result["mode"] == "path"
         assert any(r["file"] == "src/db/models.py" for r in result["results"])
 
+    @pytest.mark.asyncio
+    async def test_trailing_glob_wildcard_is_not_literal(self, setup_mcp):
+        """Regression for #1871: ``foo*`` must search like ``foo``.
+
+        ``*`` is not a SQL LIKE metacharacter, so before the strip it survived
+        into the pattern literally and matched nothing — silently.
+        """
+        from repowise.server.mcp_server import search_codebase
+
+        result = await search_codebase("service.py*", mode="path")
+        assert any(r["file"] == "src/auth/service.py" for r in result["results"])
+
+        result = await search_codebase("*service.py", mode="path")
+        assert any(r["file"] == "src/auth/service.py" for r in result["results"])
+
+    @pytest.mark.asyncio
+    async def test_mid_string_glob_is_not_silently_stripped(self, setup_mcp):
+        """A mid-string glob is a real glob; stripping it would change the
+        question, so it is left alone (substring match may return nothing,
+        but must not mis-match)."""
+        from repowise.server.mcp_server import search_codebase
+
+        result = await search_codebase("src/*/service.py", mode="path")
+        assert all("*" not in r["file"] for r in result["results"])
+
 
 class TestHybridSearch:
     """Mixed natural-language + identifier queries run hybrid."""


### PR DESCRIPTION
Problem:
- `search_codebase(query="tool_overview*", mode="path")` returns nothing, silently. Every other path query shape works; only the trailing glob fails. `*` is not a SQL LIKE metacharacter, so it is neither escaped nor translated — it survives into the pattern literally (`%tool_overview*%`) and matches no path.

Solution:
- Strip leading/trailing `*`/`?` in `search_paths_single` before building the LIKE pattern. The match is already `%...%` on both sides (a substring search), so boundary wildcards carry no information. Mid-string globs are deliberately left alone: a substring match cannot honour them, and stripping there would answer a different question than asked. `escape_like` is unchanged — this is not an escaping concern.

Result:
- Regression tests in `TestPathSearch`: trailing and leading `*` now resolve the file; mid-string glob is not silently stripped. Verified the tests FAIL on the unfixed code (stashed the fix, 1 failed as expected) and pass with it. `pytest tests/unit/server/mcp/test_search.py` 62/62 passed, `ruff check` clean.