### PR TITLE
refactor(mcp)!: get_risk's will_break is may_break

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -144,7 +144,7 @@ current ones. Changes there are welcome, but expect closer review and bring test
    ```
 5. **Check your own change** with the tool you are contributing to:
    ```bash
-   uv run repowise risk main..HEAD        # 0-10 defect score, plus will_break,
+   uv run repowise risk main..HEAD        # 0-10 defect score, plus may_break,
                                           # missing_cochanges and missing_tests
    uv run repowise impacted-tests --staged  # the tests your diff actually exercises
    uv run repowise health --file <path>   # did the file you touched get worse?

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Three deterministic signals, all computed from the graph and git history, no LLM
 
 - **Change risk.** Score any commit or `base..HEAD` range **0-10** from the shape of
   the diff, ranked against your repo's own recent commits. PR mode returns directives
-  rather than vibes: `will_break`, `missing_cochanges`, `missing_tests`, `tests_to_run`.
+  rather than vibes: `may_break`, `missing_cochanges`, `missing_tests`, `tests_to_run`.
   One command: `repowise risk main..HEAD`. ([reference →](docs/layers/CHANGE_RISK.md))
 - **Bug history.** Which files and symbols actually get bug-fixed, and how recently.
   Doc, test and config commits are filtered out so the count means what it says, and a

--- a/docs/agent/MCP_TOOLS.md
+++ b/docs/agent/MCP_TOOLS.md
@@ -453,13 +453,21 @@ Modification risk assessment for files or a set of changed files.
 
 > **Scales.** `overall_risk_score` (in `pr_blast_radius`, with an `overall_risk_score_measures` note beside it) reads where the change lands. It is not comparable to `get_change_risk.score`, which is also 0-10 and reads the shape of the diff. Ratios derived from ownership or percentile columns are 0-1 (`hotspot_score`, `owner_pct`, `recent_owner_pct`); coverage and gap fields are 0-100 (`coverage_pct`, `branch_coverage_pct`, `share_of_repo_gap_pct`, `change_entropy_pct`, `churn_percentile`). The `_pct` suffix alone does not tell you which — check this table. Every emitted float is rounded to 4 significant digits.
 
-When `changed_files` is passed, the response leads with a `directive` block. Its core lists are the local blast radius: `will_break` (production files that depend on the diff and are likely to break), `will_break_tests` (test files impacted the same way, kept separate so a burst of broken tests doesn't crowd production impact out of the capped list), `missing_cochanges` (historical co-changers absent from the diff), `missing_tests` (changed files without test coverage), and `tests_to_run` (the positive complement of `missing_tests`: the tests that exercise the changed files, as pytest-runnable arguments). Read `tests_to_run_basis` beside it, because the ids alone do not say where they came from: `measured` means the per-test coverage map proves those tests execute the changed files; `inferred` means the import graph shows those test *files* reaching the change, which is a candidate list rather than proof and needs no coverage ingest; `none` means neither source knows of a test, which is unknown and not "untested". The two are never mixed in one list. In workspace mode that directive also carries the cross-repo fallout of the changed repo:
+When `changed_files` is passed, the response leads with a `directive` block. Its core lists are the local blast radius: `may_break` (production files that reach the diff through the import graph and so may break), `may_break_tests` (test files impacted the same way, kept separate so a burst of broken tests doesn't crowd production impact out of the capped list), `missing_cochanges` (historical co-changers absent from the diff), `missing_tests` (changed files without test coverage), and `tests_to_run` (the positive complement of `missing_tests`: the tests that exercise the changed files, as pytest-runnable arguments). Read `tests_to_run_basis` beside it, because the ids alone do not say where they came from: `measured` means the per-test coverage map proves those tests execute the changed files; `inferred` means the import graph shows those test *files* reaching the change, which is a candidate list rather than proof and needs no coverage ingest; `none` means neither source knows of a test, which is unknown and not "untested". The two are never mixed in one list. In workspace mode that directive also carries the cross-repo fallout of the changed repo:
 
 - `will_break_consumers`: services in *other* repos that depend on this one (structural impact), each with `repo`, `service`, `distance`, `score`, and the edge kinds carrying the impact.
 - `missing_cross_repo_cochanges`: services in other repos that historically co-change with this one but aren't in the diff.
 - `breaking_changes`: provider contracts in this repo that changed *incompatibly* since the last index (a removed route or field, a type or field-number change, a newly-required field), each with the changed `contract_id`, the change `kind`/`severity`, and the `impacted_consumers` (repo, service, file) it endangers across repos. Schema-level truth, distinct from the topology-level `will_break_consumers`; non-breaking changes (added optional field, new endpoint) never appear. See [Breaking-Change Guard](../scale/WORKSPACES.md#breaking-change-guard).
 - `conformance_violations`: declared dependency-rule breaches the diff's repo participates in, each with the offending `source`/`target` services, the `rule` (e.g. `frontend !-> db`), and `edge_kind`. See [Architecture Conformance](../scale/WORKSPACES.md#architecture-conformance).
 - `dependency_cycles`: circular service dependencies involving this repo, each with the participating `nodes` and `length`.
+
+> **Output-schema change.** `directive.will_break` is now `directive.may_break`,
+> and `directive.will_break_tests` is now `directive.may_break_tests`. Both are
+> a reverse-import reachability walk: `get_risk` is given a file list, never a
+> diff, so it cannot know whether the symbol an importer actually uses changed.
+> The old name promised a precision the analyzer does not have.
+> `will_break_consumers` and `breaking_changes` keep "will" — those come from
+> real contract diffing.
 
 **When to use:** Before modifying files, especially hotspots. Understand what could break, who to involve in review, and whether tests cover the affected area.
 
@@ -525,6 +533,14 @@ measured map with `coverage run --contexts=test` followed by
 
 > **Output-schema change.** `impacted_tests.tests` is now
 > `impacted_tests.tests_to_run`, matching `get_risk`'s directive.
+
+`is_fix` is the defect benchmark's keyword rule read over the commit subject,
+not the conventional-commit type, so a `feat:` commit whose subject says it
+fixes something reads true; the rule is frozen for comparability rather than
+tuned. `prior_fixes` below is the tuned view: it applies a diff-shape filter on
+top of that rule, counting only commits that actually edited production code.
+`fix_history` above runs the same unfiltered rule, and `prior_fixes` is the one
+block of the three that needs an index.
 
 When the changed files carry counted bug fixes, the response also holds
 `prior_fixes`: per file, how many past bug-fix commits touched it

--- a/docs/reference/CLI_REFERENCE.md
+++ b/docs/reference/CLI_REFERENCE.md
@@ -751,7 +751,7 @@ to the model's baseline commit, not this repo.
 | `--exclude` / `-x` | Gitignore-style path pattern to omit. Repeatable; filters both the change and baseline. Root `.riskignore` patterns also apply. |
 | `--baseline` | Recent commits to sample for the repo-relative percentile (default 200; `0` shows only the absolute calibrated band) |
 | `--target` / `-t` | Score what history says about these **files** instead of a change. Repeatable; switches the command to the `get_risk` tool |
-| `--changed-file` | With `--target`: PR mode. Leads with a directive naming what will break, which co-changes and tests are missing, and what to run |
+| `--changed-file` | With `--target`: PR mode. Leads with a directive naming what may break, which co-changes and tests are missing, and what to run |
 | `--format` | Output format: `table` (default) or `json` |
 | `--full` | With `--target`: emit the complete tool payload as JSON (implies `--format json`) |
 

--- a/packages/cli/src/repowise/cli/commands/risk_cmd.py
+++ b/packages/cli/src/repowise/cli/commands/risk_cmd.py
@@ -144,11 +144,11 @@ def _render_target_risk(projected: dict, requested: tuple[str, ...]) -> None:
     directive = projected.get("directive")
     if directive:
         # PR mode leads with the directive because that is the tool's contract:
-        # what will break, what is missing, what to run.
+        # what may break, what is missing, what to run.
         console.print(f"\n[bold]Directive[/bold] {escape(str(directive.get('summary', '')))}")
         for label, key in (
-            ("Will break", "will_break"),
-            ("Tests likely broken", "will_break_tests"),
+            ("May break", "may_break"),
+            ("Tests that may break", "may_break_tests"),
             ("Missing co-changes", "missing_cochanges"),
             ("Files without tests", "missing_tests"),
             ("Tests to run", "tests_to_run"),
@@ -429,7 +429,7 @@ def _ordinal(n: int) -> str:
     multiple=True,
     metavar="PATH",
     help="With --target: PR mode. The response leads with a directive naming "
-    "what will break, which co-changes and tests are missing, and what to run.",
+    "what may break, which co-changes and tests are missing, and what to run.",
 )
 @format_option()
 @full_option()

--- a/packages/core/src/repowise/core/analysis/pr_blast.py
+++ b/packages/core/src/repowise/core/analysis/pr_blast.py
@@ -208,14 +208,14 @@ class PRBlastRadiusAnalyzer:
         "this file imports that one" and walked through it, then walked
         through *that* file's co-change partners at the next depth. On this
         repository a PR touching ``core/__init__.py`` reached five co-change
-        rows and two real importers at depth 1, and since ``will_break`` is
+        rows and two real importers at depth 1, and since ``may_break`` is
         capped at five and sorted by depth, the noise crowded out the answer.
         Those partners are already reported, correctly labelled, by
         :meth:`_cochange_warnings`.
         """
         visited: dict[str, int] = {}  # path -> depth at which it was first reached
         # Sorted, not just deduped. This walk's output is cut twice downstream
-        # — ``will_break`` takes 15 of it, and that is the first field
+        # — ``may_break`` takes 15 of it, and that is the first field
         # ``get_risk``'s PR directive tells an agent to read — so the order
         # inside a depth band decides what an agent is shown. A hash-ordered
         # seed plus an unordered ``SELECT DISTINCT`` made that order vary

--- a/packages/core/src/repowise/core/generation/editor_files/tool_table.py
+++ b/packages/core/src/repowise/core/generation/editor_files/tool_table.py
@@ -88,7 +88,7 @@ TOOL_TABLE_ROWS: dict[str, tuple[str, str]] = {
     "get_risk": (
         "get_risk(targets, changed_files?, include?)",
         "Call before editing: what history says about touching these files. "
-        "PR mode (`changed_files`) leads with a `directive`: read `will_break` "
+        "PR mode (`changed_files`) leads with a `directive`: read `may_break` "
         "/ `missing_cochanges` / `missing_tests` / `tests_to_run`.",
     ),
     "get_change_risk": (

--- a/packages/server/src/repowise/server/mcp_server/_savings/counterfactual.py
+++ b/packages/server/src/repowise/server/mcp_server/_savings/counterfactual.py
@@ -180,12 +180,18 @@ def _fixed_floor(tokens: int) -> Callable[[dict[str, Any]], int]:
     return _estimate
 
 
+#: Directive lists this estimator counts as "files the agent would have opened".
+#: Read by name out of the response, so a rename on the tool side undercounts
+#: silently instead of failing - test_risk.py asserts these keys still exist.
+RISK_RELATED_FILE_KEYS = ("may_break", "missing_cochanges")
+
+
 def _estimate_get_risk(result: dict[str, Any]) -> int:
     """Per assessed target + per PR blast-radius file, floored at ``RISK_FLOOR``.
 
     Each ``targets`` entry is a file whose churn/ownership/co-change history the
     agent would otherwise reconstruct from ``git log``/``git blame``. PR mode
-    adds a ``directive`` naming the files that break (``will_break``) and the
+    adds a ``directive`` naming the files that may break (``may_break``) and the
     co-change partners the diff missed — each one more file the agent would
     have had to find by hand.
     """
@@ -198,7 +204,7 @@ def _estimate_get_risk(result: dict[str, Any]) -> int:
         # Union the two lists: a file that both breaks and is a missed
         # co-change partner is still just one file the agent would open.
         related_files: set[str] = set()
-        for key in ("will_break", "missing_cochanges"):
+        for key in RISK_RELATED_FILE_KEYS:
             related = directive.get(key)
             if isinstance(related, list):
                 related_files.update(f for f in related if isinstance(f, str))

--- a/packages/server/src/repowise/server/mcp_server/tool_risk/directives.py
+++ b/packages/server/src/repowise/server/mcp_server/tool_risk/directives.py
@@ -44,12 +44,12 @@ _BC_CONSUMER_LIMIT = 5
 _CF_VIOLATION_LIMIT = 5
 _CF_CYCLE_LIMIT = 3
 
-#: Caps on the will-break split. Production impact leads the directive, so it
+#: Caps on the may-break split. Production impact leads the directive, so it
 #: keeps the larger budget; test fallout is a secondary signal capped tighter.
-_WILL_BREAK_LIMIT = 5
-_WILL_BREAK_TESTS_LIMIT = 3
+_MAY_BREAK_LIMIT = 5
+_MAY_BREAK_TESTS_LIMIT = 3
 #: Cap on the coverage-backed run-list. A validate-this-change set can be longer
-#: than the will-break lists (it is what you actually run), but stays glanceable;
+#: than the may-break lists (it is what you actually run), but stays glanceable;
 #: the overflow and the full per-file map live in pr_blast_radius.guarding_tests.
 _TESTS_TO_RUN_LIMIT = 10
 
@@ -166,9 +166,10 @@ def _cross_repo_directive(repo_alias: str) -> tuple[list[dict[str, Any]], list[d
     """Cross-repo half of the PR directive: downstream services in other repos.
 
     Resolves the changed repo to its system-graph nodes and ranks reachable
-    services in OTHER repos by impact, splitting structural (``will_break``) from
-    behavioral co-change (``missing_cochanges``). Returns two empty lists when
-    not in workspace mode or no system graph is available. Never raises.
+    services in OTHER repos by impact, splitting structural
+    (``will_break_consumers``) from behavioral co-change (``missing_cochanges``).
+    Returns two empty lists when not in workspace mode or no system graph is
+    available. Never raises.
     """
     will_break_consumers: list[dict[str, Any]] = []
     missing_cross_repo_cochanges: list[dict[str, Any]] = []
@@ -338,8 +339,12 @@ def _build_pr_directive(
         [p for p in (_as_path(e) for e in trimmed_blast.get("transitive_affected", [])) if p],
         exclude_spec,
     )
-    will_break = [p for p in affected if p not in test_paths][:_WILL_BREAK_LIMIT]
-    will_break_tests = [p for p in affected if p in test_paths][:_WILL_BREAK_TESTS_LIMIT]
+    # "may", not "will": this is a reverse-import reachability walk over a file
+    # list, and get_risk is never given a diff, so nothing here knows whether the
+    # symbol an importer uses actually changed. The diff-backed fields below keep
+    # "will".
+    may_break = [p for p in affected if p not in test_paths][:_MAY_BREAK_LIMIT]
+    may_break_tests = [p for p in affected if p in test_paths][:_MAY_BREAK_TESTS_LIMIT]
 
     missing_cochanges = filter_path_list(
         [p for p in (_as_path(e) for e in trimmed_blast.get("cochange_warnings", [])) if p],
@@ -454,8 +459,8 @@ def _build_pr_directive(
         )
 
     response["directive"] = {
-        "will_break": will_break,
-        "will_break_tests": will_break_tests,
+        "may_break": may_break,
+        "may_break_tests": may_break_tests,
         "missing_cochanges": missing_cochanges,
         "missing_tests": missing_tests,
         "tests_to_run": tests_to_run,
@@ -469,8 +474,8 @@ def _build_pr_directive(
         "governance_risk": governance_risk,
         "summary": (
             f"PR touches {len(changed_files)} file(s). "
-            f"~{len(will_break)} downstream file(s) likely affected, "
-            f"{len(will_break_tests)} test(s) likely broken, "
+            f"~{len(may_break)} downstream file(s) may be affected, "
+            f"{len(may_break_tests)} test(s) may break, "
             f"{len(missing_cochanges)} historical co-changer(s) missing, "
             f"{len(missing_tests)} file(s) without tests."
             f"{tests_to_run_suffix}{gov_suffix}{xr_suffix}{bc_suffix}{cf_suffix}"

--- a/packages/server/src/repowise/server/mcp_server/tool_risk/get_risk.py
+++ b/packages/server/src/repowise/server/mcp_server/tool_risk/get_risk.py
@@ -78,7 +78,7 @@ async def get_risk(
     bus factor) with graph topology (dependents, co-changes, impact surface)
     and security findings. Consult before editing a bug-fixed or busy file. Pass
     changed_files for PR mode: the response leads with a directive block
-    (will_break, missing_cochanges, missing_tests, tests_to_run) — read it
+    (may_break, missing_cochanges, missing_tests, tests_to_run) — read it
     first. tests_to_run_basis backs the run-list: measured (a coverage map
     proves those tests run the changed files) or inferred (test files the import
     graph shows reaching them; candidates, no ingest needed). To score a commit

--- a/plugins/claude-code/skills/change-review/SKILL.md
+++ b/plugins/claude-code/skills/change-review/SKILL.md
@@ -56,8 +56,9 @@ get_risk(targets=<changed files>, changed_files=<same changed files>)
 
 The response carries a `directive` block — read it first, it's a few short lists:
 
-- **`will_break`** — files/symbols that depend on what changed but are *not* in
-  the diff. These are the likely breakages. Check each one.
+- **`may_break`** — files/symbols that import their way to what changed but are
+  *not* in the diff. Reachability, not a diff: it says these depend on the
+  changed files, not that the thing they use changed. Check each one.
 - **`missing_cochanges`** — files that historically change together with the
   changed files but were left untouched. Often a forgotten update.
 - **`missing_tests`** — changed code with a test gap. Flag for new/updated tests.
@@ -100,7 +101,7 @@ and a brand-new file is "unknown, run the full suite", never "no tests needed".
 ## Write the review around evidence
 
 Lead with a risk level and the `directive` findings, each tied to a concrete
-file. Distinguish **"will break"** (a dependent outside the diff) from **"worth a
+file. Distinguish **"may break"** (a dependent outside the diff) from **"worth a
 look"** (a co-change or health regression). Don't pad with findings the tools
 didn't support.
 

--- a/plugins/codex/skills/change-review/SKILL.md
+++ b/plugins/codex/skills/change-review/SKILL.md
@@ -51,8 +51,9 @@ get_risk(targets=<changed files>, changed_files=<same changed files>)
 
 The response carries a `directive` block — read it first, it's a few short lists:
 
-- **`will_break`** — files/symbols that depend on what changed but are *not* in
-  the diff. These are the likely breakages. Check each one.
+- **`may_break`** — files/symbols that import their way to what changed but are
+  *not* in the diff. Reachability, not a diff: it says these depend on the
+  changed files, not that the thing they use changed. Check each one.
 - **`missing_cochanges`** — files that historically change together with the
   changed files but were left untouched. Often a forgotten update.
 - **`missing_tests`** — changed code with a test gap. Flag for new/updated tests.
@@ -95,7 +96,7 @@ and a brand-new file is "unknown, run the full suite", never "no tests needed".
 ## Write the review around evidence
 
 Lead with a risk level and the `directive` findings, each tied to a concrete
-file. Distinguish **"will break"** (a dependent outside the diff) from **"worth a
+file. Distinguish **"may break"** (a dependent outside the diff) from **"worth a
 look"** (a co-change or health regression). Don't pad with findings the tools
 didn't support.
 

--- a/plugins/shared/skills/change-review.md
+++ b/plugins/shared/skills/change-review.md
@@ -64,8 +64,9 @@ get_risk(targets=<changed files>, changed_files=<same changed files>)
 
 The response carries a `directive` block — read it first, it's a few short lists:
 
-- **`will_break`** — files/symbols that depend on what changed but are *not* in
-  the diff. These are the likely breakages. Check each one.
+- **`may_break`** — files/symbols that import their way to what changed but are
+  *not* in the diff. Reachability, not a diff: it says these depend on the
+  changed files, not that the thing they use changed. Check each one.
 - **`missing_cochanges`** — files that historically change together with the
   changed files but were left untouched. Often a forgotten update.
 - **`missing_tests`** — changed code with a test gap. Flag for new/updated tests.
@@ -108,7 +109,7 @@ and a brand-new file is "unknown, run the full suite", never "no tests needed".
 ## Write the review around evidence
 
 Lead with a risk level and the `directive` findings, each tied to a concrete
-file. Distinguish **"will break"** (a dependent outside the diff) from **"worth a
+file. Distinguish **"may break"** (a dependent outside the diff) from **"worth a
 look"** (a co-change or health regression). Don't pad with findings the tools
 didn't support.
 

--- a/tests/unit/cli/test_search_collapse.py
+++ b/tests/unit/cli/test_search_collapse.py
@@ -170,8 +170,8 @@ RISK_PAYLOAD = {
 PR_RISK_PAYLOAD = {
     "targets": RISK_PAYLOAD["targets"],
     "directive": {
-        "will_break": ["packages/core/src/repowise/core/pipeline/orchestrator.py"],
-        "will_break_tests": ["tests/unit/persistence/test_models.py"],
+        "may_break": ["packages/core/src/repowise/core/pipeline/orchestrator.py"],
+        "may_break_tests": ["tests/unit/persistence/test_models.py"],
         "missing_cochanges": ["packages/core/src/repowise/core/persistence/models.py"],
         "missing_tests": ["packages/core/src/repowise/core/pipeline/persist.py"],
         "tests_to_run": ["tests/unit/pipeline/test_persist.py::test_tombstone"],
@@ -199,7 +199,7 @@ PR_RISK_PAYLOAD = {
              "status": "accepted", "reason": "stale_governance"}
         ],
         "overall_risk_score": 7.4,
-        "summary": "PR touches 1 file(s). ~1 downstream file(s) likely affected.",
+        "summary": "PR touches 1 file(s). ~1 downstream file(s) may be affected.",
     },
     "pr_blast_radius": {
         "transitive_affected": ["packages/core/src/repowise/core/pipeline/orchestrator.py"],
@@ -715,7 +715,7 @@ def test_risk_table_renders_the_directive_first(monkeypatch, repo):
     # Unconditional: a guarded `assert A < B if cond else True` degrades to
     # `assert True` the moment rich wraps the line the guard looked for.
     assert out.index("Directive") < out.index("Co-changes with")
-    for expected in ("Will break", "Tests to run", "Missing co-changes",
+    for expected in ("May break", "Tests to run", "Missing co-changes",
                      "Conformance violations", "cli !-> core", "layering rule",
                      "persist tombstones", "billing-api", "removed_route",
                      "a.py -> b.py -> a.py"):

--- a/tests/unit/server/mcp/test_counterfactual.py
+++ b/tests/unit/server/mcp/test_counterfactual.py
@@ -108,13 +108,13 @@ def test_get_context_module_credit_is_capped() -> None:
     assert cf.replaced_tokens_for("get_context", result) == cf.CONTEXT_MODULE_MAX
 
 
-def test_get_risk_unions_will_break_and_missing_cochanges() -> None:
+def test_get_risk_unions_may_break_and_missing_cochanges() -> None:
     # A file that both breaks and is a missed co-change partner is one file.
     # Two targets so the total clears RISK_FLOOR — otherwise the floor masks
     # whether the overlapping file was counted once or twice.
     result = {
         "targets": {"a.py": {}, "b.py": {}},
-        "directive": {"will_break": ["c.py"], "missing_cochanges": ["c.py"]},
+        "directive": {"may_break": ["c.py"], "missing_cochanges": ["c.py"]},
     }
     expected = 2 * cf.RISK_PER_TARGET + 1 * cf.RISK_PER_RELATED_FILE
     assert expected > cf.RISK_FLOOR
@@ -156,7 +156,7 @@ def test_get_context_skeleton_file_not_double_counted() -> None:
 def test_get_risk_scales_with_targets_and_blast() -> None:
     result = {
         "targets": {"a.py": {}, "b.py": {}},
-        "directive": {"will_break": ["c.py"], "missing_cochanges": ["d.py", "e.py"]},
+        "directive": {"may_break": ["c.py"], "missing_cochanges": ["d.py", "e.py"]},
     }
     expected = 2 * cf.RISK_PER_TARGET + 3 * cf.RISK_PER_RELATED_FILE
     assert cf.replaced_tokens_for("get_risk", result) == expected

--- a/tests/unit/server/mcp/test_risk.py
+++ b/tests/unit/server/mcp/test_risk.py
@@ -95,7 +95,7 @@ async def test_get_risk_stable_file(setup_mcp):
 
 @pytest.mark.asyncio
 async def test_get_risk_pr_directive_splits_test_breakage(setup_mcp):
-    """PR mode splits test-file fallout out of will_break into will_break_tests (#672)."""
+    """PR mode splits test-file fallout out of may_break into may_break_tests (#672)."""
     from repowise.server.mcp_server import get_risk
 
     # Pass changed_files to trigger PR mode + blast-radius directive.
@@ -103,15 +103,21 @@ async def test_get_risk_pr_directive_splits_test_breakage(setup_mcp):
     directive = result["directive"]
 
     # middleware.py imports service.py → production breakage.
-    assert "src/auth/middleware.py" in directive["will_break"]
-    assert "src/auth/middleware.py" not in directive["will_break_tests"]
+    assert "src/auth/middleware.py" in directive["may_break"]
+    assert "src/auth/middleware.py" not in directive["may_break_tests"]
 
     # test_service.py imports service.py but is is_test=True → segmented out.
-    assert "tests/test_service.py" in directive["will_break_tests"]
-    assert "tests/test_service.py" not in directive["will_break"]
+    assert "tests/test_service.py" in directive["may_break_tests"]
+    assert "tests/test_service.py" not in directive["may_break"]
 
     # Summary reflects the test count.
-    assert "test(s) likely broken" in directive["summary"]
+    assert "test(s) may break" in directive["summary"]
+
+    # The savings estimator reads these lists by name; a rename that misses it
+    # undercounts silently rather than raising.
+    from repowise.server.mcp_server._savings.counterfactual import RISK_RELATED_FILE_KEYS
+
+    assert set(RISK_RELATED_FILE_KEYS) <= set(directive)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/server/mcp/test_risk_dependency_edges.py
+++ b/tests/unit/server/mcp/test_risk_dependency_edges.py
@@ -73,7 +73,7 @@ async def test_co_change_partner_is_not_blast_radius(setup_mcp, factory):
     ``_transitive_affected`` collects the sources of every edge pointing at a
     changed file and calls them "affected". A co_changes row made a file that
     merely tends to change alongside the diff look like an importer of it, and
-    the next BFS depth then walked through *that* file's partners. will_break
+    the next BFS depth then walked through *that* file's partners. may_break
     is capped and depth-sorted, so the noise crowds out the real importers.
     """
     from repowise.server.mcp_server import get_risk

--- a/tests/unit/test_no_unranked_truncation.py
+++ b/tests/unit/test_no_unranked_truncation.py
@@ -102,7 +102,7 @@ _CUTS = [
         "pr_blast._transitive_affected",
         "core/src/repowise/core/analysis/pr_blast.py",
         "key=lambda item: (item[1], item[0])",
-        "depth then path, before will_break takes 15",
+        "depth then path, before may_break takes 15",
         forbids="frontier = list(set(changed_files))",
     ),
     Cut(


### PR DESCRIPTION
## Output-schema change

`get_risk`'s PR directive:

| before | after |
|---|---|
| `directive.will_break` | `directive.may_break` |
| `directive.will_break_tests` | `directive.may_break_tests` |

`will_break_consumers` and `breaking_changes` are **unchanged**.

## Why

`will_break` is populated from `transitive_affected`, which `pr_blast.py`
builds as a pure reverse-import BFS. There is no symbol or signature diffing
anywhere in that analyzer, and there cannot be: `get_risk` takes a **file
list**, never a diff, so nothing in it knows *what* changed inside those files
— only that something did.

The result is a list of files that reach the change through the import graph.
That is useful. It is not "these will break". On a 2-file change it named five
importers including `tool_context/truncation.py`, a re-export shim that cannot
break from an internal edit. And it is the *first* field the tool instructs an
agent to read.

**This is a rename, not a new predicate.** A line-precise breakage predicate
needs the diff, which this tool does not receive.

`will_break_consumers` and `breaking_changes` keep "will" because they are
driven by real contract diffing against the last index — a removed route, a
type change, a newly-required field. They earned the word, and the split now
marks the difference between the two kinds of claim.

## Why this release

#1883 already changed `get_risk`'s response shape. Doing this now means
consumers migrate once instead of twice. Shipped as a documented schema change
with a version note in `MCP_TOOLS.md` rather than a quiet rename.

## The silent-failure site

`_savings/counterfactual.py` reads the directive key **by name** to size its
token-savings counterfactual. A missed rename there undercounts silently
rather than crashing.

It is fixed here, and the key tuple is now a named
`RISK_RELATED_FILE_KEYS` with an assertion in `test_risk.py` that those keys
still exist in a **real** PR-mode directive (not a fixture), so the next
divergence fails loudly instead of quietly costing accuracy.

## Sites

`directives.py` (keys, caps, summary), `tool_risk/get_risk.py` docstring,
`_savings/counterfactual.py`, `cli/commands/risk_cmd.py` (labels, `--help`
text, comment), `generation/editor_files/tool_table.py`, `pr_blast.py`
comments, `docs/agent/MCP_TOOLS.md`, `docs/reference/CLI_REFERENCE.md`,
`README.md`, `.github/CONTRIBUTING.md`, the three change-review skills, and
tests.

`_WILL_BREAK_LIMIT` / `_WILL_BREAK_TESTS_LIMIT` are renamed to match;
`_XR_WILL_BREAK_LIMIT` (cross-repo) is deliberately left alone and verified
intact.

No non-Python consumer exists — the directive block is not read anywhere in
`packages/web`, `packages/ui`, `packages/api-client`, `packages/types`,
`packages/vscode`, any `.j2` template, or any prompt file. Nothing parses the
summary string either, so the wording shift ("likely affected" to "may be
affected") is safe.

Historical `CHANGELOG.md` entries are left as written — they record what
shipped at the time.

## Also: document what `is_fix` means

Nothing told a reader what `is_fix` is, so `is_fix: true` on a `feat:` commit
reads like a mislabel. Two lines in `MCP_TOOLS.md`: it is the defect
benchmark's keyword rule over the commit *subject*, not the conventional-commit
type, and `prior_fixes` is where the diff-shape filter is applied on top.

**`is_fix_commit` itself is not touched.** It is contractually byte-identical
to the defect benchmark's `lib/defect_counter` (stated at `fix_shape.py:25`),
and changing it would invalidate the comparability the benchmark rests on. The
noise problem is already solved the right way round: filter after the frozen
rule, never touch the rule.

## Tests

`tests/unit/server/` in full (not just `mcp/` — `test_mcp_decision_graph.py`
and `test_mcp_kg_enrichment.py` sit outside it and are what catch response-shape
changes), plus the CLI risk renderers, persistence, analysis and
`test_integration/test_mcp.py`: **3,760 passed**.

One failure, unrelated and reproducible on `main`:
`test_kg_skip_logic.py::test_rejects_an_older_schema`, a known local
cross-test-pollution case that passes in isolation.
