### PR TITLE
fix(workspace): read the path and verb an HTTP consumer call actually names

### DIFF
--- a/packages/core/src/repowise/core/workspace/extractors/http/dialect.py
+++ b/packages/core/src/repowise/core/workspace/extractors/http/dialect.py
@@ -9,6 +9,7 @@ place.
 
 from __future__ import annotations
 
+import re
 from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
 from ..base import ScanContext
@@ -19,6 +20,7 @@ from .paths import (
     is_unusable_consumer_path,
     normalize_http_path,
     strip_leading_base_expr,
+    strip_trailing_query_expr,
 )
 
 if TYPE_CHECKING:
@@ -27,6 +29,26 @@ if TYPE_CHECKING:
 # Regex fragments for the HTTP method verbs, shared by every dialect's patterns.
 METHODS = r"get|post|put|delete|patch"
 METHODS_UPPER = r"GET|POST|PUT|DELETE|PATCH"
+
+_VERB_TOKENS = frozenset(METHODS.split("|"))
+
+# Identifier tokens, splitting camelCase and acronym runs: ``apiJSONPost`` ->
+# ``api``, ``JSON``, ``Post``.
+_CAMEL_TOKEN_RE = re.compile(r"[A-Z]+(?![a-z])|[A-Z][a-z0-9]*|[a-z0-9]+")
+
+
+def method_from_callee(callee: str, default: str = "GET") -> str:
+    """Read the HTTP verb a wrapper's *name* encodes, else *default*.
+
+    ``apiPost`` -> ``POST``, ``apiDelete`` -> ``DELETE``. A leading verb wins
+    outright so ``getPostById`` stays ``GET``; failing that, a single verb token
+    names the method, and anything more ambiguous falls back rather than guess.
+    """
+    tokens = [t.lower() for t in _CAMEL_TOKEN_RE.findall(callee)]
+    if tokens and tokens[0] in _VERB_TOKENS:
+        return tokens[0].upper()
+    verbs = [t for t in tokens if t in _VERB_TOKENS]
+    return verbs[0].upper() if len(verbs) == 1 else default
 
 
 @runtime_checkable
@@ -124,6 +146,7 @@ def build_consumer_contract(
     host = absolute_host(url)
     path = extract_path_from_url(url)
     path, base_token = strip_leading_base_expr(path)
+    path = strip_trailing_query_expr(path)
     norm_path = normalize_http_path(path)
     if is_unusable_consumer_path(norm_path):
         return None

--- a/packages/core/src/repowise/core/workspace/extractors/http/js_clients.py
+++ b/packages/core/src/repowise/core/workspace/extractors/http/js_clients.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING
 
 from ..base import line_at
 from ..langs import JS_TS
-from .dialect import METHODS, build_consumer_contract
+from .dialect import METHODS, build_consumer_contract, method_from_callee
 
 if TYPE_CHECKING:
     from repowise.core.workspace.contracts import Contract
@@ -106,7 +106,11 @@ class JsClientsDialect:
             # Require an HTTP signal: an HTTP-ish callee name or a method option.
             if not (_HTTP_NAME_RE.search(callee) or method_opt):
                 continue
-            method = method_opt.group(1).upper() if method_opt else "GET"
+            # No `method:` option: the callee name is the only verb evidence
+            # there is, and `apiPost`/`apiDelete` carry it.
+            method = (
+                method_opt.group(1).upper() if method_opt else method_from_callee(callee)
+            )
             emit(
                 method=method,
                 url=m.group(2),

--- a/packages/core/src/repowise/core/workspace/extractors/http/paths.py
+++ b/packages/core/src/repowise/core/workspace/extractors/http/paths.py
@@ -106,6 +106,24 @@ def strip_leading_base_expr(path: str) -> tuple[str, str]:
     return new_path, m.group(1).strip()
 
 
+# A trailing interpolated query string, e.g. ``/repos${qs}``. Required to follow
+# an alphanumeric so a composed segment value (``/users/user-${id}``) is spared.
+_TRAILING_QUERY_EXPR_RE = re.compile(r"(?<=[A-Za-z0-9])(?:\$\{[^}]*\})+$")
+
+
+def strip_trailing_query_expr(path: str) -> str:
+    """Drop a trailing interpolated query string from a consumer URL path.
+
+    ``/snapshots/${id}/graph${q}`` becomes ``/snapshots/${id}/graph``. The
+    expression holds ``?limit=...`` at run time, but the ``?`` is inside it, so
+    :func:`normalize_http_path` cannot see it and the call normalizes to
+    ``/snapshots/{param}/graph{param}`` — a path no provider declares. A real
+    path parameter occupies its own segment (``/users/${id}``), so only an
+    expression glued onto the preceding segment is read as a query string.
+    """
+    return _TRAILING_QUERY_EXPR_RE.sub("", path)
+
+
 _IDENTIFIER_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
 
 

--- a/packages/core/src/repowise/core/workspace/extractors/http/paths.py
+++ b/packages/core/src/repowise/core/workspace/extractors/http/paths.py
@@ -106,8 +106,9 @@ def strip_leading_base_expr(path: str) -> tuple[str, str]:
     return new_path, m.group(1).strip()
 
 
-# A trailing interpolated query string, e.g. ``/repos${qs}``. Required to follow
-# an alphanumeric so a composed segment value (``/users/user-${id}``) is spared.
+# A trailing interpolated suffix, e.g. ``/repos${qs}``. Anchored, and required
+# to follow an alphanumeric so a real parameter segment (``/users/${id}``) and a
+# separator-composed value (``/users/user-${id}``) are both left alone.
 _TRAILING_QUERY_EXPR_RE = re.compile(r"(?<=[A-Za-z0-9])(?:\$\{[^}]*\})+$")
 
 
@@ -117,9 +118,14 @@ def strip_trailing_query_expr(path: str) -> str:
     ``/snapshots/${id}/graph${q}`` becomes ``/snapshots/${id}/graph``. The
     expression holds ``?limit=...`` at run time, but the ``?`` is inside it, so
     :func:`normalize_http_path` cannot see it and the call normalizes to
-    ``/snapshots/{param}/graph{param}`` — a path no provider declares. A real
-    path parameter occupies its own segment (``/users/${id}``), so only an
-    expression glued onto the preceding segment is read as a query string.
+    ``/snapshots/{param}/graph{param}`` — a path no provider declares.
+
+    Ceiling: the only signal available is that the expression is glued onto a
+    complete segment, so an optional *path* suffix built the same way
+    (``/docs${path}`` where ``path`` is ``/${slug}`` or ``""``) also reduces to
+    its empty-suffix form. That is the route the call makes when the suffix is
+    empty, so it is still a path the caller reaches; what is lost is the
+    populated variant. Widen only with evidence of the value's shape.
     """
     return _TRAILING_QUERY_EXPR_RE.sub("", path)
 

--- a/tests/unit/workspace/test_index_clients.py
+++ b/tests/unit/workspace/test_index_clients.py
@@ -897,3 +897,122 @@ class TestPythonLeavesTheJsPassAlone:
     def test_a_python_file_with_no_client_yields_nothing(self):
         source = "import os\ndef f():\n    return os.environ.get('/not/a/url')\n"
         assert _run_py(source) == ([], 0)
+
+
+class TestTrailingQueryExpressionIsNotAPathSegment:
+    """An interpolated query string must not become a segment of the path.
+
+    The ``?`` lives inside the expression, so :func:`normalize_http_path` never
+    sees it and the call used to key on ``/snapshots/{param}/graph{param}``,
+    which no provider declares.
+    """
+
+    QUERY_SUFFIX_TS = """\
+const API_BASE = "https://api.example.com";
+
+export class HostedApiClient {
+  private async request(path: string, init?: RequestInit): Promise<Response> {
+    const res = await fetch(`${API_BASE}${path}`, init);
+    if (!res.ok) throw new Error("bad");
+    return res;
+  }
+
+  private async fetch<T>(path: string, init?: RequestInit): Promise<T> {
+    return (await this.request(path, init)).json();
+  }
+
+  getGraph(id: string, limit?: number) {
+    const q = limit != null ? `?limit=${limit}` : "";
+    return this.fetch<GraphResponse>(`/snapshots/${id}/graph${q}`);
+  }
+
+  getFile(id: string, path: string) {
+    return this.fetch<FileResponse>(`/repos/${id}/files/${path}`);
+  }
+}
+"""
+
+    def test_the_suffix_is_dropped_from_the_key(self):
+        contracts, _u, _c = _run(self.QUERY_SUFFIX_TS)
+        assert "http::GET::/snapshots/{param}/graph" in _ids(contracts)
+
+    def test_a_final_path_parameter_is_kept(self):
+        """The discriminator is the ``/`` separator, not the interpolation."""
+        contracts, _u, _c = _run(self.QUERY_SUFFIX_TS)
+        assert "http::GET::/repos/{param}/files/{param}" in _ids(contracts)
+
+    def test_it_now_reaches_the_provider_that_exists(self):
+        """End to end against a provider built by the product's own normalizer."""
+        from repowise.core.workspace.contracts import match_contracts
+        from repowise.core.workspace.extractors.http.dialect import build_provider_contract
+
+        consumers, _u, _c = _run(self.QUERY_SUFFIX_TS)
+        backend_ctx = ScanContext("backend", "app/routers/graph.py", ".py", "", {})
+        provider = build_provider_contract(
+            backend_ctx,
+            method="GET",
+            path_raw="/snapshots/{snapshot_id}/graph",
+            framework="fastapi",
+        )
+        links = match_contracts([provider, *consumers])
+        assert {lk.contract_id for lk in links} == {"http::GET::/snapshots/{param}/graph"}
+
+    def test_the_shared_normalizer_was_not_widened(self):
+        """Providers share ``normalize_http_path``; the fix stays consumer-side."""
+        from repowise.core.workspace.extractors.http.paths import normalize_http_path
+
+        assert (
+            normalize_http_path("/snapshots/{id}/graph${q}")
+            == "/snapshots/{param}/graph{param}"
+        )
+
+
+class TestTheCalleeNameCarriesTheVerb:
+    """``apiPost(...)`` is a POST. Defaulting it to GET matched no provider."""
+
+    # The shape packages/api-client/src/providers.ts really uses: verb-named
+    # wrappers imported from a sibling module, called with no `method:` option.
+    PROVIDERS_TS = """\
+import { apiPost, apiDelete } from "./client";
+
+export async function addProviderKey(providerId: string, apiKey: string) {
+  await apiPost(`/api/providers/${providerId}/key`, { api_key: apiKey });
+}
+
+export async function removeProviderKey(providerId: string, repoId?: string) {
+  const qs = repoId ? `?repo_id=${encodeURIComponent(repoId)}` : "";
+  await apiDelete(`/api/providers/${providerId}/key${qs}`);
+}
+"""
+
+    def test_the_verb_wrappers_record_their_own_methods(self):
+        ctx = ScanContext(
+            "repowise",
+            "packages/api-client/src/providers.ts",
+            ".ts",
+            self.PROVIDERS_TS,
+            {},
+        )
+        assert _ids(JsClientsDialect().extract(ctx)) == {
+            "http::POST::/api/providers/{param}/key",
+            "http::DELETE::/api/providers/{param}/key",
+        }
+
+    @pytest.mark.parametrize(
+        ("callee", "expected"),
+        [
+            ("apiPost", "POST"),
+            ("apiDelete", "DELETE"),
+            # A leading verb wins outright, so the noun `Post` cannot steal it.
+            ("getPostById", "GET"),
+        ],
+    )
+    def test_the_verb_is_read_from_the_name(self, callee, expected):
+        from repowise.core.workspace.extractors.http.dialect import method_from_callee
+
+        assert method_from_callee(callee) == expected
+
+    def test_a_name_with_no_verb_falls_back(self):
+        from repowise.core.workspace.extractors.http.dialect import method_from_callee
+
+        assert method_from_callee("fetchJSON") == "GET"


### PR DESCRIPTION
Two consumer-side precision defects kept real calls from matching a provider that already exists. The front doors (#1880), the provider dialects (#1888) and the Python consumers (#1890) landed before this; both defects here are on the consumer path only.

**A trailing interpolated query string became a path segment.** `normalize_http_path` strips `?...` only when the `?` is literal. In ``fetch(`/snapshots/${id}/graph${q}`)`` it is inside the interpolation, so the call keyed on `/snapshots/{param}/graph{param}`, which no route declares. `strip_trailing_query_expr` drops an interpolation glued onto a complete segment. `normalize_http_path` is untouched: providers share it, and a route declaration never carries an interpolated suffix.

**A verb-named callee was always recorded GET.** `apiPost` and `apiDelete` both keyed on GET, so neither matched the POST and DELETE routes at `/api/providers/{id}/key`. The method now comes from the callee identifier: camel-split the name, take a leading verb, else a single verb token, else GET. `getPostById` stays GET.

Measured over a three-repo workspace of 1,734 contracts: links rise from 435 to 445, eight from the path fix and two from the verb fix. Provider counts and every per-repo per-client consumer count are unchanged.
