### PR TITLE
fix(ingestion): parse C++ types with export macros

### DIFF
--- a/packages/core/src/repowise/core/ingestion/parser.py
+++ b/packages/core/src/repowise/core/ingestion/parser.py
@@ -210,6 +210,17 @@ def _is_bodiless_cpp_type(language: str, node_type: str, def_node: Node) -> bool
     return parent is None or parent.type != "type_definition"
 
 
+def _cpp_export_macro_parent(node: Node, parent_names: dict[int, str]) -> str | None:
+    """Return the real type name for a member inside a macro-decorated C++ type."""
+    ancestor = node.parent
+    while ancestor is not None:
+        parent_name = parent_names.get(ancestor.id)
+        if parent_name is not None:
+            return parent_name
+        ancestor = ancestor.parent
+    return None
+
+
 @cache
 def _load_compiled_query(lang: str, grammar_tag: str | None = None) -> object | None:
     """Process-wide cache of compiled tree-sitter Query objects.
@@ -617,6 +628,32 @@ class ASTParser:
         if file_info.language in _TS_JS_LANGUAGES:
             ts_deferred_exports = ts_deferred_export_names(src)
 
+        # tree-sitter-cpp parses ``struct EXPORT Name { ... }`` as a
+        # function_definition whose return type is ``struct EXPORT`` and whose
+        # bare declarator is the real type name. cpp.scm marks those matches so
+        # the specifier can keep its class/struct kind while the outer recovery
+        # node acts as the type body for nested members.
+        cpp_export_type_defs: dict[int, tuple[Node, str]] = {}
+        cpp_export_type_parents: dict[int, str] = {}
+        cpp_export_macro_names: set[str] = set()
+        if file_info.language == "cpp":
+            for capture_dict in matches:
+                type_nodes = capture_dict.get("symbol.cpp_export_type", [])
+                def_nodes = capture_dict.get("symbol.def", [])
+                name_nodes = capture_dict.get("symbol.name", [])
+                macro_nodes = capture_dict.get("symbol.cpp_export_macro", [])
+                if not type_nodes or not def_nodes or not name_nodes:
+                    continue
+                type_name = _node_text(name_nodes[0], src)
+                if not type_name:
+                    continue
+                outer_node = type_nodes[0]
+                cpp_export_type_defs[def_nodes[0].id] = (outer_node, type_name)
+                cpp_export_type_parents[outer_node.id] = type_name
+                cpp_export_macro_names.update(_node_text(node, src) for node in macro_nodes)
+
+        cpp_export_type_parent_ids = frozenset(cpp_export_type_parents)
+
         for capture_dict in matches:
             def_nodes = capture_dict.get("symbol.def", [])
             name_nodes = capture_dict.get("symbol.name", [])
@@ -630,6 +667,18 @@ class ASTParser:
             def_node = def_nodes[0]
             name = _node_text(name_nodes[0], src)
             if not name:
+                continue
+
+            export_type = cpp_export_type_defs.get(def_node.id)
+            if export_type is not None and name != export_type[1]:
+                # The ordinary struct/class query sees the same specifier, but
+                # tree-sitter calls the export macro its name. Keep only the
+                # dedicated match whose name is the outer declarator.
+                continue
+
+            if def_node.type == "preproc_def" and name in cpp_export_macro_names:
+                # A locally stubbed empty export macro is declaration
+                # scaffolding, not a runtime variable in the symbol graph.
                 continue
 
             start_line = def_node.start_point[0] + 1
@@ -656,7 +705,7 @@ class ASTParser:
             # variable_declarator's parent (lexical_declaration → "function")
             # would otherwise read as a callable ancestor.
             if node_type not in _MODULE_ANCHORED_NODE_TYPES and _has_callable_ancestor(
-                def_node, config.symbol_node_types
+                def_node, config.symbol_node_types, cpp_export_type_parent_ids
             ):
                 continue
 
@@ -681,6 +730,8 @@ class ASTParser:
             # the trailing body sibling or call-site attribution stops at the
             # signature line.
             end_line = def_node.end_point[0] + 1
+            if export_type is not None:
+                end_line = export_type[0].end_point[0] + 1
             if file_info.language == "dart" and node_type in (
                 "function_signature",
                 "getter_signature",
@@ -810,6 +861,9 @@ class ASTParser:
             # Parent class detection
             parent_name = self._find_parent(def_node, config, receiver_nodes, src)
 
+            if parent_name is None and file_info.language == "cpp" and export_type is None:
+                parent_name = _cpp_export_macro_parent(def_node, cpp_export_type_parents)
+
             # Dart mixin_declaration exposes no ``name`` field, so
             # ``_find_parent``'s field lookup misses mixin members.
             if parent_name is None and file_info.language == "dart":
@@ -884,7 +938,10 @@ class ASTParser:
                     is_exported_symbol=is_exported_symbol,
                     is_declaration=(
                         node_type in config.declaration_node_types
-                        or _is_bodiless_cpp_type(file_info.language, node_type, def_node)
+                        or (
+                            export_type is None
+                            and _is_bodiless_cpp_type(file_info.language, node_type, def_node)
+                        )
                     ),
                 )
             )

--- a/packages/core/src/repowise/core/ingestion/parser_helpers.py
+++ b/packages/core/src/repowise/core/ingestion/parser_helpers.py
@@ -76,17 +76,27 @@ def _is_async_node(node: Node, src: str) -> bool:
 _CALLABLE_KINDS: frozenset[str] = frozenset({"function", "method"})
 
 
-def _has_callable_ancestor(node: Node, symbol_kinds: dict[str, str]) -> bool:
+def _has_callable_ancestor(
+    node: Node,
+    symbol_kinds: dict[str, str],
+    ignored_node_ids: frozenset[int] = frozenset(),
+) -> bool:
     """True if ``node`` has any function/method ancestor in the AST.
 
     Used to filter out helpers defined inside another function's body
     (React event handlers, async-method-local coroutines, JS closures)
     from the top-level symbol list. Class bodies don't count — methods
     inside classes have only a ``class`` ancestor before the module root.
+
+    ``ignored_node_ids`` covers grammar-recovery nodes that a language query
+    has positively identified as type containers rather than callables.
     """
     ancestor = node.parent
     while ancestor is not None:
-        if symbol_kinds.get(ancestor.type) in _CALLABLE_KINDS:
+        if (
+            ancestor.id not in ignored_node_ids
+            and symbol_kinds.get(ancestor.type) in _CALLABLE_KINDS
+        ):
             return True
         ancestor = ancestor.parent
     return False

--- a/packages/core/src/repowise/core/ingestion/queries/cpp.scm
+++ b/packages/core/src/repowise/core/ingestion/queries/cpp.scm
@@ -8,6 +8,27 @@
 ; Symbols
 ; ---------------------------------------------------------------------------
 
+; Export-macro class/struct definitions are parsed as function definitions:
+; ``struct MYLIB_EXPORT WriteOptions { ... }``. The grammar treats the macro
+; as the specifier's name and the real type name as a bare declarator. Keep
+; the specifier as ``@symbol.def`` so kind/signature handling stays class- or
+; struct-shaped, while the outer capture identifies the aggregate body.
+(function_definition
+  type: (class_specifier
+    name: (type_identifier) @symbol.cpp_export_macro
+  ) @symbol.def
+  declarator: (identifier) @symbol.name
+  body: (compound_statement)
+) @symbol.cpp_export_type
+
+(function_definition
+  type: (struct_specifier
+    name: (type_identifier) @symbol.cpp_export_macro
+  ) @symbol.def
+  declarator: (identifier) @symbol.name
+  body: (compound_statement)
+) @symbol.cpp_export_type
+
 ; Function definition: ReturnType funcName(params) { body }
 ; The name is nested inside function_declarator
 (function_definition

--- a/packages/core/src/repowise/core/ingestion/queries/cpp.scm
+++ b/packages/core/src/repowise/core/ingestion/queries/cpp.scm
@@ -16,6 +16,7 @@
 (function_definition
   type: (class_specifier
     name: (type_identifier) @symbol.cpp_export_macro
+    !body
   ) @symbol.def
   declarator: (identifier) @symbol.name
   body: (compound_statement)
@@ -24,6 +25,7 @@
 (function_definition
   type: (struct_specifier
     name: (type_identifier) @symbol.cpp_export_macro
+    !body
   ) @symbol.def
   declarator: (identifier) @symbol.name
   body: (compound_statement)

--- a/tests/unit/ingestion/parser/test_cpp.py
+++ b/tests/unit/ingestion/parser/test_cpp.py
@@ -51,6 +51,23 @@ private:
 """
 
 
+CPP_EXPORT_MACRO_TYPES = b"""#define MYLIB_EXPORT
+
+struct MYLIB_EXPORT WriteOptions {
+    WriteOptions() = default;
+    bool sync = false;
+};
+
+class MYLIB_EXPORT ClientOptions {
+    bool enabled = true;
+};
+
+struct PlainOptions {
+    PlainOptions() = default;
+};
+"""
+
+
 class TestCppParser:
     def test_finds_class_in_header(self, parser: ASTParser) -> None:
         fi = _make_file_info("cpp_pkg/calculator.hpp", "cpp")
@@ -73,3 +90,17 @@ class TestCppParser:
         assert len(result.imports) >= 2
         module_paths = [i.module_path for i in result.imports]
         assert any("calculator.hpp" in p or "stdexcept" in p for p in module_paths)
+
+    def test_finds_types_declared_through_export_macros(self, parser: ASTParser) -> None:
+        fi = _make_file_info("cpp_pkg/options.hpp", "cpp")
+        result = parser.parse_file(fi, CPP_EXPORT_MACRO_TYPES)
+        symbols = {(symbol.parent_name, symbol.name): symbol for symbol in result.symbols}
+
+        assert symbols[(None, "WriteOptions")].kind == "struct"
+        assert symbols[(None, "WriteOptions")].is_declaration is False
+        assert symbols[("WriteOptions", "WriteOptions")].kind == "method"
+        assert symbols[(None, "ClientOptions")].kind == "class"
+        assert symbols[(None, "ClientOptions")].is_declaration is False
+        assert symbols[(None, "PlainOptions")].kind == "struct"
+        assert symbols[("PlainOptions", "PlainOptions")].kind == "method"
+        assert not any(symbol.name == "MYLIB_EXPORT" for symbol in result.symbols)


### PR DESCRIPTION
## Summary

- Recover C++ class and struct definitions that tree-sitter parses as function definitions when an export macro appears before the real type name.
- Preserve constructor parentage and suppress the participating empty export macro as a false variable symbol.
- Add regression coverage for macro-decorated struct/class definitions and the unchanged ordinary struct path.

## Related Issues

Fixes #1866

## Test Plan

- [x] `uv run pytest -q tests/unit/ingestion/parser/test_cpp.py` — 4 passed
- [x] `uv run pytest -q tests/unit/ingestion/parser tests/unit/ingestion/test_cpp_*.py` — 347 passed
- [x] `uv run pytest -q tests/unit tests/integration/test_cpp_dead_code.py` — 14,444 passed, 12 skipped, 2 xfailed; one unrelated existing mascot tagline assertion failed
- [x] `uv run ruff check .`
- [x] `npm run lint`
- [x] `npm run type-check`
- [ ] Web build passes (`npm run build`) — not applicable; no frontend files changed

## Checklist

- [x] My code follows the project's code style
- [x] I have added tests for new functionality
- [x] All tests relevant to this change pass
- [x] I have updated documentation if needed