### PR TITLE
test: align README tool-count claims

### DIFF
--- a/tests/unit/cli/test_agent_matrix.py
+++ b/tests/unit/cli/test_agent_matrix.py
@@ -227,8 +227,6 @@ COUNT_CLAIMS: tuple[tuple[str, str, str], ...] = (
     # narrower claim than the advertised surface. See NON_FLAGSHIP_TOOLS.
     ("README.md", "flagship", "**{w} task-shaped MCP tools**"),
     ("README.md", "flagship", "## The {w} MCP tools"),
-    ("README.md", "flagship", "#the-{w}-mcp-tools"),
-    ("README.md", "flagship", "decisions, and {w} MCP tools"),
     ("README.md", "flagship", "{W} is a deliberate ceiling"),
     ("docs/README.md", "flagship", "decisions, and {w} MCP tools"),
     ("docs/README.md", "flagship", "The {w} task-shaped tools,"),


### PR DESCRIPTION
Updates the README tool-count contract after the hero redesign removed two legacy text representations. Current count claims and the structural flagship-tool table check remain covered. Validation: 81 tests passed in tests/unit/cli/test_agent_matrix.py.