### PR TITLE
feat(ingestion): extract C++ in-class method declarations

### DIFF
--- a/packages/core/src/repowise/core/ingestion/call_resolver.py
+++ b/packages/core/src/repowise/core/ingestion/call_resolver.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 
 from collections import defaultdict
 from dataclasses import dataclass, replace
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any
 
 import structlog
@@ -202,6 +202,20 @@ class ResolvedCall:
     line: int  # call site line number (for diagnostics)
     origin: ResolutionOrigin  # which strategy below produced it
     edge_type: CallSiteEdgeType = "calls"  # carried through from the CallSite
+
+
+def _same_translation_unit(decl_file: str, def_file: str) -> bool:
+    """Are these two paths the same C++ translation unit?
+
+    Compared on the base name, because a public header rarely sits beside its
+    implementation (``include/pkg/thing.h`` against ``src/thing.cc``). The
+    include relation would be the better test, but a C++ include binds to the
+    path as written and usually is not a file key.
+    """
+    return (
+        decl_file == def_file
+        or PurePosixPath(decl_file).stem == PurePosixPath(def_file).stem
+    )
 
 
 class CallResolver:
@@ -802,7 +816,13 @@ class CallResolver:
                     # A declaration must never displace a definition already
                     # indexed under this name — a .cpp that forward-declares a
                     # helper above its own body holds both.
-                    file_syms.setdefault(sym.name, sym.id)
+                    #
+                    # A method declaration stays out: this index answers
+                    # unqualified lookups from importing files, and no bare name
+                    # can legally reach a method. The (class, method) index
+                    # below still takes it.
+                    if sym.parent_name is None:
+                        file_syms.setdefault(sym.name, sym.id)
                 else:
                     definitions[decl_key].append((path, sym.id))
                     # File-level symbol index (top-level symbols and methods)
@@ -817,7 +837,10 @@ class CallResolver:
                 # Global indices
                 if sym.kind in _NON_CALLABLE_KINDS:
                     self._non_callable_ids.add(sym.id)
-                self._global_symbols[sym.name].append(sym.id)
+                # Same rule as the per-file index above, for the global-unique
+                # tier.
+                if not (sym.is_declaration and sym.parent_name is not None):
+                    self._global_symbols[sym.name].append(sym.id)
 
             self._file_symbols[path] = file_syms
             self._file_methods[path] = file_methods
@@ -845,21 +868,33 @@ class CallResolver:
         that, a repo-wide unique definition is unambiguous enough to use. An
         overload set spanning several files matches neither test, and stays
         unlinked rather than guessed at.
+
+        For a METHOD that fallback additionally requires the same translation
+        unit: the key is ``(class, method)``, so a repo-wide unique definition
+        proves the method name unique and says nothing about the class, and two
+        unrelated classes of one name would pair across. A free function has no
+        class identity to get wrong and is unchanged.
         """
         redirects: dict[str, str] = {}
         for decl_file, decl_id, key in declarations:
             candidates = definitions.get(key, ())
             if not candidates:
                 continue
-            including = [
+            # Deduped by symbol id, not by row: an overload set defined in one
+            # file is several definitions sharing one id, and counting rows
+            # reads that as an ambiguity that does not exist.
+            including = {
                 sym_id
                 for def_file, sym_id in candidates
                 if decl_file in self._import_targets.get(def_file, ())
-            ]
+            }
+            distinct = {sym_id for _def_file, sym_id in candidates}
             if len(including) == 1:
-                redirects[decl_id] = including[0]
-            elif len(candidates) == 1:
-                redirects[decl_id] = candidates[0][1]
+                redirects[decl_id] = next(iter(including))
+            elif len(distinct) == 1:
+                def_file = candidates[0][0]
+                if key[0] is None or _same_translation_unit(decl_file, def_file):
+                    redirects[decl_id] = next(iter(distinct))
         return redirects
 
     @property

--- a/packages/core/src/repowise/core/ingestion/language_configs.py
+++ b/packages/core/src/repowise/core/ingestion/language_configs.py
@@ -189,6 +189,9 @@ LANGUAGE_CONFIGS: dict[str, LanguageConfig] = {
             "preproc_def": "variable",  # #define MACRO value
             "preproc_function_def": "function",  # #define MACRO(x) ...
             "declaration": "function",  # forward declarations + dtor decls
+            # In-class member-function declaration; cpp.scm anchors these on
+            # the declarator, not the enclosing ``field_declaration``.
+            "function_declarator": "function",
             "alias_declaration": "type_alias",  # using X = Y;
         },
         import_node_types=["preproc_include"],
@@ -196,7 +199,7 @@ LANGUAGE_CONFIGS: dict[str, LanguageConfig] = {
         visibility_fn=public_by_default,
         parent_extraction="nesting",
         parent_class_types=frozenset({"class_specifier", "struct_specifier"}),
-        declaration_node_types=frozenset({"declaration"}),
+        declaration_node_types=frozenset({"declaration", "function_declarator"}),
     ),
     "c": LanguageConfig(
         symbol_node_types={

--- a/packages/core/src/repowise/core/ingestion/parser.py
+++ b/packages/core/src/repowise/core/ingestion/parser.py
@@ -891,6 +891,12 @@ class ASTParser:
             if parent_name is None and file_info.language == "pascal" and name_nodes:
                 parent_name = _qualified_pascal_parent(name_nodes[0], src)
 
+            # A ``field_declaration`` cannot occur outside a class body, so a
+            # missing parent means the class did not parse. Grammar recovery,
+            # not a member function.
+            if node_type == "function_declarator" and parent_name is None:
+                continue
+
             # Upgrade function → method when a parent class is detected
             if parent_name and kind == "function":
                 kind = "method"

--- a/packages/core/src/repowise/core/ingestion/queries/cpp.scm
+++ b/packages/core/src/repowise/core/ingestion/queries/cpp.scm
@@ -150,6 +150,60 @@
   )
 ) @symbol.def
 
+; In-class member-function declaration: ``void Seek(const Slice&);``
+; An abstract class has no out-of-line definition, so without these it reaches
+; the method index empty. ``@symbol.def`` is the declarator, not the
+; ``field_declaration``: that node can hold a whole ``struct Inner { ... } m_;``
+; and would become a callable ancestor of the inner type's methods.
+; ``declarator: (field_identifier)`` directly is what keeps out a
+; function-pointer data member (``void (*cb_)(int);``).
+(field_declaration
+  declarator: (function_declarator
+    declarator: (field_identifier) @symbol.name
+    parameters: (parameter_list) @symbol.params
+  ) @symbol.def
+)
+
+; ... returning a pointer: ``virtual Iterator* NewIterator(...) = 0;``
+(field_declaration
+  declarator: (pointer_declarator
+    declarator: (function_declarator
+      declarator: (field_identifier) @symbol.name
+      parameters: (parameter_list) @symbol.params
+    ) @symbol.def
+  )
+)
+
+; ... returning a reference: ``const Slice& value() const;``
+; ``reference_declarator`` does not name its declarator field, so the inner
+; ``function_declarator`` is matched as a bare named child rather than by field.
+(field_declaration
+  declarator: (reference_declarator
+    (function_declarator
+      declarator: (field_identifier) @symbol.name
+      parameters: (parameter_list) @symbol.params
+    ) @symbol.def
+  )
+)
+
+; Pure-virtual member of an EXPORT-MACRO class: ``virtual void Seek(...) = 0;``
+; ``class EXPORT Foo { ... }`` is recovery-parsed into a ``compound_statement``
+; of ``declaration`` nodes, which the patterns above cannot reach, and ``= 0``
+; wraps the declarator in an ``init_declarator`` the one below cannot either.
+; ``value: (number_literal)`` is what excludes the recovered inline definition
+; and member-init constructor, which share the shape. ``@symbol.def`` must be
+; the ``declaration``: it is a callable kind, so anchoring inside it makes it a
+; callable ancestor and the match is dropped.
+(declaration
+  declarator: (init_declarator
+    declarator: (function_declarator
+      declarator: (identifier) @symbol.name
+      parameters: (parameter_list) @symbol.params
+    )
+    value: (number_literal)
+  )
+) @symbol.def
+
 ; Destructor declaration inside a class body: ~Foo();
 (declaration
   declarator: (function_declarator

--- a/tests/unit/ingestion/test_cpp_inclass_declarations.py
+++ b/tests/unit/ingestion/test_cpp_inclass_declarations.py
@@ -1,0 +1,269 @@
+"""A C++ in-class method declaration must become a symbol.
+
+``cpp.scm`` had patterns for ``function_definition`` and for a file-scope
+``declaration``, but none for ``field_declaration``, which is how every in-class
+declaration parses. A CONCRETE class survived it, because its out-of-line
+``Cls::m`` definition in the ``.cc`` is a ``function_definition``; an ABSTRACT
+one has no definition anywhere and reached the method index empty, so
+``leveldb::Iterator`` held no ``Seek`` and a same-named nested class answered
+every ``Iterator*`` call unopposed.
+
+Adding symbols feeds two mechanisms that had nothing to be wrong with before,
+and the last two classes here are those two: the declaration/definition
+pairing, whose name key proves nothing about the class, and the bare-name
+index, which no method should be reachable through.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+
+from repowise.core.ingestion import ASTParser, FileTraverser, GraphBuilder
+from repowise.core.ingestion.models import FileInfo
+
+
+def _parse(source: str, path: str = "lib/thing.h"):
+    info = FileInfo(
+        path=path,
+        abs_path=path,
+        language="cpp",
+        size_bytes=len(source),
+        git_hash="",
+        last_modified=datetime(2026, 1, 1),
+        is_test=False,
+        is_config=False,
+        is_api_contract=False,
+        is_entry_point=False,
+    )
+    return ASTParser().parse_file(info, source.encode())
+
+
+def _methods(source: str) -> dict[str, tuple[str | None, bool]]:
+    return {
+        s.name: (s.parent_name, s.is_declaration)
+        for s in _parse(source).symbols
+        if s.kind == "method"
+    }
+
+
+def _build(repo: Path):
+    parser = ASTParser()
+    builder = GraphBuilder(repo_path=repo)
+    for fi in FileTraverser(repo).traverse():
+        builder.add_file(parser.parse_file(fi, Path(fi.abs_path).read_bytes()))
+    return builder.build()
+
+
+def _call_targets(graph, caller_file: str) -> set[str]:
+    return {
+        t
+        for s, t, d in graph.edges(data=True)
+        if d.get("edge_type") == "calls" and str(s).startswith(caller_file + "::")
+    }
+
+
+class TestInClassDeclarationsBecomeSymbols:
+    def test_a_plain_declaration_is_a_method_declaration(self) -> None:
+        assert _methods("class B {\n public:\n  void plain(int x);\n};\n") == {
+            "plain": ("B", True)
+        }
+
+    def test_it_does_not_need_an_access_specifier(self) -> None:
+        assert _methods("class C {\n  void hidden(int x);\n};\n") == {"hidden": ("C", True)}
+
+    def test_virtual_and_pure_virtual_both_land(self) -> None:
+        assert _methods(
+            "class D {\n public:\n  virtual void virt();\n  virtual void pure() = 0;\n};\n"
+        ) == {"virt": ("D", True), "pure": ("D", True)}
+
+    def test_a_struct_member_lands_too(self) -> None:
+        assert _methods("struct F {\n  void inStruct();\n};\n") == {"inStruct": ("F", True)}
+
+    def test_a_static_member_lands(self) -> None:
+        assert _methods("class H {\n public:\n  static int make(int x);\n};\n") == {
+            "make": ("H", True)
+        }
+
+    def test_a_pointer_return_lands(self) -> None:
+        """``virtual Iterator* NewIterator() = 0;`` nests the declarator."""
+        assert _methods("class I {\n public:\n  virtual Iterator* newIter(int n) = 0;\n};\n") == {
+            "newIter": ("I", True)
+        }
+
+    def test_a_reference_return_lands(self) -> None:
+        """``reference_declarator`` does not name its declarator field."""
+        assert _methods("class G {\n public:\n  const Slice& value() const;\n};\n") == {
+            "value": ("G", True)
+        }
+
+    def test_an_inline_definition_is_not_a_declaration(self) -> None:
+        """The known positive: a body was always extracted, and still is."""
+        assert _methods("class A {\n public:\n  void withBody() { }\n};\n") == {
+            "withBody": ("A", False)
+        }
+
+
+class TestShapesThatMustNotBecomeMethods:
+    """Controls the patterns can fail. Each nests a ``function_declarator``."""
+
+    def test_a_function_pointer_data_member_is_not_a_method(self) -> None:
+        assert _methods("class P {\n  void (*callback_)(int);\n  void real();\n};\n") == {
+            "real": ("P", True)
+        }
+
+    def test_an_operator_declaration_is_not_captured(self) -> None:
+        assert _methods(
+            "class Q {\n  bool operator==(const Q& o) const;\n  void kept();\n};\n"
+        ) == {"kept": ("Q", True)}
+
+    def test_the_recovery_refusal_does_not_reach_a_class_that_parsed(self) -> None:
+        """A parentless in-class declaration is dropped as grammar recovery.
+
+        A ``field_declaration`` cannot occur outside a class body, so a missing
+        class ancestor means the class did not parse; those symbols answered
+        out-of-line definition headers that the same broken region captures as
+        calls. The refusal is corpus-measured at 11 of 6,883 in-class
+        declarations over the six cpp repos, all in two files. What must be
+        tested here is that it does not reach an ordinary class -- a derived
+        one, and one nested in a namespace, are the shapes most likely to lose
+        their parent by accident.
+        """
+        assert _methods("namespace ns {\nclass Derived : public Base {\n public:\n  void m(int x);\n};\n}\n") == {
+            "m": ("Derived", True)
+        }
+
+    def test_an_inner_types_methods_survive(self) -> None:
+        """``@symbol.def`` sits on the declarator for exactly this reason.
+
+        A ``field_declaration`` can carry a whole ``struct Inner { ... } m_;``,
+        so anchoring there would make it a callable ancestor and silently drop
+        the inner type's methods -- a removal caused by an addition.
+        """
+        assert _methods(
+            "class Outer {\n"
+            "  void plain();\n"
+            "  struct Inner {\n"
+            "    void innerBody() { }\n"
+            "    void innerDecl();\n"
+            "  } member_;\n"
+            "};\n"
+        ) == {
+            "plain": ("Outer", True),
+            "innerBody": ("Inner", False),
+            "innerDecl": ("Inner", True),
+        }
+
+
+class TestExportMacroClassBodies:
+    """``class LEVELDB_EXPORT Iterator { ... }`` is grammar-recovery shaped.
+
+    The body becomes a ``compound_statement`` and its members statement-context
+    ``declaration`` nodes, so none of the ``field_declaration`` patterns reach
+    them, and ``= 0`` wraps the declarator in an ``init_declarator`` the plain
+    forward-declaration pattern cannot match either.
+    """
+
+    def test_a_pure_virtual_member_lands(self) -> None:
+        assert _methods(
+            "class LEVELDB_EXPORT Iterator {\n"
+            " public:\n"
+            "  virtual void Seek(const Slice& t) = 0;\n"
+            "  void RegisterCleanup(int a);\n"
+            "};\n"
+        ) == {"Seek": ("Iterator", True), "RegisterCleanup": ("Iterator", True)}
+
+    def test_a_recovered_inline_definition_is_not_read_as_a_declaration(self) -> None:
+        """The same recovery gives an inline body an ``initializer_list`` value.
+
+        Without the ``number_literal`` guard that reads as a declaration, and a
+        constructor with a member-init list does too.
+        """
+        source = (
+            "class LEVELDB_EXPORT R {\n"
+            " public:\n"
+            "  size_t Index(size_t i) const { return i + 1; }\n"
+            "  virtual void Real() = 0;\n"
+            "};\n"
+        )
+        declared = {s.name for s in _parse(source).symbols if s.is_declaration}
+        assert "Index" not in declared, declared
+        # An inline body inside the recovered body degrades the parse further
+        # and lifts what follows out of the class, so ``Real`` arrives
+        # parentless. Extracting it is still right; calling it R's is not.
+        assert "Real" in declared
+
+    def test_a_deleted_function_is_not_a_method_declaration(self) -> None:
+        got = _methods(
+            "class LEVELDB_EXPORT S {\n"
+            " public:\n"
+            "  void gone(int n) = delete;\n"
+            "  virtual void kept() = 0;\n"
+            "};\n"
+        )
+        assert "gone" not in got
+        assert got["kept"] == ("S", True)
+
+
+class TestDeclarationPairingKeepsClassesApart:
+    def test_a_declaration_does_not_pair_across_two_classes_of_one_name(
+        self, tmp_path: Path
+    ) -> None:
+        """The pairing key is ``(class_name, method_name)``.
+
+        A repo-wide unique definition proves the METHOD name is unique and says
+        nothing about the class, so the bare fallback paired an abstract base's
+        declarations onto an unrelated same-named class's definitions.
+        """
+        (tmp_path / "lib").mkdir(parents=True)
+        (tmp_path / "lib" / "base.h").write_text(
+            "#pragma once\nclass Iterator {\n public:\n  virtual void Seek(int t);\n};\n"
+        )
+        (tmp_path / "lib" / "nested.h").write_text(
+            "#pragma once\nclass Iterator {\n public:\n  void Seek(int t) { }\n};\n"
+        )
+        (tmp_path / "lib" / "caller.cc").write_text(
+            '#include "lib/base.h"\nint Run() {\n  Iterator* it;\n  it->Seek(1);\n  return 0;\n}\n'
+        )
+        targets = _call_targets(_build(tmp_path), "lib/caller.cc")
+        assert not any("nested.h::Iterator::Seek" in t for t in targets), targets
+
+    def test_a_same_stem_pair_still_links(self, tmp_path: Path) -> None:
+        """The known positive: ``thing.h`` / ``thing.cc`` is one unit.
+
+        Without it the guard would be indistinguishable from switching the
+        pairing off.
+        """
+        (tmp_path / "lib").mkdir(parents=True)
+        (tmp_path / "lib" / "thing.h").write_text(
+            "#pragma once\nclass Thing {\n public:\n  int work(int n);\n};\n"
+        )
+        (tmp_path / "lib" / "thing.cc").write_text(
+            '#include "lib/thing.h"\nint Thing::work(int n) { return n; }\n'
+        )
+        (tmp_path / "lib" / "caller.cc").write_text(
+            '#include "lib/thing.h"\nint Run() {\n  Thing t;\n  return t.work(1);\n}\n'
+        )
+        targets = _call_targets(_build(tmp_path), "lib/caller.cc")
+        assert any(t.endswith("lib/thing.cc::Thing::work") for t in targets), targets
+
+
+class TestMethodDeclarationsStayOutOfTheBareNameIndex:
+    def test_a_bare_call_does_not_reach_an_included_headers_method(
+        self, tmp_path: Path
+    ) -> None:
+        """No bare name can legally reach a method.
+
+        The per-file bare-name index answers unqualified lookups from importing
+        files, so a header full of in-class declarations would let ``work(1)``
+        bind to ``Thing::work`` purely because the header was included.
+        """
+        (tmp_path / "lib").mkdir(parents=True)
+        (tmp_path / "lib" / "thing.h").write_text(
+            "#pragma once\nclass Thing {\n public:\n  int work(int n);\n};\n"
+        )
+        (tmp_path / "lib" / "caller.cc").write_text(
+            '#include "lib/thing.h"\nint Run() {\n  return work(1);\n}\n'
+        )
+        targets = _call_targets(_build(tmp_path), "lib/caller.cc")
+        assert not any("Thing::work" in t for t in targets), targets


### PR DESCRIPTION
A C++ in-class method declaration was extracted as no symbol. `cpp.scm` had
patterns for a `function_definition` and for a file-scope `declaration`, but
none for `field_declaration`, which is how every in-class declaration parses.

A concrete class survived that, because its out-of-line `Cls::m` in the `.cc` is
a definition. An abstract one has no definition anywhere and reached the method
index empty, so `leveldb::Iterator` held no `Seek` and a same-named nested class
in `db/skiplist.h` answered every `Iterator*` call unopposed.

## What changed

Four query patterns, because C++ writes the shape four ways: the bare
declaration, pointer- and reference-returning forms that nest the declarator,
and one for an export-macro class, whose body is grammar-recovery parsed so its
pure virtuals arrive as `declaration > init_declarator`. Requiring
`declarator: (field_identifier)` directly is what excludes a function-pointer
data member, which nests a `function_declarator` too; `value: (number_literal)`
is what excludes a recovered inline definition and a constructor with a
member-init list.

Extracting the declarations exposed three defects in call resolution that could
not fire while abstract classes contributed no methods. They are fixed here
rather than left downstream:

- `_link_declarations` keys on `(class, method)`, so a repo-wide unique
  definition proved the method name unique and the class not at all. It paired
  an abstract base's declarations onto an unrelated same-named class. A method
  now additionally requires the same translation unit, compared on the base name
  so a public header still pairs with its implementation across `include/` and
  `src/`.
- An overload set is one symbol, not an ambiguity. The candidate test counted
  rows, so a class declaring two same-named methods never paired its
  declaration, and every qualified call to it stopped resolving.
- A method declaration stays out of the per-file and global bare-name indexes.
  No bare name can legally reach a method, and a header full of declarations
  otherwise lets an unqualified call bind to one.

A parentless in-class declaration is refused: a `field_declaration` cannot occur
outside a class body, so a missing class ancestor means the class did not parse.

## Behaviour

Over six C++ repositories (Crow, fmt, leveldb, nlohmann-json, seastar, aria2):

| | before | after |
|---|---|---|
| files reached by a cross-file call edge | 297 | 301 |
| call edges added / removed, leveldb | | +155 / 0 |
| call edges added / removed, aria2 | | +286 / 3 |
| dead-code findings, leveldb / aria2 | 39 / 57 | 39 / 57 |

Of 114 changed edges sampled and checked against source, 106 are correct. The
three removed aria2 edges are all `kevent()`, the BSD kqueue system call, which
had been binding to a same-named member. Go and Python corpora are byte-identical
before and after, including the resolution-origin mix.

## Verification

`tests/unit/ingestion/test_cpp_inclass_declarations.py` adds 18 tests, seven of
them controls that must fail: a function-pointer data member is not a method, an
operator declaration is not captured, an inner type's methods survive, a
recovered inline definition is not read as a declaration, `= delete` is not a
declaration, a declaration does not pair across two classes of one name, and a
bare call does not reach an included header's method.
