### PR TITLE
fix(ingestion): refuse a data member on the import-merged tier

### DIFF
--- a/packages/core/src/repowise/core/ingestion/call_resolver.py
+++ b/packages/core/src/repowise/core/ingestion/call_resolver.py
@@ -1304,7 +1304,13 @@ class CallResolver:
 
         # 2b: Check all imported files for the symbol (pre-merged lookup)
         merged_syms = self._merged_symbols_for(file_path)
-        if target_name in merged_syms:
+        # A data member is not callable. Tier 3 already refuses one, but this
+        # rung answered first and at 0.85, above the tier that declines it, so
+        # the refusal only reached whichever sites tier 3 happened to see.
+        if (
+            target_name in merged_syms
+            and merged_syms[target_name] not in self._non_callable_ids
+        ):
             return ResolvedCall(
                 caller_id, merged_syms[target_name], 0.85, call.line, "import_merged"
             )

--- a/packages/core/src/repowise/core/ingestion/languages/receiver_types.py
+++ b/packages/core/src/repowise/core/ingestion/languages/receiver_types.py
@@ -336,11 +336,12 @@ RECEIVER_TYPE_LANGUAGES = frozenset(_LANGUAGE_PATTERNS)
 # answer, and consulting it could only bind a bare local name to a field.
 #
 # Kotlin is here on a count rather than on its semantics, which is the lesson
-# bug 63 cost: Python has implicit field access too, and registering it would
-# have promised nothing, because only 1.8% of its field receivers are typed
-# where this scan looks. Kotlin declares a property at class scope in its own
-# idiom, and the scan does find them — 56 of ktor's 1,349 gained edges and 100
-# of exposed's 320, hand-read 10/10 correct. Small, and measured.
+# the Python attempt cost: Python has implicit field access too, and
+# registering it would have promised nothing, because only 1.8% of its field
+# receivers are typed where this scan looks. Kotlin declares a property at
+# class scope in its own idiom, and the scan does find them — 56 of ktor's
+# 1,349 gained edges and 100 of exposed's 320, hand-read 10/10 correct. Small,
+# and measured.
 #
 # Only a `val`/`var` reaches class scope. A primary-constructor parameter with
 # a default closes on `=` there too and is not a property at all, which is why

--- a/tests/unit/ingestion/test_bare_name_index_kinds.py
+++ b/tests/unit/ingestion/test_bare_name_index_kinds.py
@@ -1,4 +1,4 @@
-"""Tier 3 must not offer a data member as a function (bug 90).
+"""Tier 3 must not offer a data member as a function.
 
 ``_resolve_free_call``'s global-unique tier answers a bare name with any
 repo symbol carrying that name. The index it consults holds every symbol,

--- a/tests/unit/ingestion/test_bare_name_index_kinds.py
+++ b/tests/unit/ingestion/test_bare_name_index_kinds.py
@@ -170,3 +170,68 @@ class TestThePredicateStaysNarrow:
         )
         assert _kinds(parsed, "doThing") == {"variable"}
         assert [e for e in _edges(parsed, tmp_path) if e[1] == "util.ts::doThing"]
+
+
+def _edges_with_imports(
+    parsed: dict[str, ParsedFile],
+    tmp_path: Path,
+    import_targets: dict[str, set[str]],
+) -> list[tuple[str, str, str]]:
+    """``_edges`` passes no imports, so the import tiers never fire there."""
+    resolver = CallResolver(parsed, import_targets, repo_path=str(tmp_path))
+    return [
+        (rc.caller_id, rc.callee_id, rc.origin)
+        for path, pf in parsed.items()
+        for rc in resolver.resolve_file(path, pf.calls)
+    ]
+
+
+class TestTheImportMergedTierRefusesTheSame:
+    """The rule is the rung's, not tier 3's.
+
+    ``import_merged`` answers a bare name from every imported file's symbols and
+    was minting the field edge at 0.85 -- above the tier that declines it. Both
+    cases declare the name TWICE, because that is the only shape where the tiers
+    disagree: tier 3 refuses an ambiguous name outright, so a single declaration
+    is refused either way and would prove nothing.
+    """
+
+    def test_an_imported_field_does_not_answer_a_bare_name(
+        self, tmp_path: Path
+    ) -> None:
+        parsed = _parse_all(
+            tmp_path,
+            {
+                "model.rs": (
+                    "rust",
+                    "pub struct Index {\n    pub map: Vec<usize>,\n}\n",
+                ),
+                "other.rs": (
+                    "rust",
+                    "pub struct Other {\n    pub map: Vec<u8>,\n}\n",
+                ),
+                # A BARE call, not `v.map(..)`: a call with a receiver takes
+                # the member path and never reaches this tier.
+                "caller.rs": ("rust", "pub fn run(v: u64) -> u64 {\n    map(v)\n}\n"),
+            },
+        )
+        assert _kinds(parsed, "map") == {"property"}
+        edges = _edges_with_imports(
+            parsed, tmp_path, {"caller.rs": {"model.rs"}, "model.rs": set(), "other.rs": set()}
+        )
+        assert not [e for e in edges if e[1] == "model.rs::map"]
+
+    def test_an_imported_function_still_answers(self, tmp_path: Path) -> None:
+        """Control: the tier is untouched where the answer really is callable."""
+        parsed = _parse_all(
+            tmp_path,
+            {
+                "util.rs": ("rust", "pub fn render() -> u8 {\n    1\n}\n"),
+                "other.rs": ("rust", "pub fn render() -> u8 {\n    2\n}\n"),
+                "caller.rs": ("rust", "pub fn run() -> u8 {\n    render()\n}\n"),
+            },
+        )
+        edges = _edges_with_imports(
+            parsed, tmp_path, {"caller.rs": {"util.rs"}, "util.rs": set(), "other.rs": set()}
+        )
+        assert [e for e in edges if e[1] == "util.rs::render" and e[2] == "import_merged"]

--- a/tests/unit/ingestion/test_rust_type_use.py
+++ b/tests/unit/ingestion/test_rust_type_use.py
@@ -3,8 +3,8 @@
 ``rust.scm`` used to capture parameter types, return types, trait bounds,
 ``dyn``/``impl`` Trait and turbofish type arguments as ``@call.target`` /
 ``@call.site``, so ``fn take(x: MyType)`` recorded the enclosing function as
-*calling* ``MyType``. A type is not callable, so every such edge was wrong
-(bug 46). The captures now carry ``@param.type`` and resolve to ``type_use``.
+*calling* ``MyType``. A type is not callable, so every such edge was wrong.
+The captures now carry ``@param.type`` and resolve to ``type_use``.
 
 Covers:
 


### PR DESCRIPTION
## What

A bare call whose name matches a field in an imported file resolved onto that
field. `args.into_iter().map(...)` in ripgrep bound to `crates/globset/src/lib.rs::map`,
which is `map: Vec<usize>`.

## How

`_non_callable_ids` — "a data member is not callable" — was consulted only in
`_global_unique_match`, the bare-name tier at confidence 0.50. The import-merged
tier answers earlier in the same function and at confidence 0.85, and returned
whatever the merged import table held. The refusal therefore only ever reached
the sites the lower tier happened to see.

The same check now guards both rungs. `property` is emitted by exactly one
mapping in `language_configs.py`, Rust's `field_declaration`, so the set is empty
in every other language and the guard cannot fire there.

## Behavior

Edges are only ever removed, never added or retargeted. A site the import-merged
tier now declines is refused again by the bare-name tier on the same symbol id,
so nothing falls through to a lower-confidence answer.

| repo | added | removed | retargeted | origin changed |
|---|---|---|---|---|
| ripgrep | 0 | 10 | 0 | 0 |
| serde | 0 | 0 | 0 | 0 |
| goose | 0 | 478 | 0 | 0 |

## Verification

A call-population diff over three Rust repositories, taken against this branch's
base and compared post-redirect.

**Removed edges, 35 sampled and read against source: 35 of 35 were wrong and no
true edge was lost.** Every destination was a struct field rather than a `fn`,
and every call site resolves into `std` (`Option::map`, `Iterator::map`,
`Iterator::count`) or an external crate (`anyhow::Context`,
`agent_client_protocol::Error::data`). One is `.max_by_key(f)`, where `f` is an
argument and not a call at all.

**Cross-file coverage, counted in files:** ripgrep 48 to 48, serde 30 to 30,
bevy 596 to 592. The four files bevy loses were each reached only through field
edges — `pub(crate) f: F`, `pub(crate) iter: P`, `hash: u64`, `pub root: Dir` —
so they were claimed rather than covered.

**Controls:** call populations over Go, TypeScript, PHP, Python and Kotlin
corpora are byte-identical before and after, on both the graded call set and the
broad set.

**Dead code:** ripgrep 39 to 39, serde 4 to 4, no findings gained or lost.

Two tests in `tests/unit/ingestion/test_bare_name_index_kinds.py`. The negative
one is a real control: it reproduces the wrong edge exactly without the guard.
Both cases declare the name twice and use a bare call, because the bare-name tier
refuses an ambiguous name on its own and a call with a receiver takes a different
path — a single declaration or a receiver call would pass either way.

Full unit suite: 14,747 passed, 3 failed, all three pre-existing Pascal cases
that need a grammar this environment does not have.

A second commit drops stale internal tracker ids from three comments. Comment
text only, no code change.
