### PR TITLE
fix(web): move asFilePageTab off the client boundary

### DIFF
--- a/packages/ui/src/files/file-page-tabs.ts
+++ b/packages/ui/src/files/file-page-tabs.ts
@@ -102,6 +102,18 @@ export function fileTabsFor(data: FileDetailResponse): FileTabDef[] {
   });
 }
 
+/** Narrow a `?tab=` string to a tab this page actually renders.
+ *
+ *  Lives here rather than beside `FilePage`: that module is `"use client"`, so
+ *  every export of it is a client reference, and a server component that
+ *  imported this one got "it's not possible to invoke a client function from
+ *  the server" instead of a tab id. */
+export function asFilePageTab(value: string | undefined): FilePageTab | undefined {
+  return value && (FILE_PAGE_TABS as readonly string[]).includes(value)
+    ? (value as FilePageTab)
+    : undefined;
+}
+
 /** The tab a `?tab=` value resolves to, given what this file actually has.
  *  A deep link to Decisions on an ungoverned file lands on Overview rather
  *  than on a tab that is not in the row. */

--- a/packages/ui/src/files/file-page.tsx
+++ b/packages/ui/src/files/file-page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, type ReactNode } from "react";
 import { ViewTabs } from "../shared/view-tabs";
-import { FILE_PAGE_TABS, type FilePageTab, type FileTabDef } from "./file-page-tabs";
+import type { FilePageTab, FileTabDef } from "./file-page-tabs";
 
 export interface FilePageProps {
   /**
@@ -70,12 +70,4 @@ export function FilePage({ header, tabs, panels, initialTab, onTabChange }: File
       </ViewTabs>
     </div>
   );
-}
-
-/** Narrow a `?tab=` string to a tab this page actually renders. Exported for
- *  server components that need it before the shell mounts. */
-export function asFilePageTab(value: string | undefined): FilePageTab | undefined {
-  return value && (FILE_PAGE_TABS as readonly string[]).includes(value)
-    ? (value as FilePageTab)
-    : undefined;
 }


### PR DESCRIPTION
## What

The file entity page (`/repos/[id]/files/[...path]`) failed to render:

```
Attempted to call asFilePageTab() from the server but asFilePageTab is on
the client. It's not possible to invoke a client function from the server.
```

## Why

`file-page.tsx` carries the `"use client"` directive, which makes every one
of its exports a client reference, including `asFilePageTab` -- a pure
function that narrows a `?tab=` string to a known tab id. The page is a
server component and calls it to decide which tab to render and whether the
heavy aggregate fields are needed, so the call happened before any client
boundary existed.

## How

Moved `asFilePageTab` into `file-page-tabs.ts`. That module already exists
for exactly this reason: it holds `FILE_PAGE_TABS`, `fileTabsFor` and
`resolveFileTab` so server components can validate `?tab=`, build the tab
row and render panels without importing client code. Its header comment
already said so.

Both modules are re-exported from `@repowise-dev/ui/files`, so no call site
changes.

## Verification

- `tsc --noEmit` clean in `packages/ui` and `packages/web`.
- File pages render, direct and via soft navigation from the knowledge
  graph; `?tab=health` and `?tab=coverage` deep links resolve to the right
  tab.