### PR TITLE
refactor(ui): quieten the AI prompt modal chrome

### DIFF
--- a/packages/ui/src/health/ai-prompt-modal.tsx
+++ b/packages/ui/src/health/ai-prompt-modal.tsx
@@ -1,14 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import {
-  Check,
-  Copy,
-  Sparkles,
-  Bot,
-  Code2,
-  Wand2,
-} from "lucide-react";
+import { Check, Copy, Sparkles } from "lucide-react";
 import {
   Dialog,
   DialogContent,
@@ -16,6 +9,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "../ui/dialog";
+import { ViewToggle } from "./code-health-controls";
 import type { AiPromptFlavor } from "./ai-prompt-builder";
 
 export interface AiPromptModalProps {
@@ -31,16 +25,18 @@ export interface AiPromptModalProps {
   description?: string;
 }
 
-const FLAVORS: {
-  value: AiPromptFlavor;
-  label: string;
-  Icon: React.ComponentType<{ className?: string }>;
-  hint: string;
-}[] = [
-  { value: "generic", label: "Generic", Icon: Wand2, hint: "Any agent — Copilot, Codex, ChatGPT, custom." },
-  { value: "claude-code", label: "Claude Code", Icon: Bot, hint: "Tuned for Claude Code's tools (Read / Edit / TodoWrite)." },
-  { value: "claude-code-mcp", label: "Claude + repowise MCP", Icon: Sparkles, hint: "Steers the agent to repowise's MCP tools (get_context / get_risk / get_why) instead of re-grepping." },
-  { value: "cursor", label: "Cursor", Icon: Code2, hint: "Uses @file context, Cursor editing conventions." },
+/** The four target agents, in the order the segmented control renders them.
+ *  No per-flavor icon: four icons on four segments decorate a choice that its
+ *  own label already names, and the hint for the active one says the rest. */
+const FLAVORS: { value: AiPromptFlavor; label: string; hint: string }[] = [
+  { value: "generic", label: "Generic", hint: "Any agent: Copilot, Codex, ChatGPT, custom." },
+  { value: "claude-code", label: "Claude Code", hint: "Tuned for Claude Code's tools (Read / Edit / TodoWrite)." },
+  {
+    value: "claude-code-mcp",
+    label: "Claude + MCP",
+    hint: "Steers the agent to repowise's MCP tools (get_context / get_risk / get_why) instead of re-grepping.",
+  },
+  { value: "cursor", label: "Cursor", hint: "Uses @file context and Cursor editing conventions." },
 ];
 
 const FLAVOR_STORAGE_KEY = "repowise:ai-prompt-flavor";
@@ -113,51 +109,32 @@ export function AiPromptModal({
           <DialogDescription>{description}</DialogDescription>
         </DialogHeader>
 
-        <div className="space-y-3">
-          <div>
-            <p className="text-xs uppercase tracking-wider text-[var(--color-text-tertiary)] mb-1.5">
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <p className="font-mono text-[10px] uppercase tracking-wider text-[var(--color-text-tertiary)]">
               Target agent
             </p>
-            <div className="grid grid-cols-2 gap-2">
-              {FLAVORS.map((f) => {
-                const active = flavor === f.value;
-                return (
-                  <button
-                    key={f.value}
-                    type="button"
-                    onClick={() => setFlavor(f.value)}
-                    className={
-                      "rounded-md border px-3 py-2 text-left transition-colors " +
-                      (active
-                        ? "border-[var(--color-accent-primary)] bg-[var(--color-accent-muted)]"
-                        : "border-[var(--color-border-default)] hover:border-[var(--color-border-hover)] hover:bg-[var(--color-bg-elevated)]")
-                    }
-                    title={f.hint}
-                  >
-                    <div className="flex items-center gap-1.5">
-                      <f.Icon className={`h-3.5 w-3.5 ${active ? "text-[var(--color-accent-primary)]" : "text-[var(--color-text-tertiary)]"}`} />
-                      <span className="text-xs font-semibold text-[var(--color-text-primary)]">
-                        {f.label}
-                      </span>
-                    </div>
-                    <p className="mt-0.5 text-xs text-[var(--color-text-tertiary)] leading-snug">
-                      {f.hint}
-                    </p>
-                  </button>
-                );
-              })}
+            <div className="w-fit">
+              <ViewToggle
+                value={flavor}
+                options={FLAVORS.map((f) => ({ value: f.value, label: f.label }))}
+                onChange={setFlavor}
+              />
             </div>
+            <p className="text-xs leading-snug text-[var(--color-text-tertiary)]">
+              {FLAVORS.find((f) => f.value === flavor)?.hint}
+            </p>
           </div>
 
           <div className="rounded-md border border-[var(--color-border-default)] bg-[var(--color-bg-inset)] max-h-[420px] overflow-y-auto">
-            <pre className="px-3 py-2 text-[11.5px] font-mono text-[var(--color-text-primary)] whitespace-pre-wrap break-words">
+            <pre className="px-3 py-2 font-mono text-xs leading-relaxed text-[var(--color-text-primary)] whitespace-pre-wrap break-words">
               {prompt}
             </pre>
           </div>
 
           <div className="flex flex-wrap items-center justify-between gap-2 text-xs text-[var(--color-text-tertiary)]">
-            <span>
-              {prompt.length.toLocaleString()} chars · approx{" "}
+            <span className="tabular-nums">
+              {prompt.length.toLocaleString()} chars, approx{" "}
               {Math.round(prompt.length / 4).toLocaleString()} tokens
             </span>
             <button

--- a/packages/ui/src/health/code-health-controls.tsx
+++ b/packages/ui/src/health/code-health-controls.tsx
@@ -62,7 +62,7 @@ export function FilterChip({
   );
 }
 
-/** Two-state segmented toggle (Queue / All files). */
+/** Segmented toggle for a single axis (Queue / All files, prompt target agent). */
 export function ViewToggle<T extends string>({
   value,
   options,


### PR DESCRIPTION
## What

The AI prompt modal read as box soup. Its target-agent picker was four
bordered cards in a 2x2 grid, each carrying an icon, a label and a two-line
hint, giving six bordered containers in a dialog that asks a single
question.

## Why

A bordered or elevated container marks an object that can be selected,
opened, dragged or configured. One option in a radio group is not that, and
repeating cards at one visual weight removes the hierarchy rather than
creating it. Picking which agent the prompt is written for is a single axis,
which is what a segmented control is for. The four icons decorated a choice
that each label already names.

## How

- Four cards to one segmented control, reusing the existing `ViewToggle`
  rather than adding a component. It was already generic over its value
  type; only its docstring claimed it was two-state.
- One hint sentence beneath the control, for the active flavor only.
- Per-flavor icons removed. `Claude + repowise MCP` shortened to
  `Claude + MCP` so four segments fit one row.
- Prompt body `11.5px` to 12px mono. 11.5 is not on the type ladder.
- `Target agent` micro-label to 10px mono, the ladder's step for an
  uppercase micro-label.
- `tabular-nums` on the char/token readout, which changes in place as the
  flavor switches.

Two bordered regions left in the dialog, down from six.

## Behavior

Unchanged. Same four flavors, same persisted preference across surfaces and
sessions, same generated prompt text. The modal is shared, so this lands on
every surface that offers a prompt: refactoring, dead code, coverage,
hotspots, security.

## Verification

- `tsc --noEmit` clean in `packages/ui`.
- Modal opened from the refactoring board, dead code and coverage surfaces;
  flavor switching, preference persistence and copy all behave as before.