### PR TITLE
release: v0.46.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "name": "repowise",
       "source": "./plugins/claude-code",
       "description": "Codebase intelligence for Claude Code. Indexes your repo into five layers (Graph, Git, Docs, Decisions, Code Health) and gives Claude deep understanding of architecture, ownership, hotspots, decisions, and defect risk — fewer greps, fewer file reads, lower cost per query.",
-      "version": "0.45.0",
+      "version": "0.46.0",
       "category": "productivity",
       "keywords": [
         "codebase",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.46.0] — 2026-08-27
+
+The headline this cycle is cross-repo contracts becoming a surface you can use rather than a graph the indexer knew about. A workspace now recognises routes once and serves them to both producers and consumers, binds each contract to a real symbol id, reads request schemas off handler signatures, and gives the whole thing a front door in the UI and over REST. Alongside it the MCP tool surface got a shared response ceiling with recoverable pagination, so no tool can silently truncate an answer with no way back, and the C++, Rust, Java and TypeScript call graphs each lost a class of wrong edge.
+
+### Added
+
+- **Cross-repo contracts have a front door.** A workspace's contracts are browsable, open from the table into what they link to, and carry the line, symbol and schema over REST (#1890, #1899). One route recogniser now serves Go, Laravel and Axum, with Django, JAX-RS, Next.js and the Hono router DSL alongside them (#1867, #1860), and a library's public API counts as a contract in its own right.
+- **Python HTTP consumers resolve through their client bindings**, so a call made through a session or a generated client still names the path and verb it actually reaches.
+- **A shared response ceiling across the MCP tools.** The five uncapped tools now answer within a canonical budget enforced at delivery, and every cap is recoverable: relationship, history and truncated test lists all carry a way back to the rows they dropped (#1924, #1930).
+- **Canonical references that round-trip.** A reference emitted by one tool can be passed to another, and `get_why` returns evidence references pointing at what it read (#1927, #1932).
+- **`claude_cli` provider**, for indexing against a Claude Code subscription instead of an API key (#1514).
+- **The knowledge graph says what it is not showing** (#1847), its arrows mean execution rather than mere reference (#1832), and a folder card is named after the module page documenting it (#1828).
+
+### Changed
+
+- **BREAKING (MCP): `get_risk`'s `will_break` field is now `may_break`** (#1892). The old name asserted a certainty the structural heuristic behind it does not have. Any client reading `will_break` must be updated.
+- **`get_overview`'s onboarding blocks are opt-in**, and `get_answer` and `get_overview` return leaner payloads for the same content.
+- **Retrieval precision improved** for `get_answer`, which can now see the call graph when expanding a question (#1933).
+- **`HEALTH_ANALYZER_VERSION` is 6 and `PARSER_SCHEMA_VERSION` is 2.** Both are picked up automatically: an existing index re-scores health on its next update rather than waiting out the decay timer, and the parse cache re-parses once so the call-graph fixes below actually apply. Neither forces a re-index.
+
+### Fixed
+
+- **C++ call resolution**: scoped `Ns::f()` calls resolve against their qualifier rather than falling to a bare name (#1915), chained calls are constrained by the inner callee's return type (#1782), in-class method declarations and receivers typed from declarations are extracted, types used only inside their own translation unit are rescued, types behind export macros parse, and an overload set resolves instead of being refused.
+- **A Rust macro invocation is no longer counted as a function call** (#1885), a Java chain rooted at an external type is no longer read as a bare-name call, and the repo-wide receiver tier no longer answers for foreign types.
+- **Health scoring inputs**: Python `match` arms count toward cyclomatic complexity (#1795), Pascal else-if chains flatten instead of nesting each arm (#1679), a comment inside a parameter list is no longer counted as a parameter (#1796), and two test-detection gaps closed, one a pairing the name heuristic could not see (#1707) and one Delphi's `Test<Stem>.dpr` convention (#1706).
+- **`is_hotspot` is emitted by the backend** rather than re-derived in the client (#1797), fix density ranks against commits rather than individual files, and `tests_to_run` ranks by files reached rather than alphabetically.
+- **`coverage add` exits non-zero when it stores nothing** (#1751), and config errors that cannot self-heal no longer promise a retry.
+- **The file page renders again**: a pure `?tab=` helper had been exported from a client module and called from the server (#1936).
+- **API timestamps render as UTC** (#1835), `CLAUDE.md` is stamped with the indexed commit rather than live `HEAD`, and a `SELECT INTO` target is no longer flagged as a cartesian join.
+
+### Documentation
+
+- The benchmarks pages lead each section with its result, pair precision with recall so neither reads alone, and state both cost denominators (#1928).
+- The MCP tool table's drifted rows and the README's tool-count claims are corrected and asserted by a test.
+
+---
+
 ## [0.45.0] — 2026-08-21
 
 The headline this cycle is test intelligence that needs no coverage report. 0.44.0 made the call graph good enough to lead with; this release walks it to answer which tests reach a file, serves that through the API, and turns the Coverage tab into a Tests tab that says something useful on a repository that has never ingested a report. Around it, Code Health's performance findings become bounded opportunities that open the matching refactoring plan, Eden AI joins as an EU-hosted provider and embedder, and pinning BLAS threads before numpy loads halves peak memory on a cold index.

--- a/packages/cli/src/repowise/cli/__init__.py
+++ b/packages/cli/src/repowise/cli/__init__.py
@@ -16,4 +16,4 @@ from repowise.cli._stdio import _ensure_utf8_stdio
 # is already UTF-8.
 _ensure_utf8_stdio()
 
-__version__ = "0.45.0"
+__version__ = "0.46.0"

--- a/packages/core/src/repowise/core/__init__.py
+++ b/packages/core/src/repowise/core/__init__.py
@@ -6,4 +6,4 @@ generation engine. This is the heart of repowise — all other packages depend o
 Namespace package: repowise.core is part of the repowise namespace.
 """
 
-__version__ = "0.45.0"
+__version__ = "0.46.0"

--- a/packages/core/src/repowise/core/analysis/health/engine.py
+++ b/packages/core/src/repowise/core/analysis/health/engine.py
@@ -99,7 +99,15 @@ log = structlog.get_logger(__name__)
 # 5: raw performance findings gain stable causal linkage and structured
 # performance-fix plans; incremental execution slices widen to preserve those
 # interprocedural interpretations.
-HEALTH_ANALYZER_VERSION = 5
+# 6: five complexity and test-detection inputs changed at once, so the stored
+# metrics disagree with what the current analyzer would compute. Python ``match``
+# arms now count toward cyclomatic complexity and Pascal else-if chains flatten
+# instead of nesting, moving ``max_ccn`` and ``max_nesting``; a comment inside a
+# parameter list is no longer counted as a parameter; and two test-detection
+# fixes (a pairing heuristic the name match could not see, and Delphi's
+# ``Test<Stem>.dpr`` convention) move ``has_test_file`` in the direction that
+# stops accusing a tested file.
+HEALTH_ANALYZER_VERSION = 6
 
 # Method-level smells that make the dataflow / Extract Method pass worthwhile.
 # Only files carrying one of these get a CFG + def/use + reaching pass built.

--- a/packages/core/src/repowise/core/upgrade/_data/CHANGELOG.md
+++ b/packages/core/src/repowise/core/upgrade/_data/CHANGELOG.md
@@ -9,6 +9,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.46.0] — 2026-08-27
+
+The headline this cycle is cross-repo contracts becoming a surface you can use rather than a graph the indexer knew about. A workspace now recognises routes once and serves them to both producers and consumers, binds each contract to a real symbol id, reads request schemas off handler signatures, and gives the whole thing a front door in the UI and over REST. Alongside it the MCP tool surface got a shared response ceiling with recoverable pagination, so no tool can silently truncate an answer with no way back, and the C++, Rust, Java and TypeScript call graphs each lost a class of wrong edge.
+
+### Added
+
+- **Cross-repo contracts have a front door.** A workspace's contracts are browsable, open from the table into what they link to, and carry the line, symbol and schema over REST (#1890, #1899). One route recogniser now serves Go, Laravel and Axum, with Django, JAX-RS, Next.js and the Hono router DSL alongside them (#1867, #1860), and a library's public API counts as a contract in its own right.
+- **Python HTTP consumers resolve through their client bindings**, so a call made through a session or a generated client still names the path and verb it actually reaches.
+- **A shared response ceiling across the MCP tools.** The five uncapped tools now answer within a canonical budget enforced at delivery, and every cap is recoverable: relationship, history and truncated test lists all carry a way back to the rows they dropped (#1924, #1930).
+- **Canonical references that round-trip.** A reference emitted by one tool can be passed to another, and `get_why` returns evidence references pointing at what it read (#1927, #1932).
+- **`claude_cli` provider**, for indexing against a Claude Code subscription instead of an API key (#1514).
+- **The knowledge graph says what it is not showing** (#1847), its arrows mean execution rather than mere reference (#1832), and a folder card is named after the module page documenting it (#1828).
+
+### Changed
+
+- **BREAKING (MCP): `get_risk`'s `will_break` field is now `may_break`** (#1892). The old name asserted a certainty the structural heuristic behind it does not have. Any client reading `will_break` must be updated.
+- **`get_overview`'s onboarding blocks are opt-in**, and `get_answer` and `get_overview` return leaner payloads for the same content.
+- **Retrieval precision improved** for `get_answer`, which can now see the call graph when expanding a question (#1933).
+- **`HEALTH_ANALYZER_VERSION` is 6 and `PARSER_SCHEMA_VERSION` is 2.** Both are picked up automatically: an existing index re-scores health on its next update rather than waiting out the decay timer, and the parse cache re-parses once so the call-graph fixes below actually apply. Neither forces a re-index.
+
+### Fixed
+
+- **C++ call resolution**: scoped `Ns::f()` calls resolve against their qualifier rather than falling to a bare name (#1915), chained calls are constrained by the inner callee's return type (#1782), in-class method declarations and receivers typed from declarations are extracted, types used only inside their own translation unit are rescued, types behind export macros parse, and an overload set resolves instead of being refused.
+- **A Rust macro invocation is no longer counted as a function call** (#1885), a Java chain rooted at an external type is no longer read as a bare-name call, and the repo-wide receiver tier no longer answers for foreign types.
+- **Health scoring inputs**: Python `match` arms count toward cyclomatic complexity (#1795), Pascal else-if chains flatten instead of nesting each arm (#1679), a comment inside a parameter list is no longer counted as a parameter (#1796), and two test-detection gaps closed, one a pairing the name heuristic could not see (#1707) and one Delphi's `Test<Stem>.dpr` convention (#1706).
+- **`is_hotspot` is emitted by the backend** rather than re-derived in the client (#1797), fix density ranks against commits rather than individual files, and `tests_to_run` ranks by files reached rather than alphabetically.
+- **`coverage add` exits non-zero when it stores nothing** (#1751), and config errors that cannot self-heal no longer promise a retry.
+- **The file page renders again**: a pure `?tab=` helper had been exported from a client module and called from the server (#1936).
+- **API timestamps render as UTC** (#1835), `CLAUDE.md` is stamped with the indexed commit rather than live `HEAD`, and a `SELECT INTO` target is no longer flagged as a cartesian join.
+
+### Documentation
+
+- The benchmarks pages lead each section with its result, pair precision with recall so neither reads alone, and state both cost denominators (#1928).
+- The MCP tool table's drifted rows and the README's tool-count claims are corrected and asserted by a test.
+
+---
+
 ## [0.45.0] — 2026-08-21
 
 The headline this cycle is test intelligence that needs no coverage report. 0.44.0 made the call graph good enough to lead with; this release walks it to answer which tests reach a file, serves that through the API, and turns the Coverage tab into a Tests tab that says something useful on a repository that has never ingested a report. Around it, Code Health's performance findings become bounded opportunities that open the matching refactoring plan, Eden AI joins as an EU-hosted provider and embedder, and pinning BLAS threads before numpy loads halves peak memory on a cold index.

--- a/packages/core/src/repowise/core/upgrade/version.py
+++ b/packages/core/src/repowise/core/upgrade/version.py
@@ -42,7 +42,13 @@ STORE_FORMAT_VERSION: int = 2
 
 #: Current parser/extractor schema. Folded into the parse-cache fingerprint in
 #: place of the package version. See :mod:`repowise.core.ingestion.parse_cache`.
-PARSER_SCHEMA_VERSION: int = 1
+#:
+#: v2: ``RawCall`` gained ``scope_name`` (the C++ ``Ns::f()`` qualifier as
+#: written) and ``receiver_call`` (the inner call of a chained expression), and
+#: a Rust macro invocation stopped being extracted as a call. A cache written
+#: before that carries neither field, so the scoped-call, chained-call and
+#: macro fixes would resolve against stale rows instead of firing.
+PARSER_SCHEMA_VERSION: int = 2
 
 #: state.json key holding the store format version that wrote the store.
 STORE_FORMAT_VERSION_KEY = "store_format_version"

--- a/packages/server/src/repowise/server/__init__.py
+++ b/packages/server/src/repowise/server/__init__.py
@@ -7,4 +7,4 @@ Provides:
     - Background job scheduler (APScheduler)
 """
 
-__version__ = "0.45.0"
+__version__ = "0.46.0"

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "repowise",
   "description": "Codebase intelligence for Claude Code. Indexes your codebase into five layers (Graph, Git, Docs, Decisions, Code Health) and exposes them through ten task-shaped MCP tools — so Claude understands architecture, ownership, hotspots, why code is built the way it is, and where the defect risk lives.",
-  "version": "0.45.0",
+  "version": "0.46.0",
   "author": {
     "name": "Repowise",
     "email": "hello@repowise.dev",

--- a/plugins/claude-code/CHANGELOG.md
+++ b/plugins/claude-code/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to the Repowise Claude Code plugin are documented here.
 
+## 0.46.0
+
+### Changed
+- The `change-review` skill reads `directive.may_break` and
+  `directive.may_break_tests`. `get_risk` renamed both fields: the old names
+  asserted a certainty the structural heuristic behind them does not have
+  (#1892).
+- `/repowise:risk`, `/repowise:impacted-tests`, `/repowise:security` and the
+  plugin README state the public risk scale the way the tool now reports it,
+  and describe fix density as ranked against commits rather than against
+  individual files (#1891, #1914).
+- No hook change this cycle: `hooks.json` still mirrors `claude_config.py`, and
+  every tool named in a command or skill is one the server lists.
+
 ## 0.45.0
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "repowise"
-version = "0.45.0"
+version = "0.46.0"
 description = "The codebase intelligence layer for your AI coding agent — dependency graph, git history, dead code, decisions, and code health, exposed over MCP"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/server.json
+++ b/server.json
@@ -8,12 +8,12 @@
     "source": "github"
   },
   "websiteUrl": "https://www.repowise.dev",
-  "version": "0.45.0",
+  "version": "0.46.0",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "repowise",
-      "version": "0.45.0",
+      "version": "0.46.0",
       "transport": {
         "type": "stdio"
       },

--- a/uv.lock
+++ b/uv.lock
@@ -3051,7 +3051,7 @@ wheels = [
 
 [[package]]
 name = "repowise"
-version = "0.45.0"
+version = "0.46.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Bumps 0.45.0 to 0.46.0 and writes the changelog for the cycle.

## What shipped this cycle

**Cross-repo contracts became something you can actually use.** They existed
before as a graph the indexer knew about. Now a workspace recognises a route
once and serves it to both the producer and its consumers, binds every contract
to a real symbol id, reads request schemas off handler signatures, and gives the
whole thing a front door in the UI and over REST. Go, Laravel and Axum share one
route recogniser, with Django, JAX-RS, Next.js and the Hono router DSL alongside
them.

**No MCP tool can quietly truncate an answer any more.** The five uncapped tools
now answer within a shared budget, and every cap that does bite carries a way
back to the rows it dropped. References emitted by one tool round-trip into
another, so an agent can follow a thread across tools instead of re-searching.

**The call graph lost a class of wrong edge in four languages.** C++ scoped and
chained calls resolve properly, a Rust macro invocation is no longer counted as
a function call, a Java chain rooted at an external type is no longer read as a
bare name, and aliased TS/JS imports record the name they actually export.

Full detail in `docs/CHANGELOG.md`.

## One breaking change

`get_risk` renamed `will_break` to `may_break` (#1892). The old name claimed a
certainty the structural heuristic behind it does not have. Anything reading the
old field needs updating.

## Two schema constants move

Both are picked up automatically. Neither forces anyone to re-index.

**`HEALTH_ANALYZER_VERSION` 5 to 6.** Five fixes this cycle change a health
number we already wrote to disk: Python `match` arms now count toward cyclomatic
complexity (#1795), Pascal else-if chains flatten instead of nesting each arm
(#1679), a comment inside a parameter list is no longer counted as a parameter
(#1796), and two test-detection fixes move `has_test_file` (#1706, #1707).
Existing indexes re-score on their next update instead of waiting out the
seven-day decay timer.

**`PARSER_SCHEMA_VERSION` 1 to 2.** `RawCall` gained `scope_name` and
`receiver_call`, and Rust macros stopped being extracted as calls. A parse cache
written before that has neither field, so the C++ and Rust call fixes above
would resolve against stale rows and silently do nothing. The bump clears the
cache once and re-parses, which is cheap.

## Test plan

- `uv build --wheel` produces the 0.46.0 wheel with all 93 command modules,
  19 tree-sitter queries and 36 templates
- `npm run build --workspace packages/web` succeeds and emits the standalone
  server with workspace code compiled in
- Release manifest, bundled changelog, upgrade and health tests pass. Three
  Pascal failures are a missing local `tree_sitter_pascal` grammar, not this
  change
- No `0.45.0` left anywhere in the tracked manifests
- Every tool named in a plugin command or skill is one the server lists, and
  `hooks.json` still matches `claude_config.py`
- Cold `init` on a 174-file repo, keyless and with a provider: 188 pages either
  way, zero tokens keyless, every MCP tool answering
