### PR TITLE
release(vscode): v0.9.0

### DIFF
--- a/packages/vscode/CHANGELOG.md
+++ b/packages/vscode/CHANGELOG.md
@@ -7,6 +7,44 @@ is the minimum server version it checks against.
 This file starts at 0.7.0. Earlier releases are described in the repository's
 release history.
 
+## 0.9.0
+
+Mostly a rebuild. The webviews compile the shared Repowise UI at build time, so
+two cycles of work on the graph, health and refactoring components reaches the
+extension here rather than when it was written.
+
+**Requires repowise 0.45.0 or newer.** The refactoring views read the unified
+recommendation contract that 0.45.0 introduced, so the status bar flags an
+older server and asks you to upgrade with `pip install --upgrade repowise`.
+
+### Refactoring
+
+- A performance finding links to the refactoring plan that addresses it, so a
+  slow path in the health view leads somewhere instead of ending as a note.
+- Recommendations arrive on one contract across health and refactoring, which
+  removes the cases where the same plan read differently in two views.
+
+### The graph
+
+- Call edges say how they got into the graph, so an inferred edge can be told
+  apart from a resolved one.
+- C++ scoped and chained calls resolve against their qualifier and return type,
+  a Rust macro invocation is no longer drawn as a function call, and a receiver
+  retyped by a framework decorator is typed correctly. Fewer wrong edges.
+- A subclass is no longer listed as a caller of the method it inherits.
+
+### Health
+
+- The Coverage tab is a Tests tab and answers on a repository that has never
+  ingested a coverage report, using the call graph and saying which tier
+  answered.
+- It reports how many tests reach a file rather than how many it happened to
+  list.
+- The risk panel names the diff-shape score as supporting evidence rather than
+  a verdict, and ranks fix density against commits rather than individual files.
+- The file detail page is on the design language and has its way in and out.
+- Timestamps render as UTC rather than in whatever the host machine assumed.
+
 ## 0.8.0
 
 The views are on the current design language, and the risk panel now leads with

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "repowise",
   "displayName": "Repowise",
   "description": "Know what your change breaks before you push. Health signals, architecture maps, and refactoring plans in your editor, and the same intelligence for your AI agent via MCP. Local and free.",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "publisher": "repowise-dev",
   "license": "AGPL-3.0-or-later",
   "homepage": "https://www.repowise.dev",

--- a/packages/vscode/src/constants.ts
+++ b/packages/vscode/src/constants.ts
@@ -17,7 +17,7 @@ export const CONFIG_SECTION = "repowise";
  * sends. `RiskRangeResponse.fix_history` is a required field and the panel
  * dereferences it, so an older server would throw rather than degrade.
  */
-export const MIN_SERVER_VERSION = "0.43.0";
+export const MIN_SERVER_VERSION = "0.45.0";
 
 /** Command ids contributed by the extension, mirrored from package.json. */
 export const Commands = {


### PR DESCRIPTION
Bumps the extension from 0.8.0 to 0.9.0.

## Why now

The extension version had not moved since `vscode-v0.8.0`, but the webviews
compile the shared Repowise UI into the VSIX at build time. Thirty commits have
landed in webview-consumed subpaths since that tag, across `graph/` (6),
`health/` (11), `refactoring/`, `docs/`, `wiki/`, `shared/` and `lib/`. All of
that work was written and merged but never reached extension users, because it
only ships on a rebuild. This is that rebuild.

## Minimum server version 0.43.0 to 0.45.0

The refactoring views read the unified recommendation contract that landed in
0.45.0 (#1784, #1816), which changed both the server routes and the
`plan-detail` and `meta` components the webviews import. An older server cannot
answer them, so the status bar flags it and points at the upgrade.

Deliberately not 0.46.0. Nothing in that range added a contract the webviews
depend on: the only 0.46.0 commit touching both a webview-consumed subpath and
a server route was copy-only on already null-guarded fields. Setting the floor
higher would block working 0.45 servers for no reason.

## What users get

Refactoring plans reachable from the performance findings that motivate them,
and one recommendation contract across health and refactoring instead of two
readings of the same plan. Call edges that say how they got into the graph,
with fewer wrong ones in C++, Rust and inherited-method cases. A Tests tab that
answers on a repository with no coverage report ingested. Risk copy that names
the diff-shape score as supporting evidence rather than a verdict.

Full detail in `packages/vscode/CHANGELOG.md`.

## Test plan

Checklist from `packages/vscode/RELEASING.md`, which requires building rather
than only type-checking:

- `type-check` clean, host and webview projects
- `build` succeeds, host bundle 122.2 KB against a 300 KB budget
- `build:webview` succeeds; largest lazy chunk is ELK at 1.44 MB, expected and
  shared by the graph and C4 views
- `test:webview`: 45 tests across 12 files pass
- `test` electron smoke: 4 pass, extension activates without spawning a
  subprocess and registers every command it contributes
- `package` produces `repowise-0.9.0.vsix`, 159 files, 2.23 MB

Not run here, since both need a GUI: the clean-profile VSIX install walkthrough
and the Cursor fork check.
