### PR TITLE
tech_stack: detect bun as the script runner for generated Commands

### DIFF
--- a/packages/core/src/repowise/core/generation/editor_files/tech_stack.py
+++ b/packages/core/src/repowise/core/generation/editor_files/tech_stack.py
@@ -437,6 +437,8 @@ def detect_build_commands(repo_path: Path) -> dict[str, str]:
             runner = "npm run" if not (repo_path / "pnpm-lock.yaml").exists() else "pnpm"
             if (repo_path / "yarn.lock").exists():
                 runner = "yarn"
+            if (repo_path / "bun.lock").exists() or (repo_path / "bun.lockb").exists():
+                runner = "bun run"
             for key, candidates in _map.items():
                 for cand in candidates:
                     if cand in scripts:


### PR DESCRIPTION
## What happens

`tech_stack.py` picks the script runner for the generated "Commands" block from lockfiles: `pnpm-lock.yaml` → pnpm, `yarn.lock` → yarn, otherwise `npm run`. Bun projects (`bun.lock` / `bun.lockb`, no npm lockfile) fall into the default, so a bun-only repo gets `npm run test`, `npm run lint`, etc. in its generated editor file — commands that contradict the project's own tooling and, in bun-only environments, don't work at all.

Observed in the field: a NestJS-on-bun repo (bun 1.3.x, `bun.lock`, `.bun-version`) whose generated `.claude/CLAUDE.md` block prescribed four `npm run` commands, regenerated on every reindex — while the repo's own instructions say "bun, not npm/node". Since the block is regenerated, fixing the file by hand doesn't stick; the runner heuristic is the only place this can be fixed.

## What changes

One more lockfile check, mirroring the pnpm/yarn detection:

```python
if (repo_path / "bun.lock").exists() or (repo_path / "bun.lockb").exists():
    runner = "bun run"
```

- `bun.lock` is the current text lockfile, `bun.lockb` the legacy binary one — both are checked.
- Placed after the yarn check so bun wins when multiple lockfiles coexist, consistent with the existing most-specific-last chain.

## Verification

`ast.parse` clean; on a repo with `bun.lock` the generated Commands block now reads `bun run test` / `bun run lint` / `bun run typecheck` (verified by patching an installed 0.39.0 and reindexing the repo above — the npm lines did not come back).

