### PR TITLE
feat(ui): upgrade architecture external dependencies

### DIFF
--- a/packages/ui/__tests__/dependencies/external-dependencies-table.test.tsx
+++ b/packages/ui/__tests__/dependencies/external-dependencies-table.test.tsx
@@ -1,0 +1,145 @@
+import * as React from "react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type {
+  ExternalSystemSummaryEntry,
+  ExternalSystemsSummary,
+} from "@repowise-dev/types/external-systems";
+import {
+  DEFAULT_EXTERNAL_DEPENDENCY_STATE,
+  ExternalDependenciesTable,
+  type ExternalDependencyTableState,
+} from "../../src/dependencies";
+
+function entry(index: number, overrides: Partial<ExternalSystemSummaryEntry> = {}): ExternalSystemSummaryEntry {
+  return {
+    package_key: `npm:pkg-${index}`,
+    name: `pkg-${index}`,
+    display_name: `pkg-${index}`,
+    ecosystem: index % 2 ? "pypi" : "npm",
+    category: "library",
+    io_kind: null,
+    runtime_declared: index % 3 !== 0,
+    dev_declared: index % 3 === 0,
+    declaration_count: 1,
+    manifest_count: 1,
+    versions: [`^${index}.0.0`],
+    versions_total: 1,
+    versions_truncated: false,
+    multiple_versions: false,
+    external_node_count: index % 4 === 0 ? 0 : 1,
+    import_edge_count: index,
+    importing_file_count: index,
+    link_state: index % 4 === 0 ? "unlinked" : "linked",
+    ...overrides,
+  };
+}
+
+function summary(items: ExternalSystemSummaryEntry[]): ExternalSystemsSummary {
+  return {
+    items,
+    returned: items.length,
+    total_packages: items.length,
+    limit: 400,
+    offset: 0,
+    truncated: false,
+    scope: "primary",
+    excluded_declarations: 7,
+    total_declarations: items.length,
+    runtime_packages: items.filter((item) => item.runtime_declared).length,
+    dev_only_packages: items.filter((item) => !item.runtime_declared && item.dev_declared).length,
+    observed_packages: items.filter((item) => item.import_edge_count > 0).length,
+    linked_packages: items.filter((item) => item.link_state === "linked").length,
+    unlinked_packages: items.filter((item) => item.link_state === "unlinked").length,
+    linked_without_imports: items.filter((item) => item.link_state === "linked" && item.import_edge_count === 0).length,
+    ecosystems: [...new Set(items.map((item) => item.ecosystem))],
+    manifest_count: 3,
+  };
+}
+
+function Harness({ data }: { data: ExternalSystemsSummary }) {
+  const [state, setState] = React.useState<ExternalDependencyTableState>({
+    ...DEFAULT_EXTERNAL_DEPENDENCY_STATE,
+    sort: "name",
+    order: "asc",
+  });
+  const [selected, setSelected] = React.useState<ExternalSystemSummaryEntry | null>(null);
+  return (
+    <ExternalDependenciesTable
+      data={data}
+      state={state}
+      onStateChange={setState}
+      selected={selected}
+      onSelectedChange={setSelected}
+    />
+  );
+}
+
+describe("ExternalDependenciesTable", () => {
+  it("keeps the rendered package page bounded and paginates", () => {
+    render(<Harness data={summary(Array.from({ length: 60 }, (_, index) => entry(index)))} />);
+
+    expect(screen.getAllByText("pkg-0").length).toBeGreaterThan(0);
+    expect(screen.queryByText("pkg-31")).not.toBeInTheDocument();
+    expect(screen.getByText("Page 1 of 3")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /next/i }));
+    expect(screen.getAllByText("pkg-31").length).toBeGreaterThan(0);
+    expect(screen.queryByText("pkg-0")).not.toBeInTheDocument();
+  });
+
+  it("searches quickly and reports an honest filtered empty state", () => {
+    render(<Harness data={summary([entry(1), entry(2), entry(3)])} />);
+    const search = screen.getByRole("searchbox", { name: "Search packages" });
+
+    fireEvent.change(search, { target: { value: "pkg-2" } });
+    expect(screen.getAllByText("pkg-2").length).toBeGreaterThan(0);
+    expect(screen.queryByText("pkg-1")).not.toBeInTheDocument();
+
+    fireEvent.change(search, { target: { value: "missing" } });
+    expect(screen.getByText("No packages match these filters")).toBeInTheDocument();
+  });
+
+  it("opens a keyboard-accessible package inspector", () => {
+    render(<Harness data={summary([entry(7, { display_name: "selected-package" })])} />);
+    const row = screen.getAllByText("selected-package")[0]!.closest("tr");
+    expect(row).not.toBeNull();
+    fireEvent.keyDown(row!, { key: "Enter" });
+
+    const dialog = screen.getByRole("dialog");
+    expect(within(dialog).getByText("selected-package")).toBeInTheDocument();
+    expect(within(dialog).getByText(/1 declaration/)).toBeInTheDocument();
+  });
+
+  it("renders a repository-level empty state", () => {
+    const onStateChange = vi.fn();
+    render(
+      <ExternalDependenciesTable
+        data={summary([])}
+        state={DEFAULT_EXTERNAL_DEPENDENCY_STATE}
+        onStateChange={onStateChange}
+        selected={null}
+        onSelectedChange={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("No external dependencies recorded")).toBeInTheDocument();
+  });
+
+  it("offers bounded server-page traversal when more summaries exist", () => {
+    const onLoadMore = vi.fn();
+    const data = { ...summary([entry(1)]), total_packages: 501, returned: 400, truncated: true };
+    render(
+      <ExternalDependenciesTable
+        data={data}
+        state={DEFAULT_EXTERNAL_DEPENDENCY_STATE}
+        onStateChange={vi.fn()}
+        selected={null}
+        onSelectedChange={vi.fn()}
+        onLoadMore={onLoadMore}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Load next 101" }));
+    expect(onLoadMore).toHaveBeenCalledOnce();
+    expect(screen.getByText(/apply to 400 loaded packages out of 501/)).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/dependencies/external-dependencies-table.tsx
+++ b/packages/ui/src/dependencies/external-dependencies-table.tsx
@@ -1,0 +1,586 @@
+"use client";
+
+import * as React from "react";
+import {
+  ArrowRight,
+  Box,
+  ChevronLeft,
+  ChevronRight,
+  ExternalLink,
+  FileCode2,
+  Search,
+} from "lucide-react";
+import type {
+  ExternalSystemSummaryEntry,
+  ExternalSystemsSummary,
+} from "@repowise-dev/types/external-systems";
+import { EmptyState } from "../shared/empty-state";
+import {
+  ResponsiveTable,
+  type ResponsiveColumn,
+} from "../shared/responsive-table";
+import { Button } from "../ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "../ui/select";
+import { Sheet, SheetContent, SheetTitle } from "../ui/sheet";
+
+export type ExternalDependencyRole = "all" | "runtime" | "dev-only" | "mixed";
+export type ExternalDependencyUsage =
+  | "all"
+  | "observed"
+  | "linked-unobserved"
+  | "unlinked";
+export type ExternalDependencySort =
+  | "importers"
+  | "edges"
+  | "name"
+  | "declarations"
+  | "manifests"
+  | "versions";
+
+export interface ExternalDependencyTableState {
+  query: string;
+  ecosystem: string;
+  role: ExternalDependencyRole;
+  usage: ExternalDependencyUsage;
+  category: string;
+  sort: ExternalDependencySort;
+  order: "asc" | "desc";
+  page: number;
+}
+
+export const DEFAULT_EXTERNAL_DEPENDENCY_STATE: ExternalDependencyTableState = {
+  query: "",
+  ecosystem: "all",
+  role: "all",
+  usage: "all",
+  category: "all",
+  sort: "importers",
+  order: "desc",
+  page: 1,
+};
+
+export interface PackageGraphEvidence {
+  centerNodeId: string;
+  importingFiles: string[];
+  importEdgeCount: number;
+  totalNodes: number;
+}
+
+export interface ExternalDependenciesTableProps {
+  data: ExternalSystemsSummary;
+  state: ExternalDependencyTableState;
+  onStateChange: (state: ExternalDependencyTableState) => void;
+  selected: ExternalSystemSummaryEntry | null;
+  onSelectedChange: (entry: ExternalSystemSummaryEntry | null) => void;
+  evidence?: PackageGraphEvidence | undefined;
+  evidenceLoading?: boolean | undefined;
+  evidenceError?: string | null | undefined;
+  graphHref?: string | undefined;
+  renderFileLink?: ((path: string, children: React.ReactNode) => React.ReactNode) | undefined;
+  pageSize?: number | undefined;
+  onLoadMore?: (() => void) | undefined;
+  loadingMore?: boolean | undefined;
+  loadMoreError?: string | null | undefined;
+  onRetryLoadMore?: (() => void) | undefined;
+}
+
+function roleOf(entry: ExternalSystemSummaryEntry): Exclude<ExternalDependencyRole, "all"> {
+  if (entry.runtime_declared && entry.dev_declared) return "mixed";
+  return entry.runtime_declared ? "runtime" : "dev-only";
+}
+
+function usageOf(entry: ExternalSystemSummaryEntry): Exclude<ExternalDependencyUsage, "all"> {
+  if (entry.import_edge_count > 0) return "observed";
+  return entry.link_state === "linked" ? "linked-unobserved" : "unlinked";
+}
+
+function compareEntries(
+  a: ExternalSystemSummaryEntry,
+  b: ExternalSystemSummaryEntry,
+  sort: ExternalDependencySort,
+): number {
+  if (sort === "name") return a.display_name.localeCompare(b.display_name);
+  const values: Record<Exclude<ExternalDependencySort, "name">, [number, number]> = {
+    importers: [a.importing_file_count, b.importing_file_count],
+    edges: [a.import_edge_count, b.import_edge_count],
+    declarations: [a.declaration_count, b.declaration_count],
+    manifests: [a.manifest_count, b.manifest_count],
+    versions: [a.versions_total, b.versions_total],
+  };
+  const [av, bv] = values[sort];
+  return av - bv || a.display_name.localeCompare(b.display_name);
+}
+
+function updateState(
+  state: ExternalDependencyTableState,
+  patch: Partial<ExternalDependencyTableState>,
+): ExternalDependencyTableState {
+  return { ...state, ...patch, page: patch.page ?? 1 };
+}
+
+function RoleLabel({ entry }: { entry: ExternalSystemSummaryEntry }) {
+  const role = roleOf(entry);
+  return (
+    <span className="text-xs text-[var(--color-text-secondary)]">
+      {role === "runtime" ? "Runtime" : role === "mixed" ? "Runtime + dev" : "Dev-only"}
+    </span>
+  );
+}
+
+function LinkageLabel({ entry }: { entry: ExternalSystemSummaryEntry }) {
+  const usage = usageOf(entry);
+  return (
+    <span className="inline-flex items-center gap-1.5 text-xs text-[var(--color-text-secondary)]">
+      <span
+        aria-hidden
+        className={
+          usage === "observed"
+            ? "h-1.5 w-1.5 rounded-full bg-[var(--color-success)]"
+            : "h-1.5 w-1.5 rounded-full bg-[var(--color-text-tertiary)]"
+        }
+      />
+      {usage === "observed"
+        ? "Observed"
+        : usage === "linked-unobserved"
+          ? "Linked, no imports"
+          : "No graph link"}
+    </span>
+  );
+}
+
+function Versions({ entry }: { entry: ExternalSystemSummaryEntry }) {
+  if (entry.versions_total === 0) {
+    return <span className="text-[var(--color-text-tertiary)]">Not specified</span>;
+  }
+  const label = entry.versions.join(", ");
+  return (
+    <span className="font-mono text-xs text-[var(--color-text-secondary)]" title={label}>
+      {label}
+      {entry.versions_truncated ? ` +${entry.versions_total - entry.versions.length}` : ""}
+      {entry.multiple_versions ? (
+        <span className="ml-1.5 font-sans text-[var(--color-text-tertiary)]">
+          ({entry.versions_total} versions)
+        </span>
+      ) : null}
+    </span>
+  );
+}
+
+function PackageInspector({
+  entry,
+  evidence,
+  evidenceLoading,
+  evidenceError,
+  graphHref,
+  renderFileLink,
+  onClose,
+}: {
+  entry: ExternalSystemSummaryEntry | null;
+  evidence?: PackageGraphEvidence | undefined;
+  evidenceLoading?: boolean | undefined;
+  evidenceError?: string | null | undefined;
+  graphHref?: string | undefined;
+  renderFileLink?: ExternalDependenciesTableProps["renderFileLink"];
+  onClose: () => void;
+}) {
+  return (
+    <Sheet open={entry !== null} onOpenChange={(open) => !open && onClose()}>
+      <SheetContent
+        side="right"
+        closeLabel="Close package details"
+        className="w-[min(92vw,440px)] sm:w-[440px]"
+      >
+        {entry ? (
+          <div className="flex min-h-0 flex-1 flex-col">
+            <header className="border-b border-[var(--color-border-default)] px-5 py-4 pr-12">
+              <p className="font-mono text-2xs uppercase tracking-wider text-[var(--color-text-tertiary)]">
+                {entry.ecosystem} package
+              </p>
+              <SheetTitle className="mt-1 break-words text-[15px]">{entry.display_name}</SheetTitle>
+              <div className="mt-2 flex flex-wrap gap-x-4 gap-y-1">
+                <RoleLabel entry={entry} />
+                <LinkageLabel entry={entry} />
+              </div>
+            </header>
+
+            <div className="min-h-0 flex-1 space-y-6 overflow-y-auto px-5 py-5">
+              <section>
+                <h3 className="text-sm font-semibold text-[var(--color-text-primary)]">Declarations</h3>
+                <p className="mt-2 text-xs text-[var(--color-text-secondary)]">
+                  {entry.declaration_count} declaration{entry.declaration_count === 1 ? "" : "s"} across {entry.manifest_count} manifest{entry.manifest_count === 1 ? "" : "s"}.
+                </p>
+                <div className="mt-2"><Versions entry={entry} /></div>
+                {entry.versions_truncated ? (
+                  <p className="mt-1 text-xs text-[var(--color-text-tertiary)]">
+                    Showing {entry.versions.length} of {entry.versions_total} declared versions.
+                  </p>
+                ) : null}
+              </section>
+
+              <section>
+                <h3 className="text-sm font-semibold text-[var(--color-text-primary)]">Import graph evidence</h3>
+                {evidenceLoading && !evidence ? (
+                  <p className="mt-2 text-xs text-[var(--color-text-tertiary)]">Loading focused graph evidence…</p>
+                ) : evidenceError ? (
+                  <p className="mt-2 text-xs text-[var(--color-text-tertiary)]">{evidenceError}</p>
+                ) : evidence ? (
+                  <>
+                    <p className="mt-2 text-xs text-[var(--color-text-secondary)]">
+                      {entry.importing_file_count} importing file{entry.importing_file_count === 1 ? "" : "s"} and {entry.import_edge_count} import edge{entry.import_edge_count === 1 ? "" : "s"} in the persisted graph.
+                    </p>
+                    <ul className="mt-3 space-y-1.5">
+                      {evidence.importingFiles.slice(0, 20).map((path) => (
+                        <li key={path} className="flex items-start gap-2 text-xs">
+                          <FileCode2 className="mt-0.5 h-3.5 w-3.5 shrink-0 text-[var(--color-text-tertiary)]" />
+                          <span className="min-w-0 break-all font-mono text-[var(--color-text-secondary)]">
+                            {renderFileLink ? renderFileLink(path, path) : path}
+                          </span>
+                        </li>
+                      ))}
+                    </ul>
+                    {entry.importing_file_count > evidence.importingFiles.length ? (
+                      <p className="mt-2 text-xs text-[var(--color-text-tertiary)]">
+                        Focused evidence returned {evidence.importingFiles.length} of {entry.importing_file_count} importing files.
+                      </p>
+                    ) : null}
+                    {entry.external_node_count > 1 ? (
+                      <p className="mt-2 text-xs text-[var(--color-text-tertiary)]">
+                        This focus shows one of {entry.external_node_count} linked graph targets. Package totals above include all targets.
+                      </p>
+                    ) : null}
+                  </>
+                ) : (
+                  <p className="mt-2 text-xs text-[var(--color-text-tertiary)]">
+                    {entry.link_state === "unlinked"
+                      ? "This declaration is not linked to a persisted graph node."
+                      : "No import edges were observed for the linked graph node."}
+                  </p>
+                )}
+              </section>
+            </div>
+
+            {graphHref ? (
+              <footer className="border-t border-[var(--color-border-default)] p-4">
+                <Button asChild className="w-full">
+                  <a href={graphHref}>
+                    Open focused package in graph
+                    <ExternalLink className="h-4 w-4" />
+                  </a>
+                </Button>
+              </footer>
+            ) : null}
+          </div>
+        ) : null}
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+export function ExternalDependenciesTable({
+  data,
+  state,
+  onStateChange,
+  selected,
+  onSelectedChange,
+  evidence,
+  evidenceLoading,
+  evidenceError,
+  graphHref,
+  renderFileLink,
+  pageSize = 25,
+  onLoadMore,
+  loadingMore,
+  loadMoreError,
+  onRetryLoadMore,
+}: ExternalDependenciesTableProps) {
+  const deferredQuery = React.useDeferredValue(state.query.trim().toLowerCase());
+  const categories = React.useMemo(
+    () => [...new Set(data.items.map((entry) => entry.category))].sort(),
+    [data.items],
+  );
+
+  const filtered = React.useMemo(() => {
+    const rows = data.items.filter((entry) => {
+      if (
+        deferredQuery &&
+        !entry.name.toLowerCase().includes(deferredQuery) &&
+        !entry.display_name.toLowerCase().includes(deferredQuery) &&
+        !entry.versions.some((version) => version.toLowerCase().includes(deferredQuery))
+      )
+        return false;
+      if (state.ecosystem !== "all" && entry.ecosystem !== state.ecosystem) return false;
+      if (state.role !== "all" && roleOf(entry) !== state.role) return false;
+      if (state.usage !== "all" && usageOf(entry) !== state.usage) return false;
+      if (state.category !== "all" && entry.category !== state.category) return false;
+      return true;
+    });
+    return rows.sort((a, b) => {
+      const result = compareEntries(a, b, state.sort);
+      return state.order === "asc" ? result : -result;
+    });
+  }, [data.items, deferredQuery, state]);
+
+  const pageCount = Math.max(1, Math.ceil(filtered.length / pageSize));
+  const page = Math.min(Math.max(1, state.page), pageCount);
+  const pageRows = filtered.slice((page - 1) * pageSize, page * pageSize);
+  const activeFilters =
+    Number(Boolean(state.query)) +
+    Number(state.ecosystem !== "all") +
+    Number(state.role !== "all") +
+    Number(state.usage !== "all") +
+    Number(state.category !== "all");
+
+  const handleSort = (key: string) => {
+    const sort = key as ExternalDependencySort;
+    onStateChange(
+      updateState(state, {
+        sort,
+        order: state.sort === sort ? (state.order === "asc" ? "desc" : "asc") : sort === "name" ? "asc" : "desc",
+      }),
+    );
+  };
+
+  const columns: ResponsiveColumn<ExternalSystemSummaryEntry>[] = [
+    {
+      key: "name",
+      header: "Package",
+      priority: 1,
+      sortable: true,
+      cellClassName: "min-w-[220px]",
+      render: (entry) => (
+        <div className="min-w-0">
+          <div className="flex items-start gap-2">
+            <Box className="mt-0.5 h-4 w-4 shrink-0 text-[var(--color-text-tertiary)]" />
+            <div className="min-w-0">
+              <p className="break-words font-mono text-sm font-medium text-[var(--color-text-primary)]">
+                {entry.display_name}
+              </p>
+              <p className="mt-0.5 text-xs text-[var(--color-text-tertiary)]">
+                {entry.ecosystem} · {entry.category}
+              </p>
+            </div>
+          </div>
+        </div>
+      ),
+    },
+    {
+      key: "versions",
+      header: "Versions",
+      priority: 2,
+      sortable: true,
+      cellClassName: "min-w-[170px] max-w-[300px]",
+      render: (entry) => <Versions entry={entry} />,
+    },
+    {
+      key: "declarations",
+      header: "Declarations",
+      mobileLabel: "Declared",
+      priority: 2,
+      align: "right",
+      sortable: true,
+      render: (entry) => (
+        <span className="font-mono text-xs tabular-nums">
+          {entry.declaration_count} / {entry.manifest_count} manifest{entry.manifest_count === 1 ? "" : "s"}
+        </span>
+      ),
+    },
+    {
+      key: "role",
+      header: "Role",
+      priority: 2,
+      render: (entry) => <RoleLabel entry={entry} />,
+    },
+    {
+      key: "importers",
+      header: "Files",
+      mobileLabel: "Importing files",
+      priority: 1,
+      align: "right",
+      sortable: true,
+      render: (entry) => <span className="font-mono tabular-nums">{entry.importing_file_count}</span>,
+    },
+    {
+      key: "edges",
+      header: "Edges",
+      mobileLabel: "Import edges",
+      priority: 3,
+      align: "right",
+      sortable: true,
+      render: (entry) => <span className="font-mono tabular-nums">{entry.import_edge_count}</span>,
+    },
+    {
+      key: "linkage",
+      header: "Graph linkage",
+      priority: 1,
+      render: (entry) => <LinkageLabel entry={entry} />,
+    },
+    {
+      key: "open",
+      header: <span className="sr-only">Open</span>,
+      priority: 3,
+      align: "right",
+      hideInCard: true,
+      render: () => <ArrowRight className="ml-auto h-4 w-4 text-[var(--color-text-tertiary)]" aria-hidden />,
+    },
+  ];
+
+  if (data.total_packages === 0) {
+    return (
+      <EmptyState
+        icon={<Box className="h-6 w-6" />}
+        title="No external dependencies recorded"
+        description="No supported manifests declared third-party packages in this repository scope."
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-5">
+      <dl className="grid grid-cols-2 border-y border-[var(--color-border-default)] sm:grid-cols-3 lg:grid-cols-6">
+        {[
+          ["Packages", data.total_packages],
+          ["Declarations", data.total_declarations],
+          ["Manifests", data.manifest_count],
+          ["Observed", data.observed_packages],
+          ["Dev-only", data.dev_only_packages],
+          ["No graph link", data.unlinked_packages],
+        ].map(([label, value]) => (
+          <div key={String(label)} className="border-b border-[var(--color-table-divider)] px-3 py-3 last:border-b-0 sm:border-b-0 sm:border-r sm:last:border-r-0">
+            <dt className="font-mono text-2xs uppercase tracking-wider text-[var(--color-text-tertiary)]">{label}</dt>
+            <dd className="mt-1 text-[22px] font-semibold tabular-nums text-[var(--color-text-primary)]">{value}</dd>
+          </div>
+        ))}
+      </dl>
+
+      <div className="space-y-3">
+        <div className="grid gap-2 sm:grid-cols-2 xl:grid-cols-[minmax(240px,1fr)_170px_170px_190px_170px_auto]">
+          <label className="relative min-w-0">
+            <span className="sr-only">Search packages</span>
+            <Search className="pointer-events-none absolute left-3 top-2.5 h-4 w-4 text-[var(--color-text-tertiary)]" />
+            <input
+              type="search"
+              value={state.query}
+              onChange={(event) => onStateChange(updateState(state, { query: event.target.value }))}
+              placeholder="Search packages or versions"
+              className="h-9 w-full rounded-md border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] pl-9 pr-3 text-sm text-[var(--color-text-primary)] outline-none placeholder:text-[var(--color-text-tertiary)] focus:ring-1 focus:ring-[var(--color-accent-primary)]"
+            />
+          </label>
+          <Select value={state.ecosystem} onValueChange={(ecosystem) => onStateChange(updateState(state, { ecosystem }))}>
+            <SelectTrigger aria-label="Filter by ecosystem"><SelectValue placeholder="All ecosystems" /></SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All ecosystems</SelectItem>
+              {data.ecosystems.map((ecosystem) => <SelectItem key={ecosystem} value={ecosystem}>{ecosystem}</SelectItem>)}
+            </SelectContent>
+          </Select>
+          <Select value={state.role} onValueChange={(role) => onStateChange(updateState(state, { role: role as ExternalDependencyRole }))}>
+            <SelectTrigger aria-label="Filter by dependency role"><SelectValue /></SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">Any role</SelectItem>
+              <SelectItem value="runtime">Runtime</SelectItem>
+              <SelectItem value="mixed">Runtime + dev</SelectItem>
+              <SelectItem value="dev-only">Dev-only</SelectItem>
+            </SelectContent>
+          </Select>
+          <Select value={state.usage} onValueChange={(usage) => onStateChange(updateState(state, { usage: usage as ExternalDependencyUsage }))}>
+            <SelectTrigger aria-label="Filter by graph linkage"><SelectValue /></SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">Any graph state</SelectItem>
+              <SelectItem value="observed">Observed imports</SelectItem>
+              <SelectItem value="linked-unobserved">Linked, no imports</SelectItem>
+              <SelectItem value="unlinked">No graph link</SelectItem>
+            </SelectContent>
+          </Select>
+          <Select value={state.category} onValueChange={(category) => onStateChange(updateState(state, { category }))}>
+            <SelectTrigger aria-label="Filter by package category"><SelectValue /></SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">Any category</SelectItem>
+              {categories.map((category) => <SelectItem key={category} value={category}>{category}</SelectItem>)}
+            </SelectContent>
+          </Select>
+          {activeFilters > 0 ? (
+            <Button variant="ghost" size="sm" className="h-9" onClick={() => onStateChange({ ...DEFAULT_EXTERNAL_DEPENDENCY_STATE, sort: state.sort, order: state.order })}>
+              Clear {activeFilters}
+            </Button>
+          ) : null}
+        </div>
+
+        <div className="flex flex-wrap items-center justify-between gap-2 text-xs text-[var(--color-text-tertiary)]">
+          <p aria-live="polite">
+            {filtered.length} {data.truncated ? "loaded " : ""}package{filtered.length === 1 ? "" : "s"} match · showing {pageRows.length ? (page - 1) * pageSize + 1 : 0}–{(page - 1) * pageSize + pageRows.length}
+          </p>
+          {data.truncated ? <p>Search, filters, and sorting apply to {data.returned} loaded packages out of {data.total_packages}.</p> : null}
+        </div>
+      </div>
+
+      <ResponsiveTable
+        rows={pageRows}
+        rowKey={(entry) => entry.package_key}
+        columns={columns}
+        onRowClick={onSelectedChange}
+        selectedKey={selected?.package_key}
+        sortField={state.sort}
+        sortOrder={state.order}
+        onSort={handleSort}
+        stacked="md"
+        caption="External package declarations and persisted import-graph evidence"
+        empty={
+          <EmptyState
+            title="No packages match these filters"
+            description="Clear a filter or search for a different package, ecosystem, or version."
+            action={{ label: "Clear filters", onClick: () => onStateChange(DEFAULT_EXTERNAL_DEPENDENCY_STATE) }}
+          />
+        }
+      />
+
+      {pageCount > 1 ? (
+        <nav className="flex items-center justify-between" aria-label="Package pages">
+          <Button variant="outline" size="sm" disabled={page === 1} onClick={() => onStateChange(updateState(state, { page: page - 1 }))}>
+            <ChevronLeft className="h-4 w-4" /> Previous
+          </Button>
+          <span className="font-mono text-xs tabular-nums text-[var(--color-text-tertiary)]">Page {page} of {pageCount}</span>
+          <Button variant="outline" size="sm" disabled={page === pageCount} onClick={() => onStateChange(updateState(state, { page: page + 1 }))}>
+            Next <ChevronRight className="h-4 w-4" />
+          </Button>
+        </nav>
+      ) : null}
+
+      {data.truncated && onLoadMore ? (
+        <div className="flex flex-col items-center gap-2 border-t border-[var(--color-border-default)] pt-4 text-center">
+          {loadMoreError ? (
+            <>
+              <p className="text-xs text-[var(--color-error)]">
+                More package summaries couldn't be loaded: {loadMoreError}
+              </p>
+              {onRetryLoadMore ? <Button variant="outline" size="sm" onClick={onRetryLoadMore}>Retry loading more</Button> : null}
+            </>
+          ) : (
+            <>
+              <p className="text-xs text-[var(--color-text-tertiary)]">
+                {data.total_packages - data.returned} package summaries remain on the server.
+              </p>
+              <Button variant="outline" size="sm" onClick={onLoadMore} disabled={loadingMore}>
+                {loadingMore ? "Loading more…" : `Load next ${Math.min(data.limit, data.total_packages - data.returned)}`}
+              </Button>
+            </>
+          )}
+        </div>
+      ) : null}
+
+      <PackageInspector
+        entry={selected}
+        evidence={evidence}
+        evidenceLoading={evidenceLoading}
+        evidenceError={evidenceError}
+        graphHref={graphHref}
+        renderFileLink={renderFileLink}
+        onClose={() => onSelectedChange(null)}
+      />
+    </div>
+  );
+}

--- a/packages/ui/src/dependencies/index.ts
+++ b/packages/ui/src/dependencies/index.ts
@@ -2,3 +2,13 @@ export {
   DependencyRegistry,
   type DependencyRegistryProps,
 } from "./dependency-registry";
+export {
+  DEFAULT_EXTERNAL_DEPENDENCY_STATE,
+  ExternalDependenciesTable,
+  type ExternalDependenciesTableProps,
+  type ExternalDependencyRole,
+  type ExternalDependencySort,
+  type ExternalDependencyTableState,
+  type ExternalDependencyUsage,
+  type PackageGraphEvidence,
+} from "./external-dependencies-table";

--- a/packages/web/src/app/repos/[id]/architecture/page.tsx
+++ b/packages/web/src/app/repos/[id]/architecture/page.tsx
@@ -95,7 +95,7 @@ const TAB_FOR_VIEW: Record<CanonicalView, string> = {
 const TABS: { id: string; label: string }[] = [
   { id: "map", label: "Map" },
   { id: "coupling", label: "Coupling" },
-  { id: "packages", label: "Packages" },
+  { id: "packages", label: "Third-party" },
   { id: "symbols", label: "Symbols" },
 ];
 

--- a/packages/web/src/components/architecture/dependencies-view.integration.test.tsx
+++ b/packages/web/src/components/architecture/dependencies-view.integration.test.tsx
@@ -1,0 +1,143 @@
+// @vitest-environment jsdom
+
+import * as React from "react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ExternalSystemsSummary } from "@repowise-dev/types/external-systems";
+
+const mocks = vi.hoisted(() => ({
+  setQueryStates: vi.fn(),
+  setPackage: vi.fn(),
+  setScope: vi.fn(),
+  infiniteResult: {} as Record<string, unknown>,
+  focusedResult: {} as Record<string, unknown>,
+  summaryKey: "",
+}));
+
+vi.mock("next/link", () => ({
+  default: ({ children, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
+    <a {...props}>{children}</a>
+  ),
+}));
+
+vi.mock("nuqs", () => {
+  const parser = (defaultValue: unknown = null) => ({
+    defaultValue,
+    withDefault(value: unknown) {
+      return parser(value);
+    },
+  });
+  return {
+    parseAsInteger: parser(),
+    parseAsString: parser(),
+    parseAsStringLiteral: () => parser(),
+    useQueryState: (name: string, value: { defaultValue?: unknown }) => [
+      value?.defaultValue ?? null,
+      name === "package" ? mocks.setPackage : mocks.setScope,
+    ],
+    useQueryStates: (config: Record<string, { defaultValue?: unknown }>) => [
+      Object.fromEntries(Object.entries(config).map(([key, value]) => [key, value.defaultValue])),
+      mocks.setQueryStates,
+    ],
+  };
+});
+
+vi.mock("swr/infinite", () => ({
+  default: (getKey: (index: number, previous: ExternalSystemsSummary | null) => string) => {
+    mocks.summaryKey = getKey(0, null);
+    return mocks.infiniteResult;
+  },
+}));
+
+vi.mock("swr", () => ({ default: () => mocks.focusedResult }));
+vi.mock("@repowise-dev/api-client", () => ({ apiGet: vi.fn() }));
+vi.mock("@/lib/api/client", () => ({}));
+
+vi.mock("@repowise-dev/ui/dependencies", async () => {
+  const actual = await vi.importActual<typeof import("@repowise-dev/ui/dependencies")>(
+    "@repowise-dev/ui/dependencies",
+  );
+  return {
+    ...actual,
+    ExternalDependenciesTable: (props: {
+      onStateChange: (state: typeof actual.DEFAULT_EXTERNAL_DEPENDENCY_STATE) => void;
+      onSelectedChange: (entry: { package_key: string }) => void;
+    }) => (
+      <div>
+        <button
+          onClick={() => props.onStateChange({ ...actual.DEFAULT_EXTERNAL_DEPENDENCY_STATE, query: "react", page: 2 })}
+        >
+          Change package query
+        </button>
+        <button onClick={() => props.onSelectedChange({ package_key: "npm:react" })}>
+          Select package
+        </button>
+      </div>
+    ),
+  };
+});
+
+import { DependenciesView } from "./dependencies-view";
+
+afterEach(cleanup);
+
+const summary: ExternalSystemsSummary = {
+  items: [],
+  returned: 0,
+  total_packages: 1,
+  limit: 400,
+  offset: 0,
+  truncated: false,
+  scope: "primary",
+  excluded_declarations: 0,
+  total_declarations: 1,
+  runtime_packages: 1,
+  dev_only_packages: 0,
+  observed_packages: 0,
+  linked_packages: 0,
+  unlinked_packages: 1,
+  linked_without_imports: 0,
+  ecosystems: ["npm"],
+  manifest_count: 1,
+};
+
+describe("DependenciesView wiring", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.infiniteResult = {
+      data: [summary],
+      error: undefined,
+      isLoading: false,
+      isValidating: false,
+      mutate: vi.fn(),
+      size: 1,
+      setSize: vi.fn(),
+    };
+    mocks.focusedResult = { data: undefined, error: undefined, isLoading: false };
+  });
+
+  it("starts from the bounded summary key and does not activate a graph request", () => {
+    render(<DependenciesView repoId="repo-id" />);
+    expect(mocks.summaryKey).toBe("external-systems-summary:repo-id:primary:0");
+    expect(mocks.focusedResult).toEqual({ data: undefined, error: undefined, isLoading: false });
+  });
+
+  it("renders loading and error states", () => {
+    mocks.infiniteResult = { ...mocks.infiniteResult, data: undefined, isLoading: true };
+    const { rerender } = render(<DependenciesView repoId="repo-id" />);
+    expect(screen.getByLabelText("Loading external dependencies")).toBeTruthy();
+
+    mocks.infiniteResult = { ...mocks.infiniteResult, isLoading: false, error: new Error("offline") };
+    rerender(<DependenciesView repoId="repo-id" />);
+    expect(screen.getByText("Couldn't load external dependencies")).toBeTruthy();
+  });
+
+  it("writes controlled filter and package selection state back to the URL layer", () => {
+    render(<DependenciesView repoId="repo-id" />);
+    fireEvent.click(screen.getByRole("button", { name: "Change package query" }));
+    expect(mocks.setQueryStates).toHaveBeenCalledWith(expect.objectContaining({ q: "react", page: 2 }));
+
+    fireEvent.click(screen.getByRole("button", { name: "Select package" }));
+    expect(mocks.setPackage).toHaveBeenCalledWith("npm:react");
+  });
+});

--- a/packages/web/src/components/architecture/dependencies-view.test.ts
+++ b/packages/web/src/components/architecture/dependencies-view.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import type { NodeSearchResult } from "../../lib/api/types";
+import {
+  chooseExternalPackageNode,
+  packageSummaryRequest,
+  PACKAGE_SUMMARY_LIMIT,
+} from "./package-graph";
+import {
+  DEFAULT_PACKAGE_QUERY_VALUES,
+  queryFromTableState,
+  tableStateFromQuery,
+} from "./package-query-state";
+
+function candidate(node_id: string): NodeSearchResult {
+  return { node_id, language: "", symbol_count: 0 };
+}
+
+describe("chooseExternalPackageNode", () => {
+  it("prefers the exact package node over subpaths and fuzzy matches", () => {
+    expect(
+      chooseExternalPackageNode(
+        [candidate("external:react-dom"), candidate("external:react/jsx-runtime"), candidate("external:react")],
+        "react",
+      ),
+    ).toBe("external:react");
+  });
+
+  it("falls back to a package subpath and ignores repository files", () => {
+    expect(
+      chooseExternalPackageNode(
+        [candidate("packages/react/index.ts"), candidate("external:@scope/pkg/subpath")],
+        "@scope/pkg",
+      ),
+    ).toBe("external:@scope/pkg/subpath");
+  });
+
+  it("returns null when node search has no external match", () => {
+    expect(chooseExternalPackageNode([candidate("src/pkg.py")], "pkg")).toBeNull();
+  });
+
+  it("does not fuzzy-focus a sibling package", () => {
+    expect(chooseExternalPackageNode([candidate("external:react-dom")], "react")).toBeNull();
+  });
+});
+
+describe("package query state", () => {
+  it("round-trips shareable filter, sort, and page state", () => {
+    const state = tableStateFromQuery({
+      ...DEFAULT_PACKAGE_QUERY_VALUES,
+      q: "react",
+      ecosystem: "npm",
+      usage: "observed",
+      sort: "edges",
+      order: "asc",
+      page: 3,
+    });
+    expect(queryFromTableState(state)).toEqual({
+      ...DEFAULT_PACKAGE_QUERY_VALUES,
+      q: "react",
+      ecosystem: "npm",
+      usage: "observed",
+      sort: "edges",
+      order: "asc",
+      page: 3,
+    });
+  });
+
+  it("clamps invalid URL pages to the first page", () => {
+    expect(tableStateFromQuery({ ...DEFAULT_PACKAGE_QUERY_VALUES, page: -4 }).page).toBe(1);
+  });
+});
+
+describe("initial package request", () => {
+  it("uses one bounded summary resource rather than a graph endpoint", () => {
+    const request = packageSummaryRequest("repo-id", "primary");
+    expect(request.path).toBe("/api/repos/repo-id/external-systems/summary");
+    expect(request.path).not.toContain("/api/graph/");
+    expect(request.params).toEqual({ scope: "primary", limit: PACKAGE_SUMMARY_LIMIT });
+  });
+});

--- a/packages/web/src/components/architecture/dependencies-view.tsx
+++ b/packages/web/src/components/architecture/dependencies-view.tsx
@@ -1,63 +1,266 @@
 "use client";
 
-import useSWR from "swr";
+import React, { useCallback, useEffect, useMemo, useRef } from "react";
 import Link from "next/link";
 import { Package } from "lucide-react";
-import { DependencyRegistry } from "@repowise-dev/ui/dependencies";
+import useSWR from "swr";
+import useSWRInfinite from "swr/infinite";
+import {
+  parseAsInteger,
+  parseAsString,
+  parseAsStringLiteral,
+  useQueryState,
+  useQueryStates,
+} from "nuqs";
+import {
+  ExternalDependenciesTable,
+  type ExternalDependencyTableState,
+  type PackageGraphEvidence,
+} from "@repowise-dev/ui/dependencies";
 import { ApiError } from "@repowise-dev/ui/shared/api-error";
-import { Skeleton } from "@repowise-dev/ui/ui/skeleton";
 import { fileEntityPath } from "@repowise-dev/ui/shared/entity";
-import { getExternalSystems } from "@/lib/api/external-systems";
+import { Skeleton } from "@repowise-dev/ui/ui/skeleton";
 import { toFriendlyMessage } from "@repowise-dev/ui/lib/errors";
+import type {
+  ExternalSystemSummaryEntry,
+  ExternalSystemsSummary,
+} from "@repowise-dev/types/external-systems";
+import { apiGet } from "@repowise-dev/api-client";
+import type { EgoGraphResponse, NodeSearchResult } from "@/lib/api/types";
+import "@/lib/api/client";
+import {
+  chooseExternalPackageNode,
+  packageSummaryRequest,
+  PACKAGE_SUMMARY_LIMIT,
+} from "./package-graph";
+import { queryFromTableState, tableStateFromQuery } from "./package-query-state";
+
+const ROLES = ["all", "runtime", "dev-only", "mixed"] as const;
+const USAGE_STATES = ["all", "observed", "linked-unobserved", "unlinked"] as const;
+const SORTS = ["importers", "edges", "name", "declarations", "manifests", "versions"] as const;
+const ORDERS = ["asc", "desc"] as const;
+const SCOPES = ["primary", "all"] as const;
+
+async function getFocusedPackageEvidence(
+  repoId: string,
+  entry: ExternalSystemSummaryEntry,
+  signal: AbortSignal,
+): Promise<PackageGraphEvidence> {
+  const candidates = await apiGet<NodeSearchResult[]>(
+    `/api/graph/${repoId}/nodes/search`,
+    { q: entry.name, limit: 20 },
+    { signal },
+  );
+  const centerNodeId = chooseExternalPackageNode(candidates, entry.name);
+  if (!centerNodeId) throw new Error("No matching external graph node was returned for this package.");
+
+  const ego = await apiGet<EgoGraphResponse>(
+    `/api/graph/${repoId}/ego`,
+    { node_id: centerNodeId, hops: 1 },
+    { signal },
+  );
+  const importingFiles = [
+    ...new Set(
+      ego.links
+        .filter((link) => link.target === centerNodeId && link.source !== centerNodeId)
+        .map((link) => link.source),
+    ),
+  ].sort();
+
+  return {
+    centerNodeId,
+    importingFiles,
+    importEdgeCount: ego.links.filter((link) => link.target === centerNodeId).length,
+    totalNodes: ego.nodes.length,
+  };
+}
 
 export function DependenciesView({ repoId }: { repoId: string }) {
-  const { data, error, isLoading, mutate } = useSWR(
-    `external-systems:${repoId}`,
-    () => getExternalSystems(repoId),
-    { revalidateOnFocus: false },
+  const summaryAbortRef = useRef<AbortController | null>(null);
+  const evidenceAbortRef = useRef<AbortController | null>(null);
+  const [scope, setScope] = useQueryState(
+    "scope",
+    parseAsStringLiteral(SCOPES).withDefault("primary"),
+  );
+  const [selectedKey, setSelectedKey] = useQueryState("package", parseAsString);
+  const [queryState, setQueryState] = useQueryStates({
+    q: parseAsString.withDefault(""),
+    ecosystem: parseAsString.withDefault("all"),
+    role: parseAsStringLiteral(ROLES).withDefault("all"),
+    usage: parseAsStringLiteral(USAGE_STATES).withDefault("all"),
+    category: parseAsString.withDefault("all"),
+    sort: parseAsStringLiteral(SORTS).withDefault("importers"),
+    order: parseAsStringLiteral(ORDERS).withDefault("desc"),
+    page: parseAsInteger.withDefault(1),
+  });
+
+  const fetchSummary = useCallback((offset: number) => {
+    summaryAbortRef.current?.abort();
+    const controller = new AbortController();
+    summaryAbortRef.current = controller;
+    const request = packageSummaryRequest(repoId, scope);
+    return apiGet<ExternalSystemsSummary>(
+      request.path,
+      { ...request.params, offset },
+      { signal: controller.signal },
+    );
+  }, [repoId, scope]);
+
+  const {
+    data: summaryPages,
+    error,
+    isLoading,
+    isValidating: summaryValidating,
+    mutate,
+    size,
+    setSize,
+  } = useSWRInfinite(
+    (pageIndex, previous: ExternalSystemsSummary | null) => {
+      if (previous && !previous.truncated) return null;
+      return `external-systems-summary:${repoId}:${scope}:${pageIndex * PACKAGE_SUMMARY_LIMIT}`;
+    },
+    (key: string) => {
+      const offset = Number(key.split(":").pop() ?? 0);
+      return fetchSummary(offset);
+    },
+    { revalidateOnFocus: false, revalidateOnReconnect: false, persistSize: false },
   );
 
+  const data = useMemo<ExternalSystemsSummary | undefined>(() => {
+    if (!summaryPages?.length) return undefined;
+    const first = summaryPages[0]!;
+    const last = summaryPages[summaryPages.length - 1]!;
+    const items = summaryPages.flatMap((page) => page.items);
+    return {
+      ...first,
+      items,
+      returned: items.length,
+      offset: 0,
+      truncated: last.truncated,
+    };
+  }, [summaryPages]);
+
+  const selected = useMemo(
+    () => data?.items.find((entry) => entry.package_key === selectedKey) ?? null,
+    [data?.items, selectedKey],
+  );
+
+  // Focused graph evidence is deliberately dormant on the initial page.
+  // Selecting a linked row activates node search plus a one-hop ego request.
+  const fetchEvidence = useCallback(() => {
+    evidenceAbortRef.current?.abort();
+    const controller = new AbortController();
+    evidenceAbortRef.current = controller;
+    return getFocusedPackageEvidence(repoId, selected!, controller.signal);
+  }, [repoId, selected]);
+  const {
+    data: evidence,
+    error: evidenceError,
+    isLoading: evidenceLoading,
+  } = useSWR(
+    selected?.link_state === "linked"
+      ? `external-system-evidence:${repoId}:${selected.package_key}`
+      : null,
+    fetchEvidence,
+    { revalidateOnFocus: false, revalidateOnReconnect: false },
+  );
+
+  useEffect(() => {
+    if (!selected || selected.link_state !== "linked") evidenceAbortRef.current?.abort();
+  }, [selected]);
+  useEffect(
+    () => () => {
+      summaryAbortRef.current?.abort();
+      evidenceAbortRef.current?.abort();
+    },
+    [],
+  );
+
+  const tableState: ExternalDependencyTableState = tableStateFromQuery(queryState);
+
+  const handleTableStateChange = (next: ExternalDependencyTableState) => {
+    void setQueryState(queryFromTableState(next));
+  };
+
   return (
-    <div className="max-w-[1600px] space-y-6 p-4 sm:p-6">
-      <div>
-        <h1 className="mb-1 flex items-center gap-2 text-xl font-semibold text-[var(--color-text-primary)]">
-          <Package className="h-5 w-5 text-[var(--color-accent-primary)]" />
-          {/* Matches the tab. "Dependencies" collided with the Map tab, which
-              IS the dependency graph — this page is the declared package
-              manifest, which is a different thing entirely. */}
-          Packages
-        </h1>
-        <p className="text-sm text-[var(--color-text-secondary)]">
-          Third-party dependencies declared in this repo&apos;s manifests.
-        </p>
+    <div className="max-w-[1600px] space-y-5 p-4 sm:p-6">
+      <div className="flex flex-col gap-3 border-b border-[var(--color-border-default)] pb-4 sm:flex-row sm:items-start sm:justify-between">
+        <div className="min-w-0">
+          <h1 className="mb-1 flex items-center gap-2 text-xl font-semibold text-[var(--color-text-primary)]">
+            <Package className="h-5 w-5 text-[var(--color-accent-primary)]" />
+            External dependencies
+          </h1>
+          <p className="max-w-3xl text-sm text-[var(--color-text-secondary)]">
+            Declared third-party packages, joined to persisted import-graph evidence. Select a package to inspect declaration counts, versions, and importing files.
+          </p>
+        </div>
+        {(scope === "all" || (data?.excluded_declarations ?? 0) > 0) ? <div className="shrink-0">
+          <label className="flex items-center gap-2 text-xs text-[var(--color-text-secondary)]">
+            <input
+              type="checkbox"
+              checked={scope === "all"}
+              onChange={(event) => {
+                void setScope(event.target.checked ? "all" : "primary");
+                void setSelectedKey(null);
+                handleTableStateChange({ ...tableState, page: 1 });
+              }}
+              className="h-4 w-4 rounded border-[var(--color-border-default)] accent-[var(--color-accent-primary)]"
+            />
+            Include auxiliary declarations
+          </label>
+          <p className="mt-1 max-w-xs text-right text-2xs text-[var(--color-text-tertiary)]">
+            {scope === "primary"
+              ? `${data?.excluded_declarations ?? 0} declarations from auxiliary directories excluded`
+              : "Showing primary and auxiliary directories present in this indexed checkout"}
+          </p>
+        </div> : null}
       </div>
 
-      {error ? (
+      {error && !data ? (
         <ApiError
-          title="Couldn't load the dependency registry"
+          title="Couldn't load external dependencies"
           message={toFriendlyMessage(error)}
           onRetry={() => void mutate()}
         />
       ) : isLoading || !data ? (
-        <div className="space-y-3">
-          <Skeleton className="h-8 w-72" />
-          <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 xl:grid-cols-3">
-            {Array.from({ length: 6 }).map((_, i) => (
-              <Skeleton key={i} className="h-20" />
-            ))}
-          </div>
+        <div className="space-y-4" aria-label="Loading external dependencies">
+          <Skeleton className="h-20 w-full" />
+          <Skeleton className="h-9 w-full" />
+          {Array.from({ length: 8 }).map((_, index) => (
+            <Skeleton key={index} className="h-12 w-full" />
+          ))}
         </div>
       ) : (
-        <DependencyRegistry
+        <ExternalDependenciesTable
           data={data}
-          renderManifestLink={(declaredIn, children) => (
+          state={tableState}
+          onStateChange={handleTableStateChange}
+          selected={selected}
+          onSelectedChange={(entry) => void setSelectedKey(entry?.package_key ?? null)}
+          evidence={evidence}
+          evidenceLoading={evidenceLoading}
+          evidenceError={
+            evidenceError
+              ? `Focused graph evidence couldn't be loaded: ${toFriendlyMessage(evidenceError)}`
+              : null
+          }
+          graphHref={
+            evidence
+              ? `/repos/${repoId}/architecture?view=files&node=${encodeURIComponent(evidence.centerNodeId)}`
+              : undefined
+          }
+          renderFileLink={(path, children) => (
             <Link
-              href={fileEntityPath(`/repos/${repoId}`, declaredIn)}
+              href={fileEntityPath(`/repos/${repoId}`, path)}
               className="hover:text-[var(--color-accent-primary)] hover:underline"
             >
               {children}
             </Link>
           )}
+          onLoadMore={data.truncated ? () => void setSize(size + 1) : undefined}
+          loadingMore={summaryValidating && summaryPages !== undefined}
+          loadMoreError={error ? toFriendlyMessage(error) : null}
+          onRetryLoadMore={error ? () => void mutate() : undefined}
         />
       )}
     </div>

--- a/packages/web/src/components/architecture/package-graph.ts
+++ b/packages/web/src/components/architecture/package-graph.ts
@@ -1,0 +1,31 @@
+import type { NodeSearchResult } from "../../lib/api/types";
+import type { ExternalSystemsSummaryScope } from "@repowise-dev/types/external-systems";
+
+export const PACKAGE_SUMMARY_LIMIT = 400;
+
+export function packageSummaryRequest(repoId: string, scope: ExternalSystemsSummaryScope) {
+  return {
+    path: `/api/repos/${repoId}/external-systems/summary`,
+    params: { scope, limit: PACKAGE_SUMMARY_LIMIT },
+  } as const;
+}
+
+function externalCandidateScore(candidate: NodeSearchResult, packageName: string): number {
+  const nodeId = candidate.node_id.toLowerCase();
+  const expected = `external:${packageName}`.toLowerCase();
+  if (nodeId === expected) return 3;
+  if (nodeId.startsWith(`${expected}/`) || nodeId.startsWith(`${expected}:`)) return 2;
+  return 0;
+}
+
+export function chooseExternalPackageNode(
+  candidates: NodeSearchResult[],
+  packageName: string,
+): string | null {
+  return candidates
+    .filter((candidate) => candidate.node_id.startsWith("external:"))
+    .map((candidate) => ({ candidate, score: externalCandidateScore(candidate, packageName) }))
+    .filter(({ score }) => score > 0)
+    .sort((a, b) => b.score - a.score || a.candidate.node_id.localeCompare(b.candidate.node_id))[0]
+    ?.candidate.node_id ?? null;
+}

--- a/packages/web/src/components/architecture/package-query-state.ts
+++ b/packages/web/src/components/architecture/package-query-state.ts
@@ -1,0 +1,48 @@
+import {
+  DEFAULT_EXTERNAL_DEPENDENCY_STATE,
+  type ExternalDependencyRole,
+  type ExternalDependencySort,
+  type ExternalDependencyTableState,
+  type ExternalDependencyUsage,
+} from "@repowise-dev/ui/dependencies";
+
+export interface PackageQueryValues {
+  q: string;
+  ecosystem: string;
+  role: ExternalDependencyRole;
+  usage: ExternalDependencyUsage;
+  category: string;
+  sort: ExternalDependencySort;
+  order: "asc" | "desc";
+  page: number;
+}
+
+export function tableStateFromQuery(values: PackageQueryValues): ExternalDependencyTableState {
+  return {
+    query: values.q,
+    ecosystem: values.ecosystem,
+    role: values.role,
+    usage: values.usage,
+    category: values.category,
+    sort: values.sort,
+    order: values.order,
+    page: Math.max(1, values.page),
+  };
+}
+
+export function queryFromTableState(state: ExternalDependencyTableState): PackageQueryValues {
+  return {
+    q: state.query,
+    ecosystem: state.ecosystem,
+    role: state.role,
+    usage: state.usage,
+    category: state.category,
+    sort: state.sort,
+    order: state.order,
+    page: Math.max(1, state.page),
+  };
+}
+
+export const DEFAULT_PACKAGE_QUERY_VALUES: PackageQueryValues = queryFromTableState(
+  DEFAULT_EXTERNAL_DEPENDENCY_STATE,
+);

--- a/packages/web/vitest.config.ts
+++ b/packages/web/vitest.config.ts
@@ -1,7 +1,11 @@
 import { defineConfig } from "vitest/config";
+import path from "node:path";
 
 export default defineConfig({
   test: {
     include: ["src/**/*.{test,spec}.{ts,tsx}"],
+  },
+  resolve: {
+    alias: { "@": path.resolve(__dirname, "src") },
   },
 });


### PR DESCRIPTION
## Summary

- Replace the Packages tab with a dense external-dependency explorer backed by the bounded summary endpoint.
- Add URL-backed search, filters, sorting, pagination, linkage details, and responsive package inspection.
- Load focused graph evidence only after package selection, with cancellation and importing-file navigation.
- Keep auxiliary-directory scope explicit without exposing checkout-specific directory names.

## Verification

- UI focused tests: 5 passed
- Web tests: 44 passed
- UI and web typechecks passed
- Web lint passed
- Production web build passed

## Measured behavior

- Primary summary: 142 packages, 59,775 bytes raw; warm median 93.78 ms and p95 103.63 ms across 20 requests.
- Initial data loading uses only the summary endpoint and renders 25 rows per page.
- No graph endpoint is requested initially. Focused React evidence was fetched after interaction: 367 nodes, 867 links, 304,964 bytes, 7.41 s through the existing ego endpoint.