### PR TITLE
fix(core): sweep page snapshots when deleting a repository

### DIFF
--- a/packages/core/src/repowise/core/persistence/crud/repository.py
+++ b/packages/core/src/repowise/core/persistence/crud/repository.py
@@ -10,12 +10,13 @@ import json
 from datetime import datetime
 from pathlib import Path
 
-from sqlalchemy import select
+from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..models import (
     GenerationJob,
     Page,
+    PageVersion,
     Repository,
     WebhookEvent,
     _new_uuid,
@@ -193,10 +194,18 @@ async def delete_repository(session: AsyncSession, repo_id: str) -> bool:
 
     NOTE: The caller should clean up the FTS index *before* calling this,
     since the CASCADE will delete Page rows and we lose the page IDs.
+
+    ``PageVersion`` is swept explicitly first. Its ``page_id`` foreign key is
+    declared without ``ondelete="CASCADE"``, so the cascade that removes the
+    repository's ``Page`` rows leaves the snapshots pointing at rows that no
+    longer exist and SQLite aborts the whole statement with ``FOREIGN KEY
+    constraint failed``. The pipeline's page-pruning paths already pre-delete
+    snapshots for exactly this reason; deletion is the one path that did not.
     """
     repo = await session.get(Repository, repo_id)
     if repo is None:
         return False
+    await session.execute(delete(PageVersion).where(PageVersion.repository_id == repo_id))
     await session.delete(repo)
     await session.flush()
     return True

--- a/tests/unit/persistence/test_delete_repository_fk.py
+++ b/tests/unit/persistence/test_delete_repository_fk.py
@@ -1,0 +1,104 @@
+"""Repository deletion under real foreign-key enforcement.
+
+The shared ``async_engine`` fixture builds its engine with
+``create_async_engine`` directly, which never issues ``PRAGMA foreign_keys=ON``
+— SQLite's default is *off*, so foreign keys are not enforced anywhere in the
+persistence suite. Production engines come from
+:func:`repowise.core.persistence.database.create_engine`, which turns the
+pragma on for every connection. A referential bug is therefore invisible to
+the existing tests and fails only against a real store, which is how
+``delete_repository`` shipped unable to delete any repository whose pages had
+ever been regenerated.
+
+These tests use the project's own ``create_engine`` so the pragmas match what
+a user's ``.repowise/wiki.db`` actually runs with.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import func, select, text
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from repowise.core.persistence.crud import (
+    delete_repository,
+    get_page_versions,
+    get_repository,
+    upsert_page,
+)
+from repowise.core.persistence.database import create_engine, init_db
+from repowise.core.persistence.models import Page, PageVersion
+from tests.unit.persistence.helpers import insert_repo, make_page_kwargs
+
+
+@pytest.fixture
+async def fk_session():
+    """Session on an in-memory store with production SQLite pragmas."""
+    engine = create_engine("sqlite+aiosqlite:///:memory:", use_static_pool=True)
+    await init_db(engine)
+    factory = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+    try:
+        async with factory() as session:
+            yield session
+    finally:
+        await engine.dispose()
+
+
+async def test_foreign_keys_are_enforced(fk_session):
+    """Guard the guard: without this pragma the tests below prove nothing."""
+    enabled = (await fk_session.execute(text("PRAGMA foreign_keys"))).scalar()
+    assert enabled == 1
+
+
+async def test_delete_repository_with_archived_page_versions(fk_session):
+    """A regenerated page leaves a snapshot; deleting the repo must still work.
+
+    ``PageVersion.page_id`` is declared without ``ondelete="CASCADE"``, so the
+    cascade that removes the repository's ``Page`` rows used to strand the
+    snapshots and abort with ``sqlite3.IntegrityError: FOREIGN KEY constraint
+    failed``, surfacing as HTTP 500 from ``DELETE /api/repos/{id}``.
+    """
+    repo = await insert_repo(fk_session, name="doomed", local_path="/tmp/doomed")
+    kwargs = make_page_kwargs(repo.id)
+
+    page = await upsert_page(fk_session, **kwargs)
+    # Second upsert archives the first revision as a PageVersion.
+    await upsert_page(fk_session, **{**kwargs, "content": "# Rewritten\n\nSecond pass."})
+    await fk_session.commit()
+
+    assert await get_page_versions(fk_session, page.id), "expected an archived snapshot"
+
+    deleted = await delete_repository(fk_session, repo.id)
+    await fk_session.commit()
+
+    assert deleted is True
+    assert await get_repository(fk_session, repo.id) is None
+    assert (await fk_session.execute(select(func.count()).select_from(PageVersion))).scalar() == 0
+    assert (await fk_session.execute(select(func.count()).select_from(Page))).scalar() == 0
+
+
+async def test_delete_repository_leaves_other_repos_untouched(fk_session):
+    """The snapshot sweep is scoped by repository_id, not global."""
+    doomed = await insert_repo(fk_session, name="doomed", local_path="/tmp/doomed")
+    keeper = await insert_repo(fk_session, name="keeper", local_path="/tmp/keeper")
+
+    for repo in (doomed, keeper):
+        kwargs = make_page_kwargs(repo.id, page_id=f"file_page:{repo.name}/main.py")
+        await upsert_page(fk_session, **kwargs)
+        await upsert_page(fk_session, **{**kwargs, "content": "# Rewritten"})
+    await fk_session.commit()
+
+    assert await delete_repository(fk_session, doomed.id) is True
+    await fk_session.commit()
+
+    surviving = (
+        (
+            await fk_session.execute(
+                select(PageVersion).where(PageVersion.repository_id == keeper.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(surviving) == 1
+    assert await get_repository(fk_session, keeper.id) is not None


### PR DESCRIPTION
Fixes #1944.

`DELETE /api/repos/{id}` returns HTTP 500 for any repository whose pages have been
regenerated at least once:

```
sqlalchemy.exc.IntegrityError: (sqlite3.IntegrityError) FOREIGN KEY constraint failed
[SQL: DELETE FROM repositories WHERE repositories.id = ?]
```

### Why

`delete_repository` leans entirely on the cascade. Every direct child of
`repositories` declares `ondelete="CASCADE"`, but the grandchild does not —
`PageVersion.page_id` (`models.py:195`) is a plain `ForeignKey("wiki_pages.id")`.
Cascading into `wiki_pages` therefore strands the snapshot rows and SQLite aborts the
statement. Snapshots are written on the second upsert of a page, so a freshly indexed
repo deletes fine and a regenerated one can never be deleted.

### The change

`delete_repository` now sweeps the repository's `PageVersion` rows first. This is the
convention the codebase already follows: all four page-pruning paths in
`pipeline/persist.py` (1066, 1151, 1217, 1312) pre-delete snapshots before deleting
pages for exactly this reason. Deletion was the one path that missed it.

I deliberately fixed this in the application layer rather than the schema. Adding
`ondelete="CASCADE"` to the model plus a migration would leave every existing user
broken: `_reconcile_schema` is additive-only and documents that FK constraint changes
on existing columns are not reconciled, and local SQLite stores never run Alembic. So
the declared FK stays as-is and the sweep is explicit — happy to add the schema change
on top as a follow-up if you'd prefer both.

Scoped by `repository_id` (a plain column on `PageVersion`, always populated from
`existing.repository_id`), so it is a single statement with no page-id fan-out.

### Tests

`tests/unit/persistence/test_delete_repository_fk.py` — three tests: the FK pragma is
actually on, a repo with archived snapshots deletes cleanly, and the sweep does not
touch another repo's snapshots.

They need their own fixture. `tests/unit/persistence/conftest.py` builds its engine
with `create_async_engine` directly, so `PRAGMA foreign_keys=ON` is never issued and
SQLite defaults to off — **no foreign key is enforced anywhere in the persistence
suite**, which is why this shipped. The new fixture uses the project's own
`create_engine` so the pragmas match a real `.repowise/wiki.db`. That is also the
reason `test_delete_repository_success` passes today: it deletes a repo with no pages,
on a connection that would not have complained either way.

Worth considering separately whether the shared fixture should adopt `create_engine`
too — it would make the whole suite FK-aware, and may well surface other latent
referential bugs.

### Verification

- New tests fail with `IntegrityError: FOREIGN KEY constraint failed` on `main`, pass with the fix.
- `uv run pytest tests/unit/persistence/ tests/unit/server/test_repos.py` → 665 passed.
- `ruff format --check` and `ruff check` clean.
- Confirmed against a real 0.46.0 store: the two repos that 500'd delete cleanly.
