### PR TITLE
fix(security): stop reporting RegExp.exec, and catch the constant secret form

### DIFF
--- a/packages/core/src/repowise/core/analysis/security_scan.py
+++ b/packages/core/src/repowise/core/analysis/security_scan.py
@@ -46,13 +46,36 @@ _CALL_PATTERNS: list[tuple[re.Pattern, str, str]] = [
 ]
 _CALL_KINDS = frozenset(kind for _, kind, _ in _CALL_PATTERNS)
 
+# ``exec`` is not a global in JavaScript; the name belongs to
+# ``RegExp.prototype.exec``. The receiver-chain prefix above therefore matches
+# ``re.exec(str)``, ``/x/.exec(s)`` and ``pattern.exec(xml)`` — idiomatic parsing
+# code, reported at ``high``. Measured on a 17-repo TypeScript corpus, every
+# ``exec_call`` hit outside Python was a regex match and none was a process
+# spawn, so the kind was pure noise on those languages.
+#
+# The dangerous call in JavaScript comes from ``child_process``, so that is what
+# gates it: a file that never names the module cannot spawn one. ``eval`` needs
+# no such gate — it is a genuine global there.
+_CHILD_PROCESS_IMPORT = re.compile(r"child_process|node:child_process")
+_JS_EXEC_CALL = re.compile(r"(?<![\w$])(?:[A-Za-z_$][\w$]*\s*\.\s*)*exec(?:File)?(?:Sync)?\s*\(")
+
 _PATTERNS: list[tuple[re.Pattern, str, str]] = [
     *_CALL_PATTERNS,
     (re.compile(r"pickle\.loads"), "pickle_loads", "high"),
     (re.compile(r"subprocess\..*shell\s*=\s*True"), "subprocess_shell_true", "high"),
     (re.compile(r"os\.system"), "os_system", "high"),
-    (re.compile(r"password\s*=\s*['\"]"), "hardcoded_password", "high"),
-    (re.compile(r"(?:api_?key|secret)\s*=\s*['\"]"), "hardcoded_secret", "high"),
+    # Case-insensitive: the constant form (``API_KEY = "..."``, ``SECRET = "..."``)
+    # is the common one for a credential pinned in source, and the lowercase-only
+    # patterns walked straight past it. Found by scanning a corpus in which a
+    # live ``N8N_API_KEY = '...'`` sat unreported.
+    #
+    # Case-insensitivity is written as a scoped inline group rather than the
+    # ``re.IGNORECASE`` flag on purpose: ``_ANY_PATTERN`` below is built by
+    # concatenating these patterns' *source text*, which drops per-pattern
+    # flags. A flag here would leave the prefilter case-sensitive and it would
+    # reject the line before the pattern ever ran.
+    (re.compile(r"(?i:password)\s*=\s*['\"]"), "hardcoded_password", "high"),
+    (re.compile(r"(?i:api_?key|secret)\s*=\s*['\"]"), "hardcoded_secret", "high"),
     (re.compile(r'f[\'"].*SELECT.*\{.*\}'), "fstring_sql", "med"),
     (re.compile(r"\.execute\(\s*[\'\"]\s*SELECT.*\+"), "concat_sql", "med"),
     (re.compile(r"verify\s*=\s*False"), "tls_verify_false", "med"),
@@ -237,13 +260,25 @@ def _call_findings(file_path: str, source: str) -> list[dict]:
     masked = _mask_comments_and_strings(source)
     lines = source.splitlines()
     findings = []
+
+    def add(kind: str, severity: str, offset: int) -> None:
+        lineno = source.count("\n", 0, offset) + 1
+        snippet = lines[lineno - 1].strip()[:120] if lineno <= len(lines) else ""
+        findings.append({"kind": kind, "severity": severity, "snippet": snippet, "line": lineno})
+
+    is_python = file_path.lower().endswith((".py", ".pyi"))
     for pattern, kind, severity in _CALL_PATTERNS:
+        if kind == "exec_call" and not is_python:
+            continue  # handled below, gated on child_process
         for match in pattern.finditer(masked):
-            lineno = source.count("\n", 0, match.start()) + 1
-            snippet = lines[lineno - 1].strip()[:120] if lineno <= len(lines) else ""
-            findings.append(
-                {"kind": kind, "severity": severity, "snippet": snippet, "line": lineno}
-            )
+            add(kind, severity, match.start())
+
+    # The module name is searched in raw source on purpose: it arrives as a
+    # string literal (``require("child_process")``), which masking blanks.
+    if not is_python and _CHILD_PROCESS_IMPORT.search(source):
+        for match in _JS_EXEC_CALL.finditer(masked):
+            add("exec_call", "high", match.start())
+
     return findings
 
 

--- a/packages/core/src/repowise/core/analysis/security_scan.py
+++ b/packages/core/src/repowise/core/analysis/security_scan.py
@@ -64,10 +64,14 @@ _PATTERNS: list[tuple[re.Pattern, str, str]] = [
     (re.compile(r"pickle\.loads"), "pickle_loads", "high"),
     (re.compile(r"subprocess\..*shell\s*=\s*True"), "subprocess_shell_true", "high"),
     (re.compile(r"os\.system"), "os_system", "high"),
-    # Case-insensitive: the constant form (``API_KEY = "..."``, ``SECRET = "..."``)
-    # is the common one for a credential pinned in source, and the lowercase-only
-    # patterns walked straight past it. Found by scanning a corpus in which a
-    # live ``N8N_API_KEY = '...'`` sat unreported.
+    # Case-insensitive: a credential pinned in source is usually written as a
+    # SCREAMING_CASE constant assigned a quoted literal, and the lowercase-only
+    # patterns walked straight past that form. Found by scanning a corpus in
+    # which a live n8n key sat unreported under exactly that spelling.
+    #
+    # The wording above avoids spelling the matched form out literally: this
+    # loop runs on raw source, comments included, so an example written out here
+    # would make the file report itself.
     #
     # Case-insensitivity is written as a scoped inline group rather than the
     # ``re.IGNORECASE`` flag on purpose: ``_ANY_PATTERN`` below is built by

--- a/tests/unit/analysis/test_security_scan.py
+++ b/tests/unit/analysis/test_security_scan.py
@@ -107,7 +107,6 @@ class TestScanFile:
         ("source", "expected"),
         [
             ("eval (payload);\n", {"eval_call"}),
-            ("exec\n  (payload);\n", {"exec_call"}),
             ("window.eval(payload);\n", {"eval_call"}),
             ("const result = `${eval(payload)}`;\n", {"eval_call"}),
             ("retrieval (payload);\n", set()),
@@ -115,11 +114,38 @@ class TestScanFile:
             ("// eval(payload)\n", set()),
             ("/* exec(payload) */\n", set()),
             ('const text = "eval(payload)";\n', set()),
+            # ``exec`` is not a global in JavaScript, so a bare call is a local
+            # function, and a call on a receiver is ``RegExp.prototype.exec``.
+            # Neither spawns anything; see the corpus test below.
+            ("exec\n  (payload);\n", set()),
+            ("const m = /^a(b)$/.exec(cell);\n", set()),
+            ("while ((m = re.exec(expr)) !== null) {}\n", set()),
         ],
     )
     def test_fallback_eval_exec_call_corpus(self, source: str, expected: set[str]) -> None:
         scanner = SecurityScanner(session=None, repo_id="r1")  # type: ignore[arg-type]
         findings = asyncio.run(scanner.scan_file("calls.js", source, symbols=[]))
+        assert {row["kind"] for row in findings if row["kind"].endswith("_call")} == expected
+
+    @pytest.mark.parametrize(
+        ("source", "expected"),
+        [
+            ('import { exec } from "child_process";\nexec(cmd);\n', {"exec_call"}),
+            ('const cp = require("child_process");\ncp.execSync(cmd);\n', {"exec_call"}),
+            (
+                'import { execFile } from "node:child_process";\nexecFile(bin, args);\n',
+                {"exec_call"},
+            ),
+            # Regex parsing in a file that also spawns: the gate is per file, so
+            # this is the residual false positive the gate cannot remove.
+            ('require("child_process");\nconst m = /a/.exec(s);\n', {"exec_call"}),
+        ],
+    )
+    def test_js_exec_is_reported_only_when_child_process_is_present(
+        self, source: str, expected: set[str]
+    ) -> None:
+        scanner = SecurityScanner(session=None, repo_id="r1")  # type: ignore[arg-type]
+        findings = asyncio.run(scanner.scan_file("spawn.ts", source, symbols=[]))
         assert {row["kind"] for row in findings if row["kind"].endswith("_call")} == expected
 
     def test_combined_prefilter_uses_the_same_safe_call_boundaries(self) -> None:
@@ -130,6 +156,29 @@ class TestScanFile:
         assert _ANY_PATTERN.search("window.eval(")
         assert not _ANY_PATTERN.search("retrieval (")
         assert not _ANY_PATTERN.search("my_eval(")
+
+    @pytest.mark.parametrize(
+        "source",
+        [
+            'const API_KEY = "abc123";\n',
+            "const N8N_API_KEY = 'abc123';\n",
+            'SECRET = "abc123"\n',
+            'PASSWORD = "abc123"\n',
+        ],
+    )
+    def test_secret_patterns_are_case_insensitive(self, source: str) -> None:
+        """The constant form is how a pinned credential is usually written.
+
+        Also covers the prefilter: ``_ANY_PATTERN`` is built from the patterns'
+        source text, so a per-pattern ``re.IGNORECASE`` flag would be dropped
+        there and the line would never reach the pattern loop.
+        """
+        from repowise.core.analysis.security_scan import _ANY_PATTERN
+
+        assert _ANY_PATTERN.search(source)
+        scanner = SecurityScanner(session=None, repo_id="r1")  # type: ignore[arg-type]
+        findings = asyncio.run(scanner.scan_file("config.ts", source, symbols=[]))
+        assert {row["kind"] for row in findings} & {"hardcoded_secret", "hardcoded_password"}
 
     def test_single_line_subprocess_shell_true_is_flagged(self) -> None:
         scanner = SecurityScanner(session=None, repo_id="r1")  # type: ignore[arg-type]


### PR DESCRIPTION
Refs #1935. Two bugs in the existing pattern registry, found by running the scan over a 17-repository corpus (1109 JS/TS/Python files) and adjudicating every hit by hand.

## `exec_call` fires on every regex match in JavaScript

`exec` is not a global in JavaScript — the name belongs to `RegExp.prototype.exec` — so the receiver-chain prefix in the pattern is exactly what makes `re.exec(expr)`, `/x/.exec(s)` and `cellPattern.exec(xml)` match. On the corpus all 9 hits were XLSX and format-parsing code, none was a process spawn, and each was reported at `high`.

Outside Python the kind now requires the file to name `child_process`, which is where the dangerous call actually comes from. On the same corpus the finding set swaps completely:

| | before | after |
|---|---|---|
| `exec_call` hits | 9, all `RegExp.exec` in parsing code | 10, all real `execSync` in build scripts and `next.config.ts` |

The gate is per file, so a file that both spawns and parses still reports every `exec(` in it. That residual is deliberate and covered by a test rather than left implicit.

## The secret patterns were case-sensitive

`hardcoded_password` and `hardcoded_secret` matched only the lowercase spelling, so the constant form a pinned credential is usually written in — `API_KEY = "..."`, `SECRET = "..."` — never fired. A live `N8N_API_KEY = '...'` sat unreported in two repositories of the corpus.

One wrinkle worth knowing for anyone touching the registry next: the fix is a scoped `(?i:...)` group rather than an `re.IGNORECASE` flag. `_ANY_PATTERN` is built by concatenating the patterns' source text, which drops per-pattern flags — with a flag the prefilter stays case-sensitive and rejects the line before the pattern loop ever runs. The first version of this fix looked correct and changed nothing. There is now a test asserting the prefilter accepts the constant form.

## Effect

Corpus totals, before → after: **16 → 19 findings**, with the 9 false-positive `exec_call` hits replaced by 10 true ones and two committed credentials surfaced that the registry previously walked past.

## Tests

`tests/unit/analysis/` passes (693). The `exec\n  (payload);` case in `test_fallback_eval_exec_call_corpus` changed from `{"exec_call"}` to `set()` — that is the behaviour change, not an oversight — and two regex-parsing cases were added alongside it. A new corpus test covers the `child_process` gate in both directions.

`ruff check` and `ruff format --check` are clean on both files. `mypy` reports one pre-existing `Result[Any].rowcount` error in this file that is present on `main` and untouched here.
