### PR TITLE
fix(openai): support GPT-5.6 function tools in chat

### DIFF
--- a/packages/core/src/repowise/core/providers/llm/openai.py
+++ b/packages/core/src/repowise/core/providers/llm/openai.py
@@ -163,6 +163,21 @@ def _openai_temperature(model: str, requested: float) -> float:
     return requested
 
 
+def _openai_chat_tool_kwargs(model: str, *, has_tools: bool) -> dict[str, Any]:
+    """Return Chat Completions overrides required by tool-enabled models.
+
+    GPT-5.6 models default to a non-none reasoning effort. OpenAI recommends
+    the Responses API for reasoning with tool-calling, while this provider's
+    repository chat loop still uses Chat Completions. Keep the family's normal
+    reasoning default for generation and only disable it when function tools
+    are attached. Migrating the shared chat protocol is a separate change.
+    """
+    leaf = _model_leaf(model)
+    if has_tools and (leaf == "gpt-5.6" or leaf.startswith("gpt-5.6-")):
+        return {"reasoning_effort": "none"}
+    return {}
+
+
 def _is_openai_text_model(model_id: str) -> bool:
     leaf = _model_leaf(model_id)
     if any(marker in leaf for marker in _OPENAI_NON_TEXT_MARKERS):
@@ -432,6 +447,7 @@ class OpenAIProvider(BaseProvider):
         }
         if tools:
             kwargs["tools"] = tools
+        kwargs.update(_openai_chat_tool_kwargs(self._model, has_tools=bool(tools)))
 
         try:
             stream = await self._client.chat.completions.create(**kwargs)

--- a/tests/unit/test_providers/test_openai_provider.py
+++ b/tests/unit/test_providers/test_openai_provider.py
@@ -392,6 +392,89 @@ async def test_generate_rejects_off_for_non_qwen_model():
 
 
 # ---------------------------------------------------------------------------
+# Streaming chat compatibility
+# ---------------------------------------------------------------------------
+
+
+class _EmptyChatStream:
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        raise StopAsyncIteration
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "gpt-5.6",
+        "gpt-5.6-sol",
+        "gpt-5.6-terra",
+        "gpt-5.6-luna",
+        "openai/gpt-5.6-sol-2026-08-01",
+    ],
+)
+async def test_stream_chat_disables_gpt_5_6_reasoning_with_function_tools(model):
+    """Use the Chat Completions-compatible setting across the GPT-5.6 family."""
+    provider = OpenAIProvider(api_key="sk-test", model=model)
+    captured_kwargs: list[dict] = []
+
+    async def fake_create(**kwargs):
+        captured_kwargs.append(kwargs)
+        return _EmptyChatStream()
+
+    with patch("openai.AsyncOpenAI") as mock_client:
+        mock_client.return_value.chat.completions.create = fake_create
+        provider._client = mock_client.return_value
+        events = [
+            event
+            async for event in provider.stream_chat(
+                messages=[{"role": "user", "content": "Inspect this repository"}],
+                tools=[
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "get_overview",
+                            "description": "Read repository overview",
+                            "parameters": {"type": "object", "properties": {}},
+                        },
+                    }
+                ],
+                system_prompt="Use repository tools.",
+            )
+        ]
+
+    assert events == []
+    assert captured_kwargs[0]["reasoning_effort"] == "none"
+    assert captured_kwargs[0]["tools"][0]["function"]["name"] == "get_overview"
+
+
+@pytest.mark.parametrize("model", ["gpt-5.6", "gpt-5.6-terra", "gpt-5.6-luna"])
+async def test_stream_chat_keeps_gpt_5_6_default_reasoning_without_tools(model):
+    provider = OpenAIProvider(api_key="sk-test", model=model)
+    captured_kwargs: list[dict] = []
+
+    async def fake_create(**kwargs):
+        captured_kwargs.append(kwargs)
+        return _EmptyChatStream()
+
+    with patch("openai.AsyncOpenAI") as mock_client:
+        mock_client.return_value.chat.completions.create = fake_create
+        provider._client = mock_client.return_value
+        events = [
+            event
+            async for event in provider.stream_chat(
+                messages=[{"role": "user", "content": "Say hello"}],
+                tools=[],
+                system_prompt="Be concise.",
+            )
+        ]
+
+    assert events == []
+    assert "reasoning_effort" not in captured_kwargs[0]
+
+
+# ---------------------------------------------------------------------------
 # Error mapping
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- make GPT-5.6 Chat Completions compatible with repository function tools by explicitly using reasoning_effort none for tool-enabled requests
- cover the gpt-5.6 alias, Sol, Terra, Luna, provider-prefixed IDs, and dated snapshots
- preserve normal reasoning defaults for indexing, generation, and tool-free chat

## Verification

- 41 focused OpenAI provider tests passed
- independent review found no substantive issues

The Responses API remains the preferred long-term transport for reasoning plus tools; that migration is intentionally outside this focused compatibility fix.