### PR TITLE
fix(providers): add codex_cli to the server provider catalog (#1530)

### DIFF
--- a/packages/server/src/repowise/server/provider_config.py
+++ b/packages/server/src/repowise/server/provider_config.py
@@ -142,6 +142,20 @@ PROVIDER_CATALOG: list[dict[str, Any]] = [
         "requires_key": False,
     },
     {
+        "id": "codex_cli",
+        "name": "Codex (Local CLI)",
+        "default_model": "codex_cli/default",
+        "models": [
+            # The CLI's model list comes from the authenticated codex catalog
+            # at runtime (see core/providers/llm/codex_cli.py), so the static
+            # catalog only names the sentinel default; list_provider_status
+            # appends the resolved active model when it isn't cataloged.
+            "codex_cli/default",
+        ],
+        "env_keys": [],
+        "requires_key": False,
+    },
+    {
         "id": "opencode",
         "name": "OpenCode (Local CLI)",
         "default_model": "opencode/default",

--- a/tests/unit/test_providers/test_provider_env_registry.py
+++ b/tests/unit/test_providers/test_provider_env_registry.py
@@ -105,7 +105,18 @@ def test_every_provider_that_can_be_auto_detected_is_in_the_order():
 
 
 def test_server_provider_catalog_agrees_with_the_registry():
+    from repowise.core.providers.llm.registry import _BUILTIN_PROVIDERS
     from repowise.server.provider_config import PROVIDER_CATALOG
+
+    catalog_ids = {entry["id"] for entry in PROVIDER_CATALOG}
+    # Every provider the CLI can resolve must appear in the server catalog so
+    # the web dashboard's provider picker never silently disagrees with what
+    # the CLI can resolve. `mock` is the one deliberate exception — it is a
+    # test/fallback provider, not something a user should pick in the UI.
+    missing = set(_BUILTIN_PROVIDERS) - catalog_ids - {"mock"}
+    assert not missing, (
+        f"server/provider_config.py is missing catalog entries for: {sorted(missing)}"
+    )
 
     mismatched = {
         entry["id"]: (entry["env_keys"], list(PROVIDER_API_KEY_ENVS[entry["id"]]))


### PR DESCRIPTION
## What

Fixes #1530. The web dashboard's provider list disagreed with the CLI: `codex_cli` is a built-in provider in the registry (`packages/core/.../llm/registry.py`) but was missing from the server's `PROVIDER_CATALOG`, which is what the dashboard renders. The catalog had `claude_cli` and `opencode` but not `codex_cli`.

## Root cause

The server catalog in `packages/server/src/repowise/server/provider_config.py` was maintained by hand, and the drift test guarding it only compared `env_keys` for providers that already existed in both places — it could not catch a *missing* entry.

## Changes

- Add a `codex_cli` entry to `PROVIDER_CATALOG` (keyless, `requires_key: false`, sentinel model `codex_cli/default`; the runtime model list comes from the authenticated codex catalog, and `list_provider_status` appends the resolved active model when it isn't cataloged).
- Harden `test_server_provider_catalog_agrees_with_the_registry` to assert every built-in provider (except `mock`) is present in the server catalog, so a future provider addition can't silently skip the dashboard again.

## Tests

`uv run pytest tests/unit/test_providers/test_provider_env_registry.py -q` → 26 passed. The hardened test fails on unpatched main.
