### PR TITLE
fix(mcp): stop get_why shedding the lanes that answer the question

### DIFF
--- a/packages/server/src/repowise/server/mcp_server/_budget/contracts.py
+++ b/packages/server/src/repowise/server/mcp_server/_budget/contracts.py
@@ -85,17 +85,30 @@ _CONTRACTS: dict[str, ResponseBudgetContract] = {
         expansion_argument="include",
         protected=("answer", "confidence", "citations", "next_action_hint"),
     ),
+    # Dropping docs and episodes whole, and first, served 0 of 50 pages and 0 of
+    # 12 episodes on a file whose decision lane was 40 near-duplicates. They are
+    # ranked tails now, so a squeeze costs rows rather than the lane, and the
+    # decision lane pays before the lanes that answer.
+    #
+    # Search mode has no top-level origin_story or git_archaeology (its origin
+    # lives under the protected target_context), so for that shape the fix is
+    # the tail entries alone; the block entries only bite in path mode.
     "get_why": ResponseBudgetContract(
         "blocks",
         (
-            "related_documentation",
-            "episodes",
+            # Titles the decisions lane already carries.
             "origin_story.linked_decisions",
             "decisions[]",
             "code_rationale",
             "git_archaeology.file_commits",
             "git_archaeology.cross_references",
             "git_archaeology.git_log",
+            # Ranked tails, moved here from the front of this tuple. Episodes
+            # last: they answer "what constrains changing this" when no decision
+            # governs the file.
+            "related_documentation[]",
+            "episodes[]",
+            "related_documentation",
             "origin_story",
         ),
         expansion_argument=None,

--- a/packages/server/src/repowise/server/mcp_server/_helpers.py
+++ b/packages/server/src/repowise/server/mcp_server/_helpers.py
@@ -294,6 +294,9 @@ _ORIGIN_STOP_WORDS = frozenset(
     {"the", "a", "an", "is", "for", "to", "of", "in", "and", "or", "with"}
 )
 
+#: Decisions the origin summary names, and the ceiling on its evidence clauses.
+_ORIGIN_NARRATED_DECISIONS = 3
+
 
 def _meaningful_words(text: str) -> set[str]:
     """Lowercase keyword set with common stop-words removed."""
@@ -381,9 +384,11 @@ def _origin_summary_parts(
         )
 
     if linked_decisions:
-        decision_titles = [d["title"] for d in linked_decisions[:3]]
-        parts.append(f"Governed by: {', '.join(decision_titles)}.")
-        for ld in linked_decisions:
+        named = linked_decisions[:_ORIGIN_NARRATED_DECISIONS]
+        parts.append(f"Governed by: {', '.join(d['title'] for d in named)}.")
+        # Unbounded, a file with 40 linked decisions got 16 evidence clauses,
+        # restating titles the caller's own cap had already removed.
+        for ld in named:
             if ld["evidence_commits"]:
                 ec = ld["evidence_commits"][0]
                 parts.append(


### PR DESCRIPTION
`get_why` on a query with targets returned 22,694 chars in which `episodes_emitted` was 0 of 12 and `related_documentation_emitted` was 0 of 50. The lanes that answer "what constrains changing this" were spent so that 40 near-duplicate decision records, and a restatement of their titles, could survive.

## What changed

**Shed order.** `related_documentation` and `episodes` were listed first, and as whole blocks, so the first squeeze dropped each lane entirely. They are ranked tails now (`[]`, trimmed and never emptied) and they shed after the decision lane rather than before it. Search mode carries no top-level `origin_story` or `git_archaeology` — its origin sits under the protected `target_context` — so for that shape the tail entries are the whole fix, and the block entries only bite in path mode.

**Origin summary.** `_origin_summary_parts` narrated one `Commit X is evidence for Y` clause per linked decision with no bound, while the "Governed by" sentence beside it took three. On a file with 40 linked decisions that was 16 clauses restating titles the caller's own cap had already removed. Both take the same slice now.

## Measured

Three questions against the live index, plus a control whose decision lane is small.

| | before | after |
|---|---|---|
| `episodes` emitted | 0/12 | 3/12 |
| `related_documentation` emitted | 0/50 | 3/50 |
| origin summary | ~2,600 chars | 801 chars |
| control file (`llm/openai.py`) | 2/2 decisions, 3/6 episodes | unchanged |

Ranking and deduplicating `target_context.governing_decisions` was tried and reverted. On four target-and-query pairs no record cleared the relevance floor, scoring 0.365 against 0.6 because terms like `skeleton` and `get_context` are carried by no record at all, and `_collapse_restatements` folded nothing. It was inert on every case.

## Verification

`tests/unit/server/mcp/` and `tests/unit/cli/test_tool_adapter_commands.py`: 1,642 passed, 2 failed. Both failures reproduce with these two files reverted to their previous versions, so they are unrelated to this change.