### PR TITLE
fix(claude-md): rank workspace contract links by confidence before the cap (#1588)

### DIFF
--- a/packages/cli/src/repowise/cli/commands/claude_md_cmd.py
+++ b/packages/cli/src/repowise/cli/commands/claude_md_cmd.py
@@ -195,7 +195,22 @@ def _curate_contract_links(links: list[dict]) -> list[dict]:
             "alembic/versions/" in (current.get("provider_file") or "") and not is_migration
         ):
             best[key] = link
-    return list(best.values())[:_MAX_CONTRACT_LINKS]
+    curated = list(best.values())
+    # The cap cuts on evidence, not insertion order: rank by confidence so a
+    # high-confidence link discovered late in the scan is never dropped for a
+    # weak one found early (the co-change list already does the same by
+    # frequency). Tiebreak on stable fields so the output doesn't shuffle
+    # between runs.
+    curated.sort(
+        key=lambda link: (
+            float(link.get("confidence", 0.0) or 0.0),
+            link.get("contract_id") or "",
+            link.get("consumer_repo") or "",
+            link.get("consumer_file") or "",
+        ),
+        reverse=True,
+    )
+    return curated[:_MAX_CONTRACT_LINKS]
 
 
 def _generate_workspace(

--- a/tests/unit/cli/test_claude_md_contract_curation.py
+++ b/tests/unit/cli/test_claude_md_contract_curation.py
@@ -16,6 +16,7 @@ def _link(
     contract_id,
     provider_file="src/models.py",
     consumer_file="src/client.ts",
+    confidence=None,
 ):
     return {
         "provider_repo": provider_repo,
@@ -24,6 +25,7 @@ def _link(
         "consumer_file": consumer_file,
         "contract_id": contract_id,
         "contract_type": "data",
+        **({"confidence": confidence} if confidence is not None else {}),
     }
 
 
@@ -58,6 +60,34 @@ def test_distinct_consumers_survive():
 def test_capped():
     links = [_link("api", "web", f"http::GET::/x{i}") for i in range(40)]
     assert len(_curate_contract_links(links)) == _MAX_CONTRACT_LINKS
+
+
+def test_cap_prefers_higher_confidence_links():
+    """Issue #1588: when more links than the cap exist, the ones that make the
+    file must be the highest-confidence ones, not the first ones scanned."""
+    weak = _link("api", "web", "http::GET::/weak", confidence=0.5)
+    strong = [
+        _link("api", "web", f"http::GET::/strong{i}", confidence=0.9)
+        for i in range(_MAX_CONTRACT_LINKS)
+    ]
+    # Weak link scanned FIRST; without the sort it would survive the cap.
+    out = _curate_contract_links([weak, *strong])
+    assert len(out) == _MAX_CONTRACT_LINKS
+    assert all("strong" in item["contract_id"] for item in out)
+
+
+def test_links_without_confidence_rank_last_but_stable():
+    """Links that predate the confidence field keep a stable order between
+    runs (tiebreak on stable fields), and never outrank a confident one."""
+    bare = [_link("api", "web", f"http::GET::/bare{i}") for i in range(_MAX_CONTRACT_LINKS)]
+    confident = _link("api", "web", "http::GET::/confident", confidence=0.8)
+    out = _curate_contract_links([*bare, confident])
+    assert out[0]["contract_id"] == "http::GET::/confident"
+
+    # Stable across calls: same input, same order.
+    assert [item["contract_id"] for item in out] == [
+        item["contract_id"] for item in _curate_contract_links([*bare, confident])
+    ]
 
 
 def test_malformed_entries_ignored():


### PR DESCRIPTION
## What

Fixes #1588. The workspace `CLAUDE.md` caps its cross-repo contract links but didn't rank them first — `_curate_contract_links` returned `list(best.values())[:_MAX_CONTRACT_LINKS]` in insertion order, so which links survived the cut was whatever order the scan deduped them into. A high-confidence link discovered late got dropped for a weak one found early. This file is loaded as context by every agent session in the workspace, making it one of the highest-visibility lists we cut anywhere.

## Root cause

`claude_md_cmd.py:198` sliced a dict's values (insertion order) instead of sorting by evidence. `ContractLink` carries `confidence`, and nothing read it. The co-change list ten lines up already sorted by frequency — the contract list just never got the same treatment.

## Changes

- Sort the curated links by `confidence` descending before applying `_MAX_CONTRACT_LINKS`.
- Tiebreak on stable fields (`contract_id`, `consumer_repo`, `consumer_file`) so identical-confidence rows don't shuffle between runs.
- Links without a `confidence` field (pre-existing data) sort to the end but stay stable.

## Tests

Two new tests in `tests/unit/cli/test_claude_md_contract_curation.py`: weak-first-but-strong-wins across the cap, and no-confidence links rank last but stay run-stable. 7 passed; full unit suite: 14,896 passed.
