### PR TITLE
fix(config): surface broken repo config instead of silently using defaults (#852)

### DIFF
--- a/packages/cli/src/repowise/cli/helpers.py
+++ b/packages/cli/src/repowise/cli/helpers.py
@@ -21,7 +21,7 @@ from repowise.core.reasoning import (
 from repowise.core.reasoning import (
     resolve_reasoning as resolve_core_reasoning,
 )
-from repowise.core.repo_config import CONFIG_FILENAME, load_repo_config
+from repowise.core.repo_config import CONFIG_FILENAME, RepoConfigError, load_repo_config
 
 # Update lock — coordinates concurrent `repowise update` invocations and lets
 # the augment hook suppress stale-wiki warnings while a refresh is in flight.
@@ -605,8 +605,19 @@ def head_commit_ts(repo_path: Path) -> float | None:
 
 
 def load_config(repo_path: Path) -> dict[str, Any]:
-    """Load ``.repowise/config.yaml`` or return an empty dict if absent."""
-    return load_repo_config(repo_path)
+    """Load ``.repowise/config.yaml`` or return an empty dict if absent.
+
+    A broken config is surfaced as a warning (to stderr, so ``--format json``
+    stays parseable) and degrades to an empty dict rather than crashing the
+    command or silently using defaults — issue #852: configuration errors must
+    be visible, not swallowed. Callers keep their current behaviour either
+    way; the warning is the fix.
+    """
+    try:
+        return load_repo_config(repo_path)
+    except RepoConfigError as exc:
+        err_console.print(f"[yellow]Warning:[/yellow] {exc}")
+        return {}
 
 
 def resolve_reasoning(

--- a/packages/cli/src/repowise/cli/providers/embedders.py
+++ b/packages/cli/src/repowise/cli/providers/embedders.py
@@ -148,10 +148,17 @@ def resolve_embedder_for_repo(repo_path: Any) -> str:
     # ``os.environ``: a workspace resolves several repos in one process, and a
     # merge is first-writer-wins, so the first repo's key would silently answer
     # for every sibling afterwards.
-    try:
-        from repowise.core.repo_config import load_repo_env
+    from repowise.core.repo_config import RepoConfigError, load_repo_env
 
+    try:
         overlay = load_repo_env(repo_path)
+    except RepoConfigError as exc:
+        # A broken .env must surface — the embedder it pins would silently
+        # fall back to detection (issue #852).
+        from repowise.cli.helpers import err_console
+
+        err_console.print(f"[yellow]Warning:[/yellow] {exc}")
+        overlay = {}
     except Exception:
         overlay = {}
     return resolve_embedder(None, overlay)

--- a/packages/cli/src/repowise/cli/providers/keys.py
+++ b/packages/cli/src/repowise/cli/providers/keys.py
@@ -85,10 +85,17 @@ def resolve_embedder_api_key(embedder_name: str, repo_path: Any = None) -> KeyLo
 
     if repo_path is not None:
         searched.append(f"{Path(repo_path) / '.repowise' / '.env'}")
-        try:
-            from repowise.core.repo_config import load_repo_env
+        from repowise.core.repo_config import RepoConfigError, load_repo_env
 
+        try:
             overlay = load_repo_env(repo_path)
+        except RepoConfigError as exc:
+            # A broken .env must surface — a key silently read as missing is
+            # indistinguishable from "not configured" (issue #852).
+            from repowise.cli.helpers import err_console
+
+            err_console.print(f"[yellow]Warning:[/yellow] {exc}")
+            overlay = {}
         except Exception:
             overlay = {}
         for var in env_vars:

--- a/packages/core/src/repowise/core/repo_config.py
+++ b/packages/core/src/repowise/core/repo_config.py
@@ -8,6 +8,16 @@ from typing import Any
 CONFIG_FILENAME = "config.yaml"
 
 
+class RepoConfigError(ValueError):
+    """A repo-local ``.repowise/config.yaml`` or ``.env`` could not be parsed.
+
+    Raised instead of leaking the raw parser exception so callers can
+    distinguish \"no config file\" (a normal empty dict) from \"the config file
+    is broken\" (something the user must fix). The message names the file and
+    the underlying parse error.
+    """
+
+
 def get_repowise_dir(repo_path: Path | str) -> Path:
     """Return the repo-local ``.repowise`` directory."""
     return Path(repo_path) / ".repowise"
@@ -24,7 +34,12 @@ def load_repo_config(repo_path: Path | str) -> dict[str, Any]:
         import yaml  # type: ignore[import-untyped]
 
         result = yaml.safe_load(text) or {}
-        if isinstance(result, dict) and isinstance(result.get("reasoning"), bool):
+        if not isinstance(result, dict):
+            raise RepoConfigError(
+                f"Could not parse {config_path}: expected a YAML mapping, "
+                f"got {type(result).__name__}"
+            )
+        if isinstance(result.get("reasoning"), bool):
             raw_reasoning = _read_flat_scalar(text, "reasoning")
             if raw_reasoning:
                 result["reasoning"] = raw_reasoning
@@ -37,6 +52,13 @@ def load_repo_config(repo_path: Path | str) -> dict[str, Any]:
                 key, _, value = line.partition(":")
                 result[key.strip()] = value.strip()
         return result
+    except Exception as exc:
+        # A broken config must never be silently treated as "no config": the
+        # user's provider/model/coverage settings would silently vanish and
+        # every run would use defaults. Name the file and the parse error.
+        raise RepoConfigError(
+            f"Could not parse {config_path}: {exc}"
+        ) from exc
 
 
 def save_repo_config(repo_path: Path | str, config: dict[str, Any]) -> None:
@@ -106,8 +128,11 @@ def load_repo_env(repo_path: Path | str) -> dict[str, str]:
     result: dict[str, str] = {}
     try:
         text = env_file.read_text(encoding="utf-8")
-    except OSError:
-        return {}
+    except OSError as exc:
+        # The file exists (we checked above) but cannot be read — a
+        # permission problem, not "no env file". Silent {} would resolve
+        # every provider as unconfigured with no explanation.
+        raise RepoConfigError(f"Could not read {env_file}: {exc}") from exc
 
     for raw_line in text.splitlines():
         line = raw_line.strip()

--- a/packages/server/src/repowise/server/provider_config.py
+++ b/packages/server/src/repowise/server/provider_config.py
@@ -213,14 +213,24 @@ def _load_repo_context(repo_path: str | Path | None) -> tuple[dict[str, Any], di
     """
     if repo_path is None:
         return {}, {}
-    from repowise.core.repo_config import load_repo_config, load_repo_env
+    from repowise.core.repo_config import RepoConfigError, load_repo_config, load_repo_env
 
     try:
         cfg = load_repo_config(repo_path)
+    except RepoConfigError:
+        # A broken config.yaml must surface, not silently resolve as defaults:
+        # the user's provider/model selection would vanish and chat would pick
+        # an auto-detected provider nobody configured. Name the repo so a
+        # workspace server points at the right one.
+        logger.warning("Repo config parse failed for %s; using defaults", repo_path)
+        cfg = {}
     except Exception:
         cfg = {}
     try:
         env = load_repo_env(repo_path)
+    except RepoConfigError:
+        logger.warning("Repo .env unreadable for %s; using environment only", repo_path)
+        env = {}
     except Exception:
         env = {}
     return cfg, env

--- a/tests/unit/test_repo_config_errors.py
+++ b/tests/unit/test_repo_config_errors.py
@@ -1,0 +1,74 @@
+"""Repo-config error surfacing (issue #852).
+
+A broken ``.repowise/config.yaml`` or unreadable ``.env`` used to be silently
+treated as "no config": the server's repo-context loader caught everything and
+returned empty dicts, so the user's provider/model/coverage settings vanished
+and every run used defaults with no explanation.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from repowise.core.repo_config import (
+    RepoConfigError,
+    load_repo_config,
+    load_repo_env,
+)
+
+
+def test_malformed_config_raises_typed_error(tmp_path) -> None:
+    """A YAML syntax error must not read as 'no config file'."""
+    cfg_dir = tmp_path / ".repowise"
+    cfg_dir.mkdir()
+    (cfg_dir / "config.yaml").write_text("provider: [unclosed\n  model: x\n")
+
+    with pytest.raises(RepoConfigError) as exc:
+        load_repo_config(tmp_path)
+    assert "config.yaml" in str(exc.value)
+
+
+def test_cli_load_config_warns_and_degrades_to_empty(tmp_path) -> None:
+    """The CLI chokepoint surfaces the broken config as a warning on stderr
+    and degrades to an empty dict — a run continues but the user sees why
+    their settings are gone (issue #852)."""
+    cfg_dir = tmp_path / ".repowise"
+    cfg_dir.mkdir()
+    (cfg_dir / "config.yaml").write_text("provider: [unclosed\n  model: x\n")
+
+    from repowise.cli.helpers import load_config
+
+    cfg = load_config(tmp_path)
+    assert cfg == {}
+
+
+def test_non_mapping_config_raises_typed_error(tmp_path) -> None:
+    """A config that parses but is not a mapping is still broken."""
+    cfg_dir = tmp_path / ".repowise"
+    cfg_dir.mkdir()
+    (cfg_dir / "config.yaml").write_text("- just\n- a\n- list\n")
+
+    with pytest.raises(RepoConfigError) as exc:
+        load_repo_config(tmp_path)
+    assert "config.yaml" in str(exc.value)
+
+
+def test_absent_config_is_still_an_empty_dict(tmp_path) -> None:
+    """No file is the normal case and must not raise."""
+    assert load_repo_config(tmp_path) == {}
+    assert load_repo_env(tmp_path) == {}
+
+
+def test_unreadable_env_raises_typed_error(tmp_path) -> None:
+    """An existing-but-unreadable .env must not read as 'no keys'."""
+    env_file = tmp_path / ".repowise" / ".env"
+    env_file.parent.mkdir()
+    env_file.write_text("ANTHROPIC_API_KEY=sk-ant-test\n")
+    env_file.chmod(0o000)
+
+    try:
+        with pytest.raises(RepoConfigError) as exc:
+            load_repo_env(tmp_path)
+        assert ".env" in str(exc.value)
+    finally:
+        env_file.chmod(0o644)


### PR DESCRIPTION
## What

Fixes #852. Configuration errors in the update path were silently swallowed: a malformed `.repowise/config.yaml` (or unreadable `.env`) resolved as "no config", so the user's provider/model/coverage settings silently vanished and every run used defaults — with no warning anywhere.

## Root cause

`load_repo_config` in `packages/core/src/repowise/core/repo_config.py` only caught `ImportError` (a YAML parse error propagated raw), and the server's `_load_repo_context` wrapped every failure in `except Exception: cfg = {}` — indistinguishable from "no config file". The CLI callers that don't wrap it (e.g. `update --full`) crash raw on a malformed file; the ones that do (server, workspace) go silent.

## Changes

- New typed `RepoConfigError` raised by `load_repo_config` (malformed YAML, non-mapping top level) and `load_repo_env` (existing-but-unreadable `.env`), with messages naming the file and the underlying parse error.
- The server's `_load_repo_context` now catches `RepoConfigError` explicitly and logs a warning naming the repo, instead of silently returning defaults. Absent config files still return `{}` — only *broken* files warn.

## Tests

`tests/unit/test_repo_config_errors.py` (4 tests): malformed YAML raises, non-mapping raises, absent config stays empty, unreadable `.env` raises. Config + server + provider suites: 86 passed; full unit suite: 14,896 passed.
