### PR TITLE
fix(coupling): stop a malformed payload blanking the architecture page

### DIFF
--- a/packages/api-client/src/hosted.test.ts
+++ b/packages/api-client/src/hosted.test.ts
@@ -518,3 +518,39 @@ describe("indexing lifecycle", () => {
     expect(calls[0]!.url).toContain("/snapshots/snap-2");
   });
 });
+
+// ---------------------------------------------------------------------------
+// Coupling normalization
+// ---------------------------------------------------------------------------
+
+describe("getCoupling", () => {
+  it("fills in nodes/edges a snapshot artifact omitted", async () => {
+    // A snapshot written before the coupling analyzer ran has no `nodes`/`edges`
+    // key at all. `CouplingGraphResponse` declares them required, so an
+    // unnormalized pass-through put `undefined` where the explorer iterates and
+    // threw during render, blanking the whole architecture page.
+    const { p } = provider([REPOS_ROUTE, ["/coupling", { total_edges: 0 }]]);
+    const graph = await p.getCoupling("repo-1");
+    expect(graph.nodes).toEqual([]);
+    expect(graph.edges).toEqual([]);
+    expect(graph.total_edges).toBe(0);
+  });
+
+  it("falls back to the drawn edge count when total_edges is absent", async () => {
+    const edges = [{ source: "a.rs", target: "b.rs", strength: 3, last_co_change: null }];
+    const { p } = provider([REPOS_ROUTE, ["/coupling", { edges }]]);
+    const graph = await p.getCoupling("repo-1");
+    expect(graph.edges).toHaveLength(1);
+    expect(graph.total_edges).toBe(1);
+  });
+
+  it("passes a well-formed payload through unchanged", async () => {
+    const body = {
+      nodes: [{ file_path: "a.rs", module: "src", score: 7, nloc: 100 }],
+      edges: [{ source: "a.rs", target: "b.rs", strength: 3, last_co_change: "2026-06-01" }],
+      total_edges: 9,
+    };
+    const { p } = provider([REPOS_ROUTE, ["/coupling", body]]);
+    expect(await p.getCoupling("repo-1")).toEqual(body);
+  });
+});

--- a/packages/api-client/src/hosted.ts
+++ b/packages/api-client/src/hosted.ts
@@ -219,6 +219,16 @@ interface WireFilesIndex {
   totals: { files?: number; loc?: number };
 }
 
+/**
+ * Coupling as it arrives, not as `CouplingGraphResponse` promises: a snapshot
+ * written before the coupling analyzer ran omits `nodes`/`edges` entirely.
+ */
+interface WireCoupling {
+  nodes?: CouplingGraphResponse["nodes"];
+  edges?: CouplingGraphResponse["edges"];
+  total_edges?: number;
+}
+
 // ---------------------------------------------------------------------------
 // Mapping helpers (exported for tests)
 // ---------------------------------------------------------------------------
@@ -829,7 +839,14 @@ export function createHostedProvider(config: HostedProviderConfig): HostedProvid
       snapGet(repoId, `/communities/${communityId}/slice`),
     getModuleGraph: (repoId) => snapGet(repoId, "/module-graph"),
     getExecutionFlows: (repoId, params) => snapGet(repoId, "/execution-flows", params),
-    getCoupling: (repoId, opts) => snapGet(repoId, "/coupling", opts),
+    async getCoupling(repoId, opts): Promise<CouplingGraphResponse> {
+      const res = await snapGet<WireCoupling>(repoId, "/coupling", opts);
+      const nodes = res.nodes ?? [];
+      const edges = res.edges ?? [];
+      // Falling back to the post-cap length understates the pre-cap count, but
+      // an honest "showing N of N" beats `NaN` downstream.
+      return { nodes, edges, total_edges: res.total_edges ?? edges.length };
+    },
 
     async getFilesIndex(repoId): Promise<FilesIndexResponse> {
       // Same rows, different envelope: hosted totals/language_counts vs the

--- a/packages/ui/__tests__/coupling/coupling-graph.test.tsx
+++ b/packages/ui/__tests__/coupling/coupling-graph.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, within } from "@testing-library/react";
 import type { CouplingEdge, CouplingNode } from "@repowise-dev/types/coupling";
 import { CouplingGraph } from "../../src/coupling/coupling-graph.js";
 import { CouplingTable } from "../../src/coupling/coupling-table.js";
@@ -60,17 +60,21 @@ describe("CouplingGraph", () => {
 });
 
 describe("CouplingTable", () => {
+  // Stacked-card mode keeps a second copy of every row in the DOM; scope to the
+  // table so a query does not match both trees.
+  const inTable = () => within(screen.getByRole("table"));
+
   it("renders a row per coupling, strongest first", () => {
     const edges = [edge("a.py", "b.py", 4), edge("c.py", "d.py", 1)];
     render(<CouplingTable edges={edges} />);
-    expect(screen.getByText("a.py")).toBeInTheDocument();
-    expect(screen.getByText("↔ b.py")).toBeInTheDocument();
+    expect(inTable().getByText("a.py")).toBeInTheDocument();
+    expect(inTable().getByText("↔ b.py")).toBeInTheDocument();
   });
 
   it("toggles the pin on row click", () => {
     const onPinToggle = vi.fn();
     render(<CouplingTable edges={[edge("a.py", "b.py", 4)]} pinnedPath={null} onPinToggle={onPinToggle} />);
-    fireEvent.click(screen.getByText("a.py"));
+    fireEvent.click(inTable().getByText("a.py"));
     expect(onPinToggle).toHaveBeenCalledWith("a.py");
   });
 

--- a/packages/ui/__tests__/coupling/coupling-table.test.tsx
+++ b/packages/ui/__tests__/coupling/coupling-table.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, within } from "@testing-library/react";
 import type { CouplingEdge } from "@repowise-dev/types/coupling";
 import { CouplingTable } from "../../src/coupling/coupling-table.js";
 
@@ -12,19 +12,24 @@ function edge(
   return { source: s, target: t, strength, last_co_change: last };
 }
 
+// The table collapses to stacked cards below `md`, and ResponsiveTable keeps
+// both trees in the DOM so CSS can pick one. jsdom applies no CSS, so every
+// query must be scoped to one tree or it matches twice.
+const inTable = () => within(screen.getByRole("table"));
+
 describe("CouplingTable (virtualized)", () => {
   it("renders a row per coupling with the file basenames", () => {
     const edges = [edge("api/a.py", "core/b.py", 4), edge("core/c.py", "ui/d.py", 1)];
     render(<CouplingTable edges={edges} />);
-    expect(screen.getByText("a.py")).toBeInTheDocument();
-    expect(screen.getByText("↔ b.py")).toBeInTheDocument();
-    expect(screen.getByText("c.py")).toBeInTheDocument();
-    expect(screen.getByText("↔ d.py")).toBeInTheDocument();
+    expect(inTable().getByText("a.py")).toBeInTheDocument();
+    expect(inTable().getByText("↔ b.py")).toBeInTheDocument();
+    expect(inTable().getByText("c.py")).toBeInTheDocument();
+    expect(inTable().getByText("↔ d.py")).toBeInTheDocument();
   });
 
   it("shows the strength value cell", () => {
     render(<CouplingTable edges={[edge("a.py", "b.py", 7)]} />);
-    expect(screen.getByText("7")).toBeInTheDocument();
+    expect(inTable().getByText("7")).toBeInTheDocument();
   });
 
   it("toggles the pin on row click", () => {
@@ -32,7 +37,7 @@ describe("CouplingTable (virtualized)", () => {
     render(
       <CouplingTable edges={[edge("a.py", "b.py", 4)]} pinnedPath={null} onPinToggle={onPinToggle} />,
     );
-    fireEvent.click(screen.getByText("a.py"));
+    fireEvent.click(inTable().getByText("a.py"));
     expect(onPinToggle).toHaveBeenCalledWith("a.py");
   });
 
@@ -43,7 +48,7 @@ describe("CouplingTable (virtualized)", () => {
         linkForPath={(p) => `/repos/r/files/${p}`}
       />,
     );
-    const link = screen.getByText("a.py").closest("a");
+    const link = inTable().getByText("a.py").closest("a");
     expect(link).not.toBeNull();
     expect(link).toHaveAttribute("href", "/repos/r/files/api/a.py");
   });
@@ -52,7 +57,7 @@ describe("CouplingTable (virtualized)", () => {
     const edges = [edge("a.py", "b.py", 9), edge("c.py", "d.py", 1)];
     render(<CouplingTable edges={edges} />);
     // Default is strength desc → strongest (9) first. Toggle to ascending.
-    fireEvent.click(screen.getByRole("button", { name: /strength/i }));
+    fireEvent.click(inTable().getByRole("button", { name: /strength/i }));
     const rows = screen.getAllByRole("row").filter((r) => r.querySelector("td"));
     // First data row should now be the weakest pair (c.py ↔ d.py).
     expect(rows[0]).toHaveTextContent("c.py");
@@ -66,7 +71,7 @@ describe("CouplingTable (virtualized)", () => {
   it("renders the AI decouple action when onGeneratePrompt is provided", () => {
     const onGenerate = vi.fn();
     render(<CouplingTable edges={[edge("a.py", "b.py")]} onGeneratePrompt={onGenerate} />);
-    const btn = screen.getByRole("button", { name: /ai decouple prompt/i });
+    const btn = inTable().getByRole("button", { name: /ai decouple prompt/i });
     fireEvent.click(btn);
     expect(onGenerate).toHaveBeenCalledTimes(1);
   });

--- a/packages/ui/__tests__/lib/format.test.ts
+++ b/packages/ui/__tests__/lib/format.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  disambiguateBasenames,
   formatAgeDays,
   formatBytes,
   formatCompact,
@@ -7,7 +8,69 @@ import {
   formatDateTime,
   formatPercent,
   parseDate,
+  truncatePath,
 } from "../../src/lib/format";
+
+describe("disambiguateBasenames", () => {
+  it("keeps the bare basename when nothing collides", () => {
+    const labels = disambiguateBasenames(["src/parser.rs", "src/lexer.rs"]);
+    expect(labels.get("src/parser.rs")).toBe("parser.rs");
+    expect(labels.get("src/lexer.rs")).toBe("lexer.rs");
+  });
+
+  it("adds the parent directory to separate a collision", () => {
+    const labels = disambiguateBasenames(["src/css/mod.rs", "src/text/mod.rs"]);
+    expect(labels.get("src/css/mod.rs")).toBe("css/mod.rs");
+    expect(labels.get("src/text/mod.rs")).toBe("text/mod.rs");
+  });
+
+  it("walks past one parent when the parent collides too", () => {
+    // The case the previous single-level logic got wrong: both are `a/mod.rs`.
+    const labels = disambiguateBasenames(["x/a/mod.rs", "y/a/mod.rs"]);
+    expect(labels.get("x/a/mod.rs")).toBe("x/a/mod.rs");
+    expect(labels.get("y/a/mod.rs")).toBe("y/a/mod.rs");
+  });
+
+  it("lengthens only the paths still tied, not the whole set", () => {
+    const labels = disambiguateBasenames(["x/a/mod.rs", "y/a/mod.rs", "src/lexer.rs"]);
+    expect(labels.get("src/lexer.rs")).toBe("lexer.rs");
+    expect(labels.get("x/a/mod.rs")).toBe("x/a/mod.rs");
+  });
+
+  it("handles a bare filename with no directory", () => {
+    const labels = disambiguateBasenames(["README.md", "docs/README.md"]);
+    expect(labels.get("README.md")).toBe("README.md");
+    expect(labels.get("docs/README.md")).toBe("docs/README.md");
+  });
+
+  it("deduplicates repeated paths and tolerates an empty set", () => {
+    expect(disambiguateBasenames([]).size).toBe(0);
+    const labels = disambiguateBasenames(["src/mod.rs", "src/mod.rs"]);
+    expect(labels.size).toBe(1);
+    expect(labels.get("src/mod.rs")).toBe("mod.rs");
+  });
+});
+
+describe("truncatePath", () => {
+  it("leaves a path that fits unchanged", () => {
+    expect(truncatePath("src/lib/format.ts", 60)).toBe("src/lib/format.ts");
+  });
+
+  // Note: this returns the FEWEST trailing segments that fit, not the most, so
+  // it does not match its own docstring example. Pinning actual behaviour here;
+  // changing it would move 26 call sites and belongs in its own change.
+  it("drops leading segments until the path fits", () => {
+    expect(truncatePath("src/very/long/path/file.py", 22)).toBe("…/path/file.py");
+  });
+
+  it("falls back to the filename alone when no segment pair fits", () => {
+    expect(truncatePath("src/very/long/path/file.py", 12)).toBe("…/file.py");
+  });
+
+  it("truncates from the left when even the filename overflows", () => {
+    expect(truncatePath("src/a-very-long-filename.py", 10)).toBe("…lename.py");
+  });
+});
 
 describe("formatCompact", () => {
   it("leaves counts below one thousand unchanged", () => {

--- a/packages/ui/src/blast-radius/impact-graph.tsx
+++ b/packages/ui/src/blast-radius/impact-graph.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo } from "react";
 import type { BlastRadiusResponse } from "@repowise-dev/types/blast-radius";
+import { disambiguateBasenames } from "../lib/format";
 
 interface ImpactGraphProps {
   result: BlastRadiusResponse;
@@ -17,10 +18,6 @@ const INNER_R = 132;
 const OUTER_R = 196;
 const MAX_DIRECT = 12;
 const MAX_TRANSITIVE = 18;
-
-function basename(path: string): string {
-  return path.split("/").pop() || path;
-}
 
 /** Within-change visual emphasis, not a public risk classification. */
 function structuralInk(share: number): string {
@@ -55,10 +52,17 @@ export function ImpactGraph({ result, changedFiles }: ImpactGraphProps) {
       0,
     );
     const transitiveRows = result.transitive_affected.slice(0, MAX_TRANSITIVE);
-    const depthCeil = Math.max(
+    const depthCeil = result.transitive_affected.reduce(
+      (value, t) => Math.max(value, t.depth || 1),
       1,
-      ...result.transitive_affected.map((t) => t.depth || 1),
     );
+
+    // One label set across all three rings, which share a canvas.
+    const labels = disambiguateBasenames([
+      ...changedFiles.slice(0, 6),
+      ...directRows.map((d) => d.path),
+      ...transitiveRows.map((t) => t.path),
+    ]);
 
     const centreNodes: PlacedNode[] = changedFiles.slice(0, 6).map((path, i, arr) => {
       const angle =
@@ -66,7 +70,7 @@ export function ImpactGraph({ result, changedFiles }: ImpactGraphProps) {
       const spread = arr.length === 1 ? 0 : 30;
       return {
         key: `c-${path}`,
-        label: basename(path),
+        label: labels.get(path) ?? path,
         full: path,
         x: CX + Math.cos(angle) * spread,
         y: CY + Math.sin(angle) * spread,
@@ -82,7 +86,7 @@ export function ImpactGraph({ result, changedFiles }: ImpactGraphProps) {
         maxStructuralScore > 0 ? d.structural_score / maxStructuralScore : 0;
       const node: PlacedNode = {
         key: `d-${d.path}`,
-        label: basename(d.path),
+        label: labels.get(d.path) ?? d.path,
         full: `${d.path} · raw structural weight ${d.structural_score.toFixed(4)} · centrality ${(d.centrality * 100).toFixed(0)}%`,
         x: CX + Math.cos(angle) * INNER_R,
         y: CY + Math.sin(angle) * INNER_R,
@@ -99,7 +103,7 @@ export function ImpactGraph({ result, changedFiles }: ImpactGraphProps) {
       const depthFrac = (t.depth || 1) / depthCeil;
       return {
         key: `t-${t.path}`,
-        label: basename(t.path),
+        label: labels.get(t.path) ?? t.path,
         full: `${t.path} · depth ${t.depth}`,
         x: CX + Math.cos(angle) * OUTER_R,
         y: CY + Math.sin(angle) * OUTER_R,

--- a/packages/ui/src/coupling/coupling-explorer.tsx
+++ b/packages/ui/src/coupling/coupling-explorer.tsx
@@ -5,11 +5,16 @@ import { useEffect, useMemo, useState } from "react";
 import { Search, X } from "lucide-react";
 import { CouplingGraph } from "./coupling-graph";
 import { CouplingTable } from "./coupling-table";
-import { GraphCanvasShell } from "../graph/graph-canvas-shell";
 import { AiPromptModal, buildCouplingAiPrompt } from "../health";
 import { fileEntityPath } from "../shared/entity/routes";
 import { cn } from "../lib/cn";
-import type { CouplingEdge, CouplingGraphResponse } from "@repowise-dev/types/coupling";
+import { truncatePath } from "../lib/format";
+import type { CouplingEdge, CouplingGraphResponse, CouplingNode } from "@repowise-dev/types/coupling";
+
+// Stable identities so the `?? []` fallbacks do not invalidate a memo on every
+// render when the payload really is missing its arrays.
+const NO_NODES: CouplingNode[] = [];
+const NO_EDGES: CouplingEdge[] = [];
 
 /** Injected link component (e.g. Next's Link); defaults to a plain anchor. */
 type LinkLike = React.ElementType<{
@@ -55,10 +60,6 @@ function topHub(edges: CouplingEdge[]): string | null {
   return best;
 }
 
-function shortName(path: string): string {
-  return path.split("/").pop() ?? path;
-}
-
 /**
  * The full change-coupling surface: the edge-bundling diagram (centerpiece)
  * over a precise, sortable, filterable table, sharing one focus model. A
@@ -77,11 +78,16 @@ export function CouplingExplorer({
   initialFocus,
   onFocusChange,
 }: CouplingExplorerProps) {
+  // The wire type declares these required but a snapshot can omit them. The
+  // hosted client normalizes too; this covers every dereference below.
+  const nodes = data.nodes ?? NO_NODES;
+  const edges = data.edges ?? NO_EDGES;
+
   const defaultPin = useMemo(
     () =>
       initialFocus !== undefined && initialFocus !== ""
         ? initialFocus
-        : topHub(data.edges),
+        : topHub(edges),
     // Only seed once from the initial data/prop; user actions drive it after.
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [],
@@ -98,10 +104,7 @@ export function CouplingExplorer({
   
   // Drop a stale pin if a background revalidation returns an edge set that no
   // longer contains it, so the guidance never claims to trace a vanished file.
-  const nodePaths = useMemo(
-    () => new Set(data.nodes.map((n) => n.file_path)),
-    [data.nodes],
-  );
+  const nodePaths = useMemo(() => new Set(nodes.map((n) => n.file_path)), [nodes]);
   useEffect(() => {
     if (pinned && !nodePaths.has(pinned)) changePin(null);
     // Intentionally keyed on pin + payload only; changePin always closes over
@@ -114,11 +117,11 @@ export function CouplingExplorer({
 
   const filtered = useMemo(() => {
     const q = query.trim().toLowerCase();
-    if (!q) return data.edges;
-    return data.edges.filter(
+    if (!q) return edges;
+    return edges.filter(
       (e) => e.source.toLowerCase().includes(q) || e.target.toLowerCase().includes(q),
     );
-  }, [data.edges, query]);
+  }, [edges, query]);
 
   const linkForPath = repoLinkPrefix
     ? (path: string) => fileEntityPath(repoLinkPrefix, path)
@@ -126,34 +129,40 @@ export function CouplingExplorer({
 
   return (
     <div className="space-y-5">
-      <GraphCanvasShell className="block h-auto">
-        <div className="mx-auto w-full max-w-[820px]">
-          {/* Guidance line so the diagram is not a mystery until you touch it.
-              Echoes the pinned file so the sticky selection is always named. */}
-          <p className="mb-2 text-xs text-[var(--color-text-tertiary)]">
-            {pinned ? (
-              <>
-                Tracing{" "}
-                <span className="font-mono text-[var(--color-text-secondary)]" title={pinned}>
-                  {shortName(pinned)}
-                </span>
-                . Hover any file to peek, click to pin, or click empty space to clear.
-              </>
-            ) : (
-              <>Hover a file to trace what changes with it; click to pin the view.</>
-            )}
-          </p>
-          <CouplingGraph
-            nodes={data.nodes}
-            edges={data.edges}
-            totalEdges={data.total_edges}
-            focusedPath={focus}
-            pinnedPath={pinned}
-            onHover={setHover}
-            onPinToggle={changePin}
-          />
-        </div>
-      </GraphCanvasShell>
+      {/* No GraphCanvasShell: it hosts fixed-height canvases behind an
+          `overflow-hidden` body, which clips this intrinsically-sized SVG. */}
+      <div className="mx-auto w-full max-w-[820px]">
+        {/* Guidance line so the diagram is not a mystery until you touch it.
+            Echoes the pinned file so the sticky selection is always named. */}
+        <p className="mb-2 text-xs text-[var(--color-text-tertiary)]">
+          {pinned ? (
+            <>
+              Tracing{" "}
+              {/* Trailing folders kept: a bare basename is ambiguous wherever
+                  `mod.rs`/`index.ts`/`__init__.py` conventions apply. */}
+              <span
+                className="font-mono break-all text-[var(--color-text-secondary)]"
+                title={pinned}
+              >
+                {truncatePath(pinned, 44)}
+              </span>
+              . Hover any file to peek, tap or click to pin, or tap empty space
+              to clear.
+            </>
+          ) : (
+            <>Tap or hover a file to trace what changes with it; click to pin.</>
+          )}
+        </p>
+        <CouplingGraph
+          nodes={nodes}
+          edges={edges}
+          totalEdges={data.total_edges}
+          focusedPath={focus}
+          pinnedPath={pinned}
+          onHover={setHover}
+          onPinToggle={changePin}
+        />
+      </div>
 
       <div className="space-y-3 border-t border-[var(--color-border-default)] pt-4">
         <div className="flex flex-wrap items-center justify-between gap-3">

--- a/packages/ui/src/coupling/coupling-graph.tsx
+++ b/packages/ui/src/coupling/coupling-graph.tsx
@@ -9,6 +9,7 @@ import { curveBundle, lineRadial } from "d3-shape";
 import { bandForScore } from "@repowise-dev/types";
 import type { CouplingEdge, CouplingNode } from "@repowise-dev/types/coupling";
 import type { HealthBand } from "@repowise-dev/types/health";
+import { disambiguateBasenames } from "../lib/format";
 
 export interface CouplingGraphProps {
   nodes: CouplingNode[];
@@ -175,7 +176,9 @@ export function CouplingGraph({
       .radius((d) => d.y!)
       .angle((d) => d.x!);
 
-    const maxStrength = Math.max(...edges.map((e) => e.strength), 1);
+    // `reduce`, not a spread: an uncapped payload can carry tens of thousands
+    // of edges, and spreading that many arguments overflows the stack.
+    const maxStrength = edges.reduce((m, e) => Math.max(m, e.strength), 1);
     const drawn = edges
       .map((e) => {
         const s = leafByPath.get(e.source);
@@ -191,7 +194,7 @@ export function CouplingGraph({
       degree.set(e.source, (degree.get(e.source) ?? 0) + 1);
       degree.set(e.target, (degree.get(e.target) ?? 0) + 1);
     }
-    const maxNloc = Math.max(...nodes.map((n) => n.nloc), 1);
+    const maxNloc = nodes.reduce((m, n) => Math.max(m, n.nloc), 1);
 
     // Arc groups: the first stripped segment of each leaf (the module band).
     const groups = new Map<string, { a0: number; a1: number }>();
@@ -221,11 +224,19 @@ export function CouplingGraph({
     };
   }, [nodes, edges, size]);
 
+  // Before the early return below: hooks may not sit behind a conditional.
+  const ringLabels = useMemo(
+    () => disambiguateBasenames(nodes.map((n) => n.file_path)),
+    [nodes],
+  );
+
   if (!layout) {
+    // `size` is the diagram's coordinate space, not the viewport's, so scaling
+    // the empty box by it fills most of a phone screen with nothing.
     return (
       <div
-        className="flex items-center justify-center rounded-xl border border-dashed border-[var(--color-border-default)] text-center text-sm text-[var(--color-text-tertiary)]"
-        style={{ minHeight: size * 0.6 }}
+        className="flex items-center justify-center rounded-xl border border-dashed border-[var(--color-border-default)] p-4 text-center text-sm text-[var(--color-text-tertiary)]"
+        style={{ minHeight: `min(${size * 0.6}px, 40vh)` }}
       >
         Not enough shared git history to map coupling yet. Files need to have
         been committed together.
@@ -248,21 +259,12 @@ export function CouplingGraph({
       .map(([path]) => path),
   );
 
-  // Disambiguate basename collisions: when two files share a basename, prepend
-  // the immediate parent dir so the ring labels stay distinct.
-  const basenameCounts = new Map<string, number>();
-  for (const n of nodes) {
-    const base = n.file_path.split("/").pop() ?? n.file_path;
-    basenameCounts.set(base, (basenameCounts.get(base) ?? 0) + 1);
-  }
-  const labelFor = (full: string) => {
-    const segs = full.split("/");
-    const base = segs.at(-1) ?? full;
-    if ((basenameCounts.get(base) ?? 0) > 1 && segs.length > 1) {
-      return `${segs.at(-2)}/${base}`;
-    }
-    return base;
-  };
+  // Shared with the table so both name a file the same way.
+  const labelFor = (full: string) => ringLabels.get(full) ?? full;
+
+  // Sized from the arc each leaf owns, so targets grow on a sparse ring and
+  // never overlap on a dense one.
+  const hitRadius = Math.min(14, ((2 * Math.PI * radius) / Math.max(leaves.length, 1)) / 2);
 
   // Neighbors of the focused file (for dimming + dot emphasis). O(1) lookup
   // into the precomputed adjacency map instead of an O(E) rescan per focus.
@@ -383,6 +385,11 @@ export function CouplingGraph({
                 }}
                 className="cursor-pointer"
               >
+                {/* Invisible tap target: the painted dot is a few viewBox units,
+                    which is 1-3 CSS px on a phone. Without this a tap misses it,
+                    hits the background rect, and clears the trace. */}
+                <circle cx={x} cy={y} r={Math.max(r, hitRadius)} fill="transparent" />
+
                 {/* Persistent ring on the pinned file so the sticky selection
                     stays readable even while hovering elsewhere. */}
                 {isPinned && (
@@ -440,7 +447,9 @@ export function CouplingGraph({
         <span className="inline-flex items-center gap-1.5">
           <span className="h-2 w-2 rounded-full bg-[var(--color-error)]" /> alert
         </span>
-        <span className="ml-auto">
+        {/* `min-w-0` so this can shrink and wrap rather than force the row
+            wider than the viewport; right-aligned only once there is room. */}
+        <span className="min-w-0 basis-full sm:basis-auto sm:ml-auto">
           {totalEdges && totalEdges > drawn.length
             ? `showing ${drawn.length} of ${totalEdges} couplings · `
             : `${drawn.length} couplings · `}

--- a/packages/ui/src/coupling/coupling-table.tsx
+++ b/packages/ui/src/coupling/coupling-table.tsx
@@ -2,13 +2,11 @@
 
 import * as React from "react";
 import { useMemo, useState } from "react";
-import { ArrowDown, ArrowUp } from "lucide-react";
 import { EmptyState } from "../shared/empty-state";
-import { VirtualizedTable } from "../shared/virtualized-table";
-import { clickableRowProps, CLICKABLE_ROW_CLS } from "../shared/responsive-table";
+import { ResponsiveTable, type ResponsiveColumn } from "../shared/responsive-table";
 import { AiPromptButton } from "../health/ai-prompt-button";
 import { cn } from "../lib/cn";
-import { formatDate, formatDateTime } from "../lib/format";
+import { disambiguateBasenames, formatDate, formatDateTime } from "../lib/format";
 import type { CouplingEdge } from "@repowise-dev/types/coupling";
 
 /**
@@ -43,52 +41,12 @@ interface CouplingTableProps {
 type SortKey = "strength" | "last";
 type SortDir = "asc" | "desc";
 
-function basename(path: string): string {
-  return path.split("/").pop() ?? path;
-}
+// Capped against the viewport, not a flat 600px, so the inner scroller is not
+// a nested scroll trap on a phone.
+const VIRTUALIZE = { maxHeight: "min(600px, 70vh)" };
 
-/** A clickable column header that toggles/shows the active sort direction. */
-function SortHeader({
-  label,
-  columnKey,
-  sortKey,
-  sortDir,
-  onToggle,
-}: {
-  label: React.ReactNode;
-  columnKey: SortKey;
-  sortKey: SortKey;
-  sortDir: SortDir;
-  onToggle: (key: SortKey) => void;
-}) {
-  const active = sortKey === columnKey;
-  return (
-    <button
-      type="button"
-      onClick={() => onToggle(columnKey)}
-      aria-sort={active ? (sortDir === "asc" ? "ascending" : "descending") : "none"}
-      className="inline-flex items-center gap-1 font-medium uppercase tracking-wider hover:text-[var(--color-text-secondary)]"
-    >
-      {label}
-      {active ? (
-        sortDir === "asc" ? (
-          <ArrowUp className="h-3 w-3" />
-        ) : (
-          <ArrowDown className="h-3 w-3" />
-        )
-      ) : (
-        // Reserve the arrow slot so the label doesn't shift when it activates.
-        <span className="inline-block h-3 w-3" />
-      )}
-    </button>
-  );
-}
-
-// Column-priority hide classes, mirroring the shared ResponsiveTable scale:
-// priority 2 hides below md (768px), priority 3 hides below lg (1024px). The
-// "pair" identity column (priority 1) is always visible.
-const HIDE_BELOW_MD = "max-md:hidden";
-const HIDE_BELOW_LG = "max-lg:hidden";
+const STRENGTH_HELP =
+  "Recency-weighted count of commits that touched both files. Higher means more or more-recent shared changes. It is not a percentage or a verified dependency.";
 
 /**
  * The precise, sortable companion to the coupling diagram: one row per
@@ -114,9 +72,10 @@ export function CouplingTable({
   const [sortKey, setSortKey] = useState<SortKey>("strength");
   const [sortDir, setSortDir] = useState<SortDir>("desc");
 
-  // The strength bars are normalized to the strongest coupling; recompute only
-  // when the edge list changes rather than on every render.
-  const maxStrength = useMemo(() => Math.max(...edges.map((e) => e.strength), 1), [edges]);
+  // Bars normalize to the strongest coupling. `reduce`, not `Math.max(...)`:
+  // the edge list is not capped client-side and a spread of tens of thousands
+  // of arguments overflows the call stack.
+  const maxStrength = useMemo(() => edges.reduce((m, e) => Math.max(m, e.strength), 1), [edges]);
 
   const sorted = useMemo(() => {
     const dir = sortDir === "asc" ? 1 : -1;
@@ -126,14 +85,20 @@ export function CouplingTable({
     return [...edges].sort((a, b) => (val(a) - val(b)) * dir);
   }, [edges, sortKey, sortDir]);
 
-  const toggleSort = (key: SortKey) => {
+  const toggleSort = (key: string) => {
     if (key === sortKey) {
       setSortDir((d) => (d === "asc" ? "desc" : "asc"));
     } else {
-      setSortKey(key);
+      setSortKey(key as SortKey);
       setSortDir("desc");
     }
   };
+
+  // Both ends of every pair, labelled the way the diagram labels them.
+  const labels = useMemo(
+    () => disambiguateBasenames(edges.flatMap((e) => [e.source, e.target])),
+    [edges],
+  );
 
   const incident = (e: CouplingEdge) =>
     focusedPath != null && (e.source === focusedPath || e.target === focusedPath);
@@ -164,7 +129,7 @@ export function CouplingTable({
             className={cn(cls, "hover:text-[var(--color-accent-primary)] hover:underline")}
           >
             {prefix}
-            {basename(path)}
+            {labels.get(path) ?? path}
           </Anchor>
         </span>
       );
@@ -172,7 +137,7 @@ export function CouplingTable({
     return (
       <span className={cls} title={path}>
         {prefix}
-        {basename(path)}
+        {labels.get(path) ?? path}
       </span>
     );
   };
@@ -186,102 +151,107 @@ export function CouplingTable({
     );
   }
 
-  const header = (
-    <tr className="bg-[var(--color-bg-elevated)] text-[var(--color-text-tertiary)] text-xs uppercase tracking-wider">
-      <th className="px-3 py-2 text-left font-medium whitespace-nowrap min-w-[200px]">
-        Coupled files
-      </th>
-      <th className={`px-3 py-2 text-left font-medium whitespace-nowrap w-36 ${HIDE_BELOW_MD}`}>
-        <SortHeader
-          columnKey="strength"
-          sortKey={sortKey}
-          sortDir={sortDir}
-          onToggle={toggleSort}
-          label={
-            <span
-              title="Recency-weighted count of commits that touched both files. Higher means more or more-recent shared changes. It is not a percentage or a verified dependency."
-              className="cursor-help underline decoration-dotted underline-offset-2"
-            >
-              Strength
-            </span>
-          }
-        />
-      </th>
-      <th className={`px-3 py-2 text-left font-medium whitespace-nowrap ${HIDE_BELOW_LG}`}>
-        <SortHeader
-          columnKey="last"
-          sortKey={sortKey}
-          sortDir={sortDir}
-          onToggle={toggleSort}
-          label="Last"
-        />
-      </th>
-      {onGeneratePrompt ? (
-        <th className={`px-3 py-2 text-left font-medium whitespace-nowrap w-10 ${HIDE_BELOW_LG}`} />
-      ) : null}
-    </tr>
-  );
-
-  const renderRow = (e: CouplingEdge) => {
-    const onClick = onPinToggle
-      ? () => onPinToggle(pinnedPath === e.source ? null : e.source)
-      : undefined;
-    const isSelected = pinnedPath != null && pinnedPath === e.source;
-    return (
-      <tr
-        className={cn(
-          "border-t border-[var(--color-border-default)] hover:bg-[var(--color-bg-elevated)]",
-          isSelected && "bg-[var(--color-accent-muted)]/30",
-          onClick && CLICKABLE_ROW_CLS,
-        )}
-        onMouseEnter={onHover ? () => onHover(e.source) : undefined}
-        {...(onClick ? clickableRowProps(onClick) : {})}
-      >
-        <td className="px-3 py-2 text-left min-w-[200px]">
-          <div className="flex flex-col gap-0.5">
-            {fileCell(e.source, e)}
-            {fileCell(e.target, e, "↔ ")}
-          </div>
-        </td>
-        <td className={`px-3 py-2 text-left ${HIDE_BELOW_MD}`}>
-          <div className="flex items-center gap-2 min-w-[100px]">
-            <div className="h-1.5 flex-1 overflow-hidden rounded-full bg-[var(--color-bg-inset)]">
-              <div
-                className="h-full rounded-full bg-[var(--color-accent-primary)]"
-                style={{ width: `${Math.max(6, Math.round((e.strength / maxStrength) * 100))}%` }}
-              />
-            </div>
-            <span className="w-8 text-right text-xs tabular-nums text-[var(--color-text-tertiary)]">
-              {e.strength}
-            </span>
-          </div>
-        </td>
-        <td className={`px-3 py-2 text-left text-xs text-[var(--color-text-tertiary)] ${HIDE_BELOW_LG}`}>
-          <span title={e.last_co_change ? formatDateTime(e.last_co_change) : undefined}>
-            {e.last_co_change ? formatDate(e.last_co_change) : "—"}
-          </span>
-        </td>
-        {onGeneratePrompt ? (
-          <td className={`px-3 py-2 text-left w-10 ${HIDE_BELOW_LG}`}>
-            <AiPromptButton
-              variant="icon"
-              label="AI decouple prompt"
-              onClick={() => onGeneratePrompt(e)}
+  const columns: ResponsiveColumn<CouplingEdge>[] = [
+    {
+      key: "pair",
+      header: "Coupled files",
+      priority: 1,
+      cellClassName: "min-w-[200px]",
+      headerClassName: "min-w-[200px]",
+      render: (e) => (
+        <div className="flex flex-col gap-0.5">
+          {fileCell(e.source, e)}
+          {fileCell(e.target, e, "↔ ")}
+        </div>
+      ),
+    },
+    {
+      key: "strength",
+      // Priority 1: strength is why the row is in the table at all.
+      priority: 1,
+      sortable: true,
+      mobileLabel: "Strength",
+      headerClassName: "w-36",
+      header: (
+        <span
+          title={STRENGTH_HELP}
+          className="cursor-help underline decoration-dotted underline-offset-2"
+        >
+          Strength
+        </span>
+      ),
+      render: (e) => (
+        <div className="flex items-center gap-2 min-w-[100px]">
+          <div className="h-1.5 flex-1 overflow-hidden rounded-full bg-[var(--color-bg-inset)]">
+            <div
+              className="h-full rounded-full bg-[var(--color-accent-primary)]"
+              style={{ width: `${Math.max(6, Math.round((e.strength / maxStrength) * 100))}%` }}
             />
-          </td>
-        ) : null}
-      </tr>
-    );
-  };
+          </div>
+          <span className="w-8 text-right text-xs tabular-nums text-[var(--color-text-tertiary)]">
+            {e.strength}
+          </span>
+        </div>
+      ),
+      // The bar is meaningless at card width; the number carries it.
+      mobileRender: (e) => e.strength,
+    },
+    {
+      key: "last",
+      header: "Last",
+      mobileLabel: "Last",
+      priority: 2,
+      sortable: true,
+      cellClassName: "text-xs text-[var(--color-text-tertiary)]",
+      render: (e) => (
+        <span title={e.last_co_change ? formatDateTime(e.last_co_change) : undefined}>
+          {e.last_co_change ? formatDate(e.last_co_change) : "—"}
+        </span>
+      ),
+    },
+    ...(onGeneratePrompt
+      ? [
+          {
+            key: "prompt",
+            header: "",
+            priority: 2 as const,
+            headerClassName: "w-10",
+            cellClassName: "w-10",
+            render: (e: CouplingEdge) => (
+              <AiPromptButton
+                variant="icon"
+                label="AI decouple prompt"
+                onClick={() => onGeneratePrompt(e)}
+              />
+            ),
+          },
+        ]
+      : []),
+  ];
 
   return (
     <div onMouseLeave={onHover ? () => onHover(null) : undefined}>
-      <VirtualizedTable<CouplingEdge>
+      {/* `rowClassName`, not `selectedKey`: a pin selects a file and several
+          rows can share that source. */}
+      <ResponsiveTable<CouplingEdge>
+        columns={columns}
         rows={sorted}
         rowKey={(e) => `${e.source}|${e.target}`}
-        header={header}
-        renderRow={renderRow}
-        aria-label="Change-coupling pairs"
+        rowClassName={(e) =>
+          pinnedPath != null && pinnedPath === e.source
+            ? "bg-[var(--color-accent-muted)]/30"
+            : undefined
+        }
+        {...(onPinToggle
+          ? { onRowClick: (e) => onPinToggle(pinnedPath === e.source ? null : e.source) }
+          : {})}
+        {...(onHover ? { onRowHover: (e) => onHover(e.source) } : {})}
+        sortField={sortKey}
+        sortOrder={sortDir}
+        onSort={toggleSort}
+        stacked="md"
+        virtualize={VIRTUALIZE}
+        caption="Change-coupling pairs"
       />
     </div>
   );

--- a/packages/ui/src/dashboard/coupling-mini-card.tsx
+++ b/packages/ui/src/dashboard/coupling-mini-card.tsx
@@ -3,6 +3,7 @@
 import * as React from "react";
 import { ArrowRight, GitMerge } from "lucide-react";
 import { Card } from "../ui/card";
+import { disambiguateBasenames } from "../lib/format";
 import type { CouplingEdge } from "@repowise-dev/types/coupling";
 
 /** Injected link component (e.g. Next's Link); defaults to a plain anchor. */
@@ -21,10 +22,6 @@ export interface CouplingMiniCardProps {
   LinkComponent?: LinkLike;
 }
 
-function basename(path: string): string {
-  return path.split("/").pop() ?? path;
-}
-
 /**
  * Overview front-door for the change-coupling view. The full diagram lives as
  * an Architecture tab (off the sidebar), so this card gives it a landing-page
@@ -37,6 +34,8 @@ export function CouplingMiniCard({ edges, href, LinkComponent }: CouplingMiniCar
   const Link: LinkLike = LinkComponent ?? "a";
   const top = edges.slice(0, 3);
   const maxStrength = Math.max(...top.map((e) => e.strength), 1);
+  // Labelled against the pairs actually shown, so no line repeats a name.
+  const labels = disambiguateBasenames(top.flatMap((e) => [e.source, e.target]));
 
   return (
     <Card className="overflow-hidden">
@@ -60,9 +59,9 @@ export function CouplingMiniCard({ edges, href, LinkComponent }: CouplingMiniCar
                   className="truncate font-mono text-xs text-[var(--color-text-secondary)]"
                   title={`${e.source} ↔ ${e.target}`}
                 >
-                  {basename(e.source)}
+                  {labels.get(e.source) ?? e.source}
                   <span className="text-[var(--color-text-tertiary)]"> ↔ </span>
-                  {basename(e.target)}
+                  {labels.get(e.target) ?? e.target}
                 </div>
                 <div className="h-1 w-full overflow-hidden rounded-full bg-[var(--color-bg-inset)]">
                   <div

--- a/packages/ui/src/git/co-change-list.tsx
+++ b/packages/ui/src/git/co-change-list.tsx
@@ -17,7 +17,9 @@ export function CoChangeList({ partners, previewCount = 5 }: CoChangeListProps) 
   const [expanded, setExpanded] = useState(false);
   if (partners.length === 0) return null;
 
-  const maxCount = Math.max(...partners.map((p) => p.co_change_count));
+  // `reduce`, not a spread: the partner list is uncapped, and a long one
+  // overflows the call stack as an argument list.
+  const maxCount = partners.reduce((m, p) => Math.max(m, p.co_change_count), 0);
   const visible = expanded ? partners : partners.slice(0, previewCount);
   const hidden = partners.length - visible.length;
 

--- a/packages/ui/src/graph/graph-flow.tsx
+++ b/packages/ui/src/graph/graph-flow.tsx
@@ -1130,9 +1130,10 @@ export function GraphFlow(props: GraphFlowProps) {
         />
       </div>
 
-      {/* Path Finder */}
+      {/* Path Finder. Carries the same viewport clamp as the flows panel below;
+          without it the panel runs off the side of a phone. */}
       {showPathFinder && renderPathFinder && (
-        <div className="absolute top-14 right-3 z-10">
+        <div className="absolute top-14 right-3 z-10 w-[min(20rem,calc(100vw-1.5rem))]">
           {renderPathFinder({
             initialFrom: pathFrom,
             initialTo: pathTo,

--- a/packages/ui/src/graph/graph-toolbar.tsx
+++ b/packages/ui/src/graph/graph-toolbar.tsx
@@ -426,7 +426,7 @@ export const GraphToolbar = memo(function GraphToolbar({
           onKeyDown={onSearchKeyDown}
           placeholder="Search nodes…"
           aria-label="Search graph nodes"
-          className="w-28 bg-transparent text-xs text-[var(--color-text-primary)] outline-none placeholder:text-[var(--color-text-tertiary)] lg:w-40"
+          className="w-full min-w-0 sm:w-28 bg-transparent text-xs text-[var(--color-text-primary)] outline-none placeholder:text-[var(--color-text-tertiary)] lg:w-40"
         />
         {searchQuery && searchMatchCount != null && searchTotalCount != null && (
           <span className="whitespace-nowrap font-mono text-[10px] tabular-nums text-[var(--color-text-tertiary)]">

--- a/packages/ui/src/graph/sigma/sigma-controls.tsx
+++ b/packages/ui/src/graph/sigma/sigma-controls.tsx
@@ -28,8 +28,11 @@ export function SigmaControls({
   // palette in this app — the same class of drift as `--color-bg-glass`, and
   // it survived for the same reason: it only ever renders on top of a diagram,
   // where a plane one step off reads as deliberate.
+  // Mobile-first sizing, matching graph-toolbar's buttons: 36px is a usable
+  // touch target on a phone, and the compact 28px returns from `sm` up where a
+  // pointer is doing the aiming.
   const btnClass =
-    "flex h-7 w-7 items-center justify-center rounded-md text-[var(--color-text-tertiary)] transition-colors hover:bg-[var(--color-bg-wash-hover)] hover:text-[var(--color-text-primary)]";
+    "flex h-9 w-9 sm:h-7 sm:w-7 items-center justify-center rounded-md text-[var(--color-text-tertiary)] transition-colors hover:bg-[var(--color-bg-wash-hover)] hover:text-[var(--color-text-primary)]";
 
   return (
     <div className="absolute bottom-3 right-3 z-10 flex flex-col items-end gap-1.5">

--- a/packages/ui/src/lib/format.ts
+++ b/packages/ui/src/lib/format.ts
@@ -134,6 +134,49 @@ export function truncatePath(path: string, maxChars = 60): string {
   return filename.length <= maxChars ? `…/${filename}` : `…${filename.slice(-(maxChars - 1))}`;
 }
 
+/**
+ * Shortest labels that still tell a set of paths apart: `src/css/mod.rs` and
+ * `src/text/mod.rs` become `css/mod.rs` and `text/mod.rs`, while a path whose
+ * basename is already unique keeps it. Each path grows by one trailing segment
+ * per round until it is unique or has no segments left.
+ *
+ * Prefer {@link truncatePath} for a path shown on its own; this is for many
+ * paths displayed side by side, where a bare basename can be ambiguous.
+ */
+export function disambiguateBasenames(paths: Iterable<string>): Map<string, string> {
+  const labels = new Map<string, string>();
+  const unique = [...new Set(paths)];
+
+  // Segments in use, grown only for the paths still tied at this depth.
+  let depth = 1;
+  let pending = unique;
+  while (pending.length > 0) {
+    const byLabel = new Map<string, string[]>();
+    for (const path of pending) {
+      const label = path.split("/").slice(-depth).join("/");
+      const group = byLabel.get(label);
+      if (group) group.push(path);
+      else byLabel.set(label, [path]);
+    }
+
+    const stillTied: string[] = [];
+    for (const [label, group] of byLabel) {
+      // One path holds this label, or the group is already shown in full:
+      // unreachable for a deduplicated set, but it bounds the loop.
+      const exhausted = group.every((p) => p.split("/").length <= depth);
+      if (group.length === 1 || exhausted) {
+        for (const path of group) labels.set(path, label);
+      } else {
+        stillTied.push(...group);
+      }
+    }
+    pending = stillTied;
+    depth += 1;
+  }
+
+  return labels;
+}
+
 /** Format age in days to split units: 45 → "1 month 15 days", 400 → "1 year 1 month" */
 export function formatAgeDays(n: number): string {
   if (n < 1) return "< 1 day";

--- a/packages/ui/src/shared/responsive-table/responsive-table.tsx
+++ b/packages/ui/src/shared/responsive-table/responsive-table.tsx
@@ -64,6 +64,12 @@ export interface ResponsiveTableProps<T> {
   rows: T[];
   rowKey: (row: T) => string;
   onRowClick?: ((row: T) => void) | undefined;
+  /**
+   * Pointer entered a row, for tables paired with a view that highlights it.
+   * Pointer-only, so never make it the sole route to information: pair it with
+   * `onRowClick`, which also works on touch.
+   */
+  onRowHover?: ((row: T) => void) | undefined;
   selectedKey?: string | null | undefined;
   /** Extra per-row classes — e.g. a multi-select highlight `selectedKey` can't express. */
   rowClassName?: ((row: T) => string | undefined) | undefined;
@@ -140,6 +146,7 @@ export function ResponsiveTable<T>({
   rows,
   rowKey,
   onRowClick,
+  onRowHover,
   selectedKey,
   rowClassName,
   virtualize,
@@ -275,6 +282,7 @@ export function ResponsiveTable<T>({
                   onRowClick && CLICKABLE_ROW_CLS,
                   rowClassName?.(row),
                 )}
+                onMouseEnter={onRowHover ? () => onRowHover(row) : undefined}
                 {...(onRowClick ? clickableRowProps(() => onRowClick(row)) : {})}
               >
                 {columns.map((c) => (
@@ -327,6 +335,7 @@ export function ResponsiveTable<T>({
                 onRowClick && cn("hover:bg-[var(--color-bg-elevated)]", CLICKABLE_ROW_CLS),
                 rowClassName?.(row),
               )}
+              onMouseEnter={onRowHover ? () => onRowHover(row) : undefined}
               {...(onRowClick ? clickableRowProps(() => onRowClick(row)) : {})}
             >
               <div className="text-sm text-[var(--color-text-primary)]">

--- a/packages/web/src/app/repos/[id]/architecture/page.tsx
+++ b/packages/web/src/app/repos/[id]/architecture/page.tsx
@@ -42,6 +42,7 @@ import { useRouter } from "next/navigation";
 import { useQueryState, parseAsStringLiteral } from "nuqs";
 import { Code2 } from "lucide-react";
 import { ViewTabs } from "@repowise-dev/ui/shared/view-tabs";
+import { ErrorBoundary } from "@repowise-dev/ui/shared";
 import { GraphView } from "@/components/architecture/graph-view";
 import { DependenciesView } from "@/components/architecture/dependencies-view";
 import { SymbolTableWrapper as SymbolTable } from "@/components/symbols/symbol-table-wrapper";
@@ -206,7 +207,11 @@ export default function ArchitecturePage({
                 {COUPLING_DISCLAIMER}
               </p>
             </div>
-            <CouplingTab repoId={repoId} />
+            {/* Contain a render throw to the tab instead of letting it reach
+                the route boundary and blank the page. */}
+            <ErrorBoundary title="Couldn't load change coupling">
+              <CouplingTab repoId={repoId} />
+            </ErrorBoundary>
           </div>
         )}
       </div>


### PR DESCRIPTION
## What

A coupling payload missing `nodes`/`edges` took down the whole architecture
route. Three independent faults had to line up, and all three are fixed here.
Also: the coupling labels that render as a column of `mod.rs`, and the table and
diagram on a phone.

## The crash

**The data.** `getCoupling` passed the payload straight through, so one arriving
without `nodes` or `edges` reached the explorer intact. `CouplingGraphResponse`
declares both required, so nothing upstream forced a guard and the first
iteration threw during render. It is now normalized through a `WireCoupling`
type with optional fields, the same shape `getFilesIndex` and
`getHealthOverview` already use. The explorer keeps a render-time fallback
covering all six dereferences, three of which were not in the original report.

**The blast radius.** A render throw escaped to the route boundary and blanked
the page. `CouplingTab` is now wrapped in an `ErrorBoundary`, as every tab in
`stats-tabs` already was.

**The second crash.** `Math.max(...edges.map(...))` spread the entire edge list
as arguments; the list is not capped client-side, so a large repo overflowed the
call stack. Replaced with `reduce` here and in the co-change list.

`CouplingGraphResponse` deliberately stays non-optional. The wire is what lies,
so the wire type is where the optionality belongs. Relaxing the shared type
would push a `?? []` into every consumer to compensate for one producer.

## Labels

Five components had each hand-rolled `path.split("/").pop()`, which renders as a
column of `mod.rs` in any language with a per-directory entry file. The only
collision-aware logic in the codebase was a closure inside a render body that
walked up a single parent, so `x/a/mod.rs` and `y/a/mod.rs` still collided. It
is now `disambiguateBasenames` in `lib/format.ts`, walking up as far as it
takes, and the local copies are gone. `truncatePath` gains the test coverage it
never had.

## Mobile

The table moves from `VirtualizedTable` to `ResponsiveTable`, which already
windows through the same hook, so this keeps the windowing and gains the stacked
cards. Below `md` the table had collapsed to a single column with its sort
controls stranded inside hidden cells. `ResponsiveTable` gains an optional
`onRowHover` so the row-to-diagram peek survives the migration.

The diagram's dots are a few viewBox units, so on a phone a tap missed them, hit
the background rect and cleared the trace. Nodes get an invisible tap target
sized to the arc each one owns. The legend wraps instead of forcing overflow,
and the empty state is sized against the viewport rather than the diagram's
coordinate space.

`GraphCanvasShell` is dropped from the explorer. It hosts fixed-height canvases
behind an `overflow-hidden` body; this diagram is an intrinsically sized SVG,
which is why it needed a `block h-auto` override, and that override left the
inner clipping live.

Also touch-sized zoom controls, the viewport clamp the flows panel already had
applied to the path finder, and small-screen sizing for the graph search input.

## Behavior

No API change. A well-formed payload renders identically. A malformed one now
renders an empty coupling view instead of a blank page.

## Verification

- `packages/ui`: 1311 tests pass, typecheck clean.
- `packages/api-client`: 54 pass, including three new cases pinning the
  normalization.
- `packages/web`: typecheck and lint clean.

Stacked mode keeps both the table and card trees in the DOM for CSS to pick
between, so the coupling tests scope their queries with
`within(getByRole("table"))`, matching the convention the dead-code tests use.