### PR TITLE
Add Railway deployment config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,89 @@
+# =============================================================================
+# repowise — Railway deployment image
+# =============================================================================
+# Derived from docker/Dockerfile, with three deployment-specific changes:
+#
+#   1. NEXT_PUBLIC_REPOWISE_API_URL is empty at build time, so the browser
+#      bundle issues same-origin requests. Railway publishes exactly one port
+#      per service, so the backend (7337) is not reachable from the internet —
+#      all browser traffic must go through the Next.js server on 3000, whose
+#      middleware rewrites /api/*, /health and /metrics to the local backend.
+#
+#   2. A wrapper entrypoint fixes ownership of the Railway volume mounted at
+#      /data (volumes attach as root) before dropping to the non-root user,
+#      and maps Railway's injected $PORT onto PORT_FRONTEND.
+#
+#   3. The postgres extra is installed so REPOWISE_DB_URL can point at a
+#      Railway PostgreSQL service without rebuilding the image.
+# =============================================================================
+
+FROM node:20-bookworm-slim AS frontend-builder
+
+WORKDIR /app
+
+COPY package.json package-lock.json* ./
+
+COPY packages/web/package.json        ./packages/web/package.json
+COPY packages/types/package.json      ./packages/types/package.json
+COPY packages/ui/package.json         ./packages/ui/package.json
+COPY packages/api-client/package.json ./packages/api-client/package.json
+
+WORKDIR /app/packages/web
+RUN npm install --production=false
+
+WORKDIR /app
+COPY packages/ ./packages/
+
+WORKDIR /app/packages/web
+ENV NEXT_TELEMETRY_DISABLED=1
+# Empty => relative URLs from the browser, proxied by src/middleware.ts.
+ENV NEXT_PUBLIC_REPOWISE_API_URL=""
+RUN npm run build
+
+# ---------------------------------------------------------------------------
+# Stage 2: Python backend + frontend runtime
+# ---------------------------------------------------------------------------
+FROM python:3.12-slim AS runtime
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=frontend-builder /usr/local/bin/node /usr/local/bin/node
+COPY --from=frontend-builder /usr/local/lib/node_modules /usr/local/lib/node_modules
+RUN ln -sf /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm
+
+WORKDIR /app
+
+COPY pyproject.toml README.md LICENSE MANIFEST.in ./
+COPY packages/core/ packages/core/
+COPY packages/cli/ packages/cli/
+COPY packages/server/ packages/server/
+RUN pip install --no-cache-dir ".[postgres]"
+
+COPY --from=frontend-builder /app/packages/web/.next/standalone /app/web
+COPY --from=frontend-builder /app/packages/web/.next/static /app/web/packages/web/.next/static
+COPY --from=frontend-builder /app/packages/web/public /app/web/packages/web/public
+
+RUN mkdir -p /data
+
+ENV REPOWISE_DB_URL=sqlite+aiosqlite:////data/wiki.db
+ENV LANCEDB_PATH=/data/lancedb
+ENV GRAPH_PATH=/data/graphs
+ENV REPOWISE_EMBEDDER=mock
+ENV PORT_BACKEND=7337
+ENV PORT_FRONTEND=3000
+ENV HOSTNAME=0.0.0.0
+
+EXPOSE 3000
+
+COPY docker/entrypoint.sh /app/entrypoint.sh
+COPY docker/railway-entrypoint.sh /app/railway-entrypoint.sh
+RUN chmod +x /app/entrypoint.sh /app/railway-entrypoint.sh
+
+RUN groupadd -r repowise && useradd -r -g repowise -d /app -s /sbin/nologin repowise \
+    && chown -R repowise:repowise /app /data
+
+# Starts as root only long enough to chown the mounted volume, then execs the
+# real entrypoint as the unprivileged repowise user.
+ENTRYPOINT ["/app/railway-entrypoint.sh"]

--- a/docker/railway-entrypoint.sh
+++ b/docker/railway-entrypoint.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Railway wrapper around docker/entrypoint.sh.
+#
+# Runs as root for two things the base entrypoint cannot do for itself, then
+# hands off to it as the unprivileged `repowise` user:
+#
+#   * Railway attaches persistent volumes owned by root, so /data would be
+#     unwritable to a non-root process. chown it on every boot — it is cheap
+#     when ownership is already correct.
+#   * Railway injects $PORT and expects the service to listen on it. The base
+#     entrypoint reads PORT_FRONTEND, so map one onto the other.
+set -e
+
+export PORT_FRONTEND="${PORT:-${PORT_FRONTEND:-3000}}"
+export PORT_BACKEND="${PORT_BACKEND:-7337}"
+
+mkdir -p /data
+chown -R repowise:repowise /data 2>/dev/null || \
+  echo "WARNING: could not chown /data; the volume may be read-only for the app user."
+
+# Already unprivileged (Railway can be configured to run as non-root): just go.
+if [ "$(id -u)" != "0" ]; then
+  exec /app/entrypoint.sh
+fi
+
+# Drop privileges with whichever util-linux helper the base image ships.
+if command -v setpriv >/dev/null 2>&1; then
+  exec setpriv --reuid=repowise --regid=repowise --init-groups /app/entrypoint.sh
+elif command -v runuser >/dev/null 2>&1; then
+  exec runuser -u repowise -- /app/entrypoint.sh
+elif command -v su >/dev/null 2>&1; then
+  exec su -s /bin/bash repowise -c /app/entrypoint.sh
+fi
+
+echo "WARNING: no privilege-drop helper found; running as root."
+exec /app/entrypoint.sh

--- a/railway.json
+++ b/railway.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://railway.app/railway.schema.json",
+  "build": {
+    "builder": "DOCKERFILE",
+    "dockerfilePath": "Dockerfile"
+  },
+  "deploy": {
+    "healthcheckPath": "/health",
+    "healthcheckTimeout": 300,
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 3
+  }
+}


### PR DESCRIPTION
The image under docker/ cannot run on Railway unchanged. This adds a Railway-specific build alongside it, leaving the existing Docker and docker-compose setups untouched.

Three things needed to differ:

* Railway publishes exactly one port per service, but docker/Dockerfile bakes NEXT_PUBLIC_REPOWISE_API_URL=http://localhost:7337 into the browser bundle, which only resolves when both ports are published to the client's own machine. Building with it empty makes the browser issue same-origin requests that packages/web/src/middleware.ts rewrites to the backend on localhost, so only port 3000 is exposed.

* Railway attaches volumes root-owned while the image runs as the non-root repowise user, leaving /data unwritable. The wrapper entrypoint chowns the mount and maps Railway's injected $PORT onto PORT_FRONTEND, then drops privileges and execs the original entrypoint, so the deployed process stays unprivileged.

* Railway falls through to Railpack auto-detection on this Python+Node monorepo and fails, so the Dockerfile sits at the repo root and railway.json pins the Dockerfile builder plus a /health healthcheck.

Verified by building the image and booting it against a root-owned volume: both servers start as uid 999, /data/wiki.db is created, /health returns 200 through the proxy, and /api/repos returns 401 without a key, 401 with a wrong key, and 200 with the right one.

Note that REPOWISE_API_KEY is required for this deployment, not optional. Without it the backend serves any loopback caller, and the Next.js middleware proxies from loopback, so the public URL would reach the whole API unauthenticated.

## Summary

<!-- What does this PR do? Keep it to 1-3 bullet points. -->

-

## Related Issues

<!-- Link any related issues: Fixes #123, Closes #456 -->

## Test Plan

<!-- How did you verify this works? -->

- [ ] Tests pass (`pytest`)
- [ ] Lint passes (`ruff check .`)
- [ ] Web build passes (`npm run build`) *(if frontend changes)*

## Checklist

- [ ] My code follows the project's code style
- [ ] I have added tests for new functionality
- [ ] All existing tests still pass
- [ ] I have updated documentation if needed
