### PR TITLE
fix(cli): restore the space in the dynamic-hint failure message

### DIFF
--- a/packages/core/src/repowise/core/pipeline/incremental.py
+++ b/packages/core/src/repowise/core/pipeline/incremental.py
@@ -214,7 +214,7 @@ def build_repo_graph(
     except Exception as exc:
         logger.warning("dynamic_hints_extraction_failed", error=str(exc))
         log(
-            f"[yellow]Dynamic hint extraction failed: {exc}. Dynamic edges"
+            f"[yellow]Dynamic hint extraction failed: {exc}. Dynamic edges "
             "will be missing from this update.[/yellow]"
         )
 


### PR DESCRIPTION
The two adjacent string literals in `_extract_dynamic_hints` join with no separator, so the warning renders as:

```
Dynamic hint extraction failed: <exc>. Dynamic edgeswill be missing from this update.
```

`packages/core/src/repowise/core/pipeline/incremental.py:217`:

```python
f"[yellow]Dynamic hint extraction failed: {exc}. Dynamic edges"
"will be missing from this update.[/yellow]"
```

The trailing space belongs on the first literal. One character.

## Credit

Spotted by @Shivang9983 on #1772. I said on that thread I would take it rather than send them round again, so this is that.

## Test Plan

- [x] Lint passes (`ruff check .`)
- [x] No test asserts on this string (`grep` over `tests/` for the message finds nothing)
- [ ] Web build passes - no frontend changes