### PR TITLE
feat(perf): name a repeated-cost cause by its caller, not just its sink

### DIFF
--- a/packages/core/src/repowise/core/analysis/health/engine.py
+++ b/packages/core/src/repowise/core/analysis/health/engine.py
@@ -88,26 +88,13 @@ log = structlog.get_logger(__name__)
 # Not a licence to move a calibrated scoring weight — those are frozen
 # independently of this stamp.
 #
-# 2: ``untested_hotspot`` gained a second test signal, and the persisted
-# ``has_test_file`` widened to match it. Both stored values are wrong on an
-# index built before that, and wrong in the direction that accuses a tested
-# file, so they should not wait out the decay timer.
-# 3: that signal moved from the import graph to the call graph, so the same two
-# values are wrong again on an index stamped 2 - this time in both directions.
-# 4: performance now uses reliable execution edges and exact call-site identity,
-# so cross-function findings produced by the calls-only graph must be refreshed.
-# 5: raw performance findings gain stable causal linkage and structured
-# performance-fix plans; incremental execution slices widen to preserve those
-# interprocedural interpretations.
-# 6: five complexity and test-detection inputs changed at once, so the stored
-# metrics disagree with what the current analyzer would compute. Python ``match``
-# arms now count toward cyclomatic complexity and Pascal else-if chains flatten
-# instead of nesting, moving ``max_ccn`` and ``max_nesting``; a comment inside a
-# parameter list is no longer counted as a parameter; and two test-detection
-# fixes (a pairing heuristic the name match could not see, and Delphi's
-# ``Test<Stem>.dpr`` convention) move ``has_test_file`` in the direction that
-# stops accusing a tested file.
-HEALTH_ANALYZER_VERSION = 6
+# Current stamp: the performance identity kernel moved to model version 2. A
+# cross-function cause is now named by the caller that repeats the work as well
+# as the sink that pays for it, so a shared infrastructure helper no longer
+# merges unrelated workflows, and execution context gained ``unknown`` instead of
+# defaulting an unclassifiable file to production. Stored opportunity ids and
+# plan links are restamped by the rescore this forces.
+HEALTH_ANALYZER_VERSION = 7
 
 # Method-level smells that make the dataflow / Extract Method pass worthwhile.
 # Only files carrying one of these get a CFG + def/use + reaching pass built.

--- a/packages/core/src/repowise/core/analysis/health/perf/__init__.py
+++ b/packages/core/src/repowise/core/analysis/health/perf/__init__.py
@@ -16,7 +16,7 @@ This package holds:
   :mod:`.opportunities` is its public face, over :mod:`.facts` (typed evidence
   read off a row), :mod:`.causal` (grouping and the versioned identity kernel),
   :mod:`.actionability` (whether the evidence supports naming a change), and
-  :mod:`.opportunity_rank` (the ordering policy).
+  :mod:`.opportunity_rank` (how much it costs and in what order it lands).
 
 Nothing here touches persistence or transport. Stored rows arrive through the
 same attribute adapter analyzer dataclasses do.
@@ -30,16 +30,19 @@ from .dialects import PERF_DIALECTS, BasePerfDialect
 from .gated import collect_blocking_io_under_lock, collect_centrality_gated
 from .io_boundaries import collect_io_names
 from .opportunities import (
+    PERFORMANCE_MODEL_VERSION,
     PerformanceFix,
     PerformanceOpportunity,
     build_performance_opportunities,
     link_performance_findings,
+    model_state,
 )
 from .promotion import apply_perf_promotions
 from .ranking import PerfRanker
 from .reachability import ReachInfo, path_to_sink, reachable_to_sink
 
 __all__ = [
+    "PERFORMANCE_MODEL_VERSION",
     "PERF_DIALECTS",
     "BasePerfDialect",
     "CallGraphIndex",
@@ -54,6 +57,7 @@ __all__ = [
     "collect_crossfn_io_in_loop",
     "collect_io_names",
     "link_performance_findings",
+    "model_state",
     "path_to_sink",
     "reachable_to_sink",
 ]

--- a/packages/core/src/repowise/core/analysis/health/perf/actionability.py
+++ b/packages/core/src/repowise/core/analysis/health/perf/actionability.py
@@ -1,20 +1,27 @@
 """Whether a group's evidence supports naming one safe change.
 
-Proven repetition is not proof that removing it is valid. Every gate returns
-``None`` rather than a weaker plan when it cannot prove its precondition,
-because a wrong plan costs more than a missing one.
+Proven repetition is not proof that removing it is valid. Every gate declines
+rather than offering a weaker plan, because a wrong plan costs more than a
+missing one, and every refusal names the fact that would settle it.
 
-The confidence here is evidence confidence: how reliably the call path was
-resolved, not whether the change is safe. That is :attr:`PerformanceFix.safety`.
+Three separate questions live here and must not collapse into one label:
+
+* evidence confidence, :func:`provenance_confidence`, asks how reliably the
+  call path was resolved;
+* fix safety, :attr:`PerformanceFix.safety`, asks how strongly the specific
+  transformation is proven;
+* actionability, :func:`actionability`, asks what to do with the group now, and
+  demotes a proven strategy whose evidence is weak.
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Any, Literal
 
 FixSafety = Literal["proven", "advisory"]
 OpportunityConfidence = Literal["high", "medium", "low"]
+ActionabilityState = Literal["plan_ready", "advisory", "investigate"]
 FixStrategy = Literal[
     "parallelize_independent_awaits",
     "replace_membership_collection",
@@ -23,6 +30,9 @@ FixStrategy = Literal[
     "batch_or_prefetch_io",
     "shrink_lock_scope",
 ]
+
+BATCHABLE_MARKERS = frozenset({"io_in_loop", "nested_loop_with_io"})
+BATCHABLE_BOUNDARIES = frozenset({"db", "network"})
 
 
 @dataclass(frozen=True, slots=True)
@@ -35,8 +45,44 @@ class PerformanceFix:
         return {"strategy": self.strategy, "safety": self.safety, "rationale": self.rationale}
 
 
+@dataclass(frozen=True, slots=True)
+class FixAssessment:
+    """The strategy this group supports, and what is still unproven.
+
+    Prerequisites are stable machine tokens rather than prose: a caller renders
+    them, and a new detector fact is expected to clear one by name. They are
+    populated whether or not a fix was returned, because an offered advisory
+    strategy has open questions too.
+    """
+
+    fix: PerformanceFix | None
+    prerequisites: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class Actionability:
+    """The verdict the rest of the system acts on.
+
+    It carries the fix as well as the label, because a demotion that moved only
+    the label would leave the plan layer reading the undemoted strategy and
+    stamping it with the confidence the demotion just withdrew.
+    """
+
+    state: ActionabilityState
+    reason: str
+    confidence: OpportunityConfidence
+    prerequisites: tuple[str, ...]
+    fix: PerformanceFix | None
+
+
 def provenance_confidence(provenance: str) -> OpportunityConfidence:
-    """Product confidence label owned beside the provenance ranking policy."""
+    """Evidence confidence: how reliably the resolved call path holds.
+
+    Only the first interprocedural hop carries a resolution basis. Deeper hops
+    are unlabelled edges that already passed the graph's reliability filter, so
+    this describes the labelled hop alone and is never presented as a verdict
+    on the whole path.
+    """
     if provenance in {"call-site", "direct"}:
         return "high"
     if provenance == "reliable-edge":
@@ -44,80 +90,142 @@ def provenance_confidence(provenance: str) -> OpportunityConfidence:
     return "low"
 
 
-def fix_for(
+def assess_fix(
     marker: str,
     markers: tuple[str, ...],
     boundary: str | None,
     details: list[dict[str, Any]],
     *,
     cross_function: bool,
-    shared_suffix: tuple[str, ...],
-) -> PerformanceFix | None:
-    """The one strategy this group's evidence supports, or nothing.
+) -> FixAssessment:
+    """The one strategy this group's evidence supports, or the missing fact.
 
     Gate order is load-bearing: marker-specific proofs run before the generic
     batching fallback, so a group that qualifies for a proven transformation is
-    never downgraded to an advisory one.
+    never downgraded to an advisory one. That ordering is why this stays an
+    explicit ladder rather than a lookup table; its branch count is the number
+    of markers, and it is the one place a wrong answer ships a wrong edit.
     """
-    if marker == "serial_await_in_loop" and all(d.get("dataflow_verified") for d in details):
-        return PerformanceFix(
-            "parallelize_independent_awaits",
-            "proven",
-            "Dataflow proves that every observed loop carries no cross-iteration dependence.",
+    if marker == "serial_await_in_loop":
+        if not all(detail.get("dataflow_verified") for detail in details):
+            return FixAssessment(None, ("loop_carried_dependence_proof",))
+        return FixAssessment(
+            PerformanceFix(
+                "parallelize_independent_awaits",
+                "proven",
+                "Dataflow proves that every observed loop carries no cross-iteration dependence.",
+            ),
+            (),
         )
     if marker == "membership_test_against_list_in_loop":
-        return PerformanceFix(
-            "replace_membership_collection",
-            "advisory",
-            "The collection is proven list-backed; element hashability and ordering/identity use still require validation.",
+        return FixAssessment(
+            PerformanceFix(
+                "replace_membership_collection",
+                "advisory",
+                "The collection is proven list-backed; element hashability and "
+                "ordering/identity use still require validation.",
+            ),
+            ("element_hashability", "ordering_and_identity_use"),
         )
     if marker == "string_concat_in_loop":
-        return PerformanceFix(
-            "buffer_string_accumulation",
-            "advisory",
-            "Repeated string accumulation is proven; intermediate accumulator observations still require validation.",
+        return FixAssessment(
+            PerformanceFix(
+                "buffer_string_accumulation",
+                "advisory",
+                "Repeated string accumulation is proven; intermediate accumulator "
+                "observations still require validation.",
+            ),
+            ("accumulator_not_observed",),
         )
-    if set(markers) <= {"io_in_loop", "nested_loop_with_io"} and boundary in {
-        "db",
-        "network",
-    }:
-        if cross_function and len(shared_suffix) < 2:
-            # A generic sink shared by otherwise unrelated callers is evidence
-            # of repeated cost, not proof that editing it is one coherent
-            # intervention. Stay visible without claiming a batch plan.
-            return None
-        return PerformanceFix(
-            "batch_or_prefetch_io",
-            "advisory",
-            "The shared I/O sink is proven; no concrete batch API or result-equivalence proof is available.",
+    if set(markers) <= BATCHABLE_MARKERS:
+        if boundary not in BATCHABLE_BOUNDARIES:
+            # Filesystem and subprocess repetition is real, but there is no
+            # batch or prefetch operation to point the caller at.
+            return FixAssessment(None, ("batch_operation_for_boundary",))
+        return FixAssessment(
+            PerformanceFix(
+                "batch_or_prefetch_io",
+                "advisory",
+                "The shared I/O sink is proven; no concrete batch API or "
+                "result-equivalence proof is available.",
+            ),
+            ("batch_api_contract", "result_equivalence"),
         )
     if marker == "blocking_io_under_lock":
-        path_starts = {
+        owners = {
             path[0] for detail in details if (path := detail.get("path")) and isinstance(path, list)
         }
-        if cross_function and len(path_starts) != 1:
-            return None
-        return PerformanceFix(
-            "shrink_lock_scope",
+        if cross_function and len(owners) != 1:
+            return FixAssessment(None, ("single_lock_owner",))
+        return FixAssessment(
+            PerformanceFix(
+                "shrink_lock_scope",
+                "advisory",
+                "I/O under the lock is proven, but shared-state ordering must be "
+                "validated before moving it.",
+            ),
+            ("shared_state_ordering",),
+        )
+    if marker == "resource_construction_in_loop":
+        if not all(detail.get("resource_invariant") is True for detail in details):
+            return FixAssessment(None, ("loop_invariant_construction_proof",))
+        return FixAssessment(
+            PerformanceFix(
+                "hoist_loop_invariant_resource",
+                "proven",
+                "Dataflow proves construction arguments and lifetime are loop invariant.",
+            ),
+            (),
+        )
+    return FixAssessment(None, ("supported_strategy_for_marker",))
+
+
+def actionability(
+    assessment: FixAssessment, evidence_confidence: OpportunityConfidence
+) -> Actionability:
+    """What to do with this group next, and why not more.
+
+    Deliberately not a restatement of fix safety. A proven strategy resting on
+    a call path we could not resolve reliably is still only advisory, and the
+    demotion names the fact that would promote it. A group with no strategy is
+    kept as investigation evidence rather than dropped.
+    """
+    fix = assessment.fix
+    if fix is None:
+        return Actionability(
+            "investigate", "no_supported_strategy", "low", assessment.prerequisites, None
+        )
+    if evidence_confidence == "low":
+        # A transformation proven against a path we could not resolve is not
+        # proven against this code. The safety label moves with the verdict so
+        # the plan layer cannot read the withdrawn one.
+        return Actionability(
             "advisory",
-            "I/O under the lock is proven, but shared-state ordering must be validated before moving it.",
+            "low_evidence_confidence",
+            "low",
+            (*assessment.prerequisites, "reliable_call_path"),
+            replace(fix, safety="advisory") if fix.safety == "proven" else fix,
         )
-    if marker == "resource_construction_in_loop" and all(
-        d.get("resource_invariant") is True for d in details
-    ):
-        return PerformanceFix(
-            "hoist_loop_invariant_resource",
-            "proven",
-            "Dataflow proves construction arguments and lifetime are loop invariant.",
+    if fix.safety == "proven":
+        return Actionability(
+            "plan_ready", "proven_strategy", "high", assessment.prerequisites, fix
         )
-    return None
+    return Actionability(
+        "advisory", "strategy_requires_validation", "medium", assessment.prerequisites, fix
+    )
 
 
 __all__ = [
+    "BATCHABLE_BOUNDARIES",
+    "BATCHABLE_MARKERS",
+    "Actionability",
+    "ActionabilityState",
+    "FixAssessment",
     "FixSafety",
     "FixStrategy",
     "OpportunityConfidence",
     "PerformanceFix",
-    "fix_for",
+    "actionability",
+    "assess_fix",
     "provenance_confidence",
 ]

--- a/packages/core/src/repowise/core/analysis/health/perf/causal.py
+++ b/packages/core/src/repowise/core/analysis/health/perf/causal.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
 from collections import defaultdict
 from typing import Any, Literal
 
@@ -22,31 +23,66 @@ from repowise.core.test_paths import is_test_related_path
 
 from .facts import ObservationFacts, detail_map, is_performance, observation_facts
 
-PERFORMANCE_MODEL_VERSION = 1
+PERFORMANCE_MODEL_VERSION = 2
 """Version of the identity, grouping, actionability, and ranking semantics.
 
-Version 1 predates this constant, so it is deliberately not an input to
-:func:`stable_id`: embedding it would rewrite every persisted ``opportunity_id``
-and orphan every stored plan link for no semantic change. A later version may
-embed it, and must bump ``HEALTH_ANALYZER_VERSION`` with it.
+From version 2 the version is the id prefix rather than a hash input, so a
+stale id is recognisable without a lookup and :func:`model_state` can answer
+from the string alone. Version 1 ids carry no digit and remain readable as
+version 1. Moving this constant means bumping ``HEALTH_ANALYZER_VERSION`` with
+it, which forces the rescore that restamps every stored finding.
 """
 
-ExecutionContext = Literal["production", "tooling", "test"]
+ExecutionContext = Literal["production", "tooling", "test", "unknown"]
 
 CausalKey = tuple[Any, ...]
+
+_ID_PREFIX = "perf"
+_ID_PATTERN = re.compile(rf"^{_ID_PREFIX}(\d*)_[0-9a-f]{{20}}$")
 
 _TOOLING_PARTS = frozenset(
     {".github", "benchmarks", "build", "devtools", "scripts", "tooling", "tools"}
 )
 
+_UNCLASSIFIABLE_PARTS = frozenset(
+    {
+        "demo",
+        "demos",
+        "doc",
+        "docs",
+        "example",
+        "examples",
+        "sample",
+        "samples",
+        "third_party",
+        "thirdparty",
+        "vendor",
+    }
+)
+"""Directories that do not say whether their code ships.
+
+Reporting these as production would assert exposure the tree does not support,
+which is the one thing the fallback must not do.
+"""
+
 
 def execution_context(file_path: str) -> ExecutionContext:
-    """Where this code runs. An identity input, so it is classified once."""
+    """Where this code runs. An identity input, so it is classified once.
+
+    ``unknown`` is a positive answer, not a gap: a path with no directory, or
+    one under a directory whose execution role is genuinely ambiguous, carries
+    no evidence either way.
+    """
+    normalized = file_path.replace("\\", "/")
+    if not normalized:
+        return "unknown"
     if is_test_related_path(file_path):
         return "test"
-    parts = {part.lower() for part in file_path.replace("\\", "/").split("/")}
-    if parts & _TOOLING_PARTS or "/cli/" in f"/{file_path.lower().replace(chr(92), '/')}/":
+    parts = {part.lower() for part in normalized.split("/")}
+    if parts & _TOOLING_PARTS or "/cli/" in f"/{normalized.lower()}/":
         return "tooling"
+    if parts & _UNCLASSIFIABLE_PARTS or "/" not in normalized:
+        return "unknown"
     return "production"
 
 
@@ -58,25 +94,32 @@ def cost_shape(marker: str) -> str:
 
 
 def causal_key(facts: ObservationFacts) -> CausalKey:
-    """The v1 identity kernel.
+    """The v2 identity kernel.
 
-    The two branches are deliberately asymmetric. A cross-function cause is
-    named by its terminal sink, so a new caller adds evidence without renaming
-    the cause; a same-function one has no shared sink and is named by its own
-    location.
+    A cross-function cause is named by the pair the intervention lives in:
+    the sink that pays the cost and the caller that repeats it. Naming it by
+    the sink alone merged every workflow that happened to reach a shared
+    infrastructure helper, so a session opener reached from many unrelated
+    callers read as one cause. Requiring the caller to match splits those, and
+    leaves a genuinely shared helper merged however many callers reach it,
+    because they all reach the sink through that helper.
+
+    A same-function cause has no call path and is named by its own location.
 
     Everything outside these tuples is display or derived data and stays out:
     prose, line ends, storage ids, rank factors, confidence, reachability, and
     provenance.
     """
     context = execution_context(facts.file_path)
-    if facts.cross_function and facts.path:
+    predecessor = facts.meaningful_predecessor
+    if facts.cross_function and predecessor is not None:
         return (
             "cross-function",
             context,
             cost_shape(facts.marker),
             facts.boundary_kind,
-            facts.path[-1],
+            predecessor,
+            facts.terminal_sink,
         )
     return (
         "local",
@@ -91,7 +134,8 @@ def causal_key(facts: ObservationFacts) -> CausalKey:
 
 def stable_id(key: CausalKey) -> str:
     payload = json.dumps(key, separators=(",", ":"), ensure_ascii=True)
-    return "perf_" + hashlib.sha256(payload.encode("utf-8")).hexdigest()[:20]
+    digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()[:20]
+    return f"{_ID_PREFIX}{PERFORMANCE_MODEL_VERSION}_{digest}"
 
 
 def key_context(key: CausalKey) -> ExecutionContext:
@@ -106,6 +150,51 @@ def key_boundary(key: CausalKey) -> str | None:
 
 def key_is_cross_function(key: CausalKey) -> bool:
     return key[0] == "cross-function"
+
+
+def key_intervention_symbol(key: CausalKey) -> str | None:
+    """The caller the whole group shares, and therefore the place to edit."""
+    return key[4] if key_is_cross_function(key) else None
+
+
+def key_terminal_sink(key: CausalKey) -> str | None:
+    """The sink the whole group shares. Read off the key, never off a member."""
+    return key[5] if key_is_cross_function(key) else None
+
+
+def opportunity_id_model_version(opportunity_id: str) -> int | None:
+    """Which model minted this id, or nothing if it was not minted here.
+
+    Version 1 ids carry no digit; from version 2 the prefix names the model.
+    """
+    match = _ID_PATTERN.match(opportunity_id)
+    if match is None:
+        return None
+    return int(match.group(1)) if match.group(1) else 1
+
+
+def model_state(opportunity_id: str) -> dict[str, Any]:
+    """Whether an id can still be resolved, and what to do when it cannot.
+
+    Ids are not translated across models. Grouping decides membership, so a
+    v1 id can name observations that v2 splits several ways, and an alias would
+    have to invent which split the caller meant. Reporting the mismatch and the
+    refresh that fixes it is the only honest answer.
+    """
+    version = opportunity_id_model_version(opportunity_id)
+    if version == PERFORMANCE_MODEL_VERSION:
+        state = "current"
+    elif version is None:
+        state = "unrecognized"
+    else:
+        state = "stale_model"
+    return {
+        "state": state,
+        "opportunity_id": opportunity_id,
+        "requested_model_version": version,
+        "performance_model_version": PERFORMANCE_MODEL_VERSION,
+        "refresh_required": state == "stale_model",
+    }
 
 
 def opportunity_id_for_finding(row: Any) -> str:
@@ -164,9 +253,13 @@ __all__ = [
     "group_observations",
     "key_boundary",
     "key_context",
+    "key_intervention_symbol",
     "key_is_cross_function",
+    "key_terminal_sink",
     "link_performance_findings",
+    "model_state",
     "opportunity_id_for_finding",
+    "opportunity_id_model_version",
     "shared_path_suffix",
     "stable_id",
 ]

--- a/packages/core/src/repowise/core/analysis/health/perf/facts.py
+++ b/packages/core/src/repowise/core/analysis/health/perf/facts.py
@@ -77,6 +77,42 @@ class ObservationFacts:
         return str(self.resolution_basis)
 
     @property
+    def terminal_sink(self) -> str | None:
+        """The last resolved node on the path, or nothing if none survived.
+
+        ``has_path`` can be true while this is ``None``: a path offered with no
+        string nodes names no sink.
+        """
+        return self.path[-1] if self.path else None
+
+    @property
+    def meaningful_predecessor(self) -> str | None:
+        """The caller that creates the repetition at the sink.
+
+        The sink is where the cost is paid; its immediate caller is where the
+        repetition is introduced, so that caller is the intervention anchor.
+        A path with fewer than two resolved nodes names no caller and carries
+        no cross-function cause.
+        """
+        return self.path[-2] if len(self.path) >= 2 else None
+
+    @property
+    def path_depth(self) -> int:
+        """Resolved hops from the loop-owning function to the sink."""
+        return len(self.path)
+
+    @property
+    def resource_fingerprint(self) -> str | None:
+        """The named API this observation repeats, where a detector recorded one.
+
+        Only the blocking-sync-in-async marker records one today. No detector
+        captures argument, query, or path literals, so this is the whole of the
+        resource identity currently available.
+        """
+        value = self.details.get("api")
+        return value if isinstance(value, str) and value else None
+
+    @property
     def site(self) -> tuple[str, Any, Any]:
         return (self.file_path, self.line_start, self.function_name)
 
@@ -98,7 +134,7 @@ def observation_facts(row: Any) -> ObservationFacts:
         reason=str(field(row, "reason", "") or ""),
         raw_marker=field(row, "biomarker_type", ""),
         boundary_kind=details.get("boundary_kind") or None,
-        path=tuple(str(node) for node in raw_path if isinstance(node, str)),
+        path=tuple(node for node in raw_path if isinstance(node, str) and node),
         # Whether a path was offered, which is not whether any of it survived
         # the string filter above. Both drive real branches.
         has_path=bool(raw_path),

--- a/packages/core/src/repowise/core/analysis/health/perf/opportunities.py
+++ b/packages/core/src/repowise/core/analysis/health/perf/opportunities.py
@@ -10,8 +10,8 @@ This file is the public face of that model. The rules behind it live in four
 modules with one owner each: :mod:`.facts` reads a row, :mod:`.causal` decides
 what shares a cause and what that cause is called, :mod:`.actionability`
 decides whether the evidence supports naming a change, and
-:mod:`.opportunity_rank` decides the order. The orchestration below holds no
-policy of its own.
+:mod:`.opportunity_rank` decides how much it costs and in what order it lands.
+The orchestration below holds no policy of its own.
 """
 
 from __future__ import annotations
@@ -20,11 +20,13 @@ from dataclasses import dataclass
 from typing import Any
 
 from .actionability import (
+    ActionabilityState,
     FixSafety,
     FixStrategy,
     OpportunityConfidence,
     PerformanceFix,
-    fix_for,
+    actionability,
+    assess_fix,
     provenance_confidence,
 )
 from .causal import (
@@ -34,19 +36,42 @@ from .causal import (
     group_observations,
     key_boundary,
     key_context,
+    key_intervention_symbol,
     key_is_cross_function,
+    key_terminal_sink,
     link_performance_findings,
+    model_state,
     opportunity_id_for_finding,
+    opportunity_id_model_version,
     shared_path_suffix,
     stable_id,
 )
 from .facts import evidence_row
-from .opportunity_rank import dominant_marker, rank_factors, rank_sort_key, weakest_provenance
+from .opportunity_rank import (
+    amplification,
+    change_risk,
+    dominant_marker,
+    exposure,
+    leverage,
+    rank_factors,
+    rank_sort_key,
+    weakest_provenance,
+    why_ranked,
+)
 
 
 @dataclass(frozen=True, slots=True)
 class PerformanceOpportunity:
+    """One cause, its evidence, and what can be done about it.
+
+    Seven facets are reported separately and must not be read as one another.
+    Two of them keep the names callers already join on: ``confidence`` is
+    evidence confidence, and ``fix.safety`` is fix safety. The remaining five
+    live in ``facets``, so no number or label is published twice.
+    """
+
     opportunity_id: str
+    performance_model_version: int
     biomarker_type: str
     biomarker_types: tuple[str, ...]
     boundary_kind: str | None
@@ -54,6 +79,7 @@ class PerformanceOpportunity:
     terminal_sink: str | None
     shared_path_suffix: tuple[str, ...]
     intervention_symbol: str | None
+    resource_fingerprints: tuple[str, ...]
     affected_call_sites_total: int
     affected_files_total: int
     observations_total: int
@@ -62,13 +88,19 @@ class PerformanceOpportunity:
     reliable_entry_reachability: bool | None
     provenance: str
     confidence: OpportunityConfidence
+    facets: dict[str, str]
+    actionability_state: ActionabilityState
+    actionability_reason: str
+    prerequisites: tuple[str, ...]
     rank_score: int
     rank_factors: dict[str, int]
+    why_ranked: tuple[dict[str, Any], ...]
     fix: PerformanceFix | None
 
     def as_dict(self) -> dict[str, Any]:
         return {
             "opportunity_id": self.opportunity_id,
+            "performance_model_version": self.performance_model_version,
             "biomarker_type": self.biomarker_type,
             "biomarker_types": list(self.biomarker_types),
             "boundary_kind": self.boundary_kind,
@@ -76,6 +108,7 @@ class PerformanceOpportunity:
             "terminal_sink": self.terminal_sink,
             "shared_path_suffix": list(self.shared_path_suffix),
             "intervention_symbol": self.intervention_symbol,
+            "resource_fingerprints": list(self.resource_fingerprints),
             "affected_call_sites_total": self.affected_call_sites_total,
             "affected_files_total": self.affected_files_total,
             "observations_total": self.observations_total,
@@ -84,8 +117,13 @@ class PerformanceOpportunity:
             "reliable_entry_reachability": self.reliable_entry_reachability,
             "provenance": self.provenance,
             "confidence": self.confidence,
+            "facets": dict(self.facets),
+            "actionability_state": self.actionability_state,
+            "actionability_reason": self.actionability_reason,
+            "prerequisites": list(self.prerequisites),
             "rank_score": self.rank_score,
             "rank_factors": dict(self.rank_factors),
+            "why_ranked": [dict(entry) for entry in self.why_ranked],
             "fix": self.fix.as_dict() if self.fix else None,
         }
 
@@ -97,69 +135,102 @@ def _reachability(values: set[Any]) -> bool | None:
     return False if values == {False} else None
 
 
+def _assemble(key: Any, members: list[Any], cap: int) -> PerformanceOpportunity:
+    """Read one group's answers off its owners. Decides nothing itself.
+
+    Context, boundary, intervention symbol, and terminal sink are kernel
+    inputs, so the group already agrees on them by construction. Taking them
+    off the key keeps one owner for each instead of reclassifying a
+    representative row.
+    """
+    context = key_context(key)
+    boundary = key_boundary(key)
+    markers = tuple(sorted({facts.marker for facts in members}))
+    marker = dominant_marker(markers)
+    sites = {facts.site for facts in members}
+    files = {site[0] for site in sites}
+    provenance = weakest_provenance({facts.provenance for facts in members})
+    evidence_confidence = provenance_confidence(provenance)
+    reachable = _reachability({facts.reliable_entry_reachability for facts in members})
+    assessment = assess_fix(
+        marker,
+        markers,
+        boundary,
+        [facts.details for facts in members],
+        cross_function=key_is_cross_function(key),
+    )
+    acted = actionability(assessment, evidence_confidence)
+    factors = rank_factors(
+        marker=marker,
+        boundary=boundary,
+        context=context,
+        reachable=reachable,
+        site_count=len(sites),
+        provenance=provenance,
+    )
+    return PerformanceOpportunity(
+        opportunity_id=stable_id(key),
+        performance_model_version=PERFORMANCE_MODEL_VERSION,
+        biomarker_type=marker,
+        biomarker_types=markers,
+        boundary_kind=boundary,
+        execution_context=context,
+        terminal_sink=key_terminal_sink(key),
+        shared_path_suffix=shared_path_suffix([facts.path for facts in members if facts.path]),
+        intervention_symbol=key_intervention_symbol(key),
+        resource_fingerprints=tuple(
+            sorted({facts.resource_fingerprint for facts in members if facts.resource_fingerprint})
+        ),
+        affected_call_sites_total=len(sites),
+        affected_files_total=len(files),
+        observations_total=len(members),
+        evidence=tuple(evidence_row(facts) for facts in members[:cap]),
+        evidence_truncated=len(members) > cap,
+        reliable_entry_reachability=reachable,
+        provenance=provenance,
+        confidence=evidence_confidence,
+        facets={
+            "actionability_confidence": acted.confidence,
+            "exposure": exposure(reachable),
+            "amplification": amplification(marker),
+            "leverage": leverage(len(sites)),
+            "change_risk": change_risk(len(files)),
+        },
+        actionability_state=acted.state,
+        actionability_reason=acted.reason,
+        prerequisites=acted.prerequisites,
+        rank_score=sum(factors.values()),
+        rank_factors=factors,
+        why_ranked=why_ranked(
+            factors,
+            {
+                "multiplier_shape": marker,
+                "boundary_kind": boundary,
+                "execution_context": context,
+                "entry_reachability": reachable,
+                "affected_call_sites": len(sites),
+                "provenance": provenance,
+            },
+        ),
+        fix=acted.fix,
+    )
+
+
 def build_performance_opportunities(
     findings: list[Any], *, evidence_limit: int = 8
 ) -> list[PerformanceOpportunity]:
     """Group and rank performance rows in one deterministic pass."""
     cap = max(0, evidence_limit)
-    opportunities: list[PerformanceOpportunity] = []
-    for key, members in group_observations(findings).items():
-        # Context and boundary are kernel inputs, so the group already agrees on
-        # them by construction. Reading them off the key keeps one owner for the
-        # classification instead of reclassifying a representative row.
-        context = key_context(key)
-        boundary = key_boundary(key)
-        paths = [facts.path for facts in members if facts.has_path]
-        suffix = shared_path_suffix(paths)
-        markers = tuple(sorted({facts.marker for facts in members}))
-        marker = dominant_marker(markers)
-        sites = {facts.site for facts in members}
-        provenance = weakest_provenance({facts.provenance for facts in members})
-        reachable = _reachability({facts.reliable_entry_reachability for facts in members})
-        factors = rank_factors(
-            marker=marker,
-            boundary=boundary,
-            context=context,
-            reachable=reachable,
-            site_count=len(sites),
-            provenance=provenance,
-        )
-        opportunities.append(
-            PerformanceOpportunity(
-                opportunity_id=stable_id(key),
-                biomarker_type=marker,
-                biomarker_types=markers,
-                boundary_kind=boundary,
-                execution_context=context,
-                terminal_sink=paths[0][-1] if paths else None,
-                shared_path_suffix=suffix,
-                intervention_symbol=suffix[0] if suffix else None,
-                affected_call_sites_total=len(sites),
-                affected_files_total=len({site[0] for site in sites}),
-                observations_total=len(members),
-                evidence=tuple(evidence_row(facts) for facts in members[:cap]),
-                evidence_truncated=len(members) > cap,
-                reliable_entry_reachability=reachable,
-                provenance=provenance,
-                confidence=provenance_confidence(provenance),
-                rank_score=sum(factors.values()),
-                rank_factors=factors,
-                fix=fix_for(
-                    marker,
-                    markers,
-                    boundary,
-                    [facts.details for facts in members],
-                    cross_function=key_is_cross_function(key),
-                    shared_suffix=suffix,
-                ),
-            )
-        )
+    opportunities = [
+        _assemble(key, members, cap) for key, members in group_observations(findings).items()
+    ]
     opportunities.sort(key=rank_sort_key)
     return opportunities
 
 
 __all__ = [
     "PERFORMANCE_MODEL_VERSION",
+    "ActionabilityState",
     "FixSafety",
     "FixStrategy",
     "PerformanceFix",
@@ -167,6 +238,8 @@ __all__ = [
     "build_performance_opportunities",
     "execution_context",
     "link_performance_findings",
+    "model_state",
     "opportunity_id_for_finding",
+    "opportunity_id_model_version",
     "provenance_confidence",
 ]

--- a/packages/core/src/repowise/core/analysis/health/perf/opportunity_rank.py
+++ b/packages/core/src/repowise/core/analysis/health/perf/opportunity_rank.py
@@ -1,8 +1,17 @@
-"""Ordering policy: the weight tables and the total order over opportunities.
+"""Ordering policy: the magnitude facets, the weight tables, and the total order.
 
 Nothing here is a score in the health sense. No value produced by this module
 is blended into ``performance_score`` or any other dimension; it is an ordering
 key whose weights are frozen policy, not fitted parameters.
+
+This module owns every judgement about how much a group costs and how far a
+change to it reaches: the marker, boundary, context, and provenance tables and
+the four magnitude facets read off them. Whether a change is *safe* is the
+neighbouring module's question, and the only thing this one takes from it is
+the actionability state that orders actionable work first.
+
+Every input is already carried on the group. Ranking issues no query of its
+own, per opportunity or otherwise.
 """
 
 from __future__ import annotations
@@ -22,8 +31,39 @@ MULTIPLIER_POINTS = {
     "string_concat_in_loop": 3,
     "lock_in_loop": 2,
 }
-CONTEXT_POINTS = {"production": 3, "tooling": 2, "test": 1}
+CONTEXT_POINTS = {"production": 3, "tooling": 2, "test": 1, "unknown": 1}
 PROVENANCE_POINTS = {"call-site": 3, "direct": 3, "reliable-edge": 2, "name-fallback": 0}
+
+AMPLIFICATION = {
+    "nested_loop_with_io": "quadratic",
+    "nested_loop_quadratic": "quadratic",
+    "hot_path_sync_io": "per_call",
+    "blocking_sync_in_async": "per_call",
+}
+"""Marker to the repetition shape its evidence supports.
+
+Everything with a loop points at the same claim, so only the exceptions are
+listed and :func:`amplification` supplies the rest. A marker nobody has
+characterised reports ``unknown`` rather than borrowing a neighbour's shape.
+"""
+
+ACTIONABILITY_ORDER = {"plan_ready": 0, "advisory": 1, "investigate": 2}
+"""Actionable work sorts above evidence, whatever the raw magnitude.
+
+A generic sink accumulates points through sheer volume. Left to the score
+alone it buries every group somebody could act on today, which is the wrong
+lead for both an agent and a person.
+"""
+
+_LEVERAGE_BANDS = ((1, "isolated"), (3, "local"), (9, "shared"))
+_CHANGE_RISK_BANDS = ((1, "contained"), (4, "moderate"))
+
+
+def _band(value: int, bands: tuple[tuple[int, str], ...], beyond: str) -> str:
+    for ceiling, label in bands:
+        if value <= ceiling:
+            return label
+    return beyond
 
 
 def dominant_marker(markers: tuple[str, ...]) -> str:
@@ -39,6 +79,39 @@ def weakest_provenance(provenances: set[str]) -> str:
     read alike and mean the opposite; that is intentional.
     """
     return min(provenances, key=lambda value: (PROVENANCE_POINTS.get(value, 0), value))
+
+
+def amplification(marker: str) -> str:
+    """The repetition shape the evidence supports, never a magnitude estimate."""
+    if marker in AMPLIFICATION:
+        return AMPLIFICATION[marker]
+    return "per_iteration" if marker in MULTIPLIER_POINTS else "unknown"
+
+
+def exposure(reachable: bool | None) -> str:
+    """How closely an entry point reaches this group.
+
+    The graph answers reachable or not for the loop-owning function and stores
+    no distance, so there is no nearer or farther to report. Unknown is the
+    common answer and stays visible as one.
+    """
+    if reachable is True:
+        return "entry_reachable"
+    return "not_entry_reachable" if reachable is False else "unknown"
+
+
+def leverage(call_sites: int) -> str:
+    """How many places one intervention would settle."""
+    return _band(call_sites, _LEVERAGE_BANDS, "broad")
+
+
+def change_risk(affected_files: int) -> str:
+    """How far the edit reaches, counted in files holding evidence.
+
+    Structural reach only. Churn and hotspot history live in the serving layer
+    and are not read here, so nothing in this module costs a query.
+    """
+    return _band(affected_files, _CHANGE_RISK_BANDS, "wide")
 
 
 def rank_factors(
@@ -58,25 +131,58 @@ def rank_factors(
     return {
         "multiplier_shape": MULTIPLIER_POINTS.get(marker, 1),
         "boundary_kind": BOUNDARY_POINTS.get(boundary or "", 0),
-        "execution_context": CONTEXT_POINTS[context],
+        "execution_context": CONTEXT_POINTS.get(context, 1),
         "entry_reachability": 3 if reachable is True else 0,
         "affected_call_sites": min(8, int(log2(site_count + 1) * 2)),
         "provenance": PROVENANCE_POINTS.get(provenance, 0),
     }
 
 
-def rank_sort_key(item: Any) -> tuple[int, int, str]:
-    """A total order: rank, then leverage, then id so ties never float."""
-    return (-item.rank_score, -item.affected_call_sites_total, item.opportunity_id)
+def why_ranked(factors: dict[str, int], values: dict[str, Any], limit: int = 3) -> tuple[dict, ...]:
+    """The few terms that actually decided this position.
+
+    Structured, not prose: each entry names the factor, the input it read, and
+    the points it contributed, so a caller can render it without parsing and a
+    reword never churns anything. Zero-point terms explain nothing and are
+    dropped, so fewer than ``limit`` entries is a normal answer.
+    """
+    ranked = sorted(
+        ((name, points) for name, points in factors.items() if points),
+        key=lambda item: (-item[1], item[0]),
+    )
+    return tuple(
+        {"factor": name, "value": values.get(name), "points": points}
+        for name, points in ranked[:limit]
+    )
+
+
+def rank_sort_key(item: Any) -> tuple[int, int, int, str]:
+    """A total order: actionable first, then rank, leverage, and id.
+
+    The id tail is what makes it total, so ties never float between runs.
+    """
+    return (
+        ACTIONABILITY_ORDER[item.actionability_state],
+        -item.rank_score,
+        -item.affected_call_sites_total,
+        item.opportunity_id,
+    )
 
 
 __all__ = [
+    "ACTIONABILITY_ORDER",
+    "AMPLIFICATION",
     "BOUNDARY_POINTS",
     "CONTEXT_POINTS",
     "MULTIPLIER_POINTS",
     "PROVENANCE_POINTS",
+    "amplification",
+    "change_risk",
     "dominant_marker",
+    "exposure",
+    "leverage",
     "rank_factors",
     "rank_sort_key",
     "weakest_provenance",
+    "why_ranked",
 ]

--- a/packages/server/src/repowise/server/routers/code_health/performance_routes.py
+++ b/packages/server/src/repowise/server/routers/code_health/performance_routes.py
@@ -95,7 +95,9 @@ async def list_performance_opportunities(
     contexts = {
         "production_tooling": {"production", "tooling"},
         "test": {"test"},
-        "all": {"production", "tooling", "test"},
+        # An unclassifiable file is reported as unknown rather than assumed to
+        # ship, so it belongs in the unfiltered view and is counted below.
+        "all": {"production", "tooling", "test", "unknown"},
     }[context]
     filtered = [item for item in opportunities if item.execution_context in contexts]
     total = len(filtered)
@@ -119,6 +121,7 @@ async def list_performance_opportunities(
             ),
             "tooling_total": sum(item.execution_context == "tooling" for item in opportunities),
             "test_total": sum(item.execution_context == "test" for item in opportunities),
+            "unknown_total": sum(item.execution_context == "unknown" for item in opportunities),
             "with_plan_total": sum(item.opportunity_id in matches for item in opportunities),
             "without_plan_total": sum(item.opportunity_id not in matches for item in opportunities),
         },

--- a/packages/types/src/health.ts
+++ b/packages/types/src/health.ts
@@ -232,7 +232,7 @@ export interface HealthFinding {
   dimension?: HealthDimension;
 }
 
-export type PerformanceExecutionContext = "production" | "tooling" | "test";
+export type PerformanceExecutionContext = "production" | "tooling" | "test" | "unknown";
 export type PerformanceOpportunityConfidence = "high" | "medium" | "low";
 
 export interface PerformanceOpportunityFix {

--- a/packages/ui/src/health/performance-view.tsx
+++ b/packages/ui/src/health/performance-view.tsx
@@ -47,8 +47,15 @@ const PAGE_SIZE = 20;
 const RAW_PAGE_SIZE = 50;
 type ContextView = "production_tooling" | "test";
 
+const CONTEXT_LABEL: Record<PerformanceOpportunity["execution_context"], string> = {
+  production: "Production",
+  tooling: "Tooling",
+  test: "Test suite",
+  unknown: "Unclassified",
+};
+
 function contextLabel(context: PerformanceOpportunity["execution_context"]): string {
-  return context === "test" ? "Test suite" : context === "tooling" ? "Tooling" : "Production";
+  return CONTEXT_LABEL[context] ?? "Unclassified";
 }
 
 function opportunityTitle(opportunity: PerformanceOpportunity): string {

--- a/tests/fixtures/perf_corpus/README.md
+++ b/tests/fixtures/perf_corpus/README.md
@@ -1,9 +1,14 @@
 # Performance opportunity corpus
 
-A small, checked-in, hand-authored corpus that pins the current behaviour of
-`repowise.core.analysis.health.perf`. It is a characterization corpus, not a
-precision corpus: every expectation records what the analyzer does today, so a
-semantic change shows up as an explicit golden diff rather than a silent one.
+A small, checked-in, hand-authored corpus that pins the behaviour of
+`repowise.core.analysis.health.perf`. Every expectation records what the
+analyzer does, so a semantic change shows up as an explicit golden diff rather
+than a silent one.
+
+Two cases are load-bearing and belong together: `generic_infra_sink` puts
+unrelated callers on one infrastructure sink and must split, and
+`shared_dominator_fan_in` puts more callers on one sink behind a shared helper
+and must stay merged. They are the two poles of the grouping rule.
 
 ## Files
 

--- a/tests/fixtures/perf_corpus/golden_opportunities.json
+++ b/tests/fixtures/perf_corpus/golden_opportunities.json
@@ -1,6 +1,158 @@
 {
   "opportunities": [
     {
+      "actionability_reason": "proven_strategy",
+      "actionability_state": "plan_ready",
+      "affected_call_sites_total": 1,
+      "affected_files_total": 1,
+      "biomarker_type": "serial_await_in_loop",
+      "biomarker_types": [
+        "serial_await_in_loop"
+      ],
+      "boundary_kind": "network",
+      "confidence": "high",
+      "evidence": [
+        {
+          "biomarker_type": "serial_await_in_loop",
+          "file_path": "src/app/fanout.py",
+          "finding_id": "async_serial_awaits-09",
+          "function_name": "gather_all",
+          "line_end": 92,
+          "line_start": 90,
+          "path": [],
+          "provenance": "direct",
+          "reason": "async_serial_awaits: serial_await_in_loop at src/app/fanout.py:90 repeats work per iteration."
+        }
+      ],
+      "evidence_truncated": false,
+      "execution_context": "production",
+      "facets": {
+        "actionability_confidence": "high",
+        "amplification": "per_iteration",
+        "change_risk": "contained",
+        "exposure": "unknown",
+        "leverage": "isolated"
+      },
+      "fix": {
+        "rationale": "Dataflow proves that every observed loop carries no cross-iteration dependence.",
+        "safety": "proven",
+        "strategy": "parallelize_independent_awaits"
+      },
+      "intervention_symbol": null,
+      "observations_total": 1,
+      "opportunity_id": "perf2_182b2a7c053167959285",
+      "performance_model_version": 2,
+      "prerequisites": [],
+      "provenance": "direct",
+      "rank_factors": {
+        "affected_call_sites": 2,
+        "boundary_kind": 4,
+        "entry_reachability": 0,
+        "execution_context": 3,
+        "multiplier_shape": 4,
+        "provenance": 3
+      },
+      "rank_score": 16,
+      "reliable_entry_reachability": null,
+      "resource_fingerprints": [],
+      "shared_path_suffix": [],
+      "terminal_sink": null,
+      "why_ranked": [
+        {
+          "factor": "boundary_kind",
+          "points": 4,
+          "value": "network"
+        },
+        {
+          "factor": "multiplier_shape",
+          "points": 4,
+          "value": "serial_await_in_loop"
+        },
+        {
+          "factor": "execution_context",
+          "points": 3,
+          "value": "production"
+        }
+      ]
+    },
+    {
+      "actionability_reason": "proven_strategy",
+      "actionability_state": "plan_ready",
+      "affected_call_sites_total": 1,
+      "affected_files_total": 1,
+      "biomarker_type": "resource_construction_in_loop",
+      "biomarker_types": [
+        "resource_construction_in_loop"
+      ],
+      "boundary_kind": "network",
+      "confidence": "high",
+      "evidence": [
+        {
+          "biomarker_type": "resource_construction_in_loop",
+          "file_path": "src/app/clients.py",
+          "finding_id": "resource_construction-16",
+          "function_name": "each",
+          "line_end": 172,
+          "line_start": 170,
+          "path": [],
+          "provenance": "direct",
+          "reason": "resource_construction: resource_construction_in_loop at src/app/clients.py:170 repeats work per iteration."
+        }
+      ],
+      "evidence_truncated": false,
+      "execution_context": "production",
+      "facets": {
+        "actionability_confidence": "high",
+        "amplification": "per_iteration",
+        "change_risk": "contained",
+        "exposure": "unknown",
+        "leverage": "isolated"
+      },
+      "fix": {
+        "rationale": "Dataflow proves construction arguments and lifetime are loop invariant.",
+        "safety": "proven",
+        "strategy": "hoist_loop_invariant_resource"
+      },
+      "intervention_symbol": null,
+      "observations_total": 1,
+      "opportunity_id": "perf2_386a99aa2876c0dd31bd",
+      "performance_model_version": 2,
+      "prerequisites": [],
+      "provenance": "direct",
+      "rank_factors": {
+        "affected_call_sites": 2,
+        "boundary_kind": 4,
+        "entry_reachability": 0,
+        "execution_context": 3,
+        "multiplier_shape": 4,
+        "provenance": 3
+      },
+      "rank_score": 16,
+      "reliable_entry_reachability": null,
+      "resource_fingerprints": [],
+      "shared_path_suffix": [],
+      "terminal_sink": null,
+      "why_ranked": [
+        {
+          "factor": "boundary_kind",
+          "points": 4,
+          "value": "network"
+        },
+        {
+          "factor": "multiplier_shape",
+          "points": 4,
+          "value": "resource_construction_in_loop"
+        },
+        {
+          "factor": "execution_context",
+          "points": 3,
+          "value": "production"
+        }
+      ]
+    },
+    {
+      "actionability_reason": "strategy_requires_validation",
+      "actionability_state": "advisory",
       "affected_call_sites_total": 2,
       "affected_files_total": 1,
       "biomarker_type": "io_in_loop",
@@ -19,6 +171,7 @@
           "line_start": 250,
           "path": [
             "src/app/entry.py::a",
+            "src/app/entry.py::_hit",
             "src/app/db.py::reach_sink"
           ],
           "provenance": "call-site",
@@ -33,6 +186,7 @@
           "line_start": 255,
           "path": [
             "src/app/entry.py::b",
+            "src/app/entry.py::_hit",
             "src/app/db.py::reach_sink"
           ],
           "provenance": "call-site",
@@ -41,10 +195,26 @@
       ],
       "evidence_truncated": false,
       "execution_context": "production",
-      "fix": null,
-      "intervention_symbol": "src/app/db.py::reach_sink",
+      "facets": {
+        "actionability_confidence": "medium",
+        "amplification": "per_iteration",
+        "change_risk": "contained",
+        "exposure": "entry_reachable",
+        "leverage": "local"
+      },
+      "fix": {
+        "rationale": "The shared I/O sink is proven; no concrete batch API or result-equivalence proof is available.",
+        "safety": "advisory",
+        "strategy": "batch_or_prefetch_io"
+      },
+      "intervention_symbol": "src/app/entry.py::_hit",
       "observations_total": 2,
-      "opportunity_id": "perf_81d11a5a80af2c45ad13",
+      "opportunity_id": "perf2_0673587e7abbea99fc0b",
+      "performance_model_version": 2,
+      "prerequisites": [
+        "batch_api_contract",
+        "result_equivalence"
+      ],
       "provenance": "call-site",
       "rank_factors": {
         "affected_call_sites": 3,
@@ -56,12 +226,33 @@
       },
       "rank_score": 20,
       "reliable_entry_reachability": true,
+      "resource_fingerprints": [],
       "shared_path_suffix": [
+        "src/app/entry.py::_hit",
         "src/app/db.py::reach_sink"
       ],
-      "terminal_sink": "src/app/db.py::reach_sink"
+      "terminal_sink": "src/app/db.py::reach_sink",
+      "why_ranked": [
+        {
+          "factor": "boundary_kind",
+          "points": 4,
+          "value": "db"
+        },
+        {
+          "factor": "multiplier_shape",
+          "points": 4,
+          "value": "io_in_loop"
+        },
+        {
+          "factor": "affected_call_sites",
+          "points": 3,
+          "value": 2
+        }
+      ]
     },
     {
+      "actionability_reason": "strategy_requires_validation",
+      "actionability_state": "advisory",
       "affected_call_sites_total": 2,
       "affected_files_total": 1,
       "biomarker_type": "io_in_loop",
@@ -104,6 +295,13 @@
       ],
       "evidence_truncated": false,
       "execution_context": "production",
+      "facets": {
+        "actionability_confidence": "medium",
+        "amplification": "per_iteration",
+        "change_risk": "contained",
+        "exposure": "entry_reachable",
+        "leverage": "local"
+      },
       "fix": {
         "rationale": "The shared I/O sink is proven; no concrete batch API or result-equivalence proof is available.",
         "safety": "advisory",
@@ -111,7 +309,12 @@
       },
       "intervention_symbol": "src/app/repo.py::fetch_page",
       "observations_total": 2,
-      "opportunity_id": "perf_9de801a6e25fb309d266",
+      "opportunity_id": "perf2_89348be6c2ba0311a0e8",
+      "performance_model_version": 2,
+      "prerequisites": [
+        "batch_api_contract",
+        "result_equivalence"
+      ],
       "provenance": "call-site",
       "rank_factors": {
         "affected_call_sites": 3,
@@ -123,13 +326,33 @@
       },
       "rank_score": 20,
       "reliable_entry_reachability": true,
+      "resource_fingerprints": [],
       "shared_path_suffix": [
         "src/app/repo.py::fetch_page",
         "src/app/db.py::execute"
       ],
-      "terminal_sink": "src/app/db.py::execute"
+      "terminal_sink": "src/app/db.py::execute",
+      "why_ranked": [
+        {
+          "factor": "boundary_kind",
+          "points": 4,
+          "value": "db"
+        },
+        {
+          "factor": "multiplier_shape",
+          "points": 4,
+          "value": "io_in_loop"
+        },
+        {
+          "factor": "affected_call_sites",
+          "points": 3,
+          "value": 2
+        }
+      ]
     },
     {
+      "actionability_reason": "strategy_requires_validation",
+      "actionability_state": "advisory",
       "affected_call_sites_total": 2,
       "affected_files_total": 1,
       "biomarker_type": "nested_loop_with_io",
@@ -149,6 +372,7 @@
           "line_start": 210,
           "path": [
             "src/app/reindex.py::one",
+            "src/app/reindex.py::_write",
             "src/app/db.py::upsert"
           ],
           "provenance": "call-site",
@@ -163,6 +387,7 @@
           "line_start": 215,
           "path": [
             "src/app/reindex.py::many",
+            "src/app/reindex.py::_write",
             "src/app/db.py::upsert"
           ],
           "provenance": "call-site",
@@ -171,10 +396,26 @@
       ],
       "evidence_truncated": false,
       "execution_context": "production",
-      "fix": null,
-      "intervention_symbol": "src/app/db.py::upsert",
+      "facets": {
+        "actionability_confidence": "medium",
+        "amplification": "quadratic",
+        "change_risk": "contained",
+        "exposure": "unknown",
+        "leverage": "local"
+      },
+      "fix": {
+        "rationale": "The shared I/O sink is proven; no concrete batch API or result-equivalence proof is available.",
+        "safety": "advisory",
+        "strategy": "batch_or_prefetch_io"
+      },
+      "intervention_symbol": "src/app/reindex.py::_write",
       "observations_total": 2,
-      "opportunity_id": "perf_f5c50464496a3100a1b8",
+      "opportunity_id": "perf2_3d62fcebb00bdf408f2c",
+      "performance_model_version": 2,
+      "prerequisites": [
+        "batch_api_contract",
+        "result_equivalence"
+      ],
       "provenance": "call-site",
       "rank_factors": {
         "affected_call_sites": 3,
@@ -186,162 +427,33 @@
       },
       "rank_score": 19,
       "reliable_entry_reachability": null,
+      "resource_fingerprints": [],
       "shared_path_suffix": [
+        "src/app/reindex.py::_write",
         "src/app/db.py::upsert"
       ],
-      "terminal_sink": "src/app/db.py::upsert"
-    },
-    {
-      "affected_call_sites_total": 4,
-      "affected_files_total": 4,
-      "biomarker_type": "io_in_loop",
-      "biomarker_types": [
-        "io_in_loop"
-      ],
-      "boundary_kind": "db",
-      "confidence": "high",
-      "evidence": [
+      "terminal_sink": "src/app/db.py::upsert",
+      "why_ranked": [
         {
-          "biomarker_type": "io_in_loop",
-          "file_path": "src/app/billing.py",
-          "finding_id": "generic_infra_sink-01",
-          "function_name": "handle",
-          "line_end": 13,
-          "line_start": 11,
-          "path": [
-            "src/app/billing.py::handle",
-            "src/app/db.py::get_session"
-          ],
-          "provenance": "call-site",
-          "reason": "generic_infra_sink: io_in_loop at src/app/billing.py:11 repeats work per iteration."
+          "factor": "multiplier_shape",
+          "points": 6,
+          "value": "nested_loop_with_io"
         },
         {
-          "biomarker_type": "io_in_loop",
-          "file_path": "src/app/job.py",
-          "finding_id": "context_split-18",
-          "function_name": "run",
-          "line_end": 202,
-          "line_start": 200,
-          "path": [
-            "src/app/job.py::run",
-            "src/app/db.py::get_session"
-          ],
-          "provenance": "call-site",
-          "reason": "context_split: io_in_loop at src/app/job.py:200 repeats work per iteration."
+          "factor": "boundary_kind",
+          "points": 4,
+          "value": "db"
         },
         {
-          "biomarker_type": "io_in_loop",
-          "file_path": "src/app/orders.py",
-          "finding_id": "generic_infra_sink-00",
-          "function_name": "handle",
-          "line_end": 12,
-          "line_start": 10,
-          "path": [
-            "src/app/orders.py::handle",
-            "src/app/db.py::get_session"
-          ],
-          "provenance": "call-site",
-          "reason": "generic_infra_sink: io_in_loop at src/app/orders.py:10 repeats work per iteration."
-        },
-        {
-          "biomarker_type": "io_in_loop",
-          "file_path": "src/app/reports.py",
-          "finding_id": "generic_infra_sink-02",
-          "function_name": "handle",
-          "line_end": 14,
-          "line_start": 12,
-          "path": [
-            "src/app/reports.py::handle",
-            "src/app/db.py::get_session"
-          ],
-          "provenance": "call-site",
-          "reason": "generic_infra_sink: io_in_loop at src/app/reports.py:12 repeats work per iteration."
+          "factor": "affected_call_sites",
+          "points": 3,
+          "value": 2
         }
-      ],
-      "evidence_truncated": false,
-      "execution_context": "production",
-      "fix": null,
-      "intervention_symbol": "src/app/db.py::get_session",
-      "observations_total": 4,
-      "opportunity_id": "perf_e358397251b660183fdd",
-      "provenance": "call-site",
-      "rank_factors": {
-        "affected_call_sites": 4,
-        "boundary_kind": 4,
-        "entry_reachability": 0,
-        "execution_context": 3,
-        "multiplier_shape": 4,
-        "provenance": 3
-      },
-      "rank_score": 18,
-      "reliable_entry_reachability": null,
-      "shared_path_suffix": [
-        "src/app/db.py::get_session"
-      ],
-      "terminal_sink": "src/app/db.py::get_session"
+      ]
     },
     {
-      "affected_call_sites_total": 2,
-      "affected_files_total": 1,
-      "biomarker_type": "blocking_io_under_lock",
-      "biomarker_types": [
-        "blocking_io_under_lock"
-      ],
-      "boundary_kind": "db",
-      "confidence": "high",
-      "evidence": [
-        {
-          "biomarker_type": "blocking_io_under_lock",
-          "file_path": "src/app/pool.py",
-          "finding_id": "distinct_lock_owners-13",
-          "function_name": "reaper",
-          "line_end": 132,
-          "line_start": 130,
-          "path": [
-            "src/app/pool.py::reaper",
-            "src/app/store.py::flush"
-          ],
-          "provenance": "call-site",
-          "reason": "distinct_lock_owners: blocking_io_under_lock at src/app/pool.py:130 repeats work per iteration."
-        },
-        {
-          "biomarker_type": "blocking_io_under_lock",
-          "file_path": "src/app/pool.py",
-          "finding_id": "distinct_lock_owners-12",
-          "function_name": "writer",
-          "line_end": 132,
-          "line_start": 130,
-          "path": [
-            "src/app/pool.py::writer",
-            "src/app/store.py::flush"
-          ],
-          "provenance": "call-site",
-          "reason": "distinct_lock_owners: blocking_io_under_lock at src/app/pool.py:130 repeats work per iteration."
-        }
-      ],
-      "evidence_truncated": false,
-      "execution_context": "production",
-      "fix": null,
-      "intervention_symbol": "src/app/store.py::flush",
-      "observations_total": 2,
-      "opportunity_id": "perf_c4ee441bf83047cd1cd8",
-      "provenance": "call-site",
-      "rank_factors": {
-        "affected_call_sites": 3,
-        "boundary_kind": 4,
-        "entry_reachability": 0,
-        "execution_context": 3,
-        "multiplier_shape": 5,
-        "provenance": 3
-      },
-      "rank_score": 18,
-      "reliable_entry_reachability": null,
-      "shared_path_suffix": [
-        "src/app/store.py::flush"
-      ],
-      "terminal_sink": "src/app/store.py::flush"
-    },
-    {
+      "actionability_reason": "strategy_requires_validation",
+      "actionability_state": "advisory",
       "affected_call_sites_total": 2,
       "affected_files_total": 1,
       "biomarker_type": "io_in_loop",
@@ -384,6 +496,13 @@
       ],
       "evidence_truncated": false,
       "execution_context": "production",
+      "facets": {
+        "actionability_confidence": "medium",
+        "amplification": "per_iteration",
+        "change_risk": "contained",
+        "exposure": "unknown",
+        "leverage": "local"
+      },
       "fix": {
         "rationale": "The shared I/O sink is proven; no concrete batch API or result-equivalence proof is available.",
         "safety": "advisory",
@@ -391,7 +510,12 @@
       },
       "intervention_symbol": "src/app/sync.py::_load",
       "observations_total": 2,
-      "opportunity_id": "perf_353153d5e9b5c681a057",
+      "opportunity_id": "perf2_af29fc10103a555c8652",
+      "performance_model_version": 2,
+      "prerequisites": [
+        "batch_api_contract",
+        "result_equivalence"
+      ],
       "provenance": "call-site",
       "rank_factors": {
         "affected_call_sites": 3,
@@ -403,13 +527,33 @@
       },
       "rank_score": 17,
       "reliable_entry_reachability": null,
+      "resource_fingerprints": [],
       "shared_path_suffix": [
         "src/app/sync.py::_load",
         "src/app/db.py::query"
       ],
-      "terminal_sink": "src/app/db.py::query"
+      "terminal_sink": "src/app/db.py::query",
+      "why_ranked": [
+        {
+          "factor": "boundary_kind",
+          "points": 4,
+          "value": "db"
+        },
+        {
+          "factor": "multiplier_shape",
+          "points": 4,
+          "value": "io_in_loop"
+        },
+        {
+          "factor": "affected_call_sites",
+          "points": 3,
+          "value": 2
+        }
+      ]
     },
     {
+      "actionability_reason": "strategy_requires_validation",
+      "actionability_state": "advisory",
       "affected_call_sites_total": 1,
       "affected_files_total": 1,
       "biomarker_type": "blocking_io_under_lock",
@@ -436,6 +580,13 @@
       ],
       "evidence_truncated": false,
       "execution_context": "production",
+      "facets": {
+        "actionability_confidence": "medium",
+        "amplification": "per_iteration",
+        "change_risk": "contained",
+        "exposure": "unknown",
+        "leverage": "isolated"
+      },
       "fix": {
         "rationale": "I/O under the lock is proven, but shared-state ordering must be validated before moving it.",
         "safety": "advisory",
@@ -443,7 +594,11 @@
       },
       "intervention_symbol": "src/app/cache.py::refresh",
       "observations_total": 1,
-      "opportunity_id": "perf_7e351bac743b6db777e7",
+      "opportunity_id": "perf2_9dfe577bc9c8b799355e",
+      "performance_model_version": 2,
+      "prerequisites": [
+        "shared_state_ordering"
+      ],
       "provenance": "call-site",
       "rank_factors": {
         "affected_call_sites": 2,
@@ -455,250 +610,33 @@
       },
       "rank_score": 17,
       "reliable_entry_reachability": null,
+      "resource_fingerprints": [],
       "shared_path_suffix": [
         "src/app/cache.py::refresh",
         "src/app/db.py::write"
       ],
-      "terminal_sink": "src/app/db.py::write"
-    },
-    {
-      "affected_call_sites_total": 1,
-      "affected_files_total": 1,
-      "biomarker_type": "serial_await_in_loop",
-      "biomarker_types": [
-        "serial_await_in_loop"
-      ],
-      "boundary_kind": "network",
-      "confidence": "high",
-      "evidence": [
+      "terminal_sink": "src/app/db.py::write",
+      "why_ranked": [
         {
-          "biomarker_type": "serial_await_in_loop",
-          "file_path": "src/app/fanout.py",
-          "finding_id": "async_serial_awaits-09",
-          "function_name": "gather_all",
-          "line_end": 92,
-          "line_start": 90,
-          "path": [],
-          "provenance": "direct",
-          "reason": "async_serial_awaits: serial_await_in_loop at src/app/fanout.py:90 repeats work per iteration."
-        }
-      ],
-      "evidence_truncated": false,
-      "execution_context": "production",
-      "fix": {
-        "rationale": "Dataflow proves that every observed loop carries no cross-iteration dependence.",
-        "safety": "proven",
-        "strategy": "parallelize_independent_awaits"
-      },
-      "intervention_symbol": null,
-      "observations_total": 1,
-      "opportunity_id": "perf_182b2a7c053167959285",
-      "provenance": "direct",
-      "rank_factors": {
-        "affected_call_sites": 2,
-        "boundary_kind": 4,
-        "entry_reachability": 0,
-        "execution_context": 3,
-        "multiplier_shape": 4,
-        "provenance": 3
-      },
-      "rank_score": 16,
-      "reliable_entry_reachability": null,
-      "shared_path_suffix": [],
-      "terminal_sink": null
-    },
-    {
-      "affected_call_sites_total": 1,
-      "affected_files_total": 1,
-      "biomarker_type": "resource_construction_in_loop",
-      "biomarker_types": [
-        "resource_construction_in_loop"
-      ],
-      "boundary_kind": "network",
-      "confidence": "high",
-      "evidence": [
-        {
-          "biomarker_type": "resource_construction_in_loop",
-          "file_path": "src/app/clients.py",
-          "finding_id": "resource_construction-17",
-          "function_name": "each_varying",
-          "line_end": 182,
-          "line_start": 180,
-          "path": [],
-          "provenance": "direct",
-          "reason": "resource_construction: resource_construction_in_loop at src/app/clients.py:180 repeats work per iteration."
-        }
-      ],
-      "evidence_truncated": false,
-      "execution_context": "production",
-      "fix": null,
-      "intervention_symbol": null,
-      "observations_total": 1,
-      "opportunity_id": "perf_266b6dd67d9b9e93e201",
-      "provenance": "direct",
-      "rank_factors": {
-        "affected_call_sites": 2,
-        "boundary_kind": 4,
-        "entry_reachability": 0,
-        "execution_context": 3,
-        "multiplier_shape": 4,
-        "provenance": 3
-      },
-      "rank_score": 16,
-      "reliable_entry_reachability": null,
-      "shared_path_suffix": [],
-      "terminal_sink": null
-    },
-    {
-      "affected_call_sites_total": 1,
-      "affected_files_total": 1,
-      "biomarker_type": "resource_construction_in_loop",
-      "biomarker_types": [
-        "resource_construction_in_loop"
-      ],
-      "boundary_kind": "network",
-      "confidence": "high",
-      "evidence": [
-        {
-          "biomarker_type": "resource_construction_in_loop",
-          "file_path": "src/app/clients.py",
-          "finding_id": "resource_construction-16",
-          "function_name": "each",
-          "line_end": 172,
-          "line_start": 170,
-          "path": [],
-          "provenance": "direct",
-          "reason": "resource_construction: resource_construction_in_loop at src/app/clients.py:170 repeats work per iteration."
-        }
-      ],
-      "evidence_truncated": false,
-      "execution_context": "production",
-      "fix": {
-        "rationale": "Dataflow proves construction arguments and lifetime are loop invariant.",
-        "safety": "proven",
-        "strategy": "hoist_loop_invariant_resource"
-      },
-      "intervention_symbol": null,
-      "observations_total": 1,
-      "opportunity_id": "perf_386a99aa2876c0dd31bd",
-      "provenance": "direct",
-      "rank_factors": {
-        "affected_call_sites": 2,
-        "boundary_kind": 4,
-        "entry_reachability": 0,
-        "execution_context": 3,
-        "multiplier_shape": 4,
-        "provenance": 3
-      },
-      "rank_score": 16,
-      "reliable_entry_reachability": null,
-      "shared_path_suffix": [],
-      "terminal_sink": null
-    },
-    {
-      "affected_call_sites_total": 1,
-      "affected_files_total": 1,
-      "biomarker_type": "serial_await_in_loop",
-      "biomarker_types": [
-        "serial_await_in_loop"
-      ],
-      "boundary_kind": "network",
-      "confidence": "high",
-      "evidence": [
-        {
-          "biomarker_type": "serial_await_in_loop",
-          "file_path": "src/app/fanout.py",
-          "finding_id": "async_serial_awaits-10",
-          "function_name": "gather_seq",
-          "line_end": 97,
-          "line_start": 95,
-          "path": [],
-          "provenance": "direct",
-          "reason": "async_serial_awaits: serial_await_in_loop at src/app/fanout.py:95 repeats work per iteration."
-        }
-      ],
-      "evidence_truncated": false,
-      "execution_context": "production",
-      "fix": null,
-      "intervention_symbol": null,
-      "observations_total": 1,
-      "opportunity_id": "perf_64fbd03504c61c115894",
-      "provenance": "direct",
-      "rank_factors": {
-        "affected_call_sites": 2,
-        "boundary_kind": 4,
-        "entry_reachability": 0,
-        "execution_context": 3,
-        "multiplier_shape": 4,
-        "provenance": 3
-      },
-      "rank_score": 16,
-      "reliable_entry_reachability": null,
-      "shared_path_suffix": [],
-      "terminal_sink": null
-    },
-    {
-      "affected_call_sites_total": 2,
-      "affected_files_total": 1,
-      "biomarker_type": "io_in_loop",
-      "biomarker_types": [
-        "io_in_loop"
-      ],
-      "boundary_kind": "filesystem",
-      "confidence": "high",
-      "evidence": [
-        {
-          "biomarker_type": "io_in_loop",
-          "file_path": "src/app/walker.py",
-          "finding_id": "filesystem_fan_out-05",
-          "function_name": "scan",
-          "line_end": 52,
-          "line_start": 50,
-          "path": [
-            "src/app/walker.py::scan",
-            "src/app/fsio.py::read_text"
-          ],
-          "provenance": "call-site",
-          "reason": "filesystem_fan_out: io_in_loop at src/app/walker.py:50 repeats work per iteration."
+          "factor": "multiplier_shape",
+          "points": 5,
+          "value": "blocking_io_under_lock"
         },
         {
-          "biomarker_type": "io_in_loop",
-          "file_path": "src/app/walker.py",
-          "finding_id": "filesystem_fan_out-06",
-          "function_name": "index",
-          "line_end": 53,
-          "line_start": 51,
-          "path": [
-            "src/app/walker.py::index",
-            "src/app/fsio.py::read_text"
-          ],
-          "provenance": "call-site",
-          "reason": "filesystem_fan_out: io_in_loop at src/app/walker.py:51 repeats work per iteration."
+          "factor": "boundary_kind",
+          "points": 4,
+          "value": "db"
+        },
+        {
+          "factor": "execution_context",
+          "points": 3,
+          "value": "production"
         }
-      ],
-      "evidence_truncated": false,
-      "execution_context": "production",
-      "fix": null,
-      "intervention_symbol": "src/app/fsio.py::read_text",
-      "observations_total": 2,
-      "opportunity_id": "perf_833888def208e12ceb5d",
-      "provenance": "call-site",
-      "rank_factors": {
-        "affected_call_sites": 3,
-        "boundary_kind": 2,
-        "entry_reachability": 0,
-        "execution_context": 3,
-        "multiplier_shape": 4,
-        "provenance": 3
-      },
-      "rank_score": 15,
-      "reliable_entry_reachability": null,
-      "shared_path_suffix": [
-        "src/app/fsio.py::read_text"
-      ],
-      "terminal_sink": "src/app/fsio.py::read_text"
+      ]
     },
     {
+      "actionability_reason": "strategy_requires_validation",
+      "actionability_state": "advisory",
       "affected_call_sites_total": 1,
       "affected_files_total": 1,
       "biomarker_type": "io_in_loop",
@@ -706,51 +644,417 @@
         "io_in_loop"
       ],
       "boundary_kind": "db",
-      "confidence": "medium",
+      "confidence": "high",
       "evidence": [
         {
           "biomarker_type": "io_in_loop",
-          "file_path": "src/app/edge.py",
-          "finding_id": "provenance_mix-23",
-          "function_name": "run",
-          "line_end": 232,
-          "line_start": 230,
+          "file_path": "src/app/billing.py",
+          "finding_id": "generic_infra_sink-01",
+          "function_name": "handle",
+          "line_end": 13,
+          "line_start": 11,
           "path": [
-            "src/app/edge.py::run",
-            "src/app/db.py::reliable_sink"
+            "src/app/billing.py::handle",
+            "src/app/db.py::get_session"
           ],
-          "provenance": "reliable-edge",
-          "reason": "provenance_mix: io_in_loop at src/app/edge.py:230 repeats work per iteration."
+          "provenance": "call-site",
+          "reason": "generic_infra_sink: io_in_loop at src/app/billing.py:11 repeats work per iteration."
         }
       ],
       "evidence_truncated": false,
       "execution_context": "production",
+      "facets": {
+        "actionability_confidence": "medium",
+        "amplification": "per_iteration",
+        "change_risk": "contained",
+        "exposure": "not_entry_reachable",
+        "leverage": "isolated"
+      },
       "fix": {
         "rationale": "The shared I/O sink is proven; no concrete batch API or result-equivalence proof is available.",
         "safety": "advisory",
         "strategy": "batch_or_prefetch_io"
       },
-      "intervention_symbol": "src/app/edge.py::run",
+      "intervention_symbol": "src/app/billing.py::handle",
       "observations_total": 1,
-      "opportunity_id": "perf_688cbe7795e13b1910b2",
-      "provenance": "reliable-edge",
+      "opportunity_id": "perf2_3d4056f8405c9313d004",
+      "performance_model_version": 2,
+      "prerequisites": [
+        "batch_api_contract",
+        "result_equivalence"
+      ],
+      "provenance": "call-site",
       "rank_factors": {
         "affected_call_sites": 2,
         "boundary_kind": 4,
         "entry_reachability": 0,
         "execution_context": 3,
         "multiplier_shape": 4,
-        "provenance": 2
+        "provenance": 3
       },
-      "rank_score": 15,
-      "reliable_entry_reachability": null,
+      "rank_score": 16,
+      "reliable_entry_reachability": false,
+      "resource_fingerprints": [],
       "shared_path_suffix": [
-        "src/app/edge.py::run",
-        "src/app/db.py::reliable_sink"
+        "src/app/billing.py::handle",
+        "src/app/db.py::get_session"
       ],
-      "terminal_sink": "src/app/db.py::reliable_sink"
+      "terminal_sink": "src/app/db.py::get_session",
+      "why_ranked": [
+        {
+          "factor": "boundary_kind",
+          "points": 4,
+          "value": "db"
+        },
+        {
+          "factor": "multiplier_shape",
+          "points": 4,
+          "value": "io_in_loop"
+        },
+        {
+          "factor": "execution_context",
+          "points": 3,
+          "value": "production"
+        }
+      ]
     },
     {
+      "actionability_reason": "strategy_requires_validation",
+      "actionability_state": "advisory",
+      "affected_call_sites_total": 1,
+      "affected_files_total": 1,
+      "biomarker_type": "io_in_loop",
+      "biomarker_types": [
+        "io_in_loop"
+      ],
+      "boundary_kind": "db",
+      "confidence": "high",
+      "evidence": [
+        {
+          "biomarker_type": "io_in_loop",
+          "file_path": "src/app/orders.py",
+          "finding_id": "generic_infra_sink-00",
+          "function_name": "handle",
+          "line_end": 12,
+          "line_start": 10,
+          "path": [
+            "src/app/orders.py::handle",
+            "src/app/db.py::get_session"
+          ],
+          "provenance": "call-site",
+          "reason": "generic_infra_sink: io_in_loop at src/app/orders.py:10 repeats work per iteration."
+        }
+      ],
+      "evidence_truncated": false,
+      "execution_context": "production",
+      "facets": {
+        "actionability_confidence": "medium",
+        "amplification": "per_iteration",
+        "change_risk": "contained",
+        "exposure": "not_entry_reachable",
+        "leverage": "isolated"
+      },
+      "fix": {
+        "rationale": "The shared I/O sink is proven; no concrete batch API or result-equivalence proof is available.",
+        "safety": "advisory",
+        "strategy": "batch_or_prefetch_io"
+      },
+      "intervention_symbol": "src/app/orders.py::handle",
+      "observations_total": 1,
+      "opportunity_id": "perf2_5abe869788cb2cebf6cf",
+      "performance_model_version": 2,
+      "prerequisites": [
+        "batch_api_contract",
+        "result_equivalence"
+      ],
+      "provenance": "call-site",
+      "rank_factors": {
+        "affected_call_sites": 2,
+        "boundary_kind": 4,
+        "entry_reachability": 0,
+        "execution_context": 3,
+        "multiplier_shape": 4,
+        "provenance": 3
+      },
+      "rank_score": 16,
+      "reliable_entry_reachability": false,
+      "resource_fingerprints": [],
+      "shared_path_suffix": [
+        "src/app/orders.py::handle",
+        "src/app/db.py::get_session"
+      ],
+      "terminal_sink": "src/app/db.py::get_session",
+      "why_ranked": [
+        {
+          "factor": "boundary_kind",
+          "points": 4,
+          "value": "db"
+        },
+        {
+          "factor": "multiplier_shape",
+          "points": 4,
+          "value": "io_in_loop"
+        },
+        {
+          "factor": "execution_context",
+          "points": 3,
+          "value": "production"
+        }
+      ]
+    },
+    {
+      "actionability_reason": "strategy_requires_validation",
+      "actionability_state": "advisory",
+      "affected_call_sites_total": 1,
+      "affected_files_total": 1,
+      "biomarker_type": "io_in_loop",
+      "biomarker_types": [
+        "io_in_loop"
+      ],
+      "boundary_kind": "db",
+      "confidence": "high",
+      "evidence": [
+        {
+          "biomarker_type": "io_in_loop",
+          "file_path": "src/app/reports.py",
+          "finding_id": "generic_infra_sink-02",
+          "function_name": "handle",
+          "line_end": 14,
+          "line_start": 12,
+          "path": [
+            "src/app/reports.py::handle",
+            "src/app/db.py::get_session"
+          ],
+          "provenance": "call-site",
+          "reason": "generic_infra_sink: io_in_loop at src/app/reports.py:12 repeats work per iteration."
+        }
+      ],
+      "evidence_truncated": false,
+      "execution_context": "production",
+      "facets": {
+        "actionability_confidence": "medium",
+        "amplification": "per_iteration",
+        "change_risk": "contained",
+        "exposure": "not_entry_reachable",
+        "leverage": "isolated"
+      },
+      "fix": {
+        "rationale": "The shared I/O sink is proven; no concrete batch API or result-equivalence proof is available.",
+        "safety": "advisory",
+        "strategy": "batch_or_prefetch_io"
+      },
+      "intervention_symbol": "src/app/reports.py::handle",
+      "observations_total": 1,
+      "opportunity_id": "perf2_7d6b729c3f43753626f2",
+      "performance_model_version": 2,
+      "prerequisites": [
+        "batch_api_contract",
+        "result_equivalence"
+      ],
+      "provenance": "call-site",
+      "rank_factors": {
+        "affected_call_sites": 2,
+        "boundary_kind": 4,
+        "entry_reachability": 0,
+        "execution_context": 3,
+        "multiplier_shape": 4,
+        "provenance": 3
+      },
+      "rank_score": 16,
+      "reliable_entry_reachability": false,
+      "resource_fingerprints": [],
+      "shared_path_suffix": [
+        "src/app/reports.py::handle",
+        "src/app/db.py::get_session"
+      ],
+      "terminal_sink": "src/app/db.py::get_session",
+      "why_ranked": [
+        {
+          "factor": "boundary_kind",
+          "points": 4,
+          "value": "db"
+        },
+        {
+          "factor": "multiplier_shape",
+          "points": 4,
+          "value": "io_in_loop"
+        },
+        {
+          "factor": "execution_context",
+          "points": 3,
+          "value": "production"
+        }
+      ]
+    },
+    {
+      "actionability_reason": "strategy_requires_validation",
+      "actionability_state": "advisory",
+      "affected_call_sites_total": 1,
+      "affected_files_total": 1,
+      "biomarker_type": "io_in_loop",
+      "biomarker_types": [
+        "io_in_loop"
+      ],
+      "boundary_kind": "db",
+      "confidence": "high",
+      "evidence": [
+        {
+          "biomarker_type": "io_in_loop",
+          "file_path": "src/app/job.py",
+          "finding_id": "context_split-18",
+          "function_name": "run",
+          "line_end": 202,
+          "line_start": 200,
+          "path": [
+            "src/app/job.py::run",
+            "src/app/db.py::get_session"
+          ],
+          "provenance": "call-site",
+          "reason": "context_split: io_in_loop at src/app/job.py:200 repeats work per iteration."
+        }
+      ],
+      "evidence_truncated": false,
+      "execution_context": "production",
+      "facets": {
+        "actionability_confidence": "medium",
+        "amplification": "per_iteration",
+        "change_risk": "contained",
+        "exposure": "unknown",
+        "leverage": "isolated"
+      },
+      "fix": {
+        "rationale": "The shared I/O sink is proven; no concrete batch API or result-equivalence proof is available.",
+        "safety": "advisory",
+        "strategy": "batch_or_prefetch_io"
+      },
+      "intervention_symbol": "src/app/job.py::run",
+      "observations_total": 1,
+      "opportunity_id": "perf2_811bb33b8d8f9e744638",
+      "performance_model_version": 2,
+      "prerequisites": [
+        "batch_api_contract",
+        "result_equivalence"
+      ],
+      "provenance": "call-site",
+      "rank_factors": {
+        "affected_call_sites": 2,
+        "boundary_kind": 4,
+        "entry_reachability": 0,
+        "execution_context": 3,
+        "multiplier_shape": 4,
+        "provenance": 3
+      },
+      "rank_score": 16,
+      "reliable_entry_reachability": null,
+      "resource_fingerprints": [],
+      "shared_path_suffix": [
+        "src/app/job.py::run",
+        "src/app/db.py::get_session"
+      ],
+      "terminal_sink": "src/app/db.py::get_session",
+      "why_ranked": [
+        {
+          "factor": "boundary_kind",
+          "points": 4,
+          "value": "db"
+        },
+        {
+          "factor": "multiplier_shape",
+          "points": 4,
+          "value": "io_in_loop"
+        },
+        {
+          "factor": "execution_context",
+          "points": 3,
+          "value": "production"
+        }
+      ]
+    },
+    {
+      "actionability_reason": "strategy_requires_validation",
+      "actionability_state": "advisory",
+      "affected_call_sites_total": 1,
+      "affected_files_total": 1,
+      "biomarker_type": "io_in_loop",
+      "biomarker_types": [
+        "io_in_loop"
+      ],
+      "boundary_kind": "db",
+      "confidence": "high",
+      "evidence": [
+        {
+          "biomarker_type": "io_in_loop",
+          "file_path": "src/app/lone.py",
+          "finding_id": "sink_without_caller-33",
+          "function_name": "run",
+          "line_end": 11,
+          "line_start": 9,
+          "path": [
+            "src/app/db.py::only_sink"
+          ],
+          "provenance": "call-site",
+          "reason": "sink_without_caller: io_in_loop at src/app/lone.py:9 repeats work per iteration."
+        }
+      ],
+      "evidence_truncated": false,
+      "execution_context": "production",
+      "facets": {
+        "actionability_confidence": "medium",
+        "amplification": "per_iteration",
+        "change_risk": "contained",
+        "exposure": "unknown",
+        "leverage": "isolated"
+      },
+      "fix": {
+        "rationale": "The shared I/O sink is proven; no concrete batch API or result-equivalence proof is available.",
+        "safety": "advisory",
+        "strategy": "batch_or_prefetch_io"
+      },
+      "intervention_symbol": null,
+      "observations_total": 1,
+      "opportunity_id": "perf2_f349f0c0ac6827ebfd86",
+      "performance_model_version": 2,
+      "prerequisites": [
+        "batch_api_contract",
+        "result_equivalence"
+      ],
+      "provenance": "call-site",
+      "rank_factors": {
+        "affected_call_sites": 2,
+        "boundary_kind": 4,
+        "entry_reachability": 0,
+        "execution_context": 3,
+        "multiplier_shape": 4,
+        "provenance": 3
+      },
+      "rank_score": 16,
+      "reliable_entry_reachability": null,
+      "resource_fingerprints": [],
+      "shared_path_suffix": [
+        "src/app/db.py::only_sink"
+      ],
+      "terminal_sink": null,
+      "why_ranked": [
+        {
+          "factor": "boundary_kind",
+          "points": 4,
+          "value": "db"
+        },
+        {
+          "factor": "multiplier_shape",
+          "points": 4,
+          "value": "io_in_loop"
+        },
+        {
+          "factor": "execution_context",
+          "points": 3,
+          "value": "production"
+        }
+      ]
+    },
+    {
+      "actionability_reason": "strategy_requires_validation",
+      "actionability_state": "advisory",
       "affected_call_sites_total": 1,
       "affected_files_total": 1,
       "biomarker_type": "io_in_loop",
@@ -777,6 +1081,13 @@
       ],
       "evidence_truncated": false,
       "execution_context": "tooling",
+      "facets": {
+        "actionability_confidence": "medium",
+        "amplification": "per_iteration",
+        "change_risk": "contained",
+        "exposure": "unknown",
+        "leverage": "isolated"
+      },
       "fix": {
         "rationale": "The shared I/O sink is proven; no concrete batch API or result-equivalence proof is available.",
         "safety": "advisory",
@@ -784,7 +1095,12 @@
       },
       "intervention_symbol": "scripts/backfill.py::run",
       "observations_total": 1,
-      "opportunity_id": "perf_a50b5b7b58559225e3c6",
+      "opportunity_id": "perf2_626e6b4848d036aede65",
+      "performance_model_version": 2,
+      "prerequisites": [
+        "batch_api_contract",
+        "result_equivalence"
+      ],
       "provenance": "call-site",
       "rank_factors": {
         "affected_call_sites": 2,
@@ -796,13 +1112,117 @@
       },
       "rank_score": 15,
       "reliable_entry_reachability": null,
+      "resource_fingerprints": [],
       "shared_path_suffix": [
         "scripts/backfill.py::run",
         "src/app/db.py::get_session"
       ],
-      "terminal_sink": "src/app/db.py::get_session"
+      "terminal_sink": "src/app/db.py::get_session",
+      "why_ranked": [
+        {
+          "factor": "boundary_kind",
+          "points": 4,
+          "value": "db"
+        },
+        {
+          "factor": "multiplier_shape",
+          "points": 4,
+          "value": "io_in_loop"
+        },
+        {
+          "factor": "provenance",
+          "points": 3,
+          "value": "call-site"
+        }
+      ]
     },
     {
+      "actionability_reason": "strategy_requires_validation",
+      "actionability_state": "advisory",
+      "affected_call_sites_total": 1,
+      "affected_files_total": 1,
+      "biomarker_type": "io_in_loop",
+      "biomarker_types": [
+        "io_in_loop"
+      ],
+      "boundary_kind": "db",
+      "confidence": "medium",
+      "evidence": [
+        {
+          "biomarker_type": "io_in_loop",
+          "file_path": "src/app/edge.py",
+          "finding_id": "provenance_mix-23",
+          "function_name": "run",
+          "line_end": 232,
+          "line_start": 230,
+          "path": [
+            "src/app/edge.py::run",
+            "src/app/db.py::reliable_sink"
+          ],
+          "provenance": "reliable-edge",
+          "reason": "provenance_mix: io_in_loop at src/app/edge.py:230 repeats work per iteration."
+        }
+      ],
+      "evidence_truncated": false,
+      "execution_context": "production",
+      "facets": {
+        "actionability_confidence": "medium",
+        "amplification": "per_iteration",
+        "change_risk": "contained",
+        "exposure": "unknown",
+        "leverage": "isolated"
+      },
+      "fix": {
+        "rationale": "The shared I/O sink is proven; no concrete batch API or result-equivalence proof is available.",
+        "safety": "advisory",
+        "strategy": "batch_or_prefetch_io"
+      },
+      "intervention_symbol": "src/app/edge.py::run",
+      "observations_total": 1,
+      "opportunity_id": "perf2_cf3653d0149e79f7a1fb",
+      "performance_model_version": 2,
+      "prerequisites": [
+        "batch_api_contract",
+        "result_equivalence"
+      ],
+      "provenance": "reliable-edge",
+      "rank_factors": {
+        "affected_call_sites": 2,
+        "boundary_kind": 4,
+        "entry_reachability": 0,
+        "execution_context": 3,
+        "multiplier_shape": 4,
+        "provenance": 2
+      },
+      "rank_score": 15,
+      "reliable_entry_reachability": null,
+      "resource_fingerprints": [],
+      "shared_path_suffix": [
+        "src/app/edge.py::run",
+        "src/app/db.py::reliable_sink"
+      ],
+      "terminal_sink": "src/app/db.py::reliable_sink",
+      "why_ranked": [
+        {
+          "factor": "boundary_kind",
+          "points": 4,
+          "value": "db"
+        },
+        {
+          "factor": "multiplier_shape",
+          "points": 4,
+          "value": "io_in_loop"
+        },
+        {
+          "factor": "execution_context",
+          "points": 3,
+          "value": "production"
+        }
+      ]
+    },
+    {
+      "actionability_reason": "strategy_requires_validation",
+      "actionability_state": "advisory",
       "affected_call_sites_total": 1,
       "affected_files_total": 1,
       "biomarker_type": "io_in_loop",
@@ -829,6 +1249,13 @@
       ],
       "evidence_truncated": false,
       "execution_context": "test",
+      "facets": {
+        "actionability_confidence": "medium",
+        "amplification": "per_iteration",
+        "change_risk": "contained",
+        "exposure": "unknown",
+        "leverage": "isolated"
+      },
       "fix": {
         "rationale": "The shared I/O sink is proven; no concrete batch API or result-equivalence proof is available.",
         "safety": "advisory",
@@ -836,7 +1263,12 @@
       },
       "intervention_symbol": "tests/test_job.py::run",
       "observations_total": 1,
-      "opportunity_id": "perf_63ace13595c0f6bf553b",
+      "opportunity_id": "perf2_b17b10884d21aeeb4df0",
+      "performance_model_version": 2,
+      "prerequisites": [
+        "batch_api_contract",
+        "result_equivalence"
+      ],
       "provenance": "call-site",
       "rank_factors": {
         "affected_call_sites": 2,
@@ -848,13 +1280,33 @@
       },
       "rank_score": 14,
       "reliable_entry_reachability": null,
+      "resource_fingerprints": [],
       "shared_path_suffix": [
         "tests/test_job.py::run",
         "src/app/db.py::get_session"
       ],
-      "terminal_sink": "src/app/db.py::get_session"
+      "terminal_sink": "src/app/db.py::get_session",
+      "why_ranked": [
+        {
+          "factor": "boundary_kind",
+          "points": 4,
+          "value": "db"
+        },
+        {
+          "factor": "multiplier_shape",
+          "points": 4,
+          "value": "io_in_loop"
+        },
+        {
+          "factor": "provenance",
+          "points": 3,
+          "value": "call-site"
+        }
+      ]
     },
     {
+      "actionability_reason": "low_evidence_confidence",
+      "actionability_state": "advisory",
       "affected_call_sites_total": 1,
       "affected_files_total": 1,
       "biomarker_type": "io_in_loop",
@@ -881,6 +1333,13 @@
       ],
       "evidence_truncated": false,
       "execution_context": "production",
+      "facets": {
+        "actionability_confidence": "low",
+        "amplification": "per_iteration",
+        "change_risk": "contained",
+        "exposure": "unknown",
+        "leverage": "isolated"
+      },
       "fix": {
         "rationale": "The shared I/O sink is proven; no concrete batch API or result-equivalence proof is available.",
         "safety": "advisory",
@@ -888,7 +1347,13 @@
       },
       "intervention_symbol": "src/app/guess.py::run",
       "observations_total": 1,
-      "opportunity_id": "perf_cdc672bf096aac79f951",
+      "opportunity_id": "perf2_a817f9001be1d323f8a2",
+      "performance_model_version": 2,
+      "prerequisites": [
+        "batch_api_contract",
+        "result_equivalence",
+        "reliable_call_path"
+      ],
       "provenance": "name-fallback",
       "rank_factors": {
         "affected_call_sites": 2,
@@ -900,13 +1365,33 @@
       },
       "rank_score": 13,
       "reliable_entry_reachability": null,
+      "resource_fingerprints": [],
       "shared_path_suffix": [
         "src/app/guess.py::run",
         "src/app/db.py::guessed_sink"
       ],
-      "terminal_sink": "src/app/db.py::guessed_sink"
+      "terminal_sink": "src/app/db.py::guessed_sink",
+      "why_ranked": [
+        {
+          "factor": "boundary_kind",
+          "points": 4,
+          "value": "db"
+        },
+        {
+          "factor": "multiplier_shape",
+          "points": 4,
+          "value": "io_in_loop"
+        },
+        {
+          "factor": "execution_context",
+          "points": 3,
+          "value": "production"
+        }
+      ]
     },
     {
+      "actionability_reason": "strategy_requires_validation",
+      "actionability_state": "advisory",
       "affected_call_sites_total": 1,
       "affected_files_total": 1,
       "biomarker_type": "membership_test_against_list_in_loop",
@@ -930,6 +1415,13 @@
       ],
       "evidence_truncated": false,
       "execution_context": "production",
+      "facets": {
+        "actionability_confidence": "medium",
+        "amplification": "per_iteration",
+        "change_risk": "contained",
+        "exposure": "unknown",
+        "leverage": "isolated"
+      },
       "fix": {
         "rationale": "The collection is proven list-backed; element hashability and ordering/identity use still require validation.",
         "safety": "advisory",
@@ -937,7 +1429,12 @@
       },
       "intervention_symbol": null,
       "observations_total": 1,
-      "opportunity_id": "perf_6b8f8be1ab10062f0a19",
+      "opportunity_id": "perf2_6b8f8be1ab10062f0a19",
+      "performance_model_version": 2,
+      "prerequisites": [
+        "element_hashability",
+        "ordering_and_identity_use"
+      ],
       "provenance": "direct",
       "rank_factors": {
         "affected_call_sites": 2,
@@ -949,10 +1446,30 @@
       },
       "rank_score": 11,
       "reliable_entry_reachability": null,
+      "resource_fingerprints": [],
       "shared_path_suffix": [],
-      "terminal_sink": null
+      "terminal_sink": null,
+      "why_ranked": [
+        {
+          "factor": "execution_context",
+          "points": 3,
+          "value": "production"
+        },
+        {
+          "factor": "multiplier_shape",
+          "points": 3,
+          "value": "membership_test_against_list_in_loop"
+        },
+        {
+          "factor": "provenance",
+          "points": 3,
+          "value": "direct"
+        }
+      ]
     },
     {
+      "actionability_reason": "strategy_requires_validation",
+      "actionability_state": "advisory",
       "affected_call_sites_total": 1,
       "affected_files_total": 1,
       "biomarker_type": "string_concat_in_loop",
@@ -976,6 +1493,13 @@
       ],
       "evidence_truncated": false,
       "execution_context": "production",
+      "facets": {
+        "actionability_confidence": "medium",
+        "amplification": "per_iteration",
+        "change_risk": "contained",
+        "exposure": "unknown",
+        "leverage": "isolated"
+      },
       "fix": {
         "rationale": "Repeated string accumulation is proven; intermediate accumulator observations still require validation.",
         "safety": "advisory",
@@ -983,7 +1507,11 @@
       },
       "intervention_symbol": null,
       "observations_total": 1,
-      "opportunity_id": "perf_e82f5ad0e9c24fe3d1a1",
+      "opportunity_id": "perf2_e82f5ad0e9c24fe3d1a1",
+      "performance_model_version": 2,
+      "prerequisites": [
+        "accumulator_not_observed"
+      ],
       "provenance": "direct",
       "rank_factors": {
         "affected_call_sites": 2,
@@ -995,8 +1523,696 @@
       },
       "rank_score": 11,
       "reliable_entry_reachability": null,
+      "resource_fingerprints": [],
       "shared_path_suffix": [],
-      "terminal_sink": null
+      "terminal_sink": null,
+      "why_ranked": [
+        {
+          "factor": "execution_context",
+          "points": 3,
+          "value": "production"
+        },
+        {
+          "factor": "multiplier_shape",
+          "points": 3,
+          "value": "string_concat_in_loop"
+        },
+        {
+          "factor": "provenance",
+          "points": 3,
+          "value": "direct"
+        }
+      ]
+    },
+    {
+      "actionability_reason": "no_supported_strategy",
+      "actionability_state": "investigate",
+      "affected_call_sites_total": 2,
+      "affected_files_total": 1,
+      "biomarker_type": "blocking_io_under_lock",
+      "biomarker_types": [
+        "blocking_io_under_lock"
+      ],
+      "boundary_kind": "db",
+      "confidence": "high",
+      "evidence": [
+        {
+          "biomarker_type": "blocking_io_under_lock",
+          "file_path": "src/app/pool.py",
+          "finding_id": "distinct_lock_owners-13",
+          "function_name": "reaper",
+          "line_end": 132,
+          "line_start": 130,
+          "path": [
+            "src/app/pool.py::reaper",
+            "src/app/store.py::flush_all",
+            "src/app/store.py::flush"
+          ],
+          "provenance": "call-site",
+          "reason": "distinct_lock_owners: blocking_io_under_lock at src/app/pool.py:130 repeats work per iteration."
+        },
+        {
+          "biomarker_type": "blocking_io_under_lock",
+          "file_path": "src/app/pool.py",
+          "finding_id": "distinct_lock_owners-12",
+          "function_name": "writer",
+          "line_end": 132,
+          "line_start": 130,
+          "path": [
+            "src/app/pool.py::writer",
+            "src/app/store.py::flush_all",
+            "src/app/store.py::flush"
+          ],
+          "provenance": "call-site",
+          "reason": "distinct_lock_owners: blocking_io_under_lock at src/app/pool.py:130 repeats work per iteration."
+        }
+      ],
+      "evidence_truncated": false,
+      "execution_context": "production",
+      "facets": {
+        "actionability_confidence": "low",
+        "amplification": "per_iteration",
+        "change_risk": "contained",
+        "exposure": "unknown",
+        "leverage": "local"
+      },
+      "fix": null,
+      "intervention_symbol": "src/app/store.py::flush_all",
+      "observations_total": 2,
+      "opportunity_id": "perf2_bb39bb7c7b9f0b1fe7a1",
+      "performance_model_version": 2,
+      "prerequisites": [
+        "single_lock_owner"
+      ],
+      "provenance": "call-site",
+      "rank_factors": {
+        "affected_call_sites": 3,
+        "boundary_kind": 4,
+        "entry_reachability": 0,
+        "execution_context": 3,
+        "multiplier_shape": 5,
+        "provenance": 3
+      },
+      "rank_score": 18,
+      "reliable_entry_reachability": null,
+      "resource_fingerprints": [],
+      "shared_path_suffix": [
+        "src/app/store.py::flush_all",
+        "src/app/store.py::flush"
+      ],
+      "terminal_sink": "src/app/store.py::flush",
+      "why_ranked": [
+        {
+          "factor": "multiplier_shape",
+          "points": 5,
+          "value": "blocking_io_under_lock"
+        },
+        {
+          "factor": "boundary_kind",
+          "points": 4,
+          "value": "db"
+        },
+        {
+          "factor": "affected_call_sites",
+          "points": 3,
+          "value": 2
+        }
+      ]
+    },
+    {
+      "actionability_reason": "no_supported_strategy",
+      "actionability_state": "investigate",
+      "affected_call_sites_total": 4,
+      "affected_files_total": 4,
+      "biomarker_type": "io_in_loop",
+      "biomarker_types": [
+        "io_in_loop"
+      ],
+      "boundary_kind": "filesystem",
+      "confidence": "high",
+      "evidence": [
+        {
+          "biomarker_type": "io_in_loop",
+          "file_path": "src/app/formatter.py",
+          "finding_id": "shared_dominator_fan_in-29",
+          "function_name": "run",
+          "line_end": 24,
+          "line_start": 22,
+          "path": [
+            "src/app/formatter.py::run",
+            "src/app/parse.py::_get_query",
+            "src/app/parse.py::_load_compiled_query"
+          ],
+          "provenance": "call-site",
+          "reason": "shared_dominator_fan_in: io_in_loop at src/app/formatter.py:22 repeats work per iteration."
+        },
+        {
+          "biomarker_type": "io_in_loop",
+          "file_path": "src/app/lexer.py",
+          "finding_id": "shared_dominator_fan_in-27",
+          "function_name": "run",
+          "line_end": 22,
+          "line_start": 20,
+          "path": [
+            "src/app/lexer.py::run",
+            "src/app/parse.py::_get_query",
+            "src/app/parse.py::_load_compiled_query"
+          ],
+          "provenance": "call-site",
+          "reason": "shared_dominator_fan_in: io_in_loop at src/app/lexer.py:20 repeats work per iteration."
+        },
+        {
+          "biomarker_type": "io_in_loop",
+          "file_path": "src/app/linter.py",
+          "finding_id": "shared_dominator_fan_in-28",
+          "function_name": "run",
+          "line_end": 23,
+          "line_start": 21,
+          "path": [
+            "src/app/linter.py::run",
+            "src/app/parse.py::_get_query",
+            "src/app/parse.py::_load_compiled_query"
+          ],
+          "provenance": "call-site",
+          "reason": "shared_dominator_fan_in: io_in_loop at src/app/linter.py:21 repeats work per iteration."
+        },
+        {
+          "biomarker_type": "io_in_loop",
+          "file_path": "src/app/resolver.py",
+          "finding_id": "shared_dominator_fan_in-30",
+          "function_name": "run",
+          "line_end": 25,
+          "line_start": 23,
+          "path": [
+            "src/app/resolver.py::run",
+            "src/app/parse.py::_get_query",
+            "src/app/parse.py::_load_compiled_query"
+          ],
+          "provenance": "call-site",
+          "reason": "shared_dominator_fan_in: io_in_loop at src/app/resolver.py:23 repeats work per iteration."
+        }
+      ],
+      "evidence_truncated": false,
+      "execution_context": "production",
+      "facets": {
+        "actionability_confidence": "low",
+        "amplification": "per_iteration",
+        "change_risk": "moderate",
+        "exposure": "unknown",
+        "leverage": "shared"
+      },
+      "fix": null,
+      "intervention_symbol": "src/app/parse.py::_get_query",
+      "observations_total": 4,
+      "opportunity_id": "perf2_a445d6f2d021ddf6a425",
+      "performance_model_version": 2,
+      "prerequisites": [
+        "batch_operation_for_boundary"
+      ],
+      "provenance": "call-site",
+      "rank_factors": {
+        "affected_call_sites": 4,
+        "boundary_kind": 2,
+        "entry_reachability": 0,
+        "execution_context": 3,
+        "multiplier_shape": 4,
+        "provenance": 3
+      },
+      "rank_score": 16,
+      "reliable_entry_reachability": null,
+      "resource_fingerprints": [],
+      "shared_path_suffix": [
+        "src/app/parse.py::_get_query",
+        "src/app/parse.py::_load_compiled_query"
+      ],
+      "terminal_sink": "src/app/parse.py::_load_compiled_query",
+      "why_ranked": [
+        {
+          "factor": "affected_call_sites",
+          "points": 4,
+          "value": 4
+        },
+        {
+          "factor": "multiplier_shape",
+          "points": 4,
+          "value": "io_in_loop"
+        },
+        {
+          "factor": "execution_context",
+          "points": 3,
+          "value": "production"
+        }
+      ]
+    },
+    {
+      "actionability_reason": "no_supported_strategy",
+      "actionability_state": "investigate",
+      "affected_call_sites_total": 1,
+      "affected_files_total": 1,
+      "biomarker_type": "resource_construction_in_loop",
+      "biomarker_types": [
+        "resource_construction_in_loop"
+      ],
+      "boundary_kind": "network",
+      "confidence": "high",
+      "evidence": [
+        {
+          "biomarker_type": "resource_construction_in_loop",
+          "file_path": "src/app/clients.py",
+          "finding_id": "resource_construction-17",
+          "function_name": "each_varying",
+          "line_end": 182,
+          "line_start": 180,
+          "path": [],
+          "provenance": "direct",
+          "reason": "resource_construction: resource_construction_in_loop at src/app/clients.py:180 repeats work per iteration."
+        }
+      ],
+      "evidence_truncated": false,
+      "execution_context": "production",
+      "facets": {
+        "actionability_confidence": "low",
+        "amplification": "per_iteration",
+        "change_risk": "contained",
+        "exposure": "unknown",
+        "leverage": "isolated"
+      },
+      "fix": null,
+      "intervention_symbol": null,
+      "observations_total": 1,
+      "opportunity_id": "perf2_266b6dd67d9b9e93e201",
+      "performance_model_version": 2,
+      "prerequisites": [
+        "loop_invariant_construction_proof"
+      ],
+      "provenance": "direct",
+      "rank_factors": {
+        "affected_call_sites": 2,
+        "boundary_kind": 4,
+        "entry_reachability": 0,
+        "execution_context": 3,
+        "multiplier_shape": 4,
+        "provenance": 3
+      },
+      "rank_score": 16,
+      "reliable_entry_reachability": null,
+      "resource_fingerprints": [],
+      "shared_path_suffix": [],
+      "terminal_sink": null,
+      "why_ranked": [
+        {
+          "factor": "boundary_kind",
+          "points": 4,
+          "value": "network"
+        },
+        {
+          "factor": "multiplier_shape",
+          "points": 4,
+          "value": "resource_construction_in_loop"
+        },
+        {
+          "factor": "execution_context",
+          "points": 3,
+          "value": "production"
+        }
+      ]
+    },
+    {
+      "actionability_reason": "no_supported_strategy",
+      "actionability_state": "investigate",
+      "affected_call_sites_total": 1,
+      "affected_files_total": 1,
+      "biomarker_type": "serial_await_in_loop",
+      "biomarker_types": [
+        "serial_await_in_loop"
+      ],
+      "boundary_kind": "network",
+      "confidence": "high",
+      "evidence": [
+        {
+          "biomarker_type": "serial_await_in_loop",
+          "file_path": "src/app/fanout.py",
+          "finding_id": "async_serial_awaits-10",
+          "function_name": "gather_seq",
+          "line_end": 97,
+          "line_start": 95,
+          "path": [],
+          "provenance": "direct",
+          "reason": "async_serial_awaits: serial_await_in_loop at src/app/fanout.py:95 repeats work per iteration."
+        }
+      ],
+      "evidence_truncated": false,
+      "execution_context": "production",
+      "facets": {
+        "actionability_confidence": "low",
+        "amplification": "per_iteration",
+        "change_risk": "contained",
+        "exposure": "unknown",
+        "leverage": "isolated"
+      },
+      "fix": null,
+      "intervention_symbol": null,
+      "observations_total": 1,
+      "opportunity_id": "perf2_64fbd03504c61c115894",
+      "performance_model_version": 2,
+      "prerequisites": [
+        "loop_carried_dependence_proof"
+      ],
+      "provenance": "direct",
+      "rank_factors": {
+        "affected_call_sites": 2,
+        "boundary_kind": 4,
+        "entry_reachability": 0,
+        "execution_context": 3,
+        "multiplier_shape": 4,
+        "provenance": 3
+      },
+      "rank_score": 16,
+      "reliable_entry_reachability": null,
+      "resource_fingerprints": [],
+      "shared_path_suffix": [],
+      "terminal_sink": null,
+      "why_ranked": [
+        {
+          "factor": "boundary_kind",
+          "points": 4,
+          "value": "network"
+        },
+        {
+          "factor": "multiplier_shape",
+          "points": 4,
+          "value": "serial_await_in_loop"
+        },
+        {
+          "factor": "execution_context",
+          "points": 3,
+          "value": "production"
+        }
+      ]
+    },
+    {
+      "actionability_reason": "no_supported_strategy",
+      "actionability_state": "investigate",
+      "affected_call_sites_total": 1,
+      "affected_files_total": 1,
+      "biomarker_type": "io_in_loop",
+      "biomarker_types": [
+        "io_in_loop"
+      ],
+      "boundary_kind": "filesystem",
+      "confidence": "high",
+      "evidence": [
+        {
+          "biomarker_type": "io_in_loop",
+          "file_path": "src/app/walker.py",
+          "finding_id": "filesystem_fan_out-05",
+          "function_name": "scan",
+          "line_end": 52,
+          "line_start": 50,
+          "path": [
+            "src/app/walker.py::scan",
+            "src/app/fsio.py::read_text"
+          ],
+          "provenance": "call-site",
+          "reason": "filesystem_fan_out: io_in_loop at src/app/walker.py:50 repeats work per iteration."
+        }
+      ],
+      "evidence_truncated": false,
+      "execution_context": "production",
+      "facets": {
+        "actionability_confidence": "low",
+        "amplification": "per_iteration",
+        "change_risk": "contained",
+        "exposure": "unknown",
+        "leverage": "isolated"
+      },
+      "fix": null,
+      "intervention_symbol": "src/app/walker.py::scan",
+      "observations_total": 1,
+      "opportunity_id": "perf2_19a89b391403e23aed4d",
+      "performance_model_version": 2,
+      "prerequisites": [
+        "batch_operation_for_boundary"
+      ],
+      "provenance": "call-site",
+      "rank_factors": {
+        "affected_call_sites": 2,
+        "boundary_kind": 2,
+        "entry_reachability": 0,
+        "execution_context": 3,
+        "multiplier_shape": 4,
+        "provenance": 3
+      },
+      "rank_score": 14,
+      "reliable_entry_reachability": null,
+      "resource_fingerprints": [],
+      "shared_path_suffix": [
+        "src/app/walker.py::scan",
+        "src/app/fsio.py::read_text"
+      ],
+      "terminal_sink": "src/app/fsio.py::read_text",
+      "why_ranked": [
+        {
+          "factor": "multiplier_shape",
+          "points": 4,
+          "value": "io_in_loop"
+        },
+        {
+          "factor": "execution_context",
+          "points": 3,
+          "value": "production"
+        },
+        {
+          "factor": "provenance",
+          "points": 3,
+          "value": "call-site"
+        }
+      ]
+    },
+    {
+      "actionability_reason": "no_supported_strategy",
+      "actionability_state": "investigate",
+      "affected_call_sites_total": 1,
+      "affected_files_total": 1,
+      "biomarker_type": "io_in_loop",
+      "biomarker_types": [
+        "io_in_loop"
+      ],
+      "boundary_kind": "filesystem",
+      "confidence": "high",
+      "evidence": [
+        {
+          "biomarker_type": "io_in_loop",
+          "file_path": "src/app/walker.py",
+          "finding_id": "filesystem_fan_out-06",
+          "function_name": "index",
+          "line_end": 53,
+          "line_start": 51,
+          "path": [
+            "src/app/walker.py::index",
+            "src/app/fsio.py::read_text"
+          ],
+          "provenance": "call-site",
+          "reason": "filesystem_fan_out: io_in_loop at src/app/walker.py:51 repeats work per iteration."
+        }
+      ],
+      "evidence_truncated": false,
+      "execution_context": "production",
+      "facets": {
+        "actionability_confidence": "low",
+        "amplification": "per_iteration",
+        "change_risk": "contained",
+        "exposure": "unknown",
+        "leverage": "isolated"
+      },
+      "fix": null,
+      "intervention_symbol": "src/app/walker.py::index",
+      "observations_total": 1,
+      "opportunity_id": "perf2_68583bf925fadb4f4731",
+      "performance_model_version": 2,
+      "prerequisites": [
+        "batch_operation_for_boundary"
+      ],
+      "provenance": "call-site",
+      "rank_factors": {
+        "affected_call_sites": 2,
+        "boundary_kind": 2,
+        "entry_reachability": 0,
+        "execution_context": 3,
+        "multiplier_shape": 4,
+        "provenance": 3
+      },
+      "rank_score": 14,
+      "reliable_entry_reachability": null,
+      "resource_fingerprints": [],
+      "shared_path_suffix": [
+        "src/app/walker.py::index",
+        "src/app/fsio.py::read_text"
+      ],
+      "terminal_sink": "src/app/fsio.py::read_text",
+      "why_ranked": [
+        {
+          "factor": "multiplier_shape",
+          "points": 4,
+          "value": "io_in_loop"
+        },
+        {
+          "factor": "execution_context",
+          "points": 3,
+          "value": "production"
+        },
+        {
+          "factor": "provenance",
+          "points": 3,
+          "value": "call-site"
+        }
+      ]
+    },
+    {
+      "actionability_reason": "no_supported_strategy",
+      "actionability_state": "investigate",
+      "affected_call_sites_total": 1,
+      "affected_files_total": 1,
+      "biomarker_type": "io_in_loop",
+      "biomarker_types": [
+        "io_in_loop"
+      ],
+      "boundary_kind": "filesystem",
+      "confidence": "high",
+      "evidence": [
+        {
+          "biomarker_type": "io_in_loop",
+          "file_path": "docs/snippets/walk.py",
+          "finding_id": "unclassified_context-31",
+          "function_name": "demo",
+          "line_end": 10,
+          "line_start": 8,
+          "path": [],
+          "provenance": "direct",
+          "reason": "unclassified_context: io_in_loop at docs/snippets/walk.py:8 repeats work per iteration."
+        }
+      ],
+      "evidence_truncated": false,
+      "execution_context": "unknown",
+      "facets": {
+        "actionability_confidence": "low",
+        "amplification": "per_iteration",
+        "change_risk": "contained",
+        "exposure": "unknown",
+        "leverage": "isolated"
+      },
+      "fix": null,
+      "intervention_symbol": null,
+      "observations_total": 1,
+      "opportunity_id": "perf2_8ffbe99d8409ad899a72",
+      "performance_model_version": 2,
+      "prerequisites": [
+        "batch_operation_for_boundary"
+      ],
+      "provenance": "direct",
+      "rank_factors": {
+        "affected_call_sites": 2,
+        "boundary_kind": 2,
+        "entry_reachability": 0,
+        "execution_context": 1,
+        "multiplier_shape": 4,
+        "provenance": 3
+      },
+      "rank_score": 12,
+      "reliable_entry_reachability": null,
+      "resource_fingerprints": [],
+      "shared_path_suffix": [],
+      "terminal_sink": null,
+      "why_ranked": [
+        {
+          "factor": "multiplier_shape",
+          "points": 4,
+          "value": "io_in_loop"
+        },
+        {
+          "factor": "provenance",
+          "points": 3,
+          "value": "direct"
+        },
+        {
+          "factor": "affected_call_sites",
+          "points": 2,
+          "value": 1
+        }
+      ]
+    },
+    {
+      "actionability_reason": "no_supported_strategy",
+      "actionability_state": "investigate",
+      "affected_call_sites_total": 1,
+      "affected_files_total": 1,
+      "biomarker_type": "io_in_loop",
+      "biomarker_types": [
+        "io_in_loop"
+      ],
+      "boundary_kind": "filesystem",
+      "confidence": "high",
+      "evidence": [
+        {
+          "biomarker_type": "io_in_loop",
+          "file_path": "bootstrap.py",
+          "finding_id": "unclassified_context-32",
+          "function_name": "main",
+          "line_end": 16,
+          "line_start": 14,
+          "path": [],
+          "provenance": "direct",
+          "reason": "unclassified_context: io_in_loop at bootstrap.py:14 repeats work per iteration."
+        }
+      ],
+      "evidence_truncated": false,
+      "execution_context": "unknown",
+      "facets": {
+        "actionability_confidence": "low",
+        "amplification": "per_iteration",
+        "change_risk": "contained",
+        "exposure": "unknown",
+        "leverage": "isolated"
+      },
+      "fix": null,
+      "intervention_symbol": null,
+      "observations_total": 1,
+      "opportunity_id": "perf2_91e5b79c0937ef51ec73",
+      "performance_model_version": 2,
+      "prerequisites": [
+        "batch_operation_for_boundary"
+      ],
+      "provenance": "direct",
+      "rank_factors": {
+        "affected_call_sites": 2,
+        "boundary_kind": 2,
+        "entry_reachability": 0,
+        "execution_context": 1,
+        "multiplier_shape": 4,
+        "provenance": 3
+      },
+      "rank_score": 12,
+      "reliable_entry_reachability": null,
+      "resource_fingerprints": [],
+      "shared_path_suffix": [],
+      "terminal_sink": null,
+      "why_ranked": [
+        {
+          "factor": "multiplier_shape",
+          "points": 4,
+          "value": "io_in_loop"
+        },
+        {
+          "factor": "provenance",
+          "points": 3,
+          "value": "direct"
+        },
+        {
+          "factor": "affected_call_sites",
+          "points": 2,
+          "value": 1
+        }
+      ]
     }
   ]
 }

--- a/tests/fixtures/perf_corpus/golden_plans.json
+++ b/tests/fixtures/perf_corpus/golden_plans.json
@@ -2,6 +2,194 @@
   "plans": [
     {
       "blast_radius": {
+        "call_sites": 1,
+        "file_count": 1,
+        "files": [
+          "src/app/fanout.py"
+        ]
+      },
+      "confidence": "high",
+      "evidence": {
+        "affected_files_total": 1,
+        "biomarker_type": "serial_await_in_loop",
+        "biomarker_types": [
+          "serial_await_in_loop"
+        ],
+        "boundary_kind": "network",
+        "execution_context": "production",
+        "observations_total": 1,
+        "provenance": "direct",
+        "rank_factors": {
+          "affected_call_sites": 2,
+          "boundary_kind": 4,
+          "entry_reachability": 0,
+          "execution_context": 3,
+          "multiplier_shape": 4,
+          "provenance": 3
+        },
+        "rank_score": 16,
+        "rationale": "Dataflow proves that every observed loop carries no cross-iteration dependence.",
+        "reliable_entry_reachability": null
+      },
+      "file_path": "src/app/fanout.py",
+      "impact_delta": 0.0,
+      "line_end": 92,
+      "line_start": 90,
+      "plan": {
+        "affected_locations": [
+          {
+            "file_path": "src/app/fanout.py",
+            "function_name": "gather_all",
+            "line_end": 92,
+            "line_start": 90
+          }
+        ],
+        "affected_locations_total": 1,
+        "evidence_truncated": false,
+        "intervention_symbol": null,
+        "opportunity_id": "perf2_182b2a7c053167959285",
+        "paths": [],
+        "paths_total": 1,
+        "safety": "proven",
+        "strategy": "parallelize_independent_awaits"
+      },
+      "refactoring_type": "performance_fix",
+      "source_biomarker": "serial_await_in_loop",
+      "target_symbol": "gather_all"
+    },
+    {
+      "blast_radius": {
+        "call_sites": 1,
+        "file_count": 1,
+        "files": [
+          "src/app/clients.py"
+        ]
+      },
+      "confidence": "high",
+      "evidence": {
+        "affected_files_total": 1,
+        "biomarker_type": "resource_construction_in_loop",
+        "biomarker_types": [
+          "resource_construction_in_loop"
+        ],
+        "boundary_kind": "network",
+        "execution_context": "production",
+        "observations_total": 1,
+        "provenance": "direct",
+        "rank_factors": {
+          "affected_call_sites": 2,
+          "boundary_kind": 4,
+          "entry_reachability": 0,
+          "execution_context": 3,
+          "multiplier_shape": 4,
+          "provenance": 3
+        },
+        "rank_score": 16,
+        "rationale": "Dataflow proves construction arguments and lifetime are loop invariant.",
+        "reliable_entry_reachability": null
+      },
+      "file_path": "src/app/clients.py",
+      "impact_delta": 0.0,
+      "line_end": 172,
+      "line_start": 170,
+      "plan": {
+        "affected_locations": [
+          {
+            "file_path": "src/app/clients.py",
+            "function_name": "each",
+            "line_end": 172,
+            "line_start": 170
+          }
+        ],
+        "affected_locations_total": 1,
+        "evidence_truncated": false,
+        "intervention_symbol": null,
+        "opportunity_id": "perf2_386a99aa2876c0dd31bd",
+        "paths": [],
+        "paths_total": 1,
+        "safety": "proven",
+        "strategy": "hoist_loop_invariant_resource"
+      },
+      "refactoring_type": "performance_fix",
+      "source_biomarker": "resource_construction_in_loop",
+      "target_symbol": "each"
+    },
+    {
+      "blast_radius": {
+        "call_sites": 2,
+        "file_count": 1,
+        "files": [
+          "src/app/entry.py"
+        ]
+      },
+      "confidence": "medium",
+      "evidence": {
+        "affected_files_total": 1,
+        "biomarker_type": "io_in_loop",
+        "biomarker_types": [
+          "io_in_loop"
+        ],
+        "boundary_kind": "db",
+        "execution_context": "production",
+        "observations_total": 2,
+        "provenance": "call-site",
+        "rank_factors": {
+          "affected_call_sites": 3,
+          "boundary_kind": 4,
+          "entry_reachability": 3,
+          "execution_context": 3,
+          "multiplier_shape": 4,
+          "provenance": 3
+        },
+        "rank_score": 20,
+        "rationale": "The shared I/O sink is proven; no concrete batch API or result-equivalence proof is available.",
+        "reliable_entry_reachability": true
+      },
+      "file_path": "src/app/entry.py",
+      "impact_delta": 0.0,
+      "line_end": 252,
+      "line_start": 250,
+      "plan": {
+        "affected_locations": [
+          {
+            "file_path": "src/app/entry.py",
+            "function_name": "a",
+            "line_end": 252,
+            "line_start": 250
+          },
+          {
+            "file_path": "src/app/entry.py",
+            "function_name": "b",
+            "line_end": 257,
+            "line_start": 255
+          }
+        ],
+        "affected_locations_total": 2,
+        "evidence_truncated": false,
+        "intervention_symbol": "src/app/entry.py::_hit",
+        "opportunity_id": "perf2_0673587e7abbea99fc0b",
+        "paths": [
+          [
+            "src/app/entry.py::a",
+            "src/app/entry.py::_hit",
+            "src/app/db.py::reach_sink"
+          ],
+          [
+            "src/app/entry.py::b",
+            "src/app/entry.py::_hit",
+            "src/app/db.py::reach_sink"
+          ]
+        ],
+        "paths_total": 2,
+        "safety": "advisory",
+        "strategy": "batch_or_prefetch_io"
+      },
+      "refactoring_type": "performance_fix",
+      "source_biomarker": "io_in_loop",
+      "target_symbol": "src/app/entry.py::_hit"
+    },
+    {
+      "blast_radius": {
         "call_sites": 2,
         "file_count": 1,
         "files": [
@@ -53,7 +241,7 @@
         "affected_locations_total": 2,
         "evidence_truncated": false,
         "intervention_symbol": "src/app/repo.py::fetch_page",
-        "opportunity_id": "perf_9de801a6e25fb309d266",
+        "opportunity_id": "perf2_89348be6c2ba0311a0e8",
         "paths": [
           [
             "src/app/api.py::list_users",
@@ -73,6 +261,81 @@
       "refactoring_type": "performance_fix",
       "source_biomarker": "io_in_loop",
       "target_symbol": "src/app/repo.py::fetch_page"
+    },
+    {
+      "blast_radius": {
+        "call_sites": 2,
+        "file_count": 1,
+        "files": [
+          "src/app/reindex.py"
+        ]
+      },
+      "confidence": "medium",
+      "evidence": {
+        "affected_files_total": 1,
+        "biomarker_type": "nested_loop_with_io",
+        "biomarker_types": [
+          "io_in_loop",
+          "nested_loop_with_io"
+        ],
+        "boundary_kind": "db",
+        "execution_context": "production",
+        "observations_total": 2,
+        "provenance": "call-site",
+        "rank_factors": {
+          "affected_call_sites": 3,
+          "boundary_kind": 4,
+          "entry_reachability": 0,
+          "execution_context": 3,
+          "multiplier_shape": 6,
+          "provenance": 3
+        },
+        "rank_score": 19,
+        "rationale": "The shared I/O sink is proven; no concrete batch API or result-equivalence proof is available.",
+        "reliable_entry_reachability": null
+      },
+      "file_path": "src/app/reindex.py",
+      "impact_delta": 0.0,
+      "line_end": 212,
+      "line_start": 210,
+      "plan": {
+        "affected_locations": [
+          {
+            "file_path": "src/app/reindex.py",
+            "function_name": "one",
+            "line_end": 212,
+            "line_start": 210
+          },
+          {
+            "file_path": "src/app/reindex.py",
+            "function_name": "many",
+            "line_end": 217,
+            "line_start": 215
+          }
+        ],
+        "affected_locations_total": 2,
+        "evidence_truncated": false,
+        "intervention_symbol": "src/app/reindex.py::_write",
+        "opportunity_id": "perf2_3d62fcebb00bdf408f2c",
+        "paths": [
+          [
+            "src/app/reindex.py::one",
+            "src/app/reindex.py::_write",
+            "src/app/db.py::upsert"
+          ],
+          [
+            "src/app/reindex.py::many",
+            "src/app/reindex.py::_write",
+            "src/app/db.py::upsert"
+          ]
+        ],
+        "paths_total": 2,
+        "safety": "advisory",
+        "strategy": "batch_or_prefetch_io"
+      },
+      "refactoring_type": "performance_fix",
+      "source_biomarker": "nested_loop_with_io",
+      "target_symbol": "src/app/reindex.py::_write"
     },
     {
       "blast_radius": {
@@ -127,7 +390,7 @@
         "affected_locations_total": 2,
         "evidence_truncated": false,
         "intervention_symbol": "src/app/sync.py::_load",
-        "opportunity_id": "perf_353153d5e9b5c681a057",
+        "opportunity_id": "perf2_af29fc10103a555c8652",
         "paths": [
           [
             "src/app/sync.py::sync_one",
@@ -195,7 +458,7 @@
         "affected_locations_total": 1,
         "evidence_truncated": false,
         "intervention_symbol": "src/app/cache.py::refresh",
-        "opportunity_id": "perf_7e351bac743b6db777e7",
+        "opportunity_id": "perf2_9dfe577bc9c8b799355e",
         "paths": [
           [
             "src/app/cache.py::refresh",
@@ -215,121 +478,7 @@
         "call_sites": 1,
         "file_count": 1,
         "files": [
-          "src/app/fanout.py"
-        ]
-      },
-      "confidence": "high",
-      "evidence": {
-        "affected_files_total": 1,
-        "biomarker_type": "serial_await_in_loop",
-        "biomarker_types": [
-          "serial_await_in_loop"
-        ],
-        "boundary_kind": "network",
-        "execution_context": "production",
-        "observations_total": 1,
-        "provenance": "direct",
-        "rank_factors": {
-          "affected_call_sites": 2,
-          "boundary_kind": 4,
-          "entry_reachability": 0,
-          "execution_context": 3,
-          "multiplier_shape": 4,
-          "provenance": 3
-        },
-        "rank_score": 16,
-        "rationale": "Dataflow proves that every observed loop carries no cross-iteration dependence.",
-        "reliable_entry_reachability": null
-      },
-      "file_path": "src/app/fanout.py",
-      "impact_delta": 0.0,
-      "line_end": 92,
-      "line_start": 90,
-      "plan": {
-        "affected_locations": [
-          {
-            "file_path": "src/app/fanout.py",
-            "function_name": "gather_all",
-            "line_end": 92,
-            "line_start": 90
-          }
-        ],
-        "affected_locations_total": 1,
-        "evidence_truncated": false,
-        "intervention_symbol": null,
-        "opportunity_id": "perf_182b2a7c053167959285",
-        "paths": [],
-        "paths_total": 1,
-        "safety": "proven",
-        "strategy": "parallelize_independent_awaits"
-      },
-      "refactoring_type": "performance_fix",
-      "source_biomarker": "serial_await_in_loop",
-      "target_symbol": "gather_all"
-    },
-    {
-      "blast_radius": {
-        "call_sites": 1,
-        "file_count": 1,
-        "files": [
-          "src/app/clients.py"
-        ]
-      },
-      "confidence": "high",
-      "evidence": {
-        "affected_files_total": 1,
-        "biomarker_type": "resource_construction_in_loop",
-        "biomarker_types": [
-          "resource_construction_in_loop"
-        ],
-        "boundary_kind": "network",
-        "execution_context": "production",
-        "observations_total": 1,
-        "provenance": "direct",
-        "rank_factors": {
-          "affected_call_sites": 2,
-          "boundary_kind": 4,
-          "entry_reachability": 0,
-          "execution_context": 3,
-          "multiplier_shape": 4,
-          "provenance": 3
-        },
-        "rank_score": 16,
-        "rationale": "Dataflow proves construction arguments and lifetime are loop invariant.",
-        "reliable_entry_reachability": null
-      },
-      "file_path": "src/app/clients.py",
-      "impact_delta": 0.0,
-      "line_end": 172,
-      "line_start": 170,
-      "plan": {
-        "affected_locations": [
-          {
-            "file_path": "src/app/clients.py",
-            "function_name": "each",
-            "line_end": 172,
-            "line_start": 170
-          }
-        ],
-        "affected_locations_total": 1,
-        "evidence_truncated": false,
-        "intervention_symbol": null,
-        "opportunity_id": "perf_386a99aa2876c0dd31bd",
-        "paths": [],
-        "paths_total": 1,
-        "safety": "proven",
-        "strategy": "hoist_loop_invariant_resource"
-      },
-      "refactoring_type": "performance_fix",
-      "source_biomarker": "resource_construction_in_loop",
-      "target_symbol": "each"
-    },
-    {
-      "blast_radius": {
-        "call_sites": 1,
-        "file_count": 1,
-        "files": [
-          "src/app/edge.py"
+          "src/app/billing.py"
         ]
       },
       "confidence": "medium",
@@ -342,40 +491,40 @@
         "boundary_kind": "db",
         "execution_context": "production",
         "observations_total": 1,
-        "provenance": "reliable-edge",
+        "provenance": "call-site",
         "rank_factors": {
           "affected_call_sites": 2,
           "boundary_kind": 4,
           "entry_reachability": 0,
           "execution_context": 3,
           "multiplier_shape": 4,
-          "provenance": 2
+          "provenance": 3
         },
-        "rank_score": 15,
+        "rank_score": 16,
         "rationale": "The shared I/O sink is proven; no concrete batch API or result-equivalence proof is available.",
-        "reliable_entry_reachability": null
+        "reliable_entry_reachability": false
       },
-      "file_path": "src/app/edge.py",
+      "file_path": "src/app/billing.py",
       "impact_delta": 0.0,
-      "line_end": 232,
-      "line_start": 230,
+      "line_end": 13,
+      "line_start": 11,
       "plan": {
         "affected_locations": [
           {
-            "file_path": "src/app/edge.py",
-            "function_name": "run",
-            "line_end": 232,
-            "line_start": 230
+            "file_path": "src/app/billing.py",
+            "function_name": "handle",
+            "line_end": 13,
+            "line_start": 11
           }
         ],
         "affected_locations_total": 1,
         "evidence_truncated": false,
-        "intervention_symbol": "src/app/edge.py::run",
-        "opportunity_id": "perf_688cbe7795e13b1910b2",
+        "intervention_symbol": "src/app/billing.py::handle",
+        "opportunity_id": "perf2_3d4056f8405c9313d004",
         "paths": [
           [
-            "src/app/edge.py::run",
-            "src/app/db.py::reliable_sink"
+            "src/app/billing.py::handle",
+            "src/app/db.py::get_session"
           ]
         ],
         "paths_total": 1,
@@ -384,7 +533,254 @@
       },
       "refactoring_type": "performance_fix",
       "source_biomarker": "io_in_loop",
-      "target_symbol": "src/app/edge.py::run"
+      "target_symbol": "src/app/billing.py::handle"
+    },
+    {
+      "blast_radius": {
+        "call_sites": 1,
+        "file_count": 1,
+        "files": [
+          "src/app/orders.py"
+        ]
+      },
+      "confidence": "medium",
+      "evidence": {
+        "affected_files_total": 1,
+        "biomarker_type": "io_in_loop",
+        "biomarker_types": [
+          "io_in_loop"
+        ],
+        "boundary_kind": "db",
+        "execution_context": "production",
+        "observations_total": 1,
+        "provenance": "call-site",
+        "rank_factors": {
+          "affected_call_sites": 2,
+          "boundary_kind": 4,
+          "entry_reachability": 0,
+          "execution_context": 3,
+          "multiplier_shape": 4,
+          "provenance": 3
+        },
+        "rank_score": 16,
+        "rationale": "The shared I/O sink is proven; no concrete batch API or result-equivalence proof is available.",
+        "reliable_entry_reachability": false
+      },
+      "file_path": "src/app/orders.py",
+      "impact_delta": 0.0,
+      "line_end": 12,
+      "line_start": 10,
+      "plan": {
+        "affected_locations": [
+          {
+            "file_path": "src/app/orders.py",
+            "function_name": "handle",
+            "line_end": 12,
+            "line_start": 10
+          }
+        ],
+        "affected_locations_total": 1,
+        "evidence_truncated": false,
+        "intervention_symbol": "src/app/orders.py::handle",
+        "opportunity_id": "perf2_5abe869788cb2cebf6cf",
+        "paths": [
+          [
+            "src/app/orders.py::handle",
+            "src/app/db.py::get_session"
+          ]
+        ],
+        "paths_total": 1,
+        "safety": "advisory",
+        "strategy": "batch_or_prefetch_io"
+      },
+      "refactoring_type": "performance_fix",
+      "source_biomarker": "io_in_loop",
+      "target_symbol": "src/app/orders.py::handle"
+    },
+    {
+      "blast_radius": {
+        "call_sites": 1,
+        "file_count": 1,
+        "files": [
+          "src/app/reports.py"
+        ]
+      },
+      "confidence": "medium",
+      "evidence": {
+        "affected_files_total": 1,
+        "biomarker_type": "io_in_loop",
+        "biomarker_types": [
+          "io_in_loop"
+        ],
+        "boundary_kind": "db",
+        "execution_context": "production",
+        "observations_total": 1,
+        "provenance": "call-site",
+        "rank_factors": {
+          "affected_call_sites": 2,
+          "boundary_kind": 4,
+          "entry_reachability": 0,
+          "execution_context": 3,
+          "multiplier_shape": 4,
+          "provenance": 3
+        },
+        "rank_score": 16,
+        "rationale": "The shared I/O sink is proven; no concrete batch API or result-equivalence proof is available.",
+        "reliable_entry_reachability": false
+      },
+      "file_path": "src/app/reports.py",
+      "impact_delta": 0.0,
+      "line_end": 14,
+      "line_start": 12,
+      "plan": {
+        "affected_locations": [
+          {
+            "file_path": "src/app/reports.py",
+            "function_name": "handle",
+            "line_end": 14,
+            "line_start": 12
+          }
+        ],
+        "affected_locations_total": 1,
+        "evidence_truncated": false,
+        "intervention_symbol": "src/app/reports.py::handle",
+        "opportunity_id": "perf2_7d6b729c3f43753626f2",
+        "paths": [
+          [
+            "src/app/reports.py::handle",
+            "src/app/db.py::get_session"
+          ]
+        ],
+        "paths_total": 1,
+        "safety": "advisory",
+        "strategy": "batch_or_prefetch_io"
+      },
+      "refactoring_type": "performance_fix",
+      "source_biomarker": "io_in_loop",
+      "target_symbol": "src/app/reports.py::handle"
+    },
+    {
+      "blast_radius": {
+        "call_sites": 1,
+        "file_count": 1,
+        "files": [
+          "src/app/job.py"
+        ]
+      },
+      "confidence": "medium",
+      "evidence": {
+        "affected_files_total": 1,
+        "biomarker_type": "io_in_loop",
+        "biomarker_types": [
+          "io_in_loop"
+        ],
+        "boundary_kind": "db",
+        "execution_context": "production",
+        "observations_total": 1,
+        "provenance": "call-site",
+        "rank_factors": {
+          "affected_call_sites": 2,
+          "boundary_kind": 4,
+          "entry_reachability": 0,
+          "execution_context": 3,
+          "multiplier_shape": 4,
+          "provenance": 3
+        },
+        "rank_score": 16,
+        "rationale": "The shared I/O sink is proven; no concrete batch API or result-equivalence proof is available.",
+        "reliable_entry_reachability": null
+      },
+      "file_path": "src/app/job.py",
+      "impact_delta": 0.0,
+      "line_end": 202,
+      "line_start": 200,
+      "plan": {
+        "affected_locations": [
+          {
+            "file_path": "src/app/job.py",
+            "function_name": "run",
+            "line_end": 202,
+            "line_start": 200
+          }
+        ],
+        "affected_locations_total": 1,
+        "evidence_truncated": false,
+        "intervention_symbol": "src/app/job.py::run",
+        "opportunity_id": "perf2_811bb33b8d8f9e744638",
+        "paths": [
+          [
+            "src/app/job.py::run",
+            "src/app/db.py::get_session"
+          ]
+        ],
+        "paths_total": 1,
+        "safety": "advisory",
+        "strategy": "batch_or_prefetch_io"
+      },
+      "refactoring_type": "performance_fix",
+      "source_biomarker": "io_in_loop",
+      "target_symbol": "src/app/job.py::run"
+    },
+    {
+      "blast_radius": {
+        "call_sites": 1,
+        "file_count": 1,
+        "files": [
+          "src/app/lone.py"
+        ]
+      },
+      "confidence": "medium",
+      "evidence": {
+        "affected_files_total": 1,
+        "biomarker_type": "io_in_loop",
+        "biomarker_types": [
+          "io_in_loop"
+        ],
+        "boundary_kind": "db",
+        "execution_context": "production",
+        "observations_total": 1,
+        "provenance": "call-site",
+        "rank_factors": {
+          "affected_call_sites": 2,
+          "boundary_kind": 4,
+          "entry_reachability": 0,
+          "execution_context": 3,
+          "multiplier_shape": 4,
+          "provenance": 3
+        },
+        "rank_score": 16,
+        "rationale": "The shared I/O sink is proven; no concrete batch API or result-equivalence proof is available.",
+        "reliable_entry_reachability": null
+      },
+      "file_path": "src/app/lone.py",
+      "impact_delta": 0.0,
+      "line_end": 11,
+      "line_start": 9,
+      "plan": {
+        "affected_locations": [
+          {
+            "file_path": "src/app/lone.py",
+            "function_name": "run",
+            "line_end": 11,
+            "line_start": 9
+          }
+        ],
+        "affected_locations_total": 1,
+        "evidence_truncated": false,
+        "intervention_symbol": null,
+        "opportunity_id": "perf2_f349f0c0ac6827ebfd86",
+        "paths": [
+          [
+            "src/app/db.py::only_sink"
+          ]
+        ],
+        "paths_total": 1,
+        "safety": "advisory",
+        "strategy": "batch_or_prefetch_io"
+      },
+      "refactoring_type": "performance_fix",
+      "source_biomarker": "io_in_loop",
+      "target_symbol": "run"
     },
     {
       "blast_radius": {
@@ -433,7 +829,7 @@
         "affected_locations_total": 1,
         "evidence_truncated": false,
         "intervention_symbol": "scripts/backfill.py::run",
-        "opportunity_id": "perf_a50b5b7b58559225e3c6",
+        "opportunity_id": "perf2_626e6b4848d036aede65",
         "paths": [
           [
             "scripts/backfill.py::run",
@@ -447,6 +843,68 @@
       "refactoring_type": "performance_fix",
       "source_biomarker": "io_in_loop",
       "target_symbol": "scripts/backfill.py::run"
+    },
+    {
+      "blast_radius": {
+        "call_sites": 1,
+        "file_count": 1,
+        "files": [
+          "src/app/edge.py"
+        ]
+      },
+      "confidence": "medium",
+      "evidence": {
+        "affected_files_total": 1,
+        "biomarker_type": "io_in_loop",
+        "biomarker_types": [
+          "io_in_loop"
+        ],
+        "boundary_kind": "db",
+        "execution_context": "production",
+        "observations_total": 1,
+        "provenance": "reliable-edge",
+        "rank_factors": {
+          "affected_call_sites": 2,
+          "boundary_kind": 4,
+          "entry_reachability": 0,
+          "execution_context": 3,
+          "multiplier_shape": 4,
+          "provenance": 2
+        },
+        "rank_score": 15,
+        "rationale": "The shared I/O sink is proven; no concrete batch API or result-equivalence proof is available.",
+        "reliable_entry_reachability": null
+      },
+      "file_path": "src/app/edge.py",
+      "impact_delta": 0.0,
+      "line_end": 232,
+      "line_start": 230,
+      "plan": {
+        "affected_locations": [
+          {
+            "file_path": "src/app/edge.py",
+            "function_name": "run",
+            "line_end": 232,
+            "line_start": 230
+          }
+        ],
+        "affected_locations_total": 1,
+        "evidence_truncated": false,
+        "intervention_symbol": "src/app/edge.py::run",
+        "opportunity_id": "perf2_cf3653d0149e79f7a1fb",
+        "paths": [
+          [
+            "src/app/edge.py::run",
+            "src/app/db.py::reliable_sink"
+          ]
+        ],
+        "paths_total": 1,
+        "safety": "advisory",
+        "strategy": "batch_or_prefetch_io"
+      },
+      "refactoring_type": "performance_fix",
+      "source_biomarker": "io_in_loop",
+      "target_symbol": "src/app/edge.py::run"
     },
     {
       "blast_radius": {
@@ -495,7 +953,7 @@
         "affected_locations_total": 1,
         "evidence_truncated": false,
         "intervention_symbol": "tests/test_job.py::run",
-        "opportunity_id": "perf_63ace13595c0f6bf553b",
+        "opportunity_id": "perf2_b17b10884d21aeeb4df0",
         "paths": [
           [
             "tests/test_job.py::run",
@@ -557,7 +1015,7 @@
         "affected_locations_total": 1,
         "evidence_truncated": false,
         "intervention_symbol": "src/app/guess.py::run",
-        "opportunity_id": "perf_cdc672bf096aac79f951",
+        "opportunity_id": "perf2_a817f9001be1d323f8a2",
         "paths": [
           [
             "src/app/guess.py::run",
@@ -619,7 +1077,7 @@
         "affected_locations_total": 1,
         "evidence_truncated": false,
         "intervention_symbol": null,
-        "opportunity_id": "perf_6b8f8be1ab10062f0a19",
+        "opportunity_id": "perf2_6b8f8be1ab10062f0a19",
         "paths": [],
         "paths_total": 1,
         "safety": "advisory",
@@ -676,7 +1134,7 @@
         "affected_locations_total": 1,
         "evidence_truncated": false,
         "intervention_symbol": null,
-        "opportunity_id": "perf_e82f5ad0e9c24fe3d1a1",
+        "opportunity_id": "perf2_e82f5ad0e9c24fe3d1a1",
         "paths": [],
         "paths_total": 1,
         "safety": "advisory",

--- a/tests/fixtures/perf_corpus/manifest.json
+++ b/tests/fixtures/perf_corpus/manifest.json
@@ -1,7 +1,7 @@
 {
-  "corpus_version": 1,
-  "performance_model_version": 1,
-  "purpose": "characterization of current grouping, identity, actionability and ranking",
+  "corpus_version": 2,
+  "performance_model_version": 2,
+  "purpose": "characterization of grouping, identity, actionability, confidence facets and ranking",
   "runner": "uv run pytest tests/unit/health/test_perf_corpus_golden.py -v",
   "rewrite_env": "REPOWISE_REWRITE_PERF_GOLDEN=1",
   "downloads_repositories": false,
@@ -10,26 +10,44 @@
     {
       "archetype": "cli_build_indexing_tool",
       "language": "python",
-      "cases": ["generic_infra_sink", "specific_shared_helper", "filesystem_fan_out"],
-      "note": "Over-represented on purpose; it is one archetype row, not the tuning target."
+      "cases": [
+        "generic_infra_sink",
+        "specific_shared_helper",
+        "filesystem_fan_out",
+        "shared_dominator_fan_in"
+      ],
+      "note": "Over-represented on purpose; it is one archetype row, not the tuning target. Holds both grouping poles: a generic sink that must split by caller and a shared helper that must stay merged however many callers reach it."
     },
     {
       "archetype": "orm_database_heavy",
       "language": "python",
-      "cases": ["generic_infra_sink", "same_file_db_helper", "async_serial_awaits"],
+      "cases": [
+        "generic_infra_sink",
+        "same_file_db_helper",
+        "async_serial_awaits"
+      ],
       "note": "Database boundary through a shared session/query helper."
     },
     {
       "archetype": "concurrent_server_worker",
       "language": "python",
-      "cases": ["single_lock_owner", "distinct_lock_owners"],
+      "cases": [
+        "single_lock_owner",
+        "distinct_lock_owners"
+      ],
       "note": "Only the lock-scope shape is expressible today."
     },
     {
       "archetype": "general_library",
       "language": "python",
-      "cases": ["membership_scan", "string_accumulation", "resource_construction"],
-      "note": "Local, same-function cost shapes with no call path."
+      "cases": [
+        "membership_scan",
+        "string_accumulation",
+        "resource_construction",
+        "unclassified_context",
+        "sink_without_caller"
+      ],
+      "note": "Local, same-function cost shapes with no call path. Classification edges: a directory that does not say whether its code ships, and a path that names a sink but no caller."
     }
   ],
   "uncovered": [
@@ -54,9 +72,20 @@
       "prerequisite": "per-language corpus rows"
     }
   ],
-  "languages_covered": ["python"],
+  "languages_covered": [
+    "python"
+  ],
   "languages_uncovered": [
-    "typescript", "java", "kotlin", "go", "rust", "csharp", "ruby", "scala", "dart", "cpp"
+    "typescript",
+    "java",
+    "kotlin",
+    "go",
+    "rust",
+    "csharp",
+    "ruby",
+    "scala",
+    "dart",
+    "cpp"
   ],
   "languages_uncovered_reason": "The opportunity layer is language-neutral: it consumes biomarker findings, not source. Per-language recall lives in tests/unit/health/test_perf_dialects.py. Adding language rows here would duplicate that suite without adding grouping evidence."
 }

--- a/tests/fixtures/perf_corpus/observations.json
+++ b/tests/fixtures/perf_corpus/observations.json
@@ -228,6 +228,7 @@
       "line_start": 130,
       "path": [
         "src/app/pool.py::writer",
+        "src/app/store.py::flush_all",
         "src/app/store.py::flush"
       ],
       "reason": "distinct_lock_owners: blocking_io_under_lock at src/app/pool.py:130 repeats work per iteration.",
@@ -246,6 +247,7 @@
       "line_start": 130,
       "path": [
         "src/app/pool.py::reaper",
+        "src/app/store.py::flush_all",
         "src/app/store.py::flush"
       ],
       "reason": "distinct_lock_owners: blocking_io_under_lock at src/app/pool.py:130 repeats work per iteration.",
@@ -382,6 +384,7 @@
       "line_start": 210,
       "path": [
         "src/app/reindex.py::one",
+        "src/app/reindex.py::_write",
         "src/app/db.py::upsert"
       ],
       "reason": "cost_shape_merge: io_in_loop at src/app/reindex.py:210 repeats work per iteration.",
@@ -400,6 +403,7 @@
       "line_start": 215,
       "path": [
         "src/app/reindex.py::many",
+        "src/app/reindex.py::_write",
         "src/app/db.py::upsert"
       ],
       "reason": "cost_shape_merge: nested_loop_with_io at src/app/reindex.py:215 repeats work per iteration.",
@@ -454,6 +458,7 @@
       "line_start": 250,
       "path": [
         "src/app/entry.py::a",
+        "src/app/entry.py::_hit",
         "src/app/db.py::reach_sink"
       ],
       "reason": "reachability_states: io_in_loop at src/app/entry.py:250 repeats work per iteration.",
@@ -472,10 +477,134 @@
       "line_start": 255,
       "path": [
         "src/app/entry.py::b",
+        "src/app/entry.py::_hit",
         "src/app/db.py::reach_sink"
       ],
       "reason": "reachability_states: io_in_loop at src/app/entry.py:255 repeats work per iteration.",
       "reliable_entry_reachability": false,
+      "resolution_basis": "call-site"
+    },
+    {
+      "biomarker_type": "io_in_loop",
+      "boundary_kind": "filesystem",
+      "case": "shared_dominator_fan_in",
+      "extra": {},
+      "file_path": "src/app/lexer.py",
+      "finding_ref": "shared_dominator_fan_in-27",
+      "function_name": "run",
+      "line_end": 22,
+      "line_start": 20,
+      "path": [
+        "src/app/lexer.py::run",
+        "src/app/parse.py::_get_query",
+        "src/app/parse.py::_load_compiled_query"
+      ],
+      "reason": "shared_dominator_fan_in: io_in_loop at src/app/lexer.py:20 repeats work per iteration.",
+      "reliable_entry_reachability": null,
+      "resolution_basis": "call-site"
+    },
+    {
+      "biomarker_type": "io_in_loop",
+      "boundary_kind": "filesystem",
+      "case": "shared_dominator_fan_in",
+      "extra": {},
+      "file_path": "src/app/linter.py",
+      "finding_ref": "shared_dominator_fan_in-28",
+      "function_name": "run",
+      "line_end": 23,
+      "line_start": 21,
+      "path": [
+        "src/app/linter.py::run",
+        "src/app/parse.py::_get_query",
+        "src/app/parse.py::_load_compiled_query"
+      ],
+      "reason": "shared_dominator_fan_in: io_in_loop at src/app/linter.py:21 repeats work per iteration.",
+      "reliable_entry_reachability": null,
+      "resolution_basis": "call-site"
+    },
+    {
+      "biomarker_type": "io_in_loop",
+      "boundary_kind": "filesystem",
+      "case": "shared_dominator_fan_in",
+      "extra": {},
+      "file_path": "src/app/formatter.py",
+      "finding_ref": "shared_dominator_fan_in-29",
+      "function_name": "run",
+      "line_end": 24,
+      "line_start": 22,
+      "path": [
+        "src/app/formatter.py::run",
+        "src/app/parse.py::_get_query",
+        "src/app/parse.py::_load_compiled_query"
+      ],
+      "reason": "shared_dominator_fan_in: io_in_loop at src/app/formatter.py:22 repeats work per iteration.",
+      "reliable_entry_reachability": null,
+      "resolution_basis": "call-site"
+    },
+    {
+      "biomarker_type": "io_in_loop",
+      "boundary_kind": "filesystem",
+      "case": "shared_dominator_fan_in",
+      "extra": {},
+      "file_path": "src/app/resolver.py",
+      "finding_ref": "shared_dominator_fan_in-30",
+      "function_name": "run",
+      "line_end": 25,
+      "line_start": 23,
+      "path": [
+        "src/app/resolver.py::run",
+        "src/app/parse.py::_get_query",
+        "src/app/parse.py::_load_compiled_query"
+      ],
+      "reason": "shared_dominator_fan_in: io_in_loop at src/app/resolver.py:23 repeats work per iteration.",
+      "reliable_entry_reachability": null,
+      "resolution_basis": "call-site"
+    },
+    {
+      "biomarker_type": "io_in_loop",
+      "boundary_kind": "filesystem",
+      "case": "unclassified_context",
+      "extra": {},
+      "file_path": "docs/snippets/walk.py",
+      "finding_ref": "unclassified_context-31",
+      "function_name": "demo",
+      "line_end": 10,
+      "line_start": 8,
+      "path": [],
+      "reason": "unclassified_context: io_in_loop at docs/snippets/walk.py:8 repeats work per iteration.",
+      "reliable_entry_reachability": null,
+      "resolution_basis": "direct"
+    },
+    {
+      "biomarker_type": "io_in_loop",
+      "boundary_kind": "filesystem",
+      "case": "unclassified_context",
+      "extra": {},
+      "file_path": "bootstrap.py",
+      "finding_ref": "unclassified_context-32",
+      "function_name": "main",
+      "line_end": 16,
+      "line_start": 14,
+      "path": [],
+      "reason": "unclassified_context: io_in_loop at bootstrap.py:14 repeats work per iteration.",
+      "reliable_entry_reachability": null,
+      "resolution_basis": "direct"
+    },
+    {
+      "biomarker_type": "io_in_loop",
+      "boundary_kind": "db",
+      "case": "sink_without_caller",
+      "extra": {},
+      "file_path": "src/app/lone.py",
+      "finding_ref": "sink_without_caller-33",
+      "function_name": "run",
+      "line_end": 11,
+      "line_start": 9,
+      "path": [
+        "src/app/db.py::only_sink"
+      ],
+      "reason": "sink_without_caller: io_in_loop at src/app/lone.py:9 repeats work per iteration.",
+      "reliable_entry_reachability": null,
       "resolution_basis": "call-site"
     }
   ]

--- a/tests/unit/health/test_perf_corpus_golden.py
+++ b/tests/unit/health/test_perf_corpus_golden.py
@@ -14,6 +14,7 @@ from repowise.core.analysis.health.perf.opportunities import (
     build_performance_opportunities,
     link_performance_findings,
 )
+from repowise.core.analysis.health.perf.opportunity_rank import ACTIONABILITY_ORDER
 from repowise.core.analysis.health.refactoring.performance_fix import (
     performance_fix_suggestions,
 )
@@ -93,7 +94,12 @@ def test_a_subset_of_the_corpus_reproduces_the_same_identities() -> None:
     subset of observations and must still stamp the ids a full run would.
     """
     whole = {item.opportunity_id: item.execution_context for item in _opportunities()}
-    for case in ("generic_infra_sink", "specific_shared_helper", "context_split"):
+    for case in (
+        "generic_infra_sink",
+        "specific_shared_helper",
+        "shared_dominator_fan_in",
+        "context_split",
+    ):
         subset = build_performance_opportunities(rows_for(case), evidence_limit=EVIDENCE_LIMIT)
         assert subset, case
         for item in subset:
@@ -116,31 +122,33 @@ def test_linking_stamps_the_id_the_builder_derives() -> None:
 @pytest.mark.parametrize(
     ("case", "expected_groups", "expected_strategies"),
     [
-        # A generic infrastructure sink merges unrelated callers into one group
-        # and refuses to claim a plan.
-        ("generic_infra_sink", 1, {None}),
-        # A specific shared helper keeps a coherent suffix and does get a plan.
+        # Three unrelated callers reach one generic session opener. They are
+        # three causes, and each one carries the plan the merged group could
+        # not: plan availability no longer falls as caller count rises.
+        ("generic_infra_sink", 3, {"batch_or_prefetch_io"}),
+        # A specific shared helper is one cause however many callers reach it.
         ("specific_shared_helper", 1, {"batch_or_prefetch_io"}),
+        ("shared_dominator_fan_in", 1, {None}),
         # Filesystem repetition is real but has no batch API to point at.
-        ("filesystem_fan_out", 1, {None}),
+        ("filesystem_fan_out", 2, {None}),
         ("same_file_db_helper", 1, {"batch_or_prefetch_io"}),
         ("async_serial_awaits", 2, {"parallelize_independent_awaits", None}),
         ("single_lock_owner", 1, {"shrink_lock_scope"}),
+        # One helper, two lock owners behind it: still one cause, still no
+        # single critical section to shorten.
         ("distinct_lock_owners", 1, {None}),
         ("membership_scan", 1, {"replace_membership_collection"}),
         ("string_accumulation", 1, {"buffer_string_accumulation"}),
         ("resource_construction", 2, {"hoist_loop_invariant_resource", None}),
         # Execution context is an identity input: one shape, three contexts.
-        # Each context holds a single caller, so its shared suffix is the whole
-        # path and a plan is offered, while ``generic_infra_sink`` above, with
-        # three callers on the same sink, gets none: plan availability falls
-        # as caller count rises, which is backwards.
         ("context_split", 3, {"batch_or_prefetch_io"}),
-        # io_in_loop and nested_loop_with_io share one cross-function identity,
-        # and two callers shorten the suffix to the sink alone, so no plan.
-        ("cost_shape_merge", 1, {None}),
+        # io_in_loop and nested_loop_with_io share one cross-function identity
+        # when they share a caller, and merging no longer costs the plan.
+        ("cost_shape_merge", 1, {"batch_or_prefetch_io"}),
         ("provenance_mix", 2, {"batch_or_prefetch_io"}),
-        ("reachability_states", 1, {None}),
+        ("reachability_states", 1, {"batch_or_prefetch_io"}),
+        ("unclassified_context", 2, {None}),
+        ("sink_without_caller", 1, {"batch_or_prefetch_io"}),
     ],
 )
 def test_case_membership_and_actionability(case, expected_groups, expected_strategies) -> None:
@@ -151,20 +159,83 @@ def test_case_membership_and_actionability(case, expected_groups, expected_strat
     } == expected_strategies
 
 
-def test_confidence_facets_available_today_are_provenance_only() -> None:
-    """Evidence confidence and actionability are not yet separable.
+def test_a_generic_sink_splits_by_caller_and_a_shared_helper_does_not() -> None:
+    """The two poles of the grouping rule, asserted against each other.
 
-    ``confidence`` is derived from call-graph provenance alone; a plan's own
-    confidence comes from ``fix.safety`` in the refactoring layer. This records
-    that the two facets are still collapsed into one label.
+    Both cases put several callers on one sink. The difference is whether a
+    helper stands between them, and that is the whole of what decides a shared
+    cause from a shared destination.
     """
-    by_case = {
-        "provenance_mix": {"medium", "low"},
-        "generic_infra_sink": {"high"},
+    generic = build_performance_opportunities(rows_for("generic_infra_sink"))
+    shared = build_performance_opportunities(rows_for("shared_dominator_fan_in"))
+    assert len(generic) == 3
+    assert {item.observations_total for item in generic} == {1}
+    assert len(shared) == 1
+    assert shared[0].observations_total == 4
+    assert shared[0].intervention_symbol == "src/app/parse.py::_get_query"
+    assert shared[0].facets["leverage"] == "shared"
+
+
+def test_an_unclassifiable_path_is_not_reported_as_production() -> None:
+    contexts = {
+        item.execution_context
+        for item in build_performance_opportunities(rows_for("unclassified_context"))
     }
-    for case, expected in by_case.items():
-        items = build_performance_opportunities(rows_for(case))
-        assert {item.confidence for item in items} == expected
+    assert contexts == {"unknown"}
+
+
+def test_a_path_that_names_no_caller_is_keyed_locally() -> None:
+    """A single-node path is a destination with no journey to it."""
+    item = build_performance_opportunities(rows_for("sink_without_caller"))[0]
+    assert item.intervention_symbol is None
+    assert item.terminal_sink is None
+
+
+def test_every_group_reports_an_actionability_state_and_a_reason() -> None:
+    """Nothing is dropped for being unexplainable; it is labelled instead."""
+    states = {"plan_ready", "advisory", "investigate"}
+    for item in _opportunities():
+        assert item.actionability_state in states
+        assert item.actionability_reason
+        if item.actionability_state == "investigate":
+            assert item.fix is None
+            assert item.prerequisites, item.opportunity_id
+
+
+def test_actionable_groups_sort_above_higher_scoring_evidence() -> None:
+    """Raw magnitude must not bury work somebody could start today."""
+    order = [item.actionability_state for item in _opportunities()]
+    assert order == sorted(order, key=ACTIONABILITY_ORDER.__getitem__)
+
+
+def test_rank_rationale_is_bounded_and_never_pads_with_nothing() -> None:
+    for item in _opportunities():
+        assert len(item.why_ranked) <= 3
+        assert all(entry["points"] > 0 for entry in item.why_ranked)
+
+
+def test_evidence_confidence_and_actionability_move_independently() -> None:
+    """The two are separate readings of one group and must be able to disagree.
+
+    ``provenance_mix`` holds the sharp pair: the same strategy on the same
+    boundary, demoted only because the call path behind it was resolved less
+    reliably.
+    """
+    by_provenance = {
+        item.provenance: item
+        for item in build_performance_opportunities(rows_for("provenance_mix"))
+    }
+    reliable = by_provenance["reliable-edge"]
+    guessed = by_provenance["name-fallback"]
+    assert reliable.fix and guessed.fix
+    assert reliable.fix.strategy == guessed.fix.strategy
+    assert reliable.confidence == "medium"
+    assert guessed.confidence == "low"
+    assert reliable.facets["actionability_confidence"] == "medium"
+    assert guessed.facets["actionability_confidence"] == "low"
+    assert reliable.actionability_reason == "strategy_requires_validation"
+    assert guessed.actionability_reason == "low_evidence_confidence"
+    assert "reliable_call_path" in guessed.prerequisites
 
 
 def test_reachability_aggregates_any_true_over_all_false() -> None:

--- a/tests/unit/health/test_perf_identity_contract.py
+++ b/tests/unit/health/test_perf_identity_contract.py
@@ -21,15 +21,16 @@ from repowise.core.analysis.health.perf.opportunities import (
     PERFORMANCE_MODEL_VERSION,
     build_performance_opportunities,
     link_performance_findings,
+    model_state,
     opportunity_id_for_finding,
 )
 from repowise.core.analysis.health.refactoring.performance_fix import (
     performance_fix_suggestions,
 )
 
-# The v1 kernel, pinned. A change to either string is a model-version change.
-CROSS_FUNCTION_ID = "perf_e358397251b660183fdd"
-LOCAL_ID = "perf_f13beed790fd3cb29ac1"
+# The v2 kernel, pinned. A change to either string is a model-version change.
+CROSS_FUNCTION_ID = "perf2_5662c38bc84c9a677164"
+LOCAL_ID = "perf2_f13beed790fd3cb29ac1"
 
 
 def _row(**overrides):
@@ -62,16 +63,42 @@ def _local_row(**overrides):
     )
 
 
-def test_the_model_version_is_pinned_and_is_not_itself_a_kernel_input() -> None:
-    """v1 ids predate the constant, so the constant stays out of the payload.
+def test_the_model_version_is_pinned_and_is_carried_by_the_id_prefix() -> None:
+    """The version is the prefix, not a hash input.
 
-    Embedding the version in the hash would rewrite every persisted
-    ``opportunity_id`` and orphan every stored plan link for no semantic
-    change. A later version may embed it; version 1 must not.
+    Putting it in the prefix costs the hash nothing and buys the one thing an
+    alias table cannot: an id says which model minted it, so a caller holding a
+    stale one is told to refresh instead of being handed the wrong group.
     """
-    assert PERFORMANCE_MODEL_VERSION == 1
+    assert PERFORMANCE_MODEL_VERSION == 2
     assert opportunity_id_for_finding(_row()) == CROSS_FUNCTION_ID
     assert opportunity_id_for_finding(_local_row()) == LOCAL_ID
+    assert CROSS_FUNCTION_ID.startswith(f"perf{PERFORMANCE_MODEL_VERSION}_")
+
+
+@pytest.mark.parametrize(
+    ("opportunity_id", "state", "version"),
+    [
+        (CROSS_FUNCTION_ID, "current", 2),
+        ("perf_e358397251b660183fdd", "stale_model", 1),
+        ("perf9_e358397251b660183fdd", "stale_model", 9),
+        ("not-an-opportunity-id", "unrecognized", None),
+    ],
+)
+def test_an_id_reports_its_own_model_and_whether_it_still_resolves(
+    opportunity_id, state, version
+) -> None:
+    """Ids are never translated across models.
+
+    Grouping decides membership, so one v1 id can name observations v2 splits
+    several ways. An alias would have to guess which split the caller meant, so
+    the mismatch is reported instead.
+    """
+    result = model_state(opportunity_id)
+    assert result["state"] == state
+    assert result["requested_model_version"] == version
+    assert result["performance_model_version"] == PERFORMANCE_MODEL_VERSION
+    assert result["refresh_required"] is (state == "stale_model")
 
 
 @pytest.mark.parametrize(
@@ -117,6 +144,10 @@ def test_derived_and_ranking_details_are_outside_the_opportunity_kernel(field, v
         ({"file_path": "tests/test_a.py"}, "execution context"),
         ({"details": {"boundary_kind": "filesystem"}}, "boundary"),
         ({"details": {"path": ["src/app/a.py::run", "src/app/db.py::other"]}}, "terminal sink"),
+        (
+            {"details": {"path": ["src/app/a.py::other", "src/app/db.py::get_session"]}},
+            "meaningful predecessor",
+        ),
         ({"biomarker_type": "membership_test_against_list_in_loop"}, "cost shape"),
     ],
 )
@@ -124,17 +155,42 @@ def test_cross_function_kernel_inputs_each_move_the_identity(mutate, reason) -> 
     assert opportunity_id_for_finding(_row(**copy.deepcopy(mutate))) != CROSS_FUNCTION_ID, reason
 
 
-def test_a_new_caller_never_changes_the_cross_function_identity() -> None:
-    """The shared cause is the identity; callers are evidence.
+def test_a_new_call_site_behind_the_same_caller_never_changes_the_identity() -> None:
+    """The shared cause is the identity; individual call sites are evidence.
 
     ``file_path``, ``function_name``, and ``line_start`` are kernel inputs for a
-    same-function observation and deliberately are not for a cross-function one.
+    same-function observation and deliberately are not for a cross-function one:
+    a second loop in the same caller adds evidence, not a cause.
     """
     original = _row()
-    other_caller = _row(file_path="src/app/b.py", function_name="other", line_start=77)
-    other_caller["details"]["path"] = ["src/app/b.py::other", "src/app/db.py::get_session"]
-    assert opportunity_id_for_finding(other_caller) == CROSS_FUNCTION_ID
-    assert len(build_performance_opportunities([original, other_caller])) == 1
+    same_caller = _row(line_start=77, line_end=79)
+    assert opportunity_id_for_finding(same_caller) == CROSS_FUNCTION_ID
+    assert len(build_performance_opportunities([original, same_caller])) == 1
+
+
+def test_an_unrelated_caller_on_the_same_sink_is_a_different_cause() -> None:
+    """A shared destination is not a shared cause.
+
+    Naming a group by its sink alone merged every workflow that happened to
+    open a session. Requiring the caller to match splits those, while callers
+    that reach the sink through one helper stay together.
+    """
+    original = _row()
+    unrelated = _row(file_path="src/app/b.py", function_name="other", line_start=77)
+    unrelated["details"]["path"] = ["src/app/b.py::other", "src/app/db.py::get_session"]
+    assert opportunity_id_for_finding(unrelated) != CROSS_FUNCTION_ID
+    assert len(build_performance_opportunities([original, unrelated])) == 2
+
+    through_helper = [_row(), _row(file_path="src/app/b.py", function_name="other")]
+    for row in through_helper:
+        row["details"]["path"] = [
+            f"{row['file_path']}::{row['function_name']}",
+            "src/app/repo.py::fetch",
+            "src/app/db.py::get_session",
+        ]
+    merged = build_performance_opportunities(through_helper)
+    assert len(merged) == 1
+    assert merged[0].intervention_symbol == "src/app/repo.py::fetch"
 
 
 @pytest.mark.parametrize(
@@ -162,14 +218,17 @@ def test_the_cost_shape_merge_applies_to_cross_function_identity_only() -> None:
     assert opportunity_id_for_finding(_local_row(biomarker_type="nested_loop_with_io")) != LOCAL_ID
 
 
-@pytest.mark.parametrize("path", [[], [5], [None]])
-def test_a_cross_function_flag_without_a_usable_path_falls_back_to_the_local_kernel(path) -> None:
+@pytest.mark.parametrize(
+    "path", [[], [5], [None], [""], ["", "src/app/db.py::get_session"], ["src/app/db.py::get_session"]]
+)
+def test_a_cross_function_flag_without_a_named_caller_falls_back_to_the_local_kernel(
+    path,
+) -> None:
     """The flag alone does not make an observation cross-function.
 
-    Only path nodes that survive the string filter can name a terminal sink, so
-    a truthy ``cross_function`` with nothing usable in ``path`` is keyed by its
-    own location. The corpus derives the flag from the path and cannot reach
-    this branch, so it is pinned here.
+    A cause needs both ends: a sink that pays the cost and a caller that
+    repeats it. A path with nothing usable in it, or with only the sink, names
+    one end, so the observation is keyed by its own location instead.
     """
     row = _row(details={"path": path})
     assert opportunity_id_for_finding(row) == LOCAL_ID
@@ -225,3 +284,12 @@ def test_a_performance_finding_has_no_content_derived_public_reference() -> None
     )
     link_performance_findings([persisted])
     assert persisted["details"]["opportunity_id"] == CROSS_FUNCTION_ID
+
+
+def test_a_path_node_that_names_nothing_never_becomes_an_intervention_symbol() -> None:
+    """An empty node is absence, not a symbol called \"\"."""
+    row = _row(details={"path": ["", "src/app/db.py::get_session"]})
+    opportunity = build_performance_opportunities([row])[0]
+    assert opportunity.intervention_symbol is None
+    assert opportunity.terminal_sink is None
+    assert opportunity.opportunity_id == LOCAL_ID

--- a/tests/unit/health/test_perf_opportunities.py
+++ b/tests/unit/health/test_perf_opportunities.py
@@ -68,13 +68,13 @@ def test_grouping_and_order_are_input_order_independent():
 
 
 def test_cross_function_id_survives_new_caller_and_stronger_multiplier_observation():
-    first = _finding("a.py", 2, call_path=("a.py::run", "db.py::fetch"))
+    first = _finding("a.py", 2, call_path=("a.py::run", "shared.py::load", "db.py::fetch"))
     original = build_performance_opportunities([first])[0]
     added = _finding(
         "b.py",
         3,
         marker="nested_loop_with_io",
-        call_path=("b.py::run", "db.py::fetch"),
+        call_path=("b.py::run", "shared.py::load", "db.py::fetch"),
     )
     expanded = build_performance_opportunities([added, first])[0]
     assert expanded.opportunity_id == original.opportunity_id
@@ -84,7 +84,11 @@ def test_cross_function_id_survives_new_caller_and_stronger_multiplier_observati
 
 def test_capped_evidence_retains_true_totals():
     rows = [
-        _finding(f"caller_{index}.py", index, call_path=(f"caller_{index}.py::run", "db.py::fetch"))
+        _finding(
+            f"caller_{index}.py",
+            index,
+            call_path=(f"caller_{index}.py::run", "shared.py::load", "db.py::fetch"),
+        )
         for index in range(1, 7)
     ]
     opportunity = build_performance_opportunities(rows, evidence_limit=2)[0]
@@ -141,16 +145,24 @@ def test_strategy_preconditions_distinguish_proven_advisory_and_no_plan():
     assert concat.fix and concat.fix.safety == "advisory"
 
 
-def test_generic_sink_without_shared_caller_stays_advisory_without_a_plan():
-    opportunity = build_performance_opportunities(
+def test_a_generic_sink_splits_by_caller_so_each_workflow_keeps_its_plan():
+    """Two unrelated callers on one session opener are two causes.
+
+    Merging them named an intervention nobody could make, and the merged group
+    then failed the coherence check and lost its plan, so the more callers a
+    sink had the less actionable it became. Each caller now keeps its own.
+    """
+    opportunities = build_performance_opportunities(
         [
             _finding("a.py", 2, call_path=("a.py::run", "db.py::get_session")),
             _finding("b.py", 3, call_path=("b.py::run", "db.py::get_session")),
         ]
-    )[0]
+    )
 
-    assert opportunity.shared_path_suffix == ("db.py::get_session",)
-    assert opportunity.fix is None
+    assert len(opportunities) == 2
+    assert {item.intervention_symbol for item in opportunities} == {"a.py::run", "b.py::run"}
+    assert all(item.fix and item.fix.strategy == "batch_or_prefetch_io" for item in opportunities)
+    assert all(item.actionability_state == "advisory" for item in opportunities)
 
 
 def test_incompatible_cross_function_cost_shapes_never_share_a_fix():
@@ -189,25 +201,29 @@ def test_lock_fix_targets_the_single_lock_owner_not_the_shared_sink():
     assert plan.target_symbol == "lock.py::critical"
 
 
-def test_distinct_lock_owners_sharing_a_sink_do_not_claim_one_lock_fix():
+def test_distinct_lock_owners_behind_one_helper_do_not_claim_one_lock_fix():
+    """One shared helper, two critical sections: no single scope to shorten."""
     opportunity = build_performance_opportunities(
         [
             _finding(
                 "a.py",
                 3,
                 marker="blocking_io_under_lock",
-                call_path=("a.py::critical", "db.py::fetch"),
+                call_path=("a.py::critical", "store.py::flush", "db.py::fetch"),
             ),
             _finding(
                 "b.py",
                 4,
                 marker="blocking_io_under_lock",
-                call_path=("b.py::critical", "db.py::fetch"),
+                call_path=("b.py::critical", "store.py::flush", "db.py::fetch"),
             ),
         ]
     )[0]
 
+    assert opportunity.observations_total == 2
     assert opportunity.fix is None
+    assert opportunity.actionability_state == "investigate"
+    assert opportunity.prerequisites == ("single_lock_owner",)
 
 
 def test_performance_fix_plan_carries_closed_strategy_and_true_totals():
@@ -230,3 +246,78 @@ def test_performance_fix_plan_carries_closed_strategy_and_true_totals():
     assert plan.plan["paths_total"] == 2
     assert plan.plan["evidence_truncated"] is True
     assert performance_fix_suggestions([opportunity], min_confidence="high") == []
+
+
+def test_a_proven_strategy_on_an_unreliable_path_is_not_offered_as_proven():
+    """The demotion has to reach the plan, not just the label.
+
+    Dataflow can prove a loop carries no cross-iteration dependence and still
+    be proving it about the wrong loop, if the call path that grouped the
+    evidence was guessed. A plan stamped high confidence on that basis is the
+    wrong plan, which costs more than no plan at all.
+
+    No detector emits this shape today: the two markers carrying a proven
+    strategy never travel with a call path, so their provenance is always
+    direct. The guard is pinned here rather than in the corpus because the
+    corpus records shapes the analyzer produces.
+    """
+    opportunity = build_performance_opportunities(
+        [
+            _finding(
+                "async.py",
+                5,
+                marker="serial_await_in_loop",
+                boundary="network",
+                call_path=("async.py::run", "http.py::send", "http.py::_write"),
+                dataflow_verified=True,
+                resolution_basis="name-fallback",
+            )
+        ]
+    )[0]
+
+    assert opportunity.confidence == "low"
+    assert opportunity.actionability_state == "advisory"
+    assert opportunity.actionability_reason == "low_evidence_confidence"
+    assert "reliable_call_path" in opportunity.prerequisites
+    assert opportunity.fix and opportunity.fix.safety == "advisory"
+    assert performance_fix_suggestions([opportunity])[0].confidence == "medium"
+
+
+def test_a_reliable_path_keeps_the_proven_strategy_and_its_plan_confidence():
+    opportunity = build_performance_opportunities(
+        [
+            _finding(
+                "async.py",
+                5,
+                marker="serial_await_in_loop",
+                boundary="network",
+                dataflow_verified=True,
+            )
+        ]
+    )[0]
+
+    assert opportunity.actionability_state == "plan_ready"
+    assert opportunity.fix and opportunity.fix.safety == "proven"
+    assert performance_fix_suggestions([opportunity])[0].confidence == "high"
+
+
+def test_a_cross_function_group_always_shares_its_last_two_path_nodes():
+    """The published suffix and the identity kernel must not drift apart.
+
+    Grouping matches on caller and sink, so the suffix can be longer than two
+    nodes but never shorter, and its tail is exactly what the key already
+    names. A redefinition of either that broke this would silently point plans
+    at a symbol the group does not share.
+    """
+    rows = [
+        _finding("a.py", 10, call_path=("a.py::run", "mid.py::step", "shared.py::load", "g.py::head")),
+        _finding("b.py", 20, call_path=("b.py::run", "other.py::step", "shared.py::load", "g.py::head")),
+    ]
+    opportunity = build_performance_opportunities(rows)[0]
+
+    assert opportunity.observations_total == 2
+    assert opportunity.shared_path_suffix == ("shared.py::load", "g.py::head")
+    assert opportunity.shared_path_suffix[-2:] == (
+        opportunity.intervention_symbol,
+        opportunity.terminal_sink,
+    )

--- a/tests/unit/server/test_performance_opportunities.py
+++ b/tests/unit/server/test_performance_opportunities.py
@@ -81,6 +81,7 @@ async def test_opportunities_are_grouped_bounded_and_split_by_context(
         "production_total": 1,
         "tooling_total": 0,
         "test_total": 1,
+        "unknown_total": 0,
         "with_plan_total": 1,
         "without_plan_total": 1,
     }
@@ -123,3 +124,30 @@ async def test_raw_evidence_is_paged_and_plan_matching_never_falls_back(
     page = (await client.get(f"/api/repos/{repo_id}/health/performance-opportunities")).json()
     assert page["items"][0]["plan_id"] is None
     assert page["items"][0]["plan_status"] == "not_persisted"
+
+
+async def test_an_unclassifiable_file_is_counted_and_stays_visible(app, client: AsyncClient):
+    """An unknown context must not mean an unlisted opportunity.
+
+    Reporting an unclassifiable file as production was the thing to fix. Losing
+    it from every view instead would be the same mistake pointing the other way.
+    """
+    repo = await create_test_repo(client)
+    findings = [
+        _finding(
+            "docs/snippets/walk.py",
+            10,
+            ["docs/snippets/walk.py::demo", "src/shared.py::load", "src/db.py::fetch"],
+        )
+    ]
+    link_performance_findings(findings)
+    async with app.state.session_factory() as session:
+        await crud.save_health_findings(session, repo["id"], findings)
+        await session.commit()
+
+    response = await client.get(
+        f"/api/repos/{repo['id']}/health/performance-opportunities", params={"context": "all"}
+    )
+    body = response.json()
+    assert body["summary"]["unknown_total"] == 1
+    assert [item["execution_context"] for item in body["items"]] == ["unknown"]


### PR DESCRIPTION
## What changed

A cross-function performance opportunity was keyed by the terminal sink alone, so every workflow that happened to reach a shared infrastructure helper merged into one group. On this repository's own index, a session opener touched from 13 unrelated callers read as a single cause, and the intervention it named was one nobody could make.

The batching gate then compounded it. It refused a plan whenever the group's shared call-path suffix was shorter than two nodes, and that suffix shortens as callers diversify, so the more places a sink was hit from, the less actionable it became.

A cause is now keyed by the sink **and** the caller that repeats the work. Generic sinks split by workflow, a genuinely shared helper stays merged however many callers reach it, and the suffix is two nodes by construction, so the gate is unreachable and removed.

Alongside that:

- Seven facets are reported separately instead of one collapsed confidence label. `confidence` stays evidence confidence, `fix.safety` stays fix safety, and `facets` adds actionability confidence, exposure, amplification, leverage and change risk. No value is published twice.
- `actionability_state` is `plan_ready`, `advisory` or `investigate`, each with a deterministic reason and named prerequisites. A proven strategy resting on a call path that could not be resolved reliably is demoted, and the demotion travels with the fix so the plan layer cannot stamp it as proven.
- `why_ranked` publishes at most three non-zero factors, and ordering is actionable-first. Everything it reads is already on the group; no per-opportunity query was added.
- Observations that support no strategy are kept as investigation evidence, never dropped.
- Only facts the graph already produces are consumed. A resolution basis covers the first interprocedural hop, and is documented as such rather than projected onto the whole path.
- Execution context gained `unknown`, so a file with no directory or one under a directory that does not say whether its code ships is no longer reported as production. It is counted in the opportunities summary and included in the unfiltered view.

## Behaviour

`PERFORMANCE_MODEL_VERSION` is 2 and `HEALTH_ANALYZER_VERSION` is 7. Every `opportunity_id` is now `perf2_...`; the model version is the id prefix rather than a hash input, so a stale id is self-describing and `model_state` reports `current`, `stale_model` or `unrecognized` without an alias table. The analyzer bump forces the rescore that restamps stored findings and plan links.

Measured on this repository's index, 859 observations over 379 files:

| | before | after |
|---|---:|---:|
| Opportunities | 719 | 799 |
| Carrying a strategy | 210 | 255 |
| Groups mixing more than one immediate caller | 19 | 0 |

The two incoherent leads split as intended: a shared file reader at 19 observations from 19 callers became 19 causes, and the session opener 14 from 13 became 13. The coherent one held: 32 observations through a single query helper stayed one cause. A filesystem walk merged its 11 observations onto the glob helper, which is the symbol worth editing. The top-ranked item is now something with a plan; previously all four were plan-less.

Construction cost is flat: 44.0 ms to 44.5 ms median over the same rows, and 61.3 to 55.7 microseconds per opportunity produced. Doubling the input costs 1.67x.

## Tests

- 325 targeted tests across the opportunity, identity, corpus-golden, cross-function, incremental-parity, scoring, refactoring, REST and MCP suites.
- The checked-in corpus grew from 27 observations across 14 cases to 34 across 17. Three existing cases were reshaped so a shared helper stands between caller and sink, which is what keeps them testing their own point. New cases cover a shared dominator with four unrelated callers that must stay merged, an unclassifiable execution context, and a path that names a sink but no caller. Uncovered archetypes stay declared uncovered rather than faked.
- Both goldens were regenerated once through `REPOWISE_REWRITE_PERF_GOLDEN=1`; every membership and ordering change traces to the key change.
- Shared UI 1,351 tests and types 96 tests pass; both packages typecheck.
- Analyzer benchmark 24.9 s against its 30 s ceiling.
