### PR TITLE
fix(core): validate REPOWISE_EMBEDDING_DIMS at parse points (#826)

### DIFF
--- a/packages/core/src/repowise/core/providers/embedding/ollama.py
+++ b/packages/core/src/repowise/core/providers/embedding/ollama.py
@@ -74,7 +74,20 @@ class OllamaEmbedder:
         env_dimensions = os.environ.get("OLLAMA_EMBEDDING_DIMS") or os.environ.get(
             "REPOWISE_EMBEDDING_DIMS"
         )
-        self._requested_dimensions = dimensions or (int(env_dimensions) if env_dimensions else None)
+        resolved_dims: int | None = None
+        if dimensions is not None:
+            if dimensions <= 0:
+                raise ValueError("dimensions must be a positive integer")
+            resolved_dims = dimensions
+        elif env_dimensions:
+            try:
+                parsed = int(env_dimensions)
+            except (ValueError, OverflowError):
+                parsed = 0
+            if parsed > 0:
+                resolved_dims = parsed
+            # else: silently fall through to model inference, matching timeout behaviour
+        self._requested_dimensions = resolved_dims
         self._dimensions = self._requested_dimensions or _infer_dimensions(self._model)
         self._timeout = resolve_embedding_timeout(
             timeout, _DEFAULT_TIMEOUT, provider_env="OLLAMA_EMBEDDING_TIMEOUT"

--- a/packages/server/src/repowise/server/app.py
+++ b/packages/server/src/repowise/server/app.py
@@ -113,7 +113,23 @@ def _build_embedder():
     if name == "gemini":
         from repowise.core.providers.embedding.gemini import GeminiEmbedder
 
-        dims = int(os.environ.get("REPOWISE_EMBEDDING_DIMS", "768"))
+        dims_raw = os.environ.get("REPOWISE_EMBEDDING_DIMS")
+        dims = 768
+        if dims_raw:
+            try:
+                parsed = int(dims_raw)
+            except (ValueError, OverflowError):
+                parsed = 0
+            if parsed > 0:
+                dims = parsed
+            else:
+                import sys
+
+                print(
+                    f"REPOWISE_EMBEDDING_DIMS={dims_raw!r} is not a positive integer;"
+                    f" using {dims}.",
+                    file=sys.stderr,
+                )
         # Honour the indexed embedding model so serve doesn't silently rebuild
         # the embedder with a different default than init used (issue #426).
         model = os.environ.get("REPOWISE_EMBEDDING_MODEL")

--- a/packages/server/src/repowise/server/mcp_server/_server.py
+++ b/packages/server/src/repowise/server/mcp_server/_server.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import os
+import sys
 from contextlib import asynccontextmanager
 from typing import Any
 
@@ -167,8 +168,30 @@ def _embedder_kwargs(name: str) -> dict[str, Any]:
     if model:
         kwargs["model"] = model
     if name == "gemini":
-        dims = os.environ.get("REPOWISE_EMBEDDING_DIMS")
-        kwargs["output_dimensionality"] = int(dims) if dims else 768
+        dims_raw = os.environ.get("REPOWISE_EMBEDDING_DIMS")
+        dims = 768
+        if dims_raw:
+            try:
+                parsed = int(dims_raw)
+            except (ValueError, OverflowError):
+                parsed = 0
+            if parsed > 0:
+                dims = parsed
+            else:
+                _log.warning(
+                    "embedding_dims_invalid",
+                    extra={
+                        "var": "REPOWISE_EMBEDDING_DIMS",
+                        "value": dims_raw,
+                        "using": dims,
+                    },
+                )
+                print(
+                    f"REPOWISE_EMBEDDING_DIMS={dims_raw!r} is not a positive integer;"
+                    f" using {dims}.",
+                    file=sys.stderr,
+                )
+        kwargs["output_dimensionality"] = dims
 
     env_vars = _EMBEDDER_KEY_ENV.get(name, ())
     if env_vars and not any(os.environ.get(var) for var in env_vars):

--- a/tests/unit/server/test_embedding_dims_validation.py
+++ b/tests/unit/server/test_embedding_dims_validation.py
@@ -1,0 +1,82 @@
+"""``REPOWISE_EMBEDDING_DIMS`` must not reach any embedder constructor unvalidated.
+
+``_server.py:171`` passed ``int(dims) if dims else 768`` straight through, so
+``REPOWISE_EMBEDDING_DIMS=-5`` gave the gemini embedder a negative width with
+no warning. The same hole existed in ``app.py`` for the non-MCP code path.
+
+These tests verify that non-positive, non-numeric, and otherwise malformed
+values fall back to 768 and reach stderr, matching the pattern
+``resolve_embedding_timeout`` already follows for timeout env vars.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from repowise.server.mcp_server._server import _embedder_kwargs
+
+
+def _clear_dims(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("REPOWISE_EMBEDDING_DIMS", raising=False)
+    monkeypatch.delenv("REPOWISE_EMBEDDING_MODEL", raising=False)
+
+
+def test_valid_dims_are_passed_through(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_dims(monkeypatch)
+    monkeypatch.setenv("REPOWISE_EMBEDDING_DIMS", "256")
+    kwargs = _embedder_kwargs("gemini")
+    assert kwargs["output_dimensionality"] == 256
+
+
+def test_missing_dims_default_to_768(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_dims(monkeypatch)
+    kwargs = _embedder_kwargs("gemini")
+    assert kwargs["output_dimensionality"] == 768
+
+
+@pytest.mark.parametrize("bad", ["-5", "0", "-1", "abc", "3.14", "inf", "nan", ""])
+def test_bad_dims_fall_back_to_768(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture, bad: str
+) -> None:
+    _clear_dims(monkeypatch)
+    if bad:
+        monkeypatch.setenv("REPOWISE_EMBEDDING_DIMS", bad)
+    kwargs = _embedder_kwargs("gemini")
+    assert kwargs["output_dimensionality"] == 768
+    if bad:
+        assert "not a positive integer" in capsys.readouterr().err
+
+
+def test_non_gemini_does_not_read_dims(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_dims(monkeypatch)
+    monkeypatch.setenv("REPOWISE_EMBEDDING_DIMS", "256")
+    kwargs = _embedder_kwargs("openai")
+    assert "output_dimensionality" not in kwargs
+
+
+# -- Direct constructor guards (OllamaEmbedder) --
+
+
+def test_ollama_rejects_negative_dimensions() -> None:
+    from repowise.core.providers.embedding.ollama import OllamaEmbedder
+
+    with pytest.raises(ValueError, match="positive"):
+        OllamaEmbedder(dimensions=-5)
+
+
+def test_ollama_rejects_zero_dimensions() -> None:
+    from repowise.core.providers.embedding.ollama import OllamaEmbedder
+
+    with pytest.raises(ValueError, match="positive"):
+        OllamaEmbedder(dimensions=0)
+
+
+def test_ollama_bad_env_dims_fall_back(monkeypatch: pytest.MonkeyPatch) -> None:
+    from repowise.core.providers.embedding.ollama import OllamaEmbedder
+
+    _clear_dims(monkeypatch)
+    monkeypatch.delenv("OLLAMA_EMBEDDING_DIMS", raising=False)
+    monkeypatch.setenv("REPOWISE_EMBEDDING_DIMS", "-5")
+    embedder = OllamaEmbedder()
+    # Should not crash; dimensions fall back to model inference
+    assert embedder.dimensions > 0


### PR DESCRIPTION
Hi @RaghavChamadiya, thanks for the guidance! As requested, I closed #842 and opened this fresh branch off `main` to address the remaining hole.

This focuses entirely on validating the numeric env vars at their parse points:
1. `_server.py` and `app.py`: `REPOWISE_EMBEDDING_DIMS` is now properly validated. If it's negative or unparseable, it falls back to 768 and prints a warning to `stderr` (matching the `resolve_embedding_timeout` pattern).
2. Direct-constructor guards added for `OllamaEmbedder(dimensions=-5)` to raise `ValueError`.
3. Added `test_embedding_dims_validation.py` to cover both the parse fallback behaviour and the constructor rejection.

Let me know if this hits the mark!
