### PR TITLE
fix(tests): match the co-change edge gate the builder actually applies

### DIFF
--- a/tests/integration/test_git_intelligence_integration.py
+++ b/tests/integration/test_git_intelligence_integration.py
@@ -92,32 +92,35 @@ async def test_co_change_edges_in_graph() -> None:
     edges_before = graph.number_of_edges()
 
     # -- Mock git metadata with co-change partners -------------------------
+    # ``frequency`` is the shared-commit support the gate reads; the decayed
+    # ``co_change_count`` becomes the edge weight. A record carrying only the
+    # weight has no support and is filtered out, which is the point of the gate.
     git_meta_map = {
         "pkg/alpha.py": {
             "co_change_partners_json": json.dumps(
                 [
-                    {"file_path": "pkg/beta.py", "co_change_count": 5},
+                    {"file_path": "pkg/beta.py", "co_change_count": 5, "frequency": 5},
                 ]
             ),
         },
         "pkg/beta.py": {
             "co_change_partners_json": json.dumps(
                 [
-                    {"file_path": "pkg/alpha.py", "co_change_count": 5},
-                    {"file_path": "pkg/gamma.py", "co_change_count": 4},
+                    {"file_path": "pkg/alpha.py", "co_change_count": 5, "frequency": 5},
+                    {"file_path": "pkg/gamma.py", "co_change_count": 4, "frequency": 4},
                 ]
             ),
         },
         "pkg/gamma.py": {
             "co_change_partners_json": json.dumps(
                 [
-                    {"file_path": "pkg/beta.py", "co_change_count": 4},
+                    {"file_path": "pkg/beta.py", "co_change_count": 4, "frequency": 4},
                 ]
             ),
         },
     }
 
-    added = builder.add_co_change_edges(git_meta_map, min_count=3)
+    added = builder.add_co_change_edges(git_meta_map, min_support=3)
 
     # Two unique pairs above threshold: (alpha, beta) and (beta, gamma)
     assert added == 2


### PR DESCRIPTION
## What changed

`test_co_change_edges_in_graph` calls `add_co_change_edges(git_meta_map, min_count=3)`, but the builder's parameter is `min_support`, so the case raises `TypeError` before it asserts anything.

The rename came with a semantic change: the gate reads shared-commit **support**, not the decayed co-change **weight**, because the weight's scale depends on how wide the commits were. Support is parsed from a partner record's `frequency`. This fixture set only `co_change_count`, so fixing the keyword alone would leave every pair at zero support, add no edges, and fail on the count instead.

So both halves move: each partner record gains a `frequency`, and the call uses `min_support`.

## Behaviour

No product change. This is a test catching up to the contract it exercises.

## Tests

`tests/integration/test_git_intelligence_integration.py` passes (2 passed). The integration job is the only one that runs this file, which is how the rename landed with the fast job green.
