### PR TITLE
fix(tests): regenerate the performance corpus golden for the current finding id

### DIFF
--- a/tests/fixtures/perf_corpus/golden_opportunities.json
+++ b/tests/fixtures/perf_corpus/golden_opportunities.json
@@ -15,7 +15,7 @@
         {
           "biomarker_type": "serial_await_in_loop",
           "file_path": "src/app/fanout.py",
-          "finding_id": "hf1_b157597c538312230160",
+          "finding_id": "finding_28eb6a8735fdf18585c6",
           "function_name": "gather_all",
           "line_end": 92,
           "line_start": 90,
@@ -90,7 +90,7 @@
         {
           "biomarker_type": "resource_construction_in_loop",
           "file_path": "src/app/clients.py",
-          "finding_id": "hf1_5ad540ed5be9ff91a083",
+          "finding_id": "finding_7598efa2a35d26832a2e",
           "function_name": "each",
           "line_end": 172,
           "line_start": 170,
@@ -165,7 +165,7 @@
         {
           "biomarker_type": "io_in_loop",
           "file_path": "src/app/entry.py",
-          "finding_id": "hf1_0823db7a2e988fb8b165",
+          "finding_id": "finding_a201efe1e1c9df9c6097",
           "function_name": "a",
           "line_end": 252,
           "line_start": 250,
@@ -180,7 +180,7 @@
         {
           "biomarker_type": "io_in_loop",
           "file_path": "src/app/entry.py",
-          "finding_id": "hf1_578bec48b788a57ce085",
+          "finding_id": "finding_c7cbdc90f0dffc630671",
           "function_name": "b",
           "line_end": 257,
           "line_start": 255,
@@ -265,7 +265,7 @@
         {
           "biomarker_type": "io_in_loop",
           "file_path": "src/app/api.py",
-          "finding_id": "hf1_e944c79df994e87201d0",
+          "finding_id": "finding_7a93e35224cdbe6464f5",
           "function_name": "list_users",
           "line_end": 32,
           "line_start": 30,
@@ -280,7 +280,7 @@
         {
           "biomarker_type": "io_in_loop",
           "file_path": "src/app/api.py",
-          "finding_id": "hf1_369c4ed522b7c79bb338",
+          "finding_id": "finding_b502c8ca8878ade8c752",
           "function_name": "list_orders",
           "line_end": 33,
           "line_start": 31,
@@ -366,7 +366,7 @@
         {
           "biomarker_type": "io_in_loop",
           "file_path": "src/app/reindex.py",
-          "finding_id": "hf1_f326415f03634da6edff",
+          "finding_id": "finding_edae08cde216b8678b58",
           "function_name": "one",
           "line_end": 212,
           "line_start": 210,
@@ -381,7 +381,7 @@
         {
           "biomarker_type": "nested_loop_with_io",
           "file_path": "src/app/reindex.py",
-          "finding_id": "hf1_1ca34d0590635ad5fa7e",
+          "finding_id": "finding_37906110543334a495f1",
           "function_name": "many",
           "line_end": 217,
           "line_start": 215,
@@ -466,7 +466,7 @@
         {
           "biomarker_type": "io_in_loop",
           "file_path": "src/app/sync.py",
-          "finding_id": "hf1_ddc30fca4e968dc937dc",
+          "finding_id": "finding_030499578345115bf627",
           "function_name": "sync_one",
           "line_end": 72,
           "line_start": 70,
@@ -481,7 +481,7 @@
         {
           "biomarker_type": "io_in_loop",
           "file_path": "src/app/sync.py",
-          "finding_id": "hf1_8a8dbf682cb16d7351a0",
+          "finding_id": "finding_ff3e61eed3f93515485b",
           "function_name": "sync_all",
           "line_end": 73,
           "line_start": 71,
@@ -566,7 +566,7 @@
         {
           "biomarker_type": "blocking_io_under_lock",
           "file_path": "src/app/cache.py",
-          "finding_id": "hf1_42138363b2d56be00569",
+          "finding_id": "finding_1e5678e8e33fd6960a6b",
           "function_name": "refresh",
           "line_end": 112,
           "line_start": 110,
@@ -649,7 +649,7 @@
         {
           "biomarker_type": "io_in_loop",
           "file_path": "src/app/billing.py",
-          "finding_id": "hf1_5e1434284085c8d89807",
+          "finding_id": "finding_6379ce5a318505017239",
           "function_name": "handle",
           "line_end": 13,
           "line_start": 11,
@@ -733,7 +733,7 @@
         {
           "biomarker_type": "io_in_loop",
           "file_path": "src/app/orders.py",
-          "finding_id": "hf1_b5e9b88139938221b07f",
+          "finding_id": "finding_cad43bf01be5d5f78ee3",
           "function_name": "handle",
           "line_end": 12,
           "line_start": 10,
@@ -817,7 +817,7 @@
         {
           "biomarker_type": "io_in_loop",
           "file_path": "src/app/reports.py",
-          "finding_id": "hf1_5a4726fc8549aab5f4a3",
+          "finding_id": "finding_aac082c5466872ab8b9b",
           "function_name": "handle",
           "line_end": 14,
           "line_start": 12,
@@ -901,7 +901,7 @@
         {
           "biomarker_type": "io_in_loop",
           "file_path": "src/app/job.py",
-          "finding_id": "hf1_6076ccc742fcda80f642",
+          "finding_id": "finding_4bc7b73af1f456af57b6",
           "function_name": "run",
           "line_end": 202,
           "line_start": 200,
@@ -985,7 +985,7 @@
         {
           "biomarker_type": "io_in_loop",
           "file_path": "src/app/lone.py",
-          "finding_id": "hf1_7ecc1136a23953fb0936",
+          "finding_id": "finding_85307ceeab392a03daf6",
           "function_name": "run",
           "line_end": 11,
           "line_start": 9,
@@ -1067,7 +1067,7 @@
         {
           "biomarker_type": "io_in_loop",
           "file_path": "scripts/backfill.py",
-          "finding_id": "hf1_5ff8013358afaf016e7c",
+          "finding_id": "finding_9317f3939e8ba7a1dd00",
           "function_name": "run",
           "line_end": 202,
           "line_start": 200,
@@ -1151,7 +1151,7 @@
         {
           "biomarker_type": "io_in_loop",
           "file_path": "src/app/edge.py",
-          "finding_id": "hf1_af7e43a631e63d3a640c",
+          "finding_id": "finding_14ea9dfdb77b0df39e75",
           "function_name": "run",
           "line_end": 232,
           "line_start": 230,
@@ -1235,7 +1235,7 @@
         {
           "biomarker_type": "io_in_loop",
           "file_path": "tests/test_job.py",
-          "finding_id": "hf1_0a2ba842c19f76c1c567",
+          "finding_id": "finding_059a3a02cba6c95befa3",
           "function_name": "run",
           "line_end": 202,
           "line_start": 200,
@@ -1319,7 +1319,7 @@
         {
           "biomarker_type": "io_in_loop",
           "file_path": "src/app/guess.py",
-          "finding_id": "hf1_5f39d2fe1231369724a4",
+          "finding_id": "finding_2c964005af179686b46e",
           "function_name": "run",
           "line_end": 242,
           "line_start": 240,
@@ -1404,7 +1404,7 @@
         {
           "biomarker_type": "membership_test_against_list_in_loop",
           "file_path": "src/app/filters.py",
-          "finding_id": "hf1_5b38d822737127eff696",
+          "finding_id": "finding_ffe2b0bc5340930cea74",
           "function_name": "select",
           "line_end": 152,
           "line_start": 150,
@@ -1482,7 +1482,7 @@
         {
           "biomarker_type": "string_concat_in_loop",
           "file_path": "src/app/render.py",
-          "finding_id": "hf1_b1d031c5caf612deae23",
+          "finding_id": "finding_05e1666dc8637c4749e3",
           "function_name": "to_csv",
           "line_end": 162,
           "line_start": 160,
@@ -1559,7 +1559,7 @@
         {
           "biomarker_type": "blocking_io_under_lock",
           "file_path": "src/app/pool.py",
-          "finding_id": "hf1_53aa0b7de62bef7cf3a1",
+          "finding_id": "finding_0f4d6ed4b8e62ab7acec",
           "function_name": "reaper",
           "line_end": 132,
           "line_start": 130,
@@ -1574,7 +1574,7 @@
         {
           "biomarker_type": "blocking_io_under_lock",
           "file_path": "src/app/pool.py",
-          "finding_id": "hf1_70aae64c974e10e8567e",
+          "finding_id": "finding_0a1cbec352aadd5800a1",
           "function_name": "writer",
           "line_end": 132,
           "line_start": 130,
@@ -1654,7 +1654,7 @@
         {
           "biomarker_type": "io_in_loop",
           "file_path": "src/app/formatter.py",
-          "finding_id": "hf1_49feb9a4d9831db3880b",
+          "finding_id": "finding_b853807b08e242e784f5",
           "function_name": "run",
           "line_end": 24,
           "line_start": 22,
@@ -1669,7 +1669,7 @@
         {
           "biomarker_type": "io_in_loop",
           "file_path": "src/app/lexer.py",
-          "finding_id": "hf1_02b54f38fbb30a5c663f",
+          "finding_id": "finding_7e425174e879fb9f9d23",
           "function_name": "run",
           "line_end": 22,
           "line_start": 20,
@@ -1684,7 +1684,7 @@
         {
           "biomarker_type": "io_in_loop",
           "file_path": "src/app/linter.py",
-          "finding_id": "hf1_b142f6e353eb4b957ec5",
+          "finding_id": "finding_34d631c0ff0bed50aafd",
           "function_name": "run",
           "line_end": 23,
           "line_start": 21,
@@ -1699,7 +1699,7 @@
         {
           "biomarker_type": "io_in_loop",
           "file_path": "src/app/resolver.py",
-          "finding_id": "hf1_f43aa873be79bf90590a",
+          "finding_id": "finding_ef6b980a3a371a707424",
           "function_name": "run",
           "line_end": 25,
           "line_start": 23,
@@ -1779,7 +1779,7 @@
         {
           "biomarker_type": "resource_construction_in_loop",
           "file_path": "src/app/clients.py",
-          "finding_id": "hf1_199ce617b3bc8a442dc6",
+          "finding_id": "finding_82ac8251d294a1dabcf9",
           "function_name": "each_varying",
           "line_end": 182,
           "line_start": 180,
@@ -1852,7 +1852,7 @@
         {
           "biomarker_type": "serial_await_in_loop",
           "file_path": "src/app/fanout.py",
-          "finding_id": "hf1_a20deca6f8a2935a9f60",
+          "finding_id": "finding_c1f4482918ae3823bedb",
           "function_name": "gather_seq",
           "line_end": 97,
           "line_start": 95,
@@ -1925,7 +1925,7 @@
         {
           "biomarker_type": "io_in_loop",
           "file_path": "src/app/walker.py",
-          "finding_id": "hf1_1ac91145d11248da1c67",
+          "finding_id": "finding_2bf692d084c65fdb5995",
           "function_name": "scan",
           "line_end": 52,
           "line_start": 50,
@@ -2004,7 +2004,7 @@
         {
           "biomarker_type": "io_in_loop",
           "file_path": "src/app/walker.py",
-          "finding_id": "hf1_6f6b30a7872faf6737f0",
+          "finding_id": "finding_aa5de561c0b650b976ac",
           "function_name": "index",
           "line_end": 53,
           "line_start": 51,
@@ -2083,7 +2083,7 @@
         {
           "biomarker_type": "io_in_loop",
           "file_path": "docs/snippets/walk.py",
-          "finding_id": "hf1_233c919884cf9aa50001",
+          "finding_id": "finding_8e360766909208ee01a2",
           "function_name": "demo",
           "line_end": 10,
           "line_start": 8,
@@ -2156,7 +2156,7 @@
         {
           "biomarker_type": "io_in_loop",
           "file_path": "bootstrap.py",
-          "finding_id": "hf1_072c88fe4bfe6a1bab1f",
+          "finding_id": "finding_23610573a960e1c72ac3",
           "function_name": "main",
           "line_end": 16,
           "line_start": 14,


### PR DESCRIPTION
## What changed

`test_opportunity_payloads_and_order_match_the_golden` fails on `main`: the golden holds `hf1_...` finding ids while the code emits `finding_...`.

The public finding id changed shape twice during review of #1981. It first carried an explicit kernel prefix, then moved back to the repository's `finding_<digest>` reference form once the cross-tool reference contract turned out to key off that prefix, with the kernel version folded into the hash instead. The golden was regenerated after the first change and not after the second.

Regenerated through `REPOWISE_REWRITE_PERF_GOLDEN=1`.

## Behaviour

No product change. The ids in the fixture now match the ids the code mints.

## Tests

`tests/unit/health/test_perf_corpus_golden.py` passes (29 passed, 2 skipped). The diff is exactly 34 changed lines, all of them `finding_id`; membership, order, rank, facets and `golden_plans.json` are untouched.
