### PR TITLE
feat(ui): move loading motion from the box to the region

### DIFF
--- a/packages/ui/__tests__/wiki/security-panel.test.tsx
+++ b/packages/ui/__tests__/wiki/security-panel.test.tsx
@@ -23,7 +23,7 @@ describe("SecurityPanel", () => {
 
   it("renders a skeleton while loading", () => {
     const { container } = render(<SecurityPanel findings={undefined} isLoading />);
-    expect(container.querySelector(".animate-pulse")).toBeInTheDocument();
+    expect(container.querySelector("[data-skeleton]")).toBeInTheDocument();
     expect(screen.queryByText(/no security signals/i)).not.toBeInTheDocument();
   });
 

--- a/packages/ui/src/chat/chat-dock.tsx
+++ b/packages/ui/src/chat/chat-dock.tsx
@@ -11,6 +11,7 @@ import { useEffect, useRef, useState, type CSSProperties, type ReactNode } from 
 import type { ChatArtifact, ChatUIMessage } from "@repowise-dev/types/chat";
 import { BrandMark } from "../shared/brand-mark";
 import { Button } from "../ui/button";
+import { ActivityDot } from "../ui/activity-dot";
 import { cn } from "../lib/cn";
 import type { SourceReference } from "./source-citations";
 import { ChatComposer } from "./chat-composer";
@@ -275,14 +276,11 @@ export function ChatDock({
           </span>
           {statusText && (
             <span aria-hidden>
-              <span
-                className={cn(
-                  "block h-1.5 w-1.5 rounded-full",
-                  isStreaming
-                    ? "bg-[var(--color-text-tertiary)] motion-safe:animate-pulse"
-                    : "bg-[var(--color-accent-secondary)]",
-                )}
-              />
+              {isStreaming ? (
+                <ActivityDot className="block h-1.5 w-1.5 bg-[var(--color-text-tertiary)]" />
+              ) : (
+                <span className="block h-1.5 w-1.5 rounded-full bg-[var(--color-accent-secondary)]" />
+              )}
             </span>
           )}
         </button>

--- a/packages/ui/src/chat/chat-interface.tsx
+++ b/packages/ui/src/chat/chat-interface.tsx
@@ -29,6 +29,7 @@ import {
 } from "react";
 import { ArrowDown, Send, PanelRight } from "lucide-react";
 import { Button } from "../ui/button";
+import { ActivityDot } from "../ui/activity-dot";
 import { ScrollArea } from "../ui/scroll-area";
 import { cn } from "../lib/cn";
 import { BrandMark } from "../shared/brand-mark";
@@ -313,11 +314,13 @@ export function ChatInterface({
                 size="sm"
                 className={cn(
                   "h-8 text-xs gap-1.5 tabular-nums",
-                  artifactPulse &&
-                    "animate-pulse text-[var(--color-accent-secondary)]",
+                  artifactPulse && "text-[var(--color-accent-secondary)]",
                 )}
                 onClick={() => setArtifactPanelOpen(true)}
               >
+                {artifactPulse ? (
+                  <ActivityDot className="h-1.5 w-1.5 bg-[var(--color-accent-secondary)]" />
+                ) : null}
                 <PanelRight className="h-4 w-4" />
                 <span className="sr-only sm:not-sr-only">Artifacts</span>
                 {totalArtifactCount}

--- a/packages/ui/src/costs/distill-savings-card.tsx
+++ b/packages/ui/src/costs/distill-savings-card.tsx
@@ -2,6 +2,7 @@
 
 import { Scissors, Sparkles, Zap } from "lucide-react";
 import { Card, CardContent } from "../ui/card";
+import { Skeleton, SkeletonRegion } from "../ui/skeleton";
 import { formatCost, formatTokens } from "../lib/format";
 
 export interface DistillSavingsGroup {
@@ -76,7 +77,9 @@ export function DistillSavingsCard({ data }: DistillSavingsCardProps) {
     return (
       <Card>
         <CardContent className="py-10">
-          <div className="h-24 w-full animate-pulse rounded-lg bg-[var(--color-bg-inset)]" />
+          <SkeletonRegion label="Loading agent token savings">
+            <Skeleton className="h-24 w-full rounded-lg" />
+          </SkeletonRegion>
         </CardContent>
       </Card>
     );

--- a/packages/ui/src/dashboard/active-job-banner.tsx
+++ b/packages/ui/src/dashboard/active-job-banner.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { Loader2, CheckCircle, XCircle, ExternalLink } from "lucide-react";
+import { CheckCircle, XCircle, ExternalLink } from "lucide-react";
+import { Spinner } from "../ui/spinner";
 import { Progress } from "../ui/progress";
 import { formatNumber, formatRelativeTime } from "../lib/format";
 import type { Job } from "@repowise-dev/types/jobs";
@@ -46,7 +47,7 @@ export function ActiveJobBanner({ job, detailsHref }: ActiveJobBannerProps) {
   return (
     <div className="px-4 py-2 border-b border-[var(--color-border-default)] bg-[var(--color-bg-inset)]">
       <div className="flex items-center gap-3">
-        {isRunning && <Loader2 className="h-3.5 w-3.5 animate-spin text-[var(--color-accent-primary)] shrink-0" />}
+        {isRunning && <Spinner size="sm" className="text-[var(--color-accent-primary)]" />}
         {isDone && <CheckCircle className="h-3.5 w-3.5 text-[var(--color-success)] shrink-0" />}
         {isFailed && <XCircle className="h-3.5 w-3.5 text-[var(--color-error)] shrink-0" />}
 

--- a/packages/ui/src/dashboard/quick-actions.tsx
+++ b/packages/ui/src/dashboard/quick-actions.tsx
@@ -286,7 +286,7 @@ export function QuickActions({
             onClick={() => handleClick(primary)}
           >
             <PrimaryIcon
-              className={`h-3.5 w-3.5 ${loading === primary.key ? "animate-spin" : ""}`}
+              className={`h-3.5 w-3.5 ${loading === primary.key ? "motion-safe:animate-spin" : ""}`}
             />
             {primary.label}
           </Button>
@@ -325,7 +325,7 @@ export function QuickActions({
                           action.destructive
                             ? "text-[var(--color-warning)]"
                             : "text-[var(--color-text-tertiary)]"
-                        } ${loading === action.key ? "animate-spin" : ""}`}
+                        } ${loading === action.key ? "motion-safe:animate-spin" : ""}`}
                       />
                       <span className="min-w-0">
                         <span className="block text-xs font-medium text-[var(--color-text-primary)]">
@@ -363,7 +363,7 @@ export function QuickActions({
                 disabled={loading !== null}
                 onClick={() => handleClick(action)}
               >
-                <Icon className={`h-3.5 w-3.5 ${isLoading ? "animate-spin" : ""}`} />
+                <Icon className={`h-3.5 w-3.5 ${isLoading ? "motion-safe:animate-spin" : ""}`} />
                 {action.label}
               </Button>
             );

--- a/packages/ui/src/docs/docs-page-actions.tsx
+++ b/packages/ui/src/docs/docs-page-actions.tsx
@@ -6,10 +6,10 @@ import {
   Download,
   FileText,
   FolderArchive,
-  Loader2,
   PanelRight,
   PanelRightClose,
 } from "lucide-react";
+import { Spinner } from "../ui/spinner";
 import { Button } from "../ui/button";
 import { ConfidenceBadge } from "../wiki/confidence-badge";
 import { READER_PERSONAS, type ReaderPersona } from "./reader-persona";
@@ -125,7 +125,7 @@ export function ExportMenu({
         aria-expanded={open}
       >
         {isExporting ? (
-          <Loader2 className="h-3.5 w-3.5 mr-1.5 animate-spin" />
+          <Spinner size="sm" className="mr-1.5" />
         ) : (
           <Download className="h-3.5 w-3.5 mr-1.5" />
         )}

--- a/packages/ui/src/graph/graph-doc-panel.tsx
+++ b/packages/ui/src/graph/graph-doc-panel.tsx
@@ -7,9 +7,9 @@ import {
   ExternalLink,
   Clock,
   Cpu,
-  Loader2,
   AlertCircle,
 } from "lucide-react";
+import { Spinner } from "../ui/spinner";
 import { Button } from "../ui/button";
 import { Badge } from "../ui/badge";
 import { Markdown } from "../shared/markdown";
@@ -105,7 +105,7 @@ export function GraphDocPanel({
       <div ref={scrollRef} className="flex-1 overflow-y-auto">
         {isLoading && (
           <div className="flex items-center justify-center h-32">
-            <Loader2 className="h-5 w-5 animate-spin text-[var(--color-accent-primary)]" />
+            <Spinner size="lg" label="Loading documentation" className="text-[var(--color-accent-primary)]" />
           </div>
         )}
 

--- a/packages/ui/src/graph/path-finder-panel.tsx
+++ b/packages/ui/src/graph/path-finder-panel.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useState, useEffect, useRef, useCallback } from "react";
-import { Route, Loader2, X, ArrowRight, Search, ChevronDown } from "lucide-react";
+import { Route, X, ArrowRight, Search, ChevronDown } from "lucide-react";
+import { Spinner } from "../ui/spinner";
 import { Button } from "../ui/button";
 import { useDebounce } from "../hooks/use-debounce";
 import type { GraphPath, NodeSearchResult } from "@repowise-dev/types/graph";
@@ -238,7 +239,7 @@ export function PathFinderPanel({
         }}
       >
         {loading ? (
-          <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          <Spinner size="sm" />
         ) : (
           <Route className="h-3.5 w-3.5" />
         )}

--- a/packages/ui/src/graph/sigma/sigma-controls.tsx
+++ b/packages/ui/src/graph/sigma/sigma-controls.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { ZoomIn, ZoomOut, Maximize, Focus, Play, Pause } from "lucide-react";
+import { ActivityDot } from "../../ui/activity-dot";
 
 interface SigmaControlsProps {
   onZoomIn: () => void;
@@ -37,7 +38,8 @@ export function SigmaControls({
   return (
     <div className="absolute bottom-3 right-3 z-10 flex flex-col items-end gap-1.5">
       {isLayoutRunning && (
-        <div className="animate-pulse whitespace-nowrap rounded-md border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)]/85 px-2 py-1 text-[10px] text-[var(--color-accent-primary)] shadow-sm backdrop-blur-sm">
+        <div className="flex items-center gap-1.5 whitespace-nowrap rounded-md border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)]/85 px-2 py-1 text-[10px] text-[var(--color-accent-primary)] shadow-sm backdrop-blur-sm">
+          <ActivityDot className="h-1.5 w-1.5" />
           Arranging…
         </div>
       )}

--- a/packages/ui/src/health/map/legend.tsx
+++ b/packages/ui/src/health/map/legend.tsx
@@ -13,6 +13,7 @@ import { Fragment } from "react";
 import type { KeyboardEvent as ReactKeyboardEvent } from "react";
 import { OVERLAY_ORDER, OVERLAY_SPECS, type LegendRow, type OverlaySpec } from "./lens";
 import type { CodeHealthOverlay } from "./types";
+import { ActivityDot } from "../../ui/activity-dot";
 
 /** One key swatch: a disc in the row's fill. */
 function Swatch({ row, size }: { row: LegendRow; size: number }) {
@@ -49,7 +50,7 @@ export function MapLegendRows({ spec, loading }: { spec: OverlaySpec; loading: b
   if (loading) {
     return (
       <div className="flex items-center gap-1.5 text-[var(--color-text-tertiary)]">
-        <span className="h-2.5 w-2.5 animate-pulse rounded-full bg-[var(--color-text-tertiary)]" />
+        <ActivityDot className="h-2.5 w-2.5 bg-[var(--color-text-tertiary)]" />
         loading {spec.label.toLowerCase()}…
       </div>
     );
@@ -161,7 +162,7 @@ export function MapLegend({
     >
       {loading ? (
         <span className="flex items-center gap-1.5">
-          <span className="h-2 w-2 animate-pulse rounded-full bg-[var(--color-text-tertiary)]" />
+          <ActivityDot className="bg-[var(--color-text-tertiary)]" />
           loading {spec.label.toLowerCase()}…
         </span>
       ) : (

--- a/packages/ui/src/health/performance/evidence.tsx
+++ b/packages/ui/src/health/performance/evidence.tsx
@@ -5,6 +5,7 @@ import useSWR from "swr";
 import type { HealthFinding, PerformanceOpportunityEvidence } from "@repowise-dev/types/health";
 
 import { PaginationControls } from "../../shared/pagination-controls";
+import { Skeleton, SkeletonRegion } from "../../ui/skeleton";
 import type { PerformanceViewAdapter } from "./adapter";
 
 /**
@@ -71,7 +72,9 @@ export function RawObservations({
             </p>
           ) : null}
           {isLoading && !data ? (
-            <div className="h-24 animate-pulse rounded bg-[var(--color-bg-surface)]" />
+            <SkeletonRegion label="Loading observations">
+              <Skeleton className="h-24 rounded" />
+            </SkeletonRegion>
           ) : (
             <ul className="divide-y divide-[var(--color-border-default)] border-y border-[var(--color-border-default)]">
               {rows.map((row, index) => (

--- a/packages/ui/src/health/performance/legacy.tsx
+++ b/packages/ui/src/health/performance/legacy.tsx
@@ -5,6 +5,7 @@ import { Gauge } from "lucide-react";
 import type { HealthFinding } from "@repowise-dev/types/health";
 
 import { EmptyState } from "../../shared/empty-state";
+import { Skeleton, SkeletonRegion } from "../../ui/skeleton";
 import { BiomarkerList } from "../biomarker-list";
 import type { PerformanceViewAdapter } from "./adapter";
 
@@ -21,7 +22,12 @@ export function LegacyPerformanceFindings({ adapter }: { adapter: PerformanceVie
     () => adapter.listFindings({ dimension: "performance", limit: 100 }),
     { revalidateOnFocus: false },
   );
-  if (isLoading) return <div className="h-72 animate-pulse rounded bg-[var(--color-bg-surface)]" />;
+  if (isLoading)
+    return (
+      <SkeletonRegion label="Loading performance findings">
+        <Skeleton className="h-72 rounded" />
+      </SkeletonRegion>
+    );
   if (error || !data?.length) {
     return (
       <EmptyState

--- a/packages/ui/src/health/performance/states.tsx
+++ b/packages/ui/src/health/performance/states.tsx
@@ -4,6 +4,7 @@ import { AlertTriangle, Gauge, Info } from "lucide-react";
 import type { PerformanceOpportunitySummary } from "@repowise-dev/types/health";
 
 import { EmptyState } from "../../shared/empty-state";
+import { Skeleton, SkeletonRegion } from "../../ui/skeleton";
 
 /**
  * Every state the queue can be in other than "here are the rows". They are
@@ -15,18 +16,15 @@ import { EmptyState } from "../../shared/empty-state";
 
 export function QueueSkeleton() {
   return (
-    <div className="space-y-8" aria-busy="true">
-      <div className="h-32 animate-pulse rounded bg-[var(--color-bg-surface)]" />
-      <div className="h-10 animate-pulse rounded bg-[var(--color-bg-surface)]" />
+    <SkeletonRegion className="space-y-8" label="Loading performance opportunities">
+      <Skeleton className="h-32 rounded" />
+      <Skeleton className="h-10 rounded" />
       <div className="space-y-px">
         {[0, 1, 2, 3, 4].map((row) => (
-          <div key={row} className="h-[86px] animate-pulse bg-[var(--color-bg-surface)]" />
+          <Skeleton key={row} className="h-[86px] rounded-none" />
         ))}
       </div>
-      <span className="sr-only" role="status">
-        Loading performance opportunities
-      </span>
-    </div>
+    </SkeletonRegion>
   );
 }
 

--- a/packages/ui/src/hooks/index.ts
+++ b/packages/ui/src/hooks/index.ts
@@ -1,1 +1,2 @@
 export * from "./use-debounce";
+export * from "./use-prefers-reduced-motion";

--- a/packages/ui/src/hooks/use-prefers-reduced-motion.ts
+++ b/packages/ui/src/hooks/use-prefers-reduced-motion.ts
@@ -1,0 +1,27 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/**
+ * Tracks `prefers-reduced-motion: reduce`.
+ *
+ * Only for motion CSS cannot reach — a JS-driven animation, a Lottie that
+ * autoplays, a canvas loop. Anything expressible in CSS should use the
+ * `motion-safe:` / `motion-reduce:` variants instead, which need no state and
+ * no hydration pass.
+ *
+ * Starts `false` so server and first client render agree; the effect
+ * corrects it on mount.
+ */
+export function usePrefersReducedMotion(): boolean {
+  const [reduced, setReduced] = useState(false);
+  useEffect(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return;
+    const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
+    setReduced(mq.matches);
+    const onChange = () => setReduced(mq.matches);
+    mq.addEventListener("change", onChange);
+    return () => mq.removeEventListener("change", onChange);
+  }, []);
+  return reduced;
+}

--- a/packages/ui/src/jobs/generation-progress.tsx
+++ b/packages/ui/src/jobs/generation-progress.tsx
@@ -1,8 +1,10 @@
 "use client";
 
-import { Ban, CheckCircle, XCircle, Loader2, AlertTriangle, RotateCw, Settings, X } from "lucide-react";
+import { Ban, CheckCircle, XCircle, AlertTriangle, RotateCw, Settings, X } from "lucide-react";
+import { Spinner } from "../ui/spinner";
 import { Progress } from "../ui/progress";
 import { Badge } from "../ui/badge";
+import { ActivityDot } from "../ui/activity-dot";
 import { Button } from "../ui/button";
 import { JobLog, type JobLogEntry } from "./job-log";
 import { formatTokens, formatNumber } from "../lib/format";
@@ -86,7 +88,7 @@ export function GenerationProgress({
   return (
     <div className="space-y-3">
       <div className="flex items-center gap-2">
-        {isInflight && <Loader2 className="h-4 w-4 animate-spin text-[var(--color-accent-primary)] shrink-0" />}
+        {isInflight && <Spinner className="text-[var(--color-accent-primary)]" />}
         {isDone && <CheckCircle className="h-4 w-4 text-[var(--color-fresh)] shrink-0" />}
         {isFailed && <XCircle className="h-4 w-4 text-[var(--color-outdated)] shrink-0" />}
         {isCancelled && <Ban className="h-4 w-4 text-[var(--color-text-tertiary)] shrink-0" />}
@@ -156,7 +158,7 @@ export function GenerationProgress({
           <span>Cost: ${actualCost.toFixed(4)}</span>
           {isRunning && (
             <span className="inline-flex items-center gap-0.5 rounded bg-[var(--color-accent-primary)]/15 px-1 py-px text-[10px] font-medium text-[var(--color-accent-primary)]">
-              <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-[var(--color-accent-primary)]" />
+              <ActivityDot className="h-1.5 w-1.5" />
               live
             </span>
           )}

--- a/packages/ui/src/onboarding/add-repo-wizard.tsx
+++ b/packages/ui/src/onboarding/add-repo-wizard.tsx
@@ -6,10 +6,10 @@ import {
   ArrowLeft,
   CheckCircle2,
   FileText,
-  Loader2,
   Settings,
   XCircle,
 } from "lucide-react";
+import { Spinner } from "../ui/spinner";
 import { Button } from "../ui/button";
 import {
   Dialog,
@@ -401,7 +401,7 @@ export function AddRepoWizard({ adapter, open, onOpenChange }: AddRepoWizardProp
               <DialogTitle>Getting ready to index</DialogTitle>
             </DialogHeader>
             <div className="flex flex-col items-center gap-3 py-8">
-              <Loader2 className="h-6 w-6 animate-spin text-[var(--color-accent-primary)]" />
+              <Spinner size="xl" className="text-[var(--color-accent-primary)]" />
               <p className="text-sm text-[var(--color-text-secondary)]">
                 Checking the provider and sizing the repository…
               </p>

--- a/packages/ui/src/refactoring/generate-code-panel.tsx
+++ b/packages/ui/src/refactoring/generate-code-panel.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import * as React from "react";
-import { Check, Copy, Loader2, RotateCw, Sparkles, TriangleAlert, Wand2 } from "lucide-react";
+import { Check, Copy, RotateCw, Sparkles, TriangleAlert, Wand2 } from "lucide-react";
+import { Spinner } from "../ui/spinner";
 import { DiffView } from "./diff-view";
 import {
   generatedVerdict,
@@ -76,7 +77,7 @@ export function GenerateCodePanel({ plan, onGenerate }: GenerateCodePanelProps) 
   if (state.status === "loading") {
     return (
       <div className="flex items-center gap-2 text-sm text-[var(--color-text-secondary)]">
-        <Loader2 className="h-4 w-4 animate-spin text-[var(--color-accent-primary)]" />
+        <Spinner className="text-[var(--color-accent-primary)]" />
         Generating the refactored code…
       </div>
     );

--- a/packages/ui/src/refactoring/refactoring-drawer.tsx
+++ b/packages/ui/src/refactoring/refactoring-drawer.tsx
@@ -23,6 +23,7 @@ import type { ReactNode } from "react";
 import { Layers, Sparkles, TrendingUp, Wand2 } from "lucide-react";
 
 import { Sheet, SheetContent, SheetTitle } from "../ui/sheet";
+import { Skeleton, SkeletonRegion } from "../ui/skeleton";
 import { formatNumber } from "../lib/format";
 import { PlanComparison } from "./plan-comparison";
 import { GenerateCodePanel } from "./generate-code-panel";
@@ -88,10 +89,10 @@ export function RefactoringDrawer({
             <SheetTitle className="border-b border-[var(--color-border-default)] px-5 py-4 pr-12 text-[15px]">
               Loading structured plan
             </SheetTitle>
-            <div className="space-y-4 px-5 py-5" aria-busy="true">
-              <div className="h-16 animate-pulse bg-[var(--color-bg-surface)]" />
-              <div className="h-40 animate-pulse bg-[var(--color-bg-surface)]" />
-            </div>
+            <SkeletonRegion className="space-y-4 px-5 py-5" label="Loading structured plan">
+              <Skeleton className="h-16 rounded-none" />
+              <Skeleton className="h-40 rounded-none" />
+            </SkeletonRegion>
           </>
         ) : error ? (
           <>

--- a/packages/ui/src/refactoring/refactoring-settings-card.tsx
+++ b/packages/ui/src/refactoring/refactoring-settings-card.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import * as React from "react";
-import { Check, Loader2, TriangleAlert, Wand2 } from "lucide-react";
+import { Check, TriangleAlert, Wand2 } from "lucide-react";
+import { Spinner } from "../ui/spinner";
 import { Switch } from "../ui/switch";
 import { Input } from "../ui/input";
 import { Label } from "../ui/label";
@@ -84,7 +85,7 @@ export function RefactoringSettingsCard({
   if (loading || value === null) {
     return (
       <div className="flex items-center gap-2 text-sm text-[var(--color-text-secondary)]">
-        <Loader2 className="h-4 w-4 animate-spin" />
+        <Spinner />
         Loading settings…
       </div>
     );
@@ -154,7 +155,7 @@ export function RefactoringSettingsCard({
           disabled={!dirty || save === "saving"}
           className="inline-flex items-center gap-1.5 rounded-lg bg-[var(--color-accent-primary)] px-3.5 py-2 text-sm font-semibold text-[var(--color-bg-surface)] transition-opacity hover:opacity-90 disabled:opacity-50"
         >
-          {save === "saving" ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
+          {save === "saving" ? <Spinner /> : null}
           Save
         </button>
         {save === "saved" ? (

--- a/packages/ui/src/settings/provider-settings.tsx
+++ b/packages/ui/src/settings/provider-settings.tsx
@@ -4,11 +4,11 @@ import { useState } from "react";
 import {
   Check,
   KeyRound,
-  Loader2,
   Plug,
   Trash2,
   X,
 } from "lucide-react";
+import { Spinner } from "../ui/spinner";
 import { Badge } from "../ui/badge";
 import { Button } from "../ui/button";
 import { Input } from "../ui/input";
@@ -200,7 +200,7 @@ function ProviderRow({
               aria-label={`Use ${provider.name}`}
             >
               {busy === "activate" ? (
-                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                <Spinner size="sm" />
               ) : (
                 "Use"
               )}
@@ -217,7 +217,7 @@ function ProviderRow({
               aria-label={`Test ${provider.name} connection`}
             >
               {status === "testing" ? (
-                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                <Spinner size="sm" />
               ) : (
                 <Plug className="h-3.5 w-3.5" />
               )}
@@ -248,7 +248,7 @@ function ProviderRow({
               aria-label={`Remove ${provider.name} key`}
             >
               {busy === "remove" ? (
-                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                <Spinner size="sm" />
               ) : (
                 <Trash2 className="h-3.5 w-3.5" />
               )}
@@ -288,7 +288,7 @@ function ProviderRow({
             aria-label={`Save ${provider.name} API key`}
           >
             {busy === "save" ? (
-              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              <Spinner size="sm" />
             ) : (
               "Save"
             )}

--- a/packages/ui/src/settings/settings-primitives.tsx
+++ b/packages/ui/src/settings/settings-primitives.tsx
@@ -12,7 +12,8 @@
  */
 
 import * as React from "react";
-import { Check, Copy, Loader2 } from "lucide-react";
+import { Check, Copy } from "lucide-react";
+import { Spinner } from "../ui/spinner";
 import { cn } from "../lib/cn";
 
 export const SETTINGS_MICRO_LABEL =
@@ -113,7 +114,7 @@ export function SaveIndicator({
     >
       {state === "saving" && (
         <>
-          <Loader2 className="h-3 w-3 animate-spin" aria-hidden />
+          <Spinner size="xs" />
           Saving…
         </>
       )}

--- a/packages/ui/src/shared/index.ts
+++ b/packages/ui/src/shared/index.ts
@@ -30,8 +30,10 @@ export { OwlLoader, type OwlLoaderProps } from "./owl-loader";
 export {
   TableSkeleton,
   CardSkeleton,
+  PageSkeleton,
   type TableSkeletonProps,
   type CardSkeletonProps,
+  type PageSkeletonProps,
 } from "./loading-skeletons";
 export { PageShell, type PageShellProps } from "./page-shell";
 export { ViewTabs, type ViewTab, type ViewTabsProps } from "./view-tabs";

--- a/packages/ui/src/shared/loading-skeletons.tsx
+++ b/packages/ui/src/shared/loading-skeletons.tsx
@@ -1,5 +1,14 @@
-import { Skeleton } from "../ui/skeleton";
+import type { ReactNode } from "react";
+
+import { Skeleton, SkeletonRegion } from "../ui/skeleton";
 import { cn } from "../lib/cn";
+import {
+  PAGE_SHELL_CONTAINER,
+  PAGE_SHELL_DESCRIPTION,
+  PAGE_SHELL_HEADER,
+  PAGE_SHELL_MAX_WIDTH,
+  PAGE_SHELL_TITLE,
+} from "./page-shell";
 
 export interface TableSkeletonProps {
   /** Number of placeholder rows. Default 6. */
@@ -10,11 +19,11 @@ export interface TableSkeletonProps {
 /** Loading placeholder shaped like a table: a stack of row-height bars. */
 export function TableSkeleton({ rows = 6, className }: TableSkeletonProps) {
   return (
-    <div className={cn("space-y-2", className)} aria-hidden>
+    <SkeletonRegion className={cn("space-y-2", className)} label="Loading rows">
       {Array.from({ length: rows }).map((_, i) => (
         <Skeleton key={i} className="h-10 w-full" />
       ))}
-    </div>
+    </SkeletonRegion>
   );
 }
 
@@ -27,12 +36,11 @@ export interface CardSkeletonProps {
 /** Loading placeholder shaped like a card: a title bar over shorter lines. */
 export function CardSkeleton({ lines = 3, className }: CardSkeletonProps) {
   return (
-    <div
+    <SkeletonRegion
       className={cn(
         "rounded-lg border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-4 space-y-3",
         className,
       )}
-      aria-hidden
     >
       <Skeleton className="h-4 w-1/3" />
       <div className="space-y-2">
@@ -40,6 +48,58 @@ export function CardSkeleton({ lines = 3, className }: CardSkeletonProps) {
           <Skeleton key={i} className={cn("h-3", i === lines - 1 ? "w-2/3" : "w-full")} />
         ))}
       </div>
-    </div>
+    </SkeletonRegion>
+  );
+}
+
+export interface PageSkeletonProps {
+  /** Must match the `maxWidth` the real page passes to `PageShell`. */
+  maxWidth?: keyof typeof PAGE_SHELL_MAX_WIDTH;
+  /** Set false for a page whose `PageShell` has no `description`. */
+  description?: boolean;
+  /** Set false for a page whose `PageShell` has no `actions`. */
+  actions?: boolean;
+  label?: string;
+  /** Body shapes. Omit to reserve nothing below the header. */
+  children?: ReactNode;
+}
+
+/**
+ * The `PageShell` frame, waiting. Each bar sits inside the real heading or
+ * description element and is sized `1lh`, so it reserves that element's own
+ * line box rather than a guessed pixel height. Change the type scale and the
+ * placeholder follows; there is no literal to fall out of sync.
+ *
+ * The header is exact. The body is whatever you pass: give it shapes only
+ * where you actually know the layout, because a guessed body reflows on
+ * arrival, which reads slower than having reserved nothing.
+ */
+export function PageSkeleton({
+  maxWidth = "default",
+  description = true,
+  actions = true,
+  label = "Loading page",
+  children,
+}: PageSkeletonProps) {
+  return (
+    <SkeletonRegion
+      className={cn(PAGE_SHELL_CONTAINER, PAGE_SHELL_MAX_WIDTH[maxWidth])}
+      label={label}
+    >
+      <header className={PAGE_SHELL_HEADER}>
+        <div className="min-w-0 flex-1 space-y-1">
+          <h1 className={PAGE_SHELL_TITLE}>
+            <Skeleton className="h-[1lh] w-52 max-w-full" />
+          </h1>
+          {description && (
+            <p className={PAGE_SHELL_DESCRIPTION}>
+              <Skeleton className="block h-[1lh] w-full" />
+            </p>
+          )}
+        </div>
+        {actions && <Skeleton className="h-8 w-24 shrink-0" />}
+      </header>
+      {children}
+    </SkeletonRegion>
   );
 }

--- a/packages/ui/src/shared/owl-loader.tsx
+++ b/packages/ui/src/shared/owl-loader.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { DotLottieReact } from "@lottiefiles/dotlottie-react";
 import { cn } from "../lib/cn";
+import { usePrefersReducedMotion } from "../hooks/use-prefers-reduced-motion";
 import { BrandMark } from "./brand-mark";
 
 export interface OwlLoaderProps {
@@ -17,10 +18,14 @@ export interface OwlLoaderProps {
 }
 
 /**
- * Brand loading animation — the owl Lottie, centered. Falls back to a
- * pulsing static brand mark if the animation asset fails to load, so a
- * missing lottie asset never breaks a loading state. The asset itself stays
- * per-app (lazy-fetched, CDN-cached) — only the component is shared.
+ * Brand loading animation — the owl Lottie, centered. Falls back to the
+ * static brand mark if the animation asset fails to load, so a missing
+ * lottie asset never breaks a loading state. The asset itself stays per-app
+ * (lazy-fetched, CDN-cached) — only the component is shared.
+ *
+ * Under reduced motion the same still mark is the equivalent still, and the
+ * Lottie is never mounted — a paused animation would still pay for the WASM
+ * runtime and the JSON fetch.
  */
 export function OwlLoader({
   src = "/owl-loading.json",
@@ -31,6 +36,8 @@ export function OwlLoader({
   className,
 }: OwlLoaderProps) {
   const [failed, setFailed] = useState(false);
+  const reducedMotion = usePrefersReducedMotion();
+  const still = failed || reducedMotion;
 
   return (
     <div
@@ -41,15 +48,13 @@ export function OwlLoader({
         className,
       )}
     >
-      {failed ? (
-        <span className="motion-safe:animate-pulse">
-          <BrandMark
-            darkSrc={logoDarkSrc}
-            lightSrc={logoLightSrc}
-            size={size * 0.6}
-            alt=""
-          />
-        </span>
+      {still ? (
+        <BrandMark
+          darkSrc={logoDarkSrc}
+          lightSrc={logoLightSrc}
+          size={size * 0.6}
+          alt=""
+        />
       ) : (
         <DotLottieReact
           src={src}

--- a/packages/ui/src/shared/page-shell.tsx
+++ b/packages/ui/src/shared/page-shell.tsx
@@ -1,6 +1,26 @@
 import * as React from "react";
 import { cn } from "../lib/cn";
 
+/**
+ * The frame's own geometry, exported so a loading placeholder can reserve the
+ * exact same box (see `PageSkeleton`). A literal copied into a skeleton is a
+ * reflow waiting to happen; sharing the string makes drift impossible.
+ */
+export const PAGE_SHELL_CONTAINER =
+  "mx-auto w-full p-[var(--page-pad)] space-y-[var(--section-gap)]";
+export const PAGE_SHELL_MAX_WIDTH = {
+  default: "max-w-[1280px]",
+  wide: "max-w-[1600px]",
+} as const;
+export const PAGE_SHELL_HEADER =
+  "flex flex-wrap items-start justify-between gap-4";
+/** The h1's type styles, so a placeholder inherits the real line box. */
+export const PAGE_SHELL_TITLE =
+  "flex items-center gap-2 text-xl font-semibold text-[var(--color-text-primary)]";
+/** The description's type styles, including the readable-measure cap. */
+export const PAGE_SHELL_DESCRIPTION =
+  "max-w-[68ch] text-sm text-[var(--color-text-secondary)]";
+
 export interface PageShellProps {
   title: string;
   icon?: React.ReactNode;
@@ -30,21 +50,21 @@ export function PageShell({
   return (
     <div
       className={cn(
-        "mx-auto w-full p-[var(--page-pad)] space-y-[var(--section-gap)]",
-        maxWidth === "wide" ? "max-w-[1600px]" : "max-w-[1280px]",
+        PAGE_SHELL_CONTAINER,
+        PAGE_SHELL_MAX_WIDTH[maxWidth],
         className,
       )}
     >
-      <header className="flex flex-wrap items-start justify-between gap-4">
+      <header className={PAGE_SHELL_HEADER}>
         <div className="min-w-0 space-y-1">
-          <h1 className="flex items-center gap-2 text-xl font-semibold text-[var(--color-text-primary)]">
+          <h1 className={PAGE_SHELL_TITLE}>
             {icon}
             {title}
           </h1>
           {description && (
             // Capped at a readable measure. Unbounded, this ran the full
             // 1280 on a wide viewport, which is roughly 160 characters.
-            <p className="max-w-[68ch] text-sm text-[var(--color-text-secondary)] [text-wrap:pretty]">
+            <p className={cn(PAGE_SHELL_DESCRIPTION, "[text-wrap:pretty]")}>
               {description}
             </p>
           )}

--- a/packages/ui/src/ui/activity-dot.tsx
+++ b/packages/ui/src/ui/activity-dot.tsx
@@ -1,0 +1,30 @@
+import { cn } from "../lib/cn";
+
+/**
+ * "Something is happening right now" — a stream arriving, a layout running,
+ * a job in flight. Deliberately a different verb from a wait: skeletons
+ * sweep, live activity breathes, on the slower 2.4s cadence `WorkingOrb`
+ * already uses. Before this existed both used `animate-pulse` and a reader
+ * could not tell a placeholder from a live signal.
+ *
+ * Decorative by default. The state it marks must also be in text nearby,
+ * because under reduced motion the dot is simply still.
+ *
+ * Size and color are className overrides; the defaults suit a status row.
+ */
+export function ActivityDot({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLSpanElement>) {
+  return (
+    <span
+      aria-hidden="true"
+      className={cn(
+        "inline-block h-2 w-2 shrink-0 rounded-full bg-[var(--color-accent-primary)]",
+        "motion-safe:animate-[pulse_2.4s_ease-in-out_infinite] motion-reduce:animate-none",
+        className,
+      )}
+      {...props}
+    />
+  );
+}

--- a/packages/ui/src/ui/index.ts
+++ b/packages/ui/src/ui/index.ts
@@ -1,3 +1,4 @@
+export * from "./activity-dot";
 export * from "./badge";
 export * from "./button";
 export * from "./card";
@@ -13,6 +14,7 @@ export * from "./separator";
 export * from "./sheet";
 export * from "./skeleton";
 export * from "./slider";
+export * from "./spinner";
 export * from "./switch";
 export * from "./tabs";
 export * from "./tooltip";

--- a/packages/ui/src/ui/skeleton.tsx
+++ b/packages/ui/src/ui/skeleton.tsx
@@ -1,18 +1,58 @@
 import { cn } from "../lib/cn";
 
+/**
+ * A still placeholder box. It does NOT animate on its own: motion belongs to
+ * the pending region, so a page full of skeletons reads as one wait rather
+ * than as N independent ones. Wrap the region in `SkeletonRegion` to add the
+ * sweep; a bare `Skeleton` is a correct, calm silhouette.
+ *
+ * Fill is always `--color-bg-elevated`. A placeholder on any other plane
+ * makes two adjacent loading states look like two different things.
+ */
 function Skeleton({
   className,
   ...props
 }: React.HTMLAttributes<HTMLDivElement>) {
   return (
     <div
-      className={cn(
-        "animate-pulse rounded-md bg-[var(--color-bg-elevated)]",
-        className,
-      )}
+      data-skeleton=""
+      className={cn("rounded-md bg-[var(--color-bg-elevated)]", className)}
       {...props}
     />
   );
 }
 
-export { Skeleton };
+export interface SkeletonRegionProps
+  extends React.HTMLAttributes<HTMLDivElement> {
+  /**
+   * Announced to assistive tech in place of the silhouette. Say what is
+   * loading — "Loading performance opportunities" beats "Loading".
+   */
+  label?: string;
+}
+
+/**
+ * Marks a block of the page as pending and runs one slow sweep across every
+ * `Skeleton` inside it (see `.skeleton-region` in the shared stylesheet).
+ * Reduced motion leaves the still silhouette.
+ *
+ * Wrap the region that is waiting, not each box. Nesting two regions is not
+ * wrong, but it buys nothing: the sweep is viewport-anchored either way.
+ */
+function SkeletonRegion({
+  className,
+  children,
+  label = "Loading…",
+  ...props
+}: SkeletonRegionProps) {
+  return (
+    <div aria-busy="true" className={cn("skeleton-region", className)} {...props}>
+      {children}
+      <span className="sr-only" role="status">
+        {label}
+      </span>
+    </div>
+  );
+}
+
+export { Skeleton, SkeletonRegion };

--- a/packages/ui/src/ui/spinner.tsx
+++ b/packages/ui/src/ui/spinner.tsx
@@ -1,0 +1,45 @@
+import { Loader2 } from "lucide-react";
+
+import { cn } from "../lib/cn";
+
+const SIZES = {
+  xs: "h-3 w-3",
+  sm: "h-3.5 w-3.5",
+  md: "h-4 w-4",
+  lg: "h-5 w-5",
+  xl: "h-6 w-6",
+} as const;
+
+export interface SpinnerProps
+  extends Omit<React.SVGAttributes<SVGSVGElement>, "role"> {
+  size?: keyof typeof SIZES;
+  /**
+   * Accessible name. Omit when a status word sits next to the spinner — the
+   * word is the announcement and a second one is noise; the icon is then
+   * hidden from assistive tech. Pass it when the spinner stands alone.
+   */
+  label?: string;
+}
+
+/**
+ * In-place indeterminate work under ~400ms: a button, a row, an inline
+ * action. Pair it with a status word ("Saving…"), which is also what carries
+ * the meaning under reduced motion, where the glyph stops turning.
+ *
+ * Not for page or panel content — that gets a matched `Skeleton`. Not for
+ * determinate work with a real total — that gets `Progress`.
+ *
+ * Color inherits from the caller. Pass `text-[var(--color-accent-primary)]`
+ * where the spinner is the subject rather than a detail of a control.
+ */
+export function Spinner({ size = "md", label, className, ...props }: SpinnerProps) {
+  return (
+    <Loader2
+      {...(label
+        ? { role: "status", "aria-label": label }
+        : { "aria-hidden": true })}
+      className={cn(SIZES[size], "shrink-0 motion-safe:animate-spin", className)}
+      {...props}
+    />
+  );
+}

--- a/packages/ui/src/wiki/confidence-badge.tsx
+++ b/packages/ui/src/wiki/confidence-badge.tsx
@@ -10,6 +10,7 @@ import {
 } from "../lib/confidence";
 import { formatConfidence, formatDate } from "../lib/format";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../ui/tooltip";
+import { ActivityDot } from "../ui/activity-dot";
 
 interface ConfidenceBadgeProps {
   score: number;
@@ -50,14 +51,17 @@ export function ConfidenceBadge({
         className,
       )}
     >
-      <span
-        className={cn(
-          "h-1.5 w-1.5 shrink-0 rounded-full",
-          status === "fresh" && "bg-[var(--color-success)]",
-          status === "stale" && "animate-pulse bg-[var(--color-warning)]",
-          status === "outdated" && "bg-[var(--color-error)]",
-        )}
-      />
+      {status === "stale" ? (
+        <ActivityDot className="h-1.5 w-1.5 bg-[var(--color-warning)]" />
+      ) : (
+        <span
+          className={cn(
+            "h-1.5 w-1.5 shrink-0 rounded-full",
+            status === "fresh" && "bg-[var(--color-success)]",
+            status === "outdated" && "bg-[var(--color-error)]",
+          )}
+        />
+      )}
       {/* Hidden visually, never from a screen reader: the colour is the signal
           on a phone, but "Fresh" is still the name of the state. */}
       <span className={cn(compact && "sr-only sm:not-sr-only")}>{label}</span>

--- a/packages/ui/src/wiki/regenerate-button.tsx
+++ b/packages/ui/src/wiki/regenerate-button.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import type { ReactNode } from "react";
-import { Loader2, RefreshCw, Sparkles } from "lucide-react";
+import { RefreshCw, Sparkles } from "lucide-react";
+import { Spinner } from "../ui/spinner";
 import { Button } from "../ui/button";
 import {
   Dialog,
@@ -50,7 +51,7 @@ export function RegenerateButton({
   inline = false,
 }: RegenerateButtonProps) {
   const isWrite = mode === "write";
-  const Icon = isLoading ? Loader2 : isWrite ? Sparkles : RefreshCw;
+  const Icon = isWrite ? Sparkles : RefreshCw;
 
   return (
     <>
@@ -62,7 +63,11 @@ export function RegenerateButton({
           className="inline-flex items-center gap-1 rounded-full border border-[var(--color-accent-primary)]/40 bg-[var(--color-accent-muted)] px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider text-[var(--color-accent-primary)] transition-colors hover:bg-[var(--color-accent-muted)] hover:text-[var(--color-accent-hover)] disabled:opacity-60"
           aria-label={isWrite ? "Write this page with AI" : "Regenerate this page"}
         >
-          <Icon className={cn("h-2.5 w-2.5", isLoading && "animate-spin")} />
+          {isLoading ? (
+            <Spinner className="h-2.5 w-2.5" />
+          ) : (
+            <Icon className="h-2.5 w-2.5" />
+          )}
           {isWrite ? "Write with AI" : "Regenerate"}
         </button>
       ) : (
@@ -78,13 +83,16 @@ export function RegenerateButton({
           )}
           aria-label={isWrite ? "Write this page with AI" : "Regenerate this page"}
         >
-          <Icon
-            className={cn(
-              "h-3.5 w-3.5",
-              isLoading && "animate-spin",
-              isWrite && !isLoading && "text-[var(--color-accent-primary)]",
-            )}
-          />
+          {isLoading ? (
+            <Spinner size="sm" />
+          ) : (
+            <Icon
+              className={cn(
+                "h-3.5 w-3.5",
+                isWrite && "text-[var(--color-accent-primary)]",
+              )}
+            />
+          )}
           <span className="hidden sm:inline">
             {isWrite ? "Write with AI" : "Regenerate"}
           </span>
@@ -293,7 +301,7 @@ export function GenerateConfirmDialog({
             >
               {estimateLoading ? (
                 <span className="inline-flex items-center gap-1.5">
-                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                  <Spinner size="sm" />
                   Analyzing the repository to price this accurately…
                 </span>
               ) : estimate ? (
@@ -334,7 +342,7 @@ export function GenerateConfirmDialog({
               </Button>
               <Button size="sm" onClick={onConfirm} disabled={launching}>
                 {launching ? (
-                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                  <Spinner size="sm" />
                 ) : isWrite ? (
                   <>
                     <Sparkles className="mr-1.5 h-3.5 w-3.5" />

--- a/packages/ui/src/zoom/ZoomCanvas.tsx
+++ b/packages/ui/src/zoom/ZoomCanvas.tsx
@@ -26,6 +26,7 @@ import type { ZoomMap, ZoomNode, ZoomRelation } from "./types";
 import { describeRelations, summarizeRelations } from "./relation-summary";
 import { healthBandLabel, KIND_LABEL, nodeRoles } from "./node-signals";
 import { useThemeVersion } from "../shared/use-theme-tokens";
+import { usePrefersReducedMotion } from "../hooks/use-prefers-reduced-motion";
 
 export interface ZoomCanvasHandle {
   /** Fly the camera to frame a node by id. Returns false if it is not laid out. */
@@ -66,19 +67,6 @@ interface HoverState {
   node: ZoomNode;
   sx: number;
   sy: number;
-}
-
-function usePrefersReducedMotion(): boolean {
-  const [reduced, setReduced] = useState(false);
-  useEffect(() => {
-    if (typeof window === "undefined" || !window.matchMedia) return;
-    const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
-    setReduced(mq.matches);
-    const onChange = () => setReduced(mq.matches);
-    mq.addEventListener("change", onChange);
-    return () => mq.removeEventListener("change", onChange);
-  }, []);
-  return reduced;
 }
 
 export const ZoomCanvas = forwardRef<ZoomCanvasHandle, ZoomCanvasProps>(function ZoomCanvas(

--- a/packages/ui/styles/globals.css
+++ b/packages/ui/styles/globals.css
@@ -807,3 +807,58 @@ body {
     stroke-dashoffset: -20;
   }
 }
+
+/* -------------------------------------------------------------------- */
+/* Loading sweep                                                         */
+/* -------------------------------------------------------------------- */
+
+/* The `Skeleton` primitive paints a still fill. Motion belongs to the
+   pending REGION, not to each box: ~190 boxes on their own clocks is what
+   reads as busy. Wrapping a region in `SkeletonRegion` runs one slow pass
+   over every skeleton inside it.
+
+   `background-attachment: fixed` anchors the gradient to the viewport, so
+   every box in the region shows its own slice of ONE moving plane and the
+   highlight travels across the region rather than restarting inside each
+   box. Where a browser degrades fixed attachment to scroll, the sweep falls
+   back to per-box — still one shared clock, just not one shared plane.
+
+   Under reduced motion the global rule near "Reduced Motion" above collapses
+   this to a single 0.01ms pass, leaving the still silhouette. */
+
+:root {
+  /* Light: elevated is warm paper, so the sweep reads as a shadow passing. */
+  --color-skeleton-sweep: var(--color-bg-inset);
+}
+
+.dark {
+  /* Dark: the ground is near-black, so the sweep reads as light passing. */
+  --color-skeleton-sweep: var(--color-bg-overlay);
+}
+
+.skeleton-region [data-skeleton] {
+  background-image: linear-gradient(
+    100deg,
+    transparent 42%,
+    var(--color-skeleton-sweep) 50%,
+    transparent 58%
+  );
+  background-repeat: no-repeat;
+  background-attachment: fixed;
+  background-size: 200vw 100%;
+  animation: skeleton-sweep 1.9s ease-in-out infinite;
+}
+
+/* The highlight sits at 50% of a 200vw-wide image, so it lands at viewport
+   x = 100vw + position. Offsetting -120vw..20vw walks it from just off the
+   left edge to just off the right, once per cycle. Anywhere the image does
+   not reach, `no-repeat` leaves the flat fill — which is the resting state,
+   so there is no seam. */
+@keyframes skeleton-sweep {
+  from {
+    background-position: -120vw 0;
+  }
+  to {
+    background-position: 20vw 0;
+  }
+}

--- a/packages/web/src/app/repos/[id]/code-health/page.tsx
+++ b/packages/web/src/app/repos/[id]/code-health/page.tsx
@@ -356,7 +356,7 @@ export default function CodeHealthPage() {
       maxWidth="wide"
       actions={
         <Button size="sm" variant="outline" onClick={refresh} disabled={refreshing}>
-          <RotateCw className={`mr-1.5 h-3.5 w-3.5 ${refreshing ? "animate-spin" : ""}`} />{" "}
+          <RotateCw className={`mr-1.5 h-3.5 w-3.5 ${refreshing ? "motion-safe:animate-spin" : ""}`} />{" "}
           {refreshing ? "Refreshing…" : "Refresh"}
         </Button>
       }

--- a/packages/web/src/app/repos/[id]/loading.tsx
+++ b/packages/web/src/app/repos/[id]/loading.tsx
@@ -1,5 +1,25 @@
-import { OwlLoader } from "@repowise-dev/ui/shared/owl-loader";
+import { PageSkeleton } from "@repowise-dev/ui/shared/loading-skeletons";
+import { Skeleton } from "@repowise-dev/ui/ui/skeleton";
 
+/**
+ * The Suspense fallback for every repo tab that has no `loading.tsx` of its
+ * own — 24 routes at the time of writing, so this fires on essentially every
+ * sidebar click.
+ *
+ * It used to be the owl. That put two different loading treatments in
+ * sequence for one navigation: the owl for the route transition, then the
+ * page's own skeleton for its data fetch. The owl is a brand moment, kept for
+ * a cold start of the app shell where there is genuinely no layout to mirror.
+ * Here there is a layout to mirror: every one of these pages is a `PageShell`.
+ *
+ * The header is exact because the frame is shared. The body is one reserved
+ * block rather than a guessed composition — 24 routes differ below the
+ * header, and a specific guess would reflow on arrival for most of them.
+ */
 export default function RepoLoading() {
-  return <OwlLoader />;
+  return (
+    <PageSkeleton label="Loading">
+      <Skeleton className="h-[60vh] min-h-80 w-full rounded-xl" />
+    </PageSkeleton>
+  );
 }

--- a/packages/web/src/app/repos/[id]/refactoring/page.tsx
+++ b/packages/web/src/app/repos/[id]/refactoring/page.tsx
@@ -19,6 +19,7 @@ import { Wrench, RotateCw } from "lucide-react";
 import { PageShell } from "@repowise-dev/ui/shared/page-shell";
 import { ViewTabs } from "@repowise-dev/ui/shared/view-tabs";
 import { fileEntityPath } from "@repowise-dev/ui/shared/entity";
+import { Skeleton, SkeletonRegion } from "@repowise-dev/ui/ui/skeleton";
 import {
   RefactoringBoard,
   RefactoringDrawer,
@@ -203,11 +204,11 @@ export default function RefactoringPage({ params }: { params: Promise<{ id: stri
           </div>
         ) : isLoading ? (
           // Matches the real layout's shapes: a lede block, a ribbon, a field.
-          <div className="space-y-8">
-            <div className="h-32 animate-pulse rounded-xl bg-[var(--color-bg-surface)]" />
-            <div className="h-16 animate-pulse rounded-xl bg-[var(--color-bg-surface)]" />
-            <div className="h-72 animate-pulse rounded-xl bg-[var(--color-bg-surface)]" />
-          </div>
+          <SkeletonRegion className="space-y-8" label="Loading refactoring plans">
+            <Skeleton className="h-32 rounded-xl" />
+            <Skeleton className="h-16 rounded-xl" />
+            <Skeleton className="h-72 rounded-xl" />
+          </SkeletonRegion>
         ) : (
           <RefactoringBoard
             plans={plans}

--- a/packages/web/src/app/workspace/sync-buttons.tsx
+++ b/packages/web/src/app/workspace/sync-buttons.tsx
@@ -72,7 +72,7 @@ export function SyncButton({
         aria-label={buttonText}
       >
         <RefreshCw
-          className={`h-3 w-3 ${state.kind === "running" ? "animate-spin" : ""}`}
+          className={`h-3 w-3 ${state.kind === "running" ? "motion-safe:animate-spin" : ""}`}
         />
         {state.kind === "running" ? "Syncing…" : buttonText}
       </button>

--- a/packages/web/src/components/repos/coordinator-health-panel.tsx
+++ b/packages/web/src/components/repos/coordinator-health-panel.tsx
@@ -106,7 +106,7 @@ export function CoordinatorHealthPanel({ repoId, initial }: Props) {
         onClick={refresh}
         disabled={loading}
       >
-        <RefreshCw className={`h-3.5 w-3.5 mr-1.5 ${loading ? "animate-spin" : ""}`} />
+        <RefreshCw className={`h-3.5 w-3.5 mr-1.5 ${loading ? "motion-safe:animate-spin" : ""}`} />
         {loading ? "Checking…" : "Refresh"}
       </Button>
     </div>

--- a/packages/web/src/components/risk/security-tab.tsx
+++ b/packages/web/src/components/risk/security-tab.tsx
@@ -62,8 +62,10 @@ export function SecurityTab({ repoId }: { repoId: string }) {
           Findings refresh on every sync.
         </p>
         <Button size="sm" variant="outline" onClick={handleRescan} disabled={rescanning}>
-          <RotateCw className={`h-3.5 w-3.5 mr-1.5 ${rescanning ? "animate-spin" : ""}`} />
-          Re-scan
+          <RotateCw
+            className={`h-3.5 w-3.5 mr-1.5 ${rescanning ? "motion-safe:animate-spin" : ""}`}
+          />
+          {rescanning ? "Re-scanning…" : "Re-scan"}
         </Button>
       </div>
 

--- a/packages/web/src/components/settings/connection-section.tsx
+++ b/packages/web/src/components/settings/connection-section.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useRef } from "react";
-import { Loader2 } from "lucide-react";
+import { Spinner } from "@repowise-dev/ui/ui/spinner";
 import { config } from "@/lib/config";
 import { getHealth } from "@/lib/api/health";
 import { OverviewSection } from "@repowise-dev/ui/overview";
@@ -132,7 +132,7 @@ export function ConnectionSection() {
             >
               {testing ? (
                 <>
-                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                  <Spinner size="sm" />
                   Testing
                 </>
               ) : (

--- a/packages/web/src/components/zoom/zoom-export-button.tsx
+++ b/packages/web/src/components/zoom/zoom-export-button.tsx
@@ -23,7 +23,8 @@
  */
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import { FileType2, Loader2, ChevronDown } from "lucide-react";
+import { FileType2, ChevronDown } from "lucide-react";
+import { Spinner } from "@repowise-dev/ui/ui/spinner";
 import { toast } from "sonner";
 import { getStructurizrDsl } from "@repowise-dev/api-client/c4";
 import { downloadTextFile } from "@/lib/utils/download";
@@ -105,7 +106,7 @@ export function ZoomExportButton({
         className="inline-flex items-center gap-1.5 rounded-lg border border-[var(--color-border-default)] px-2.5 py-1.5 text-xs font-medium text-[var(--color-text-secondary)] transition-colors hover:text-[var(--color-text-primary)] disabled:cursor-not-allowed disabled:opacity-50"
       >
         {working ? (
-          <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          <Spinner size="sm" />
         ) : (
           <FileType2 className="h-3.5 w-3.5" />
         )}


### PR DESCRIPTION
`Skeleton` pulsed per element, unguarded. With ~190 call sites across `packages/ui` and `packages/web` that is 190 independent clocks, which is what makes a loading page read as busy rather than as one wait.

## What changed

Motion moves from the box to the region. `Skeleton` now paints a still fill; wrapping a pending block in the new `SkeletonRegion` runs one slow sweep across every skeleton inside it. The gradient is viewport-anchored, so boxes show slices of a single moving plane instead of each restarting the sweep internally. `Skeleton` keeps its signature, so no call site had to change.

Three more primitives and one fix, all in the same substrate:

- **`Spinner`** owns the reduced-motion guard, the size scale, and the color for in-place indeterminate work. 18 bare `Loader2 animate-spin` sites converted; the 9 where the icon's identity is the affordance keep their icon and gain `motion-safe:`. Color inherits, so nothing shifts visually.
- **`ActivityDot`** gives live activity its own verb on the slower cadence `WorkingOrb` already used. Six sites stop sharing `animate-pulse` with skeletons — three were pulsing a whole label or pill rather than a dot, so a reader could not tell a placeholder from a live signal.
- **`usePrefersReducedMotion`** was private to `ZoomCanvas`; it is now a shared hook rather than a second copy.
- `OwlLoader` reads reduced motion and renders its static brand mark, never mounting the Lottie or its WASM runtime.
- The six ad-hoc placeholders that bypassed `Skeleton` on `--color-bg-surface` and `--color-bg-inset` now draw from `--color-bg-elevated`, so adjacent loading states match.

`PageSkeleton` and the `PAGE_SHELL_*` geometry constants land here too, to replace the owl at `repos/[id]/loading.tsx`. That file is the Suspense fallback for 24 repo tabs with no `loading.tsx` of their own, so it fired on nearly every sidebar click and put two different loading treatments in sequence for one navigation. Its bars sit inside the real heading and description elements at `1lh`, reserving those elements' own line boxes rather than a guessed pixel height.

## Behavior

With reduced motion on, nothing animates and nothing becomes invisible. Otherwise a pending region sweeps once every 1.9s.

## Verification

Zero unguarded `animate-pulse` / `animate-spin` remain in either package. `packages/ui` type-checks and its suite passes; `packages/web` type-checks, lints, and builds. One test pinned `.animate-pulse` as a proxy for "is a skeleton" and now pins `[data-skeleton]`.