### PR TITLE
feat(ui): shape components, and retire the owl from the repo routes

### DIFF
--- a/packages/ui/src/costs/chart-height.ts
+++ b/packages/ui/src/costs/chart-height.ts
@@ -1,0 +1,19 @@
+/**
+ * Chart geometry, shared so a skeleton and the chart it stands in for cannot
+ * disagree. A literal height in a placeholder is a reflow waiting to drift:
+ * the daily-spend skeleton was `h-48` (192px) against a 220px chart, which
+ * snapped the page down 28px on every load.
+ */
+
+/** Default plot height for the fixed-height cost charts. */
+export const CHART_HEIGHT = 220;
+
+/**
+ * The operation-breakdown chart grows with its rows, so its height is a
+ * function rather than a constant. A placeholder that does not know the row
+ * count should render at `operationBreakdownHeight(0)`, the floor, and let
+ * the chart grow downward rather than reserving a guess that is usually wrong.
+ */
+export function operationBreakdownHeight(rows: number): number {
+  return Math.max(180, rows * 24 + 40);
+}

--- a/packages/ui/src/costs/daily-spend-chart.tsx
+++ b/packages/ui/src/costs/daily-spend-chart.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer } from "recharts";
+import { CHART_HEIGHT } from "./chart-height";
 import { formatCost } from "../lib/format";
 
 export interface DailySpendChartProps {
@@ -13,7 +14,7 @@ export interface DailySpendChartProps {
  * Daily generation-spend bars. A peer of OperationBreakdown / ProviderComparison
  * so the Costs page composes all charts from `ui` and they restyle on a bump.
  */
-export function DailySpendChart({ groups, height = 220 }: DailySpendChartProps) {
+export function DailySpendChart({ groups, height = CHART_HEIGHT }: DailySpendChartProps) {
   if (groups.length === 0) {
     return (
       <p className="text-sm text-[var(--color-text-secondary)] py-8 text-center">

--- a/packages/ui/src/costs/operation-breakdown.tsx
+++ b/packages/ui/src/costs/operation-breakdown.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, Cell } from "recharts";
+import { operationBreakdownHeight } from "./chart-height";
 import { formatCost } from "../lib/format";
 
 export interface OperationBreakdownProps {
@@ -39,7 +40,7 @@ export function OperationBreakdown({ groups, metric = "cost_usd" }: OperationBre
   }
 
   return (
-    <ResponsiveContainer width="100%" height={Math.max(180, sorted.length * 24 + 40)}>
+    <ResponsiveContainer width="100%" height={operationBreakdownHeight(sorted.length)}>
       <BarChart
         data={sorted}
         layout="vertical"

--- a/packages/ui/src/costs/savings-trend-chart.tsx
+++ b/packages/ui/src/costs/savings-trend-chart.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer } from "recharts";
+import { CHART_HEIGHT } from "./chart-height";
 import { formatTokens } from "../lib/format";
 
 export interface SavingsTrendChartProps {
@@ -16,7 +17,7 @@ export interface SavingsTrendChartProps {
  * Costs page can show savings accruing over time, not just a lifetime total.
  * Renders the `per_day` array that the page already fetches.
  */
-export function SavingsTrendChart({ groups, height = 220 }: SavingsTrendChartProps) {
+export function SavingsTrendChart({ groups, height = CHART_HEIGHT }: SavingsTrendChartProps) {
   const data = [...groups]
     .filter((g) => g.saved_tokens > 0)
     .sort((a, b) => a.group.localeCompare(b.group));

--- a/packages/ui/src/shared/index.ts
+++ b/packages/ui/src/shared/index.ts
@@ -31,9 +31,13 @@ export {
   TableSkeleton,
   CardSkeleton,
   PageSkeleton,
+  StatGridSkeleton,
+  ChartSkeleton,
   type TableSkeletonProps,
   type CardSkeletonProps,
   type PageSkeletonProps,
+  type StatGridSkeletonProps,
+  type ChartSkeletonProps,
 } from "./loading-skeletons";
 export { PageShell, type PageShellProps } from "./page-shell";
 export { ViewTabs, type ViewTab, type ViewTabsProps } from "./view-tabs";

--- a/packages/ui/src/shared/loading-skeletons.tsx
+++ b/packages/ui/src/shared/loading-skeletons.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 
 import { Skeleton, SkeletonRegion } from "../ui/skeleton";
+import { MetricCard } from "./metric-card";
 import { cn } from "../lib/cn";
 import {
   PAGE_SHELL_CONTAINER,
@@ -100,6 +101,77 @@ export function PageSkeleton({
         {actions && <Skeleton className="h-8 w-24 shrink-0" />}
       </header>
       {children}
+    </SkeletonRegion>
+  );
+}
+
+export interface StatGridSkeletonProps {
+  /** Number of tiles. Match the count the loaded grid will render. */
+  count?: number;
+  /**
+   * Tailwind grid-column classes. Must match the real grid's, or the tiles
+   * reflow into a different number of rows when data lands.
+   */
+  columns?: string;
+  /** Set true where the real tiles carry a one-line description. */
+  description?: boolean;
+  className?: string;
+}
+
+/**
+ * A row of stat tiles, waiting. Each tile is a real `MetricCard` with bars in
+ * place of its label and value, so the height is the card's own height rather
+ * than a guess. The hand-rolled version of this was `h-24` (96px) against a
+ * card that measures 80-88px, so the grid snapped upward on arrival.
+ */
+export function StatGridSkeleton({
+  count = 3,
+  columns = "grid-cols-1 sm:grid-cols-3",
+  description = false,
+  className,
+}: StatGridSkeletonProps) {
+  return (
+    <SkeletonRegion
+      className={cn("grid gap-3", columns, className)}
+      label="Loading metrics"
+    >
+      {Array.from({ length: count }).map((_, i) => (
+        <MetricCard
+          key={i}
+          label={<Skeleton className="block h-[1lh] w-24" />}
+          value={<Skeleton className="block h-[1lh] w-16" />}
+          {...(description
+            ? { description: <Skeleton className="block h-[1lh] w-32" /> }
+            : {})}
+        />
+      ))}
+    </SkeletonRegion>
+  );
+}
+
+export interface ChartSkeletonProps {
+  /**
+   * Pass the SAME height the chart is given. Import the chart's own constant
+   * rather than retyping a number, so the two cannot drift apart.
+   */
+  height: number;
+  className?: string;
+  label?: string;
+}
+
+/**
+ * A plot area, waiting, at exactly the height the chart will occupy. Takes
+ * `height` as a required prop for that reason: a default would invite call
+ * sites to omit it and silently reserve the wrong box.
+ */
+export function ChartSkeleton({
+  height,
+  className,
+  label = "Loading chart",
+}: ChartSkeletonProps) {
+  return (
+    <SkeletonRegion className={className} label={label}>
+      <Skeleton className="w-full" style={{ height }} />
     </SkeletonRegion>
   );
 }

--- a/packages/ui/src/shared/metric-card.tsx
+++ b/packages/ui/src/shared/metric-card.tsx
@@ -3,10 +3,16 @@ import { cn } from "../lib/cn";
 import { Card, CardContent } from "../ui/card";
 
 export interface MetricCardProps {
-  label: string;
+  /**
+   * Usually a string. Typed as a node so a loading placeholder can pass a
+   * `Skeleton` and get this component's real height rather than guessing at
+   * it (see `StatGridSkeleton`).
+   */
+  label: React.ReactNode;
   value: React.ReactNode;
-  /** One-line context rendered beneath the value. */
-  description?: string;
+  /** One-line context rendered beneath the value. Node, so a placeholder can
+   *  pass a `Skeleton` and reserve the real line. */
+  description?: React.ReactNode;
   /**
    * Signed change indicator. `positive` is a good-vs-bad flag (drives
    * success/error colouring), not up-vs-down. Set `neutral` to render the

--- a/packages/web/src/app/layout.tsx
+++ b/packages/web/src/app/layout.tsx
@@ -8,6 +8,7 @@ import { TooltipProvider } from "@repowise-dev/ui/ui/tooltip";
 import { ThemeProvider } from "@/components/layout/theme-provider";
 import { ThemedToaster } from "@/components/layout/themed-toaster";
 import { Sidebar } from "@/components/layout/sidebar";
+import { AppShellSkeleton } from "@/components/layout/app-shell-skeleton";
 import { MobileNav } from "@/components/layout/mobile-nav";
 import { CommandPalette } from "@/components/search/command-palette";
 import { ContextDrawerShell } from "@/components/layout/context-drawer-provider";
@@ -66,7 +67,7 @@ export default async function RootLayout({
         <NuqsAdapter>
         <SWRProvider>
         <TooltipProvider delayDuration={300}>
-          <Suspense fallback={null}>
+          <Suspense fallback={<AppShellSkeleton />}>
             <ContextDrawerShell>
               <div className="flex h-screen flex-col overflow-hidden">
                 <UpgradeBanner />

--- a/packages/web/src/app/repos/[id]/architecture/loading.tsx
+++ b/packages/web/src/app/repos/[id]/architecture/loading.tsx
@@ -1,5 +1,23 @@
-import { OwlLoader } from "@repowise-dev/ui/shared/owl-loader";
+import { SkeletonRegion, Skeleton } from "@repowise-dev/ui/ui/skeleton";
 
-export default function Loading() {
-  return <OwlLoader label="Loading architecture…" />;
+/**
+ * Architecture is a full-height canvas rather than a `PageShell`, so this
+ * mirrors that frame instead: the tab row at its real padding, then the
+ * canvas filling the rest. Matching `h-full` / `flex-1` matters more here
+ * than elsewhere, because the canvas below sizes itself from this box.
+ */
+export default function ArchitectureLoading() {
+  return (
+    <SkeletonRegion
+      className="flex h-full flex-col"
+      label="Loading architecture"
+    >
+      <div className="shrink-0 px-4 pt-3 sm:px-6">
+        <Skeleton className="h-9 w-80 max-w-full rounded-lg" />
+      </div>
+      <div className="min-h-0 flex-1 p-4 sm:p-6">
+        <Skeleton className="h-full w-full rounded-lg" />
+      </div>
+    </SkeletonRegion>
+  );
 }

--- a/packages/web/src/app/repos/[id]/commits/loading.tsx
+++ b/packages/web/src/app/repos/[id]/commits/loading.tsx
@@ -1,5 +1,19 @@
-import { OwlLoader } from "@repowise-dev/ui/shared/owl-loader";
+import { PageSkeleton, TableSkeleton } from "@repowise-dev/ui/shared/loading-skeletons";
+import { Skeleton } from "@repowise-dev/ui/ui/skeleton";
 
+/**
+ * Mirrors the Commits layout: the shell header, the lede stats, the
+ * evolution chart section, then the commit table.
+ */
 export default function CommitsLoading() {
-  return <OwlLoader />;
+  return (
+    <PageSkeleton actions={false} label="Loading commits">
+      <Skeleton className="h-28 w-full rounded-xl" />
+      <div className="space-y-3">
+        <Skeleton className="h-5 w-64" />
+        <Skeleton className="h-40 w-full rounded-xl" />
+      </div>
+      <TableSkeleton rows={8} />
+    </PageSkeleton>
+  );
 }

--- a/packages/web/src/app/repos/[id]/coverage/loading.tsx
+++ b/packages/web/src/app/repos/[id]/coverage/loading.tsx
@@ -1,5 +1,0 @@
-import { OwlLoader } from "@repowise-dev/ui/shared/owl-loader";
-
-export default function CoverageRedirectLoading() {
-  return <OwlLoader />;
-}

--- a/packages/web/src/app/repos/[id]/docs/coverage/loading.tsx
+++ b/packages/web/src/app/repos/[id]/docs/coverage/loading.tsx
@@ -1,5 +1,28 @@
-import { OwlLoader } from "@repowise-dev/ui/shared/owl-loader";
+import { StatGridSkeleton } from "@repowise-dev/ui/shared/loading-skeletons";
+import { SkeletonRegion, Skeleton } from "@repowise-dev/ui/ui/skeleton";
 
-export default function CoverageLoading() {
-  return <OwlLoader />;
+/**
+ * Mirrors the docs coverage layout: the docs header band, then the donut
+ * beside its three stat cards, then the page list. The cards are real
+ * `MetricCard` boxes via `StatGridSkeleton`, so they do not resize on
+ * arrival the way a guessed height would.
+ */
+export default function DocsCoverageLoading() {
+  return (
+    <SkeletonRegion className="flex h-full flex-col" label="Loading coverage">
+      <div className="shrink-0 border-b border-[var(--color-border-default)] px-4 py-3 sm:px-6">
+        <Skeleton className="h-6 w-56 max-w-full" />
+      </div>
+      <div className="max-w-[1600px] flex-1 space-y-6 p-4 sm:p-6">
+        <div className="flex flex-col gap-6 lg:flex-row lg:items-start">
+          <div className="flex shrink-0 flex-col items-center gap-4 lg:w-56">
+            <Skeleton className="h-40 w-40 rounded-full" />
+            <Skeleton className="h-5 w-40" />
+          </div>
+          <StatGridSkeleton count={3} className="flex-1" />
+        </div>
+        <Skeleton className="h-72 w-full rounded-xl" />
+      </div>
+    </SkeletonRegion>
+  );
 }

--- a/packages/web/src/app/repos/[id]/knowledge-graph/loading.tsx
+++ b/packages/web/src/app/repos/[id]/knowledge-graph/loading.tsx
@@ -1,5 +1,16 @@
-import { OwlLoader } from "@repowise-dev/ui/shared/owl-loader";
+import { PageSkeleton } from "@repowise-dev/ui/shared/loading-skeletons";
+import { Skeleton } from "@repowise-dev/ui/ui/skeleton";
 
-export default function Loading() {
-  return <OwlLoader label="Loading knowledge graph…" />;
+/**
+ * Mirrors the Knowledge Graph layout. `maxWidth` and the 520px canvas box
+ * both match the page: the page's own in-flight state renders a centred
+ * `h-[520px]` band, so this hands over to it without the canvas changing
+ * size.
+ */
+export default function KnowledgeGraphLoading() {
+  return (
+    <PageSkeleton maxWidth="wide" label="Loading knowledge graph">
+      <Skeleton className="h-[520px] w-full rounded-lg" />
+    </PageSkeleton>
+  );
 }

--- a/packages/web/src/app/repos/[id]/wiki/[...slug]/loading.tsx
+++ b/packages/web/src/app/repos/[id]/wiki/[...slug]/loading.tsx
@@ -1,5 +1,0 @@
-import { OwlLoader } from "@repowise-dev/ui/shared/owl-loader";
-
-export default function WikiPageLoading() {
-  return <OwlLoader />;
-}

--- a/packages/web/src/components/layout/app-shell-skeleton.tsx
+++ b/packages/web/src/components/layout/app-shell-skeleton.tsx
@@ -1,0 +1,38 @@
+import { SkeletonRegion, Skeleton } from "@repowise-dev/ui/ui/skeleton";
+
+/**
+ * The shell itself, waiting. This is the one place with no page layout to
+ * mirror, because the shell is what has not painted yet: it stands in for the
+ * sidebar rail and the content column, at the sidebar's own expanded width.
+ *
+ * It replaces `fallback={null}`, which showed nothing at all while the shell
+ * suspended, so a slow first paint looked like a blank app rather than a
+ * loading one.
+ */
+export function AppShellSkeleton() {
+  return (
+    <SkeletonRegion
+      className="flex h-screen overflow-hidden"
+      label="Loading Repowise"
+    >
+      {/* Matches Sidebar's expanded width (`w-[260px]`). */}
+      <div className="hidden w-[260px] shrink-0 flex-col gap-2 border-r border-[var(--color-border-default)] p-4 md:flex">
+        <Skeleton className="h-8 w-32" />
+        <div className="mt-4 space-y-1.5">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <Skeleton key={i} className="h-9 w-full" />
+          ))}
+        </div>
+        <Skeleton className="mt-4 h-3 w-24" />
+        <div className="space-y-1.5">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <Skeleton key={i} className="h-9 w-full" />
+          ))}
+        </div>
+      </div>
+      <div className="flex-1 p-[var(--page-pad)]">
+        <Skeleton className="h-full w-full rounded-xl" />
+      </div>
+    </SkeletonRegion>
+  );
+}


### PR DESCRIPTION
Based on #1993.

`TableSkeleton` and `CardSkeleton` went almost unused because they did not cover the shapes people actually needed, so every surface hand-rolled a composition and each one guessed its own heights. Both stay; the gap is filled instead.

## Shapes

- **`StatGridSkeleton`** renders real `MetricCard` boxes with bars in place of the label and value, so a tile row reserves the card's own height. The hand-rolled version was `h-24` against a card measuring 80-88px, so the grid snapped upward on arrival.
- **`ChartSkeleton`** takes `height` as a required prop, and the cost charts now read theirs from a shared `CHART_HEIGHT`. The daily-spend placeholder was `h-48` against a 220px chart: 28px of deterministic reflow on every load. A default would have invited call sites to omit it and reserve the wrong box silently.
- `MetricCard`'s `label` and `description` widen from `string` to `ReactNode`, which is what lets a placeholder be the real component rather than a same-ish copy of it.

## Routes

Two of the remaining owl routes turned out to be bare `redirect()` calls: `coverage/` and `wiki/[...slug]/` were rendering a loading screen for a redirect, so you watched the owl before the real destination's own loading state. Those `loading.tsx` files are deleted rather than converted.

The other four mirror their pages, including the frames that are not `PageShell` — architecture is a full-height canvas and docs coverage is a header band over a donut and stat cards, so they match `h-full` and the tab row's real padding rather than being forced into the page frame.

`layout.tsx` had `Suspense fallback={null}`, so a slow first paint showed a blank app rather than a loading one. It gets `AppShellSkeleton`, standing in for the sidebar rail and the content column.

The owl keeps one home, `app/loading.tsx`, where there is no layout to mirror yet.

## Verification

`OwlLoader` now appears in exactly one route file. Both packages type-check, `packages/ui`'s suite passes, and `packages/web` lints and builds.