### PR TITLE
feat(ui): costs error states, and the sidebar's scale, reachability and rhythm

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -86,6 +86,7 @@
     "./dependencies": "./src/dependencies/index.ts",
     "./dependencies/*": "./src/dependencies/*.tsx",
     "./costs": "./src/costs/index.ts",
+    "./costs/chart-height": "./src/costs/chart-height.ts",
     "./costs/*": "./src/costs/*.tsx",
     "./security": "./src/security/index.ts",
     "./security/*": "./src/security/*.tsx",

--- a/packages/ui/src/costs/daily-spend-chart.tsx
+++ b/packages/ui/src/costs/daily-spend-chart.tsx
@@ -16,50 +16,61 @@ export interface DailySpendChartProps {
  */
 export function DailySpendChart({ groups, height = CHART_HEIGHT }: DailySpendChartProps) {
   if (groups.length === 0) {
+    // Sized to the plot box it stands in for. Collapsing to two lines of
+    // text snapped the card up ~150px the moment an empty response landed,
+    // which reads as the page breaking rather than as "nothing here yet".
     return (
-      <p className="text-sm text-[var(--color-text-secondary)] py-8 text-center">
+      <div
+        className="flex items-center justify-center text-center text-sm text-[var(--color-text-secondary)]"
+        style={{ height }}
+      >
         No cost data available.
-      </p>
+      </div>
     );
   }
 
   const data = [...groups].sort((a, b) => a.group.localeCompare(b.group));
 
+  // The plot box is reserved before recharts measures it. A bare
+  // ResponsiveContainer renders nothing until its ResizeObserver fires, so
+  // the card grew into place on every mount.
   return (
-    <ResponsiveContainer width="100%" height={height}>
-      <BarChart data={data} margin={{ top: 8, right: 8, bottom: 0, left: 0 }}>
-        <XAxis
-          dataKey="group"
-          tick={{ fill: "var(--color-text-tertiary)", fontSize: 11 }}
-          axisLine={false}
-          tickLine={false}
-          interval="preserveStartEnd"
-          minTickGap={24}
-          tickFormatter={(v: string) => {
-            const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(v);
-            return m ? `${Number(m[2])}/${Number(m[3])}` : v;
-          }}
-        />
-        <YAxis
-          tick={{ fill: "var(--color-text-tertiary)", fontSize: 10 }}
-          axisLine={false}
-          tickLine={false}
-          tickFormatter={(v: number) => `$${v.toFixed(3)}`}
-        />
-        <Tooltip
-          cursor={{ fill: "var(--color-bg-elevated)" }}
-          contentStyle={{
-            background: "var(--color-bg-overlay)",
-            border: "1px solid var(--color-border-default)",
-            borderRadius: "6px",
-            fontSize: "12px",
-            color: "var(--color-text-primary)",
-          }}
-          formatter={(value) => [formatCost(Number(value)), "Cost"]}
-          labelFormatter={(label) => `Date: ${String(label)}`}
-        />
-        <Bar dataKey="cost_usd" fill="var(--color-accent-primary)" radius={[4, 4, 0, 0]} />
-      </BarChart>
-    </ResponsiveContainer>
+    <div style={{ height: height }}>
+      <ResponsiveContainer width="100%" height="100%">
+        <BarChart data={data} margin={{ top: 8, right: 8, bottom: 0, left: 0 }}>
+          <XAxis
+            dataKey="group"
+            tick={{ fill: "var(--color-text-tertiary)", fontSize: 11 }}
+            axisLine={false}
+            tickLine={false}
+            interval="preserveStartEnd"
+            minTickGap={24}
+            tickFormatter={(v: string) => {
+              const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(v);
+              return m ? `${Number(m[2])}/${Number(m[3])}` : v;
+            }}
+          />
+          <YAxis
+            tick={{ fill: "var(--color-text-tertiary)", fontSize: 10 }}
+            axisLine={false}
+            tickLine={false}
+            tickFormatter={(v: number) => `$${v.toFixed(3)}`}
+          />
+          <Tooltip
+            cursor={{ fill: "var(--color-bg-elevated)" }}
+            contentStyle={{
+              background: "var(--color-bg-overlay)",
+              border: "1px solid var(--color-border-default)",
+              borderRadius: "6px",
+              fontSize: "12px",
+              color: "var(--color-text-primary)",
+            }}
+            formatter={(value) => [formatCost(Number(value)), "Cost"]}
+            labelFormatter={(label) => `Date: ${String(label)}`}
+          />
+          <Bar dataKey="cost_usd" fill="var(--color-accent-primary)" radius={[4, 4, 0, 0]} />
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
   );
 }

--- a/packages/ui/src/costs/distill-savings-card.tsx
+++ b/packages/ui/src/costs/distill-savings-card.tsx
@@ -74,11 +74,64 @@ export function DistillSavingsCard({ data }: DistillSavingsCardProps) {
   const hasData = !!data?.available && total > 0;
 
   if (!data) {
+    // Mirrors the populated card below rather than reserving a flat block:
+    // headline, the two right-aligned totals, the breakdown bar with its
+    // legend, and the two detail columns. The flat version stood 176px tall
+    // against a card that measures 350-450px, so the whole page jumped on
+    // first paint.
     return (
       <Card>
-        <CardContent className="py-10">
+        <CardContent className="py-6">
           <SkeletonRegion label="Loading agent token savings">
-            <Skeleton className="h-24 w-full rounded-lg" />
+            <div className="flex flex-wrap items-end justify-between gap-4">
+              <div>
+                <div className="flex items-center gap-2 text-xs uppercase tracking-wide">
+                  <Skeleton className="block h-[1lh] w-48" />
+                </div>
+                <div className="mt-1 flex items-baseline gap-3">
+                  <span className="text-4xl font-semibold">
+                    <Skeleton className="block h-[1lh] w-32" />
+                  </span>
+                  <span className="text-2xl font-semibold">
+                    <Skeleton className="block h-[1lh] w-24" />
+                  </span>
+                </div>
+                <p className="mt-1 text-xs">
+                  <Skeleton className="block h-[1lh] w-56" />
+                </p>
+              </div>
+              <div className="flex gap-6">
+                {[0, 1].map((i) => (
+                  <div key={i}>
+                    <div className="text-lg font-semibold">
+                      <Skeleton className="block h-[1lh] w-20" />
+                    </div>
+                    <div className="text-xs">
+                      <Skeleton className="mt-0.5 block h-[1lh] w-28" />
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <Skeleton className="mt-4 h-2.5 w-full rounded-full" />
+            <div className="mt-1.5 flex items-center gap-4 text-xs">
+              <Skeleton className="block h-[1lh] w-24" />
+              <Skeleton className="block h-[1lh] w-24" />
+            </div>
+
+            <div className="mt-4 grid grid-cols-1 gap-x-8 gap-y-4 sm:grid-cols-2">
+              {[0, 1].map((col) => (
+                <div key={col} className="space-y-2">
+                  <div className="text-xs">
+                    <Skeleton className="block h-[1lh] w-32" />
+                  </div>
+                  {Array.from({ length: 5 }).map((_, row) => (
+                    <Skeleton key={row} className="h-4 w-full" />
+                  ))}
+                </div>
+              ))}
+            </div>
           </SkeletonRegion>
         </CardContent>
       </Card>

--- a/packages/ui/src/costs/operation-breakdown.tsx
+++ b/packages/ui/src/costs/operation-breakdown.tsx
@@ -32,57 +32,67 @@ const PALETTE = [
 export function OperationBreakdown({ groups, metric = "cost_usd" }: OperationBreakdownProps) {
   const sorted = [...groups].sort((a, b) => (b[metric] ?? 0) - (a[metric] ?? 0)).slice(0, 12);
   if (sorted.length === 0) {
+    // Sized to this chart's own floor, so an empty result occupies the same
+    // box the skeleton reserved.
     return (
-      <p className="text-sm text-[var(--color-text-secondary)] py-8 text-center">
+      <div
+        className="flex items-center justify-center text-center text-sm text-[var(--color-text-secondary)]"
+        style={{ height: operationBreakdownHeight(0) }}
+      >
         No data to break down.
-      </p>
+      </div>
     );
   }
 
+  // The plot box is reserved before recharts measures it. A bare
+  // ResponsiveContainer renders nothing until its ResizeObserver fires, so
+  // the card grew into place on every mount.
   return (
-    <ResponsiveContainer width="100%" height={operationBreakdownHeight(sorted.length)}>
-      <BarChart
-        data={sorted}
-        layout="vertical"
-        margin={{ top: 4, right: 16, bottom: 0, left: 8 }}
-      >
-        <XAxis
-          type="number"
-          tick={{ fill: "var(--color-text-tertiary)", fontSize: 10 }}
-          axisLine={false}
-          tickLine={false}
-          tickFormatter={(v: number) => (metric === "cost_usd" ? `$${v.toFixed(3)}` : String(v))}
-        />
-        <YAxis
-          type="category"
-          dataKey="group"
-          tick={{ fill: "var(--color-text-secondary)", fontSize: 11 }}
-          axisLine={false}
-          tickLine={false}
-          width={140}
-        />
-        <Tooltip
-          cursor={{ fill: "var(--color-bg-elevated)" }}
-          contentStyle={{
-            background: "var(--color-bg-overlay)",
-            border: "1px solid var(--color-border-default)",
-            borderRadius: 6,
-            fontSize: 12,
-            color: "var(--color-text-primary)",
-          }}
-          formatter={(value) => {
-            const n = typeof value === "number" ? value : 0;
-            return metric === "cost_usd"
-              ? [formatCost(n), "Cost"]
-              : [n.toLocaleString(), metric.replace("_", " ")];
-          }}
-        />
-        <Bar dataKey={metric} radius={[0, 4, 4, 0]}>
-          {sorted.map((row, i) => (
-            <Cell key={row.group} fill={PALETTE[i % PALETTE.length] ?? "var(--color-accent-primary)"} />
-          ))}
-        </Bar>
-      </BarChart>
-    </ResponsiveContainer>
+    <div style={{ height: operationBreakdownHeight(sorted.length) }}>
+      <ResponsiveContainer width="100%" height="100%">
+        <BarChart
+          data={sorted}
+          layout="vertical"
+          margin={{ top: 4, right: 16, bottom: 0, left: 8 }}
+        >
+          <XAxis
+            type="number"
+            tick={{ fill: "var(--color-text-tertiary)", fontSize: 10 }}
+            axisLine={false}
+            tickLine={false}
+            tickFormatter={(v: number) => (metric === "cost_usd" ? `$${v.toFixed(3)}` : String(v))}
+          />
+          <YAxis
+            type="category"
+            dataKey="group"
+            tick={{ fill: "var(--color-text-secondary)", fontSize: 11 }}
+            axisLine={false}
+            tickLine={false}
+            width={140}
+          />
+          <Tooltip
+            cursor={{ fill: "var(--color-bg-elevated)" }}
+            contentStyle={{
+              background: "var(--color-bg-overlay)",
+              border: "1px solid var(--color-border-default)",
+              borderRadius: 6,
+              fontSize: 12,
+              color: "var(--color-text-primary)",
+            }}
+            formatter={(value) => {
+              const n = typeof value === "number" ? value : 0;
+              return metric === "cost_usd"
+                ? [formatCost(n), "Cost"]
+                : [n.toLocaleString(), metric.replace("_", " ")];
+            }}
+          />
+          <Bar dataKey={metric} radius={[0, 4, 4, 0]}>
+            {sorted.map((row, i) => (
+              <Cell key={row.group} fill={PALETTE[i % PALETTE.length] ?? "var(--color-accent-primary)"} />
+            ))}
+          </Bar>
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
   );
 }

--- a/packages/ui/src/costs/savings-trend-chart.tsx
+++ b/packages/ui/src/costs/savings-trend-chart.tsx
@@ -23,52 +23,61 @@ export function SavingsTrendChart({ groups, height = CHART_HEIGHT }: SavingsTren
     .sort((a, b) => a.group.localeCompare(b.group));
 
   if (data.length === 0) {
+    // Sized to the plot box, so an empty day series does not shrink the card.
     return (
-      <p className="text-sm text-[var(--color-text-secondary)] py-8 text-center">
+      <div
+        className="flex items-center justify-center text-center text-sm text-[var(--color-text-secondary)]"
+        style={{ height }}
+      >
         No savings recorded yet.
-      </p>
+      </div>
     );
   }
 
+  // The plot box is reserved before recharts measures it. A bare
+  // ResponsiveContainer renders nothing until its ResizeObserver fires, so
+  // the card grew into place on every mount.
   return (
-    <ResponsiveContainer width="100%" height={height}>
-      <BarChart data={data} margin={{ top: 8, right: 8, bottom: 0, left: 0 }}>
-        <XAxis
-          dataKey="group"
-          tick={{ fill: "var(--color-text-tertiary)", fontSize: 11 }}
-          axisLine={false}
-          tickLine={false}
-          interval="preserveStartEnd"
-          minTickGap={24}
-          tickFormatter={(v: string) => {
-            const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(v);
-            return m ? `${Number(m[2])}/${Number(m[3])}` : v;
-          }}
-        />
-        <YAxis
-          tick={{ fill: "var(--color-text-tertiary)", fontSize: 10 }}
-          axisLine={false}
-          tickLine={false}
-          tickFormatter={(v: number) => formatTokens(v)}
-        />
-        <Tooltip
-          cursor={{ fill: "var(--color-bg-elevated)" }}
-          contentStyle={{
-            background: "var(--color-bg-overlay)",
-            border: "1px solid var(--color-border-default)",
-            borderRadius: "6px",
-            fontSize: "12px",
-            color: "var(--color-text-primary)",
-          }}
-          formatter={(value) => [`${formatTokens(Number(value))} tokens`, "Saved"]}
-          labelFormatter={(label) => `Date: ${String(label)}`}
-        />
-        <Bar
-          dataKey="saved_tokens"
-          fill="var(--color-savings-distill)"
-          radius={[4, 4, 0, 0]}
-        />
-      </BarChart>
-    </ResponsiveContainer>
+    <div style={{ height: height }}>
+      <ResponsiveContainer width="100%" height="100%">
+        <BarChart data={data} margin={{ top: 8, right: 8, bottom: 0, left: 0 }}>
+          <XAxis
+            dataKey="group"
+            tick={{ fill: "var(--color-text-tertiary)", fontSize: 11 }}
+            axisLine={false}
+            tickLine={false}
+            interval="preserveStartEnd"
+            minTickGap={24}
+            tickFormatter={(v: string) => {
+              const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(v);
+              return m ? `${Number(m[2])}/${Number(m[3])}` : v;
+            }}
+          />
+          <YAxis
+            tick={{ fill: "var(--color-text-tertiary)", fontSize: 10 }}
+            axisLine={false}
+            tickLine={false}
+            tickFormatter={(v: number) => formatTokens(v)}
+          />
+          <Tooltip
+            cursor={{ fill: "var(--color-bg-elevated)" }}
+            contentStyle={{
+              background: "var(--color-bg-overlay)",
+              border: "1px solid var(--color-border-default)",
+              borderRadius: "6px",
+              fontSize: "12px",
+              color: "var(--color-text-primary)",
+            }}
+            formatter={(value) => [`${formatTokens(Number(value))} tokens`, "Saved"]}
+            labelFormatter={(label) => `Date: ${String(label)}`}
+          />
+          <Bar
+            dataKey="saved_tokens"
+            fill="var(--color-savings-distill)"
+            radius={[4, 4, 0, 0]}
+          />
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
   );
 }

--- a/packages/ui/src/shared/theme-toggle.tsx
+++ b/packages/ui/src/shared/theme-toggle.tsx
@@ -85,7 +85,7 @@ export function ThemeToggle({ compact = false, className }: ThemeToggleProps) {
             onClick={() => setTheme(opt.value)}
             className={cn(
               "inline-flex items-center justify-center gap-1.5 rounded-md text-xs font-medium transition-colors",
-              compact ? "px-2 py-1.5" : "px-3 py-1.5",
+              compact ? "px-1.5 py-1" : "px-3 py-1.5",
               // Selected-ness comes from the ancestor `dark` class, so it is
               // right on the first painted frame. Each option is styled
               // selected in its own theme and quiet in the other.

--- a/packages/ui/src/shared/theme-toggle.tsx
+++ b/packages/ui/src/shared/theme-toggle.tsx
@@ -15,9 +15,12 @@
  * The migration only fires for non light/dark values, so an explicit Light or
  * Dark choice is never rewritten.
  *
- * Renders nothing theme-dependent until mounted so the control doesn't flash
- * the wrong selection during hydration (next-themes returns `undefined` on
- * the server).
+ * The selected option is expressed in CSS off the `dark` class that
+ * next-themes writes on `<html>` before first paint, NOT off React state.
+ * `useTheme()` returns `undefined` on the server, so a state-driven control
+ * renders one frame with neither option selected. Reading the class instead
+ * means the first painted frame is already correct. `aria-checked` still
+ * waits for mount, because markup cannot be derived from an ancestor class.
  */
 
 import { useEffect, useState } from "react";
@@ -29,6 +32,15 @@ const OPTIONS = [
   { value: "light" as const, label: "Light", icon: Sun },
   { value: "dark" as const, label: "Dark", icon: Moon },
 ];
+
+const SELECTED =
+  "bg-[var(--color-bg-surface)] text-[var(--color-text-primary)] shadow-[var(--shadow-sm)]";
+const UNSELECTED =
+  "bg-transparent text-[var(--color-text-secondary)] shadow-none hover:text-[var(--color-text-primary)]";
+const DARK_SELECTED =
+  "dark:bg-[var(--color-bg-surface)] dark:text-[var(--color-text-primary)] dark:shadow-[var(--shadow-sm)]";
+const DARK_UNSELECTED =
+  "dark:bg-transparent dark:text-[var(--color-text-secondary)] dark:shadow-none dark:hover:text-[var(--color-text-primary)]";
 
 export interface ThemeToggleProps {
   /** Hide the text labels and render an icon-only compact control. */
@@ -55,29 +67,31 @@ export function ThemeToggle({ compact = false, className }: ThemeToggleProps) {
     <div
       role="radiogroup"
       aria-label="Theme preference"
-      className={cn(
-        "inline-flex items-center gap-1 rounded-lg border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] p-1",
-        className,
-      )}
+      // No resting border, fill, or shadow: this is a once-per-session
+      // control and the permanent track was carrying more weight than the
+      // navigation above it. The selected pill is the only ground.
+      className={cn("inline-flex items-center gap-1 rounded-lg p-0.5", className)}
     >
       {OPTIONS.map((opt) => {
         const Icon = opt.icon;
-        const selected = mounted && theme === opt.value;
         return (
           <button
             key={opt.value}
             type="button"
             role="radio"
-            aria-checked={selected}
+            aria-checked={mounted && theme === opt.value}
             aria-label={opt.label}
             title={opt.label}
             onClick={() => setTheme(opt.value)}
             className={cn(
               "inline-flex items-center justify-center gap-1.5 rounded-md text-xs font-medium transition-colors",
               compact ? "px-2 py-1.5" : "px-3 py-1.5",
-              selected
-                ? "bg-[var(--color-bg-surface)] text-[var(--color-text-primary)] shadow-[var(--shadow-sm)]"
-                : "text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)]",
+              // Selected-ness comes from the ancestor `dark` class, so it is
+              // right on the first painted frame. Each option is styled
+              // selected in its own theme and quiet in the other.
+              opt.value === "light"
+                ? [SELECTED, DARK_UNSELECTED]
+                : [UNSELECTED, DARK_SELECTED],
             )}
           >
             <Icon className="h-3.5 w-3.5 shrink-0" />

--- a/packages/web/src/app/layout.tsx
+++ b/packages/web/src/app/layout.tsx
@@ -36,18 +36,24 @@ export default async function RootLayout({
   children: React.ReactNode;
 }) {
   // Fetch repos + workspace info server-side for the sidebar.
-  // Gracefully fall back to empty/null if the API is unavailable.
+  //
+  // A rejection is NOT an empty account. Falling back to `[]` silently made
+  // an unreachable API render the exact first-run "add your first repo"
+  // invitation a genuine new user sees, so a user whose server was down was
+  // being onboarded instead of told. `reposUnavailable` keeps the two apart.
   let repos: Awaited<ReturnType<typeof listRepos>> = [];
   let workspace: WorkspaceResponse | null = null;
+  let reposUnavailable = false;
   try {
     const [reposResult, wsResult] = await Promise.allSettled([
       listRepos(),
       getWorkspace(),
     ]);
     if (reposResult.status === "fulfilled") repos = reposResult.value;
+    else reposUnavailable = true;
     if (wsResult.status === "fulfilled") workspace = wsResult.value;
   } catch {
-    // API not available — show empty sidebar
+    reposUnavailable = true;
   }
 
   return (
@@ -72,7 +78,11 @@ export default async function RootLayout({
               <div className="flex h-screen flex-col overflow-hidden">
                 <UpgradeBanner />
                 <div className="flex flex-1 overflow-hidden">
-                <Sidebar repos={repos} workspace={workspace} />
+                <Sidebar
+                  repos={repos}
+                  workspace={workspace}
+                  reposUnavailable={reposUnavailable}
+                />
                 <div className="flex flex-1 flex-col min-w-0 overflow-hidden">
                   <MobileNav repos={repos} workspace={workspace} />
                   {/* A flex column, so anything a route layout stacks above

--- a/packages/web/src/app/repos/[id]/costs/page.tsx
+++ b/packages/web/src/app/repos/[id]/costs/page.tsx
@@ -6,9 +6,12 @@ import { useParams } from "next/navigation";
 import { DollarSign } from "lucide-react";
 import { MetricCard } from "@repowise-dev/ui/shared/metric-card";
 import { PageShell } from "@repowise-dev/ui/shared/page-shell";
+import { ApiError } from "@repowise-dev/ui/shared/api-error";
+import { ChartSkeleton, StatGridSkeleton } from "@repowise-dev/ui/shared/loading-skeletons";
 import { Card, CardContent, CardHeader, CardTitle } from "@repowise-dev/ui/ui/card";
-import { Skeleton } from "@repowise-dev/ui/ui/skeleton";
+import { SkeletonRegion, Skeleton } from "@repowise-dev/ui/ui/skeleton";
 import { Tabs, ScrollableTabsList, TabsTrigger, TabsContent } from "@repowise-dev/ui/ui/tabs";
+import { CHART_HEIGHT, operationBreakdownHeight } from "@repowise-dev/ui/costs/chart-height";
 import {
   CostHeatmap,
   DailySpendChart,
@@ -27,35 +30,67 @@ export default function CostsPage() {
   const id = params.id;
   const [tab, setTab] = useState("daily");
 
-  const { data: summary, isLoading: loadingSummary } = useSWR<CostSummary>(
+  const {
+    data: summary,
+    error: summaryError,
+    isLoading: loadingSummary,
+    mutate: retrySummary,
+  } = useSWR<CostSummary>(
     `costs-summary:${id}`,
     () => getCostSummary(id),
     { revalidateOnFocus: false },
   );
 
-  const { data: dayGroups, isLoading: loadingDay } = useSWR<CostGroup[]>(
+  const {
+    data: dayGroups,
+    error: dayError,
+    isLoading: loadingDay,
+    mutate: retryDay,
+  } = useSWR<CostGroup[]>(
     `costs-groups:${id}:day`,
     () => listCosts(id, { by: "day" }),
     { revalidateOnFocus: false },
   );
 
-  const { data: modelGroups } = useSWR<CostGroup[]>(
+  const {
+    data: modelGroups,
+    error: modelError,
+    mutate: retryModel,
+  } = useSWR<CostGroup[]>(
     `costs-groups:${id}:model`,
     () => listCosts(id, { by: "model" }),
     { revalidateOnFocus: false },
   );
 
-  const { data: opGroups } = useSWR<CostGroup[]>(
+  const {
+    data: opGroups,
+    error: opError,
+    mutate: retryOp,
+  } = useSWR<CostGroup[]>(
     `costs-groups:${id}:operation`,
     () => listCosts(id, { by: "operation" }),
     { revalidateOnFocus: false },
   );
 
-  const { data: distillSavings } = useSWR<DistillSavings>(
+  const {
+    data: distillSavings,
+    error: distillError,
+    mutate: retryDistill,
+  } = useSWR<DistillSavings>(
     `distill-savings:${id}`,
     () => getDistillSavings(id),
     { revalidateOnFocus: false },
   );
+
+  // A discriminated union rather than a bare string, so the populated branch
+  // carries the data it is populated with and TypeScript can see that.
+  const savings = distillError
+    ? ({ kind: "error" } as const)
+    : distillSavings === undefined
+      ? ({ kind: "pending" } as const)
+      : distillSavings.available
+        ? ({ kind: "populated", data: distillSavings } as const)
+        : ({ kind: "unavailable" } as const);
 
   return (
     <PageShell
@@ -66,29 +101,61 @@ export default function CostsPage() {
     >
       {/* Hero: the honest results surface — all tokens & dollars saved for the
           coding agent, across distill (CLI + hook) and MCP tool responses. */}
-      <DistillSavingsCard data={distillSavings} />
-
-      {/* ROI: ties the saved dollars above to the generation spend below, so the
-          reader doesn't have to do the division themselves. */}
-      {distillSavings?.available && summary ? (
-        <RoiCard
-          savedUsd={distillSavings.estimated_usd_saved}
-          spentUsd={summary.total_cost_usd}
-          savedTokens={distillSavings.saved_tokens + distillSavings.mcp_tokens}
-        />
-      ) : null}
-
-      {/* Savings over time — renders the per_day series the page already
-          fetches (total agent tokens saved per day, distill + MCP). */}
-      {distillSavings?.available && (distillSavings.per_day?.length ?? 0) > 0 ? (
+      {distillError ? (
         <Card>
-          <CardHeader className="pb-2">
-            <CardTitle className="text-sm">Agent tokens saved by day</CardTitle>
-          </CardHeader>
-          <CardContent className="pt-0">
-            <SavingsTrendChart groups={distillSavings.per_day} />
+          <CardContent className="py-6">
+            <ApiError
+              title="Couldn't load agent savings"
+              message="The savings endpoint did not respond. Everything below is unaffected."
+              onRetry={() => void retryDistill()}
+            />
           </CardContent>
         </Card>
+      ) : (
+        <DistillSavingsCard data={distillSavings} />
+      )}
+
+      {/* ROI and the savings trend are gated on `available`, which is a
+          SEMANTIC state, not a load state: a repo that has never run distill
+          legitimately has neither card. Three states, not a boolean, because
+          a plain `available &&` renders nothing while the request is still in
+          flight and then inserts ~400px above the tabs on arrival.
+
+          pending     → reserve the populated height
+          unavailable → render nothing, reserve nothing
+          populated   → the cards */}
+      {savings.kind === "pending" ? (
+        <>
+          <Skeleton className="h-[104px] w-full rounded-xl" />
+          <Card>
+            <CardHeader className="pb-2">
+              <CardTitle className="text-sm">Agent tokens saved by day</CardTitle>
+            </CardHeader>
+            <CardContent className="pt-0">
+              <ChartSkeleton height={CHART_HEIGHT} label="Loading savings trend" />
+            </CardContent>
+          </Card>
+        </>
+      ) : savings.kind === "populated" ? (
+        <>
+          {summary ? (
+            <RoiCard
+              savedUsd={savings.data.estimated_usd_saved}
+              spentUsd={summary.total_cost_usd}
+              savedTokens={savings.data.saved_tokens + savings.data.mcp_tokens}
+            />
+          ) : null}
+          {(savings.data.per_day?.length ?? 0) > 0 ? (
+            <Card>
+              <CardHeader className="pb-2">
+                <CardTitle className="text-sm">Agent tokens saved by day</CardTitle>
+              </CardHeader>
+              <CardContent className="pt-0">
+                <SavingsTrendChart groups={savings.data.per_day} />
+              </CardContent>
+            </Card>
+          ) : null}
+        </>
       ) : null}
 
       <Tabs value={tab} onValueChange={setTab} className="w-full">
@@ -106,8 +173,13 @@ export default function CostsPage() {
               <CardTitle className="text-sm">Daily Spend (USD)</CardTitle>
             </CardHeader>
             <CardContent className="pt-0">
-              {loadingDay ? (
-                <Skeleton className="h-48 w-full" />
+              {dayError ? (
+                <ApiError
+                  title="Couldn't load daily spend"
+                  onRetry={() => void retryDay()}
+                />
+              ) : loadingDay ? (
+                <ChartSkeleton height={CHART_HEIGHT} label="Loading daily spend" />
               ) : (
                 <DailySpendChart groups={dayGroups ?? []} />
               )}
@@ -145,32 +217,44 @@ export default function CostsPage() {
                 }
               />
             </div>
+          ) : summaryError ? (
+            <ApiError
+              title="Couldn't load efficiency"
+              onRetry={() => void retrySummary()}
+            />
           ) : (
-            <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
-              {Array.from({ length: 3 }).map((_, i) => (
-                <Skeleton key={i} className="h-24 w-full rounded-lg" />
-              ))}
-            </div>
+            <StatGridSkeleton count={3} />
           )}
         </TabsContent>
 
         <TabsContent value="hotspots" className="mt-4">
-          {opGroups ? (
+          {opError ? (
+            <ApiError title="Couldn't load hotspots" onRetry={() => void retryOp()} />
+          ) : opGroups ? (
             <CostHeatmap
               groups={opGroups.map((g) => ({ group: g.group, cost_usd: g.cost_usd, calls: g.calls }))}
               title="Cost concentration by operation"
               emptyHint="No operation-level data yet."
             />
           ) : (
-            <Skeleton className="h-40 w-full" />
+            // Heatmap cell heights are data-driven, so there is no height to
+            // match. Reserve the floor and let it grow rather than asserting
+            // a number that is wrong for every repo but one.
+            <SkeletonRegion label="Loading hotspots">
+              <Skeleton className="min-h-40 w-full" />
+            </SkeletonRegion>
           )}
         </TabsContent>
 
         <TabsContent value="providers" className="mt-4">
-          {modelGroups ? (
+          {modelError ? (
+            <ApiError title="Couldn't load providers" onRetry={() => void retryModel()} />
+          ) : modelGroups ? (
             <ProviderComparison modelGroups={modelGroups} />
           ) : (
-            <Skeleton className="h-40 w-full" />
+            <SkeletonRegion label="Loading providers">
+              <Skeleton className="min-h-40 w-full" />
+            </SkeletonRegion>
           )}
         </TabsContent>
 
@@ -180,10 +264,21 @@ export default function CostsPage() {
               <CardTitle className="text-sm">Spend by operation</CardTitle>
             </CardHeader>
             <CardContent className="pt-0">
-              {opGroups ? (
+              {opError ? (
+                <ApiError
+                  title="Couldn't load spend by operation"
+                  onRetry={() => void retryOp()}
+                />
+              ) : opGroups ? (
                 <OperationBreakdown groups={opGroups} />
               ) : (
-                <Skeleton className="h-40 w-full" />
+                // The chart's own floor, from its own formula: the row count
+                // is unknown until the data lands, and the chart only grows
+                // from here.
+                <ChartSkeleton
+                  height={operationBreakdownHeight(0)}
+                  label="Loading spend by operation"
+                />
               )}
             </CardContent>
           </Card>
@@ -197,11 +292,16 @@ export default function CostsPage() {
           Indexing &amp; generation cost
         </p>
         {loadingSummary ? (
-          <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
-            {Array.from({ length: 4 }).map((_, i) => (
-              <Skeleton key={i} className="h-24 w-full rounded-lg" />
-            ))}
-          </div>
+          <StatGridSkeleton
+            count={4}
+            columns="grid-cols-2 sm:grid-cols-4"
+            description
+          />
+        ) : summaryError ? (
+          <ApiError
+            title="Couldn't load generation cost"
+            onRetry={() => void retrySummary()}
+          />
         ) : summary ? (
           <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
             <MetricCard

--- a/packages/web/src/components/layout/app-shell-skeleton.tsx
+++ b/packages/web/src/components/layout/app-shell-skeleton.tsx
@@ -15,8 +15,8 @@ export function AppShellSkeleton() {
       className="flex h-screen overflow-hidden"
       label="Loading Repowise"
     >
-      {/* Matches Sidebar's expanded width (`w-[260px]`). */}
-      <div className="hidden w-[260px] shrink-0 flex-col gap-2 border-r border-[var(--color-border-default)] p-4 md:flex">
+      {/* Matches Sidebar's expanded width (`w-[280px]`). */}
+      <div className="hidden w-[280px] shrink-0 flex-col gap-2 border-r border-[var(--color-border-default)] p-4 md:flex">
         <Skeleton className="h-8 w-32" />
         <div className="mt-4 space-y-1.5">
           {Array.from({ length: 3 }).map((_, i) => (

--- a/packages/web/src/components/layout/mobile-nav.tsx
+++ b/packages/web/src/components/layout/mobile-nav.tsx
@@ -116,14 +116,21 @@ export function MobileNav({ repos = [], workspace }: MobileNavProps) {
                       key={item.href}
                       href={item.href}
                       className={cn(
-                        "flex items-center gap-2.5 rounded-lg px-2 py-2 text-base transition-colors",
+                        "flex items-center gap-2.5 rounded-lg px-2 py-1.5 text-base transition-colors",
                         isActive
-                          ? "bg-[var(--color-accent-muted)] text-[var(--color-accent-primary)]"
+                          ? "bg-[var(--color-bg-elevated)] font-medium text-[var(--color-text-primary)]"
                           : "text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-elevated)] hover:text-[var(--color-text-primary)]",
                       )}
                     >
-                      <Icon className="h-[18px] w-[18px] shrink-0" />
-                      {item.label}
+                      <span className="flex h-4 w-4 shrink-0 items-center justify-center">
+                        <Icon
+                          className={cn(
+                            "h-4 w-4",
+                            isActive && "text-[var(--color-accent-primary)]",
+                          )}
+                        />
+                      </span>
+                      <span className="truncate">{item.label}</span>
                     </Link>
                   );
                 })}
@@ -131,11 +138,12 @@ export function MobileNav({ repos = [], workspace }: MobileNavProps) {
 
               {isWorkspace && (
                 <>
-                  <Separator className="my-4" />
-                  <p className="mb-2 px-2 text-xs font-medium uppercase tracking-wider text-[var(--color-text-tertiary)]">
+                  <p className="mb-1 mt-4 px-2 text-xs font-medium uppercase tracking-wider text-[var(--color-text-tertiary)]">
                     Workspace
                   </p>
-                  <nav className="space-y-1">
+                  {/* Children of the Workspace group, same as on desktop:
+                      indented, ruled, and at the nested size. */}
+                  <nav className="ml-3.5 space-y-0.5 border-l border-[var(--color-border-default)] pl-3">
                     {WORKSPACE_NAV.map((item) => {
                       const Icon = item.icon;
                       const isActive = (item as { exact?: boolean }).exact
@@ -146,14 +154,21 @@ export function MobileNav({ repos = [], workspace }: MobileNavProps) {
                           key={item.href}
                           href={item.href}
                           className={cn(
-                            "flex items-center gap-2.5 rounded-lg px-2 py-2 text-base transition-colors",
+                            "flex items-center gap-2.5 rounded-lg px-2 py-1.5 text-xs transition-colors",
                             isActive
-                              ? "bg-[var(--color-accent-muted)] text-[var(--color-accent-primary)]"
+                              ? "bg-[var(--color-bg-elevated)] font-medium text-[var(--color-text-primary)]"
                               : "text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-elevated)] hover:text-[var(--color-text-primary)]",
                           )}
                         >
-                          <Icon className="h-[18px] w-[18px] shrink-0" />
-                          {item.label}
+                          <span className="flex h-4 w-4 shrink-0 items-center justify-center">
+                            <Icon
+                              className={cn(
+                                "h-4 w-4",
+                                isActive && "text-[var(--color-accent-primary)]",
+                              )}
+                            />
+                          </span>
+                          <span className="truncate">{item.label}</span>
                         </Link>
                       );
                     })}
@@ -176,16 +191,19 @@ export function MobileNav({ repos = [], workspace }: MobileNavProps) {
                           <button
                             onClick={() => toggleRepo(repo.id)}
                             aria-expanded={isExpanded}
-                            className="flex w-full items-center gap-2.5 rounded-lg px-2 py-2 text-base transition-colors hover:bg-[var(--color-bg-elevated)] text-[var(--color-text-secondary)]"
+                            title={repo.name}
+                            className="flex w-full items-center gap-2.5 rounded-lg px-2 py-1.5 text-base transition-colors hover:bg-[var(--color-bg-elevated)] text-[var(--color-text-secondary)]"
                           >
-                            <Circle className="h-2 w-2 shrink-0 fill-[var(--color-text-tertiary)] text-[var(--color-text-tertiary)]" />
-                            <span className="flex-1 truncate text-left font-medium">
+                            <span className="flex h-4 w-4 shrink-0 items-center justify-center">
+                              <Circle className="h-2 w-2 fill-[var(--color-text-tertiary)] text-[var(--color-text-tertiary)]" />
+                            </span>
+                            <span className="min-w-0 flex-1 truncate text-left">
                               {repo.name}
                             </span>
                             {isExpanded ? (
-                              <ChevronDown className="h-4 w-4 shrink-0 opacity-40" />
+                              <ChevronDown className="h-3.5 w-3.5 shrink-0 opacity-40" />
                             ) : (
-                              <ChevronRight className="h-4 w-4 shrink-0 opacity-40" />
+                              <ChevronRight className="h-3.5 w-3.5 shrink-0 opacity-40" />
                             )}
                           </button>
                           {isExpanded && (
@@ -209,12 +227,19 @@ export function MobileNav({ repos = [], workspace }: MobileNavProps) {
                                         className={cn(
                                           "flex items-center gap-2.5 rounded-lg px-2 py-1.5 text-xs transition-colors",
                                           isActive
-                                            ? "bg-[var(--color-accent-muted)] text-[var(--color-accent-primary)]"
+                                            ? "bg-[var(--color-bg-elevated)] font-medium text-[var(--color-text-primary)]"
                                             : "text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-elevated)] hover:text-[var(--color-text-primary)]",
                                         )}
                                       >
-                                        <Icon className="h-4 w-4 shrink-0" />
-                                        {item.label}
+                                        <span className="flex h-4 w-4 shrink-0 items-center justify-center">
+                                          <Icon
+                                            className={cn(
+                                              "h-4 w-4",
+                                              isActive && "text-[var(--color-accent-primary)]",
+                                            )}
+                                          />
+                                        </span>
+                                        <span className="truncate">{item.label}</span>
                                       </Link>
                                     );
                                   })}
@@ -243,12 +268,15 @@ export function MobileNav({ repos = [], workspace }: MobileNavProps) {
             </div>
           </ScrollArea>
 
-          <div className="flex flex-col gap-3 border-t border-[var(--color-border-default)] px-4 py-3">
-            {/* Mobile had no theme control anywhere in the shell, so the
-                preference was simply unreachable on a phone. */}
-            <ThemeToggle className="w-full justify-between" />
+          <div className="flex flex-col gap-2 border-t border-[var(--color-border-default)] px-4 py-2.5">
             <FeedbackButton />
-            <VersionFooter />
+            {/* Mobile had no theme control anywhere in the shell, so the
+                preference was simply unreachable on a phone. It shares the
+                version row, same as the desktop footer. */}
+            <div className="flex items-center justify-between gap-2">
+              <VersionFooter />
+              <ThemeToggle compact />
+            </div>
           </div>
         </SheetContent>
       </Sheet>

--- a/packages/web/src/components/layout/mobile-nav.tsx
+++ b/packages/web/src/components/layout/mobile-nav.tsx
@@ -18,6 +18,7 @@ import { Separator } from "@repowise-dev/ui/ui/separator";
 import { AddRepoDialog } from "@/components/repos/add-repo-dialog";
 import { VersionFooter } from "./version-footer";
 import { FeedbackButton } from "./feedback-button";
+import { ThemeToggle } from "@repowise-dev/ui/shared/theme-toggle";
 import { cn } from "@/lib/utils/cn";
 import {
   GLOBAL_NAV,
@@ -115,7 +116,7 @@ export function MobileNav({ repos = [], workspace }: MobileNavProps) {
                       key={item.href}
                       href={item.href}
                       className={cn(
-                        "flex items-center gap-2.5 rounded-lg px-2 py-2 text-sm transition-colors",
+                        "flex items-center gap-2.5 rounded-lg px-2 py-2 text-base transition-colors",
                         isActive
                           ? "bg-[var(--color-accent-muted)] text-[var(--color-accent-primary)]"
                           : "text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-elevated)] hover:text-[var(--color-text-primary)]",
@@ -145,7 +146,7 @@ export function MobileNav({ repos = [], workspace }: MobileNavProps) {
                           key={item.href}
                           href={item.href}
                           className={cn(
-                            "flex items-center gap-2.5 rounded-lg px-2 py-2 text-sm transition-colors",
+                            "flex items-center gap-2.5 rounded-lg px-2 py-2 text-base transition-colors",
                             isActive
                               ? "bg-[var(--color-accent-muted)] text-[var(--color-accent-primary)]"
                               : "text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-elevated)] hover:text-[var(--color-text-primary)]",
@@ -175,7 +176,7 @@ export function MobileNav({ repos = [], workspace }: MobileNavProps) {
                           <button
                             onClick={() => toggleRepo(repo.id)}
                             aria-expanded={isExpanded}
-                            className="flex w-full items-center gap-2.5 rounded-lg px-2 py-2 text-sm transition-colors hover:bg-[var(--color-bg-elevated)] text-[var(--color-text-secondary)]"
+                            className="flex w-full items-center gap-2.5 rounded-lg px-2 py-2 text-base transition-colors hover:bg-[var(--color-bg-elevated)] text-[var(--color-text-secondary)]"
                           >
                             <Circle className="h-2 w-2 shrink-0 fill-[var(--color-text-tertiary)] text-[var(--color-text-tertiary)]" />
                             <span className="flex-1 truncate text-left font-medium">
@@ -206,7 +207,7 @@ export function MobileNav({ repos = [], workspace }: MobileNavProps) {
                                         key={item.href}
                                         href={item.href}
                                         className={cn(
-                                          "flex items-center gap-2.5 rounded-lg px-2 py-1.5 text-[13px] transition-colors",
+                                          "flex items-center gap-2.5 rounded-lg px-2 py-1.5 text-xs transition-colors",
                                           isActive
                                             ? "bg-[var(--color-accent-muted)] text-[var(--color-accent-primary)]"
                                             : "text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-elevated)] hover:text-[var(--color-text-primary)]",
@@ -243,6 +244,9 @@ export function MobileNav({ repos = [], workspace }: MobileNavProps) {
           </ScrollArea>
 
           <div className="flex flex-col gap-3 border-t border-[var(--color-border-default)] px-4 py-3">
+            {/* Mobile had no theme control anywhere in the shell, so the
+                preference was simply unreachable on a phone. */}
+            <ThemeToggle className="w-full justify-between" />
             <FeedbackButton />
             <VersionFooter />
           </div>

--- a/packages/web/src/components/layout/sidebar.tsx
+++ b/packages/web/src/components/layout/sidebar.tsx
@@ -113,7 +113,7 @@ export function Sidebar({
     <aside
       className={cn(
         "hidden md:flex h-full flex-col border-r border-[var(--color-border-default)] bg-[var(--color-bg-surface)] shrink-0 motion-safe:transition-all motion-safe:duration-200",
-        isIconOnly ? "w-[56px]" : "w-[260px]",
+        isIconOnly ? "w-[56px]" : "w-[280px]",
       )}
     >
       {/* Logo. Collapsed (56px) can't fit logo + toggle on one row — the
@@ -172,13 +172,13 @@ export function Sidebar({
               cross-repo views tuck behind a toggle unless one is active. */}
           {isWorkspace && (
             <>
-              <Separator className="my-4" />
+              {isIconOnly && <Separator className="my-4" />}
               {!isIconOnly && (
                 <button
                   onClick={() => setWorkspaceNavOpen((v) => !v)}
                   aria-expanded={workspaceNavOpen}
                   aria-controls="sidebar-workspace-nav"
-                  className="mb-1 flex w-full items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium uppercase tracking-wider text-[var(--color-text-tertiary)] transition-colors hover:bg-[var(--color-bg-elevated)] hover:text-[var(--color-text-secondary)]"
+                  className="mb-1 mt-4 flex w-full items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium uppercase tracking-wider text-[var(--color-text-tertiary)] transition-colors hover:bg-[var(--color-bg-elevated)] hover:text-[var(--color-text-secondary)]"
                 >
                   <span className="flex-1 truncate text-left">Workspace</span>
                   {workspaceNavOpen ? (
@@ -189,7 +189,20 @@ export function Sidebar({
                 </button>
               )}
               {(isIconOnly || workspaceNavOpen) && (
-                <nav className="space-y-1" id="sidebar-workspace-nav">
+                // Workspace is a disclosure, exactly like a repository, so its
+                // items are CHILDREN and get the child treatment: the same
+                // indent, rule, and `sm` size a repo's own nav items get.
+                // They were rendering at level-1 size, which made System Map
+                // and Conformance look heavier than the repositories they
+                // sit under.
+                <nav
+                  className={cn(
+                    "space-y-0.5",
+                    !isIconOnly &&
+                      "ml-3.5 mt-0.5 border-l border-[var(--color-border-default)] pl-3",
+                  )}
+                  id="sidebar-workspace-nav"
+                >
                   {(isIconOnly && !isWorkspaceRoute
                     ? WORKSPACE_NAV.slice(0, 1)
                     : WORKSPACE_NAV
@@ -198,6 +211,7 @@ export function Sidebar({
                       key={item.href}
                       item={item}
                       isActive={item.exact ? pathname === item.href : pathname.startsWith(`${item.href}`)}
+                      size={isIconOnly ? "default" : "sm"}
                       iconOnly={isIconOnly}
                     />
                   ))}
@@ -263,7 +277,7 @@ export function Sidebar({
                       <Link
                         key={repo.id}
                         href={indexHref}
-                        className="flex w-full items-center gap-2.5 rounded-lg px-2 py-2 text-base text-[var(--color-text-tertiary)] transition-colors hover:bg-[var(--color-bg-elevated)]"
+                        className={cn(ROW, ROW_L1, "text-[var(--color-text-tertiary)] hover:bg-[var(--color-bg-elevated)]")}
                         title={
                           isMissing
                             ? "Directory missing — open Workspace to remove or fix"
@@ -272,8 +286,10 @@ export function Sidebar({
                               : "Not indexed yet. Open the repo to index."
                         }
                       >
-                        <Circle className="h-2 w-2 shrink-0 stroke-current" />
-                        <span className="flex-1 truncate text-left font-medium">
+                        <RowGlyph>
+                          <Circle className="h-2 w-2 stroke-current" />
+                        </RowGlyph>
+                        <span className="min-w-0 flex-1 truncate text-left">
                           {repo.workspace_alias ?? repo.name}
                         </span>
                         <span className="shrink-0 rounded-full bg-[var(--color-bg-elevated)] px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-[var(--color-text-tertiary)]">
@@ -340,23 +356,31 @@ export function Sidebar({
                         onClick={() => toggleRepo(repo.id)}
                         aria-expanded={isExpanded}
                         aria-controls={`sidebar-repo-${repo.id}`}
-                        className={cn(
-                          "flex w-full items-center gap-2.5 rounded-lg px-2 py-2 text-base transition-colors hover:bg-[var(--color-bg-elevated)]",
-                          isActive
-                            ? "text-[var(--color-text-primary)]"
-                            : "text-[var(--color-text-secondary)]",
-                        )}
+                        // The name still truncates at ~24 characters, so the
+                        // title carries the rest.
+                        title={repo.name}
+                        className={cn(ROW, ROW_L1, isActive ? ROW_ACTIVE : ROW_IDLE)}
                       >
-                        <Circle
-                          className={cn("h-2 w-2 shrink-0", isActive ? "fill-[var(--color-accent-primary)] text-[var(--color-accent-primary)]" : "fill-[var(--color-text-tertiary)] text-[var(--color-text-tertiary)]")}
-                        />
-                        <span className="flex-1 truncate text-left font-medium">
+                        <RowGlyph>
+                          <Circle
+                            className={cn(
+                              "h-2 w-2",
+                              isActive
+                                ? "fill-[var(--color-accent-primary)] text-[var(--color-accent-primary)]"
+                                : "fill-[var(--color-text-tertiary)] text-[var(--color-text-tertiary)]",
+                            )}
+                          />
+                        </RowGlyph>
+                        <span className="min-w-0 flex-1 truncate text-left">
                           {repo.name}
                         </span>
+                        {/* Narrower than the leading slot on purpose: this is
+                            a disclosure affordance, not a peer of the icon
+                            column, and every px here is a px off the name. */}
                         {isExpanded ? (
-                          <ChevronDown className="h-4 w-4 shrink-0 opacity-40" />
+                          <ChevronDown className="h-3.5 w-3.5 shrink-0 opacity-40" />
                         ) : (
-                          <ChevronRight className="h-4 w-4 shrink-0 opacity-40" />
+                          <ChevronRight className="h-3.5 w-3.5 shrink-0 opacity-40" />
                         )}
                       </button>
                       {isExpanded && (
@@ -428,14 +452,19 @@ export function Sidebar({
           at 56px the whole footer used to disappear, so theme, feedback, and
           version were unreachable without expanding first. */}
       {isIconOnly ? (
-        <div className="flex flex-col items-center border-t border-[var(--color-border-default)] py-2">
+        <div className="flex flex-col items-center border-t border-[var(--color-border-default)] py-1.5">
           <ThemeToggle compact />
         </div>
       ) : (
-        <div className="flex flex-col gap-3 border-t border-[var(--color-border-default)] px-4 py-3">
-          <ThemeToggle className="w-full justify-between" />
+        <div className="flex flex-col gap-2 border-t border-[var(--color-border-default)] px-3 py-2">
           <FeedbackButton />
-          <VersionFooter />
+          {/* Version and theme share a row. The toggle was a full-width
+              bordered track stacked on its own line, which made a
+              once-per-session control the tallest thing in the footer. */}
+          <div className="flex items-center justify-between gap-2">
+            <VersionFooter />
+            <ThemeToggle compact />
+          </div>
         </div>
       )}
     </aside>
@@ -464,16 +493,46 @@ function SidebarSearchButton({ iconOnly }: { iconOnly: boolean }) {
   }
 
   return (
-    <button
-      onClick={openPalette}
-      className="flex w-full items-center gap-2.5 rounded-lg px-2 py-2 text-base text-[var(--color-text-secondary)] transition-colors hover:bg-[var(--color-bg-elevated)] hover:text-[var(--color-text-primary)]"
-    >
-      <Search className="h-[18px] w-[18px] shrink-0" />
+    <button onClick={openPalette} className={cn(ROW, ROW_L1, ROW_IDLE)}>
+      <RowGlyph>
+        <Search className="h-4 w-4" />
+      </RowGlyph>
       <span className="flex-1 truncate text-left">Search</span>
       <kbd className="rounded border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-1.5 py-0.5 text-[10px] text-[var(--color-text-tertiary)]">
         ⌘K
       </kbd>
     </button>
+  );
+}
+
+/**
+ * One row shape for the whole sidebar, so every level-1 row (Dashboard,
+ * Settings, Search, each repository) is the same height and every label
+ * starts at the same x. The leading slot is a FIXED 18px box whatever it
+ * holds — an 18px icon or an 8px status dot — because otherwise the repo
+ * labels sat 10px left of the global-nav labels and the column read ragged.
+ */
+const ROW = "flex w-full items-center gap-2 rounded-lg px-2 transition-colors";
+const ROW_L1 = "py-1.5 text-base";
+const ROW_L2 = "py-1.5 text-xs";
+
+/**
+ * Selected, quietly. This used to be an accent-muted wash plus accent text,
+ * which coloured the entire row; on a sidebar where several rows can look
+ * active at once that reads as noise. The ground carries the selection and a
+ * single accent touch on the leading glyph carries the identity.
+ */
+const ROW_ACTIVE =
+  "bg-[var(--color-bg-elevated)] font-medium text-[var(--color-text-primary)]";
+const ROW_IDLE =
+  "text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-elevated)] hover:text-[var(--color-text-primary)]";
+
+/** The fixed-width leading slot that keeps every label on the same column. */
+function RowGlyph({ children }: { children: React.ReactNode }) {
+  return (
+    <span className="flex h-4 w-4 shrink-0 items-center justify-center">
+      {children}
+    </span>
   );
 }
 
@@ -500,7 +559,7 @@ function SidebarNavItem({
             className={cn(
               "flex items-center justify-center rounded-lg p-2.5 transition-colors",
               isActive
-                ? "bg-[var(--color-accent-muted)] text-[var(--color-accent-primary)]"
+                ? "bg-[var(--color-bg-elevated)] text-[var(--color-accent-primary)]"
                 : "text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-elevated)] hover:text-[var(--color-text-primary)]",
             )}
           >
@@ -515,15 +574,17 @@ function SidebarNavItem({
   return (
     <Link
       href={item.href}
-      className={cn(
-        "flex items-center gap-2.5 rounded-lg px-2 transition-colors",
-        size === "sm" ? "py-1.5 text-xs" : "py-2 text-base",
-        isActive
-          ? "bg-[var(--color-accent-muted)] text-[var(--color-accent-primary)]"
-          : "text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-elevated)] hover:text-[var(--color-text-primary)]",
-      )}
+      title={item.label}
+      className={cn(ROW, size === "sm" ? ROW_L2 : ROW_L1, isActive ? ROW_ACTIVE : ROW_IDLE)}
     >
-      <Icon className={cn("shrink-0", size === "sm" ? "h-4 w-4" : "h-[18px] w-[18px]")} />
+      <RowGlyph>
+        <Icon
+          className={cn(
+            size === "sm" ? "h-3.5 w-3.5" : "h-4 w-4",
+            isActive && "text-[var(--color-accent-primary)]",
+          )}
+        />
+      </RowGlyph>
       <span className="truncate">{item.label}</span>
     </Link>
   );

--- a/packages/web/src/components/layout/sidebar.tsx
+++ b/packages/web/src/components/layout/sidebar.tsx
@@ -32,9 +32,20 @@ interface SidebarProps {
   repos?: RepoResponse[];
   activeRepoId?: string;
   workspace?: WorkspaceResponse | null;
+  /**
+   * The repo list could not be fetched, as opposed to being genuinely empty.
+   * Without this the two render identically and a user whose API is down gets
+   * invited to onboard.
+   */
+  reposUnavailable?: boolean;
 }
 
-export function Sidebar({ repos = [], activeRepoId, workspace }: SidebarProps) {
+export function Sidebar({
+  repos = [],
+  activeRepoId,
+  workspace,
+  reposUnavailable = false,
+}: SidebarProps) {
   const isWorkspace = workspace?.is_workspace ?? false;
   const pathname = usePathname();
   const derivedActiveRepoId = React.useMemo(() => {
@@ -101,7 +112,7 @@ export function Sidebar({ repos = [], activeRepoId, workspace }: SidebarProps) {
   return (
     <aside
       className={cn(
-        "hidden md:flex h-full flex-col border-r border-[var(--color-border-default)] bg-[var(--color-bg-surface)] transition-all duration-200 shrink-0",
+        "hidden md:flex h-full flex-col border-r border-[var(--color-border-default)] bg-[var(--color-bg-surface)] shrink-0 motion-safe:transition-all motion-safe:duration-200",
         isIconOnly ? "w-[56px]" : "w-[260px]",
       )}
     >
@@ -110,7 +121,10 @@ export function Sidebar({ repos = [], activeRepoId, workspace }: SidebarProps) {
       <div
         className={cn(
           "flex items-center gap-3",
-          isIconOnly ? "flex-col gap-1.5 px-0 pt-3 pb-1" : "h-14 px-4",
+          // Derived from content rather than asserted. `h-14` was the only
+          // fixed height in the sidebar, spent on static branding, and it set
+          // the 56px-vs-36px proportion against the nav rows below.
+          isIconOnly ? "flex-col gap-1.5 px-0 pt-3 pb-1" : "px-4 py-2.5",
         )}
       >
         <BrandLogo size={28} />
@@ -129,7 +143,12 @@ export function Sidebar({ repos = [], activeRepoId, workspace }: SidebarProps) {
           aria-expanded={!isIconOnly}
           aria-controls="sidebar-nav"
         >
-          <PanelLeft className={cn("h-4 w-4 transition-transform", isIconOnly && "rotate-180")} />
+          <PanelLeft
+            className={cn(
+              "h-4 w-4 motion-safe:transition-transform",
+              isIconOnly && "rotate-180",
+            )}
+          />
         </button>
       </div>
 
@@ -191,8 +210,10 @@ export function Sidebar({ repos = [], activeRepoId, workspace }: SidebarProps) {
             <>
               {!isIconOnly && (
                 <>
-                  <Separator className="my-4" />
-                  <p className="mb-2 px-2 text-xs font-medium uppercase tracking-wider text-[var(--color-text-tertiary)]">
+                  {/* A label or a rule, not both: the separator plus the
+                      heading plus the brand block above them stacked ~150px
+                      of chrome in front of the first repo row. */}
+                  <p className="mb-2 mt-4 px-2 text-xs font-medium uppercase tracking-wider text-[var(--color-text-tertiary)]">
                     Repositories
                   </p>
                 </>
@@ -242,7 +263,7 @@ export function Sidebar({ repos = [], activeRepoId, workspace }: SidebarProps) {
                       <Link
                         key={repo.id}
                         href={indexHref}
-                        className="flex w-full items-center gap-2.5 rounded-lg px-2 py-2 text-sm text-[var(--color-text-tertiary)] transition-colors hover:bg-[var(--color-bg-elevated)]"
+                        className="flex w-full items-center gap-2.5 rounded-lg px-2 py-2 text-base text-[var(--color-text-tertiary)] transition-colors hover:bg-[var(--color-bg-elevated)]"
                         title={
                           isMissing
                             ? "Directory missing — open Workspace to remove or fix"
@@ -320,7 +341,7 @@ export function Sidebar({ repos = [], activeRepoId, workspace }: SidebarProps) {
                         aria-expanded={isExpanded}
                         aria-controls={`sidebar-repo-${repo.id}`}
                         className={cn(
-                          "flex w-full items-center gap-2.5 rounded-lg px-2 py-2 text-sm transition-colors hover:bg-[var(--color-bg-elevated)]",
+                          "flex w-full items-center gap-2.5 rounded-lg px-2 py-2 text-base transition-colors hover:bg-[var(--color-bg-elevated)]",
                           isActive
                             ? "text-[var(--color-text-primary)]"
                             : "text-[var(--color-text-secondary)]",
@@ -378,17 +399,39 @@ export function Sidebar({ repos = [], activeRepoId, workspace }: SidebarProps) {
           {repos.length === 0 && !isIconOnly && (
             <>
               <Separator className="my-4" />
-              {/* First run: no repos to list, so the add action carries the sidebar. */}
-              <div className="px-0.5">
-                <AddRepoDialog />
-              </div>
+              {reposUnavailable ? (
+                // Say what happened. Offering "add your first repo" to
+                // someone whose server is unreachable is both wrong and
+                // unactionable.
+                <div className="space-y-1 px-2">
+                  <p className="text-xs font-medium text-[var(--color-text-primary)]">
+                    Can&apos;t reach the API
+                  </p>
+                  <p className="text-xs text-[var(--color-text-secondary)]">
+                    Your repositories could not be loaded. Check that the
+                    Repowise server is running, then reload.
+                  </p>
+                </div>
+              ) : (
+                // First run: no repos to list, so the add action carries the
+                // sidebar.
+                <div className="px-0.5">
+                  <AddRepoDialog />
+                </div>
+              )}
             </>
           )}
         </div>
       </ScrollArea>
 
-      {/* Footer */}
-      {!isIconOnly && (
+      {/* Footer. Collapsed, it keeps the theme control rather than vanishing:
+          at 56px the whole footer used to disappear, so theme, feedback, and
+          version were unreachable without expanding first. */}
+      {isIconOnly ? (
+        <div className="flex flex-col items-center border-t border-[var(--color-border-default)] py-2">
+          <ThemeToggle compact />
+        </div>
+      ) : (
         <div className="flex flex-col gap-3 border-t border-[var(--color-border-default)] px-4 py-3">
           <ThemeToggle className="w-full justify-between" />
           <FeedbackButton />
@@ -423,7 +466,7 @@ function SidebarSearchButton({ iconOnly }: { iconOnly: boolean }) {
   return (
     <button
       onClick={openPalette}
-      className="flex w-full items-center gap-2.5 rounded-lg px-2 py-2 text-sm text-[var(--color-text-secondary)] transition-colors hover:bg-[var(--color-bg-elevated)] hover:text-[var(--color-text-primary)]"
+      className="flex w-full items-center gap-2.5 rounded-lg px-2 py-2 text-base text-[var(--color-text-secondary)] transition-colors hover:bg-[var(--color-bg-elevated)] hover:text-[var(--color-text-primary)]"
     >
       <Search className="h-[18px] w-[18px] shrink-0" />
       <span className="flex-1 truncate text-left">Search</span>
@@ -474,7 +517,7 @@ function SidebarNavItem({
       href={item.href}
       className={cn(
         "flex items-center gap-2.5 rounded-lg px-2 transition-colors",
-        size === "sm" ? "py-1.5 text-[13px]" : "py-2 text-sm",
+        size === "sm" ? "py-1.5 text-xs" : "py-2 text-base",
         isActive
           ? "bg-[var(--color-accent-muted)] text-[var(--color-accent-primary)]"
           : "text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-elevated)] hover:text-[var(--color-text-primary)]",


### PR DESCRIPTION
Based on #1994.

## Costs

`grep -n error` on the costs page returned nothing across five `useSWR` calls, so a failed request left `data === undefined` forever and pulsed indefinitely. A broken network was pixel-identical to a slow one, permanently.

Each of the five regions now takes its `error` and its `mutate` and renders `ApiError` with a retry in place of its own content. Per-region rather than per-page: the fetches are independent, and one dead endpoint should not blank the four that answered.

The ROI and savings-trend cards were gated on `distillSavings?.available`, which is a semantic state wearing a load state's clothes. While the request is in flight the value is `undefined`, so both rendered `null` and then inserted ~400px above the tabs on arrival. They now run on a three-state discriminated union: pending reserves the populated height, unavailable reserves nothing, populated carries the data.

Placeholders are rebuilt from the components' own dimensions — the stat strips through `StatGridSkeleton`, the daily chart at the shared `CHART_HEIGHT`, the operation breakdown at its own formula's floor, and the hero card mirroring the populated card's structure instead of standing 176px tall against a 350-450px card.

Two smaller ones. Every chart's empty state collapsed 160-220px of reserved box into two lines of text, so an empty response snapped the card upward; they are now sized to the plot box they stand in for. And each `ResponsiveContainer` rendered nothing until its ResizeObserver fired, so the box is reserved by an outer div. Width measurement is left alone: seeding `initialDimension` trades a blank first frame for a visibly wrong-width one that then snaps.

## Sidebar

Every interactive label was off the scan scale, including `text-[13px]` written as a literal. Labels move to `text-base` (15px here) and nested items take the second step to 12px.

Every level-1 row now shares one shape, with the leading glyph in a fixed 16px slot whatever it holds. Repo rows led with an 8px dot and the global nav with an 18px icon, so their labels started 10px apart and the column read ragged. Dashboard, Settings, Search and the repositories now sit on one column at one height, trimmed from 38px to 34px.

Workspace is a disclosure exactly like a repository, but its items rendered at level-1 size, which made System Map and Conformance look heavier than the repositories they sit under. They get the child treatment: same indent, rule, and size a repo's own nav items get.

Selected was an accent-muted wash plus accent text, colouring the whole row. The ground now carries the selection and a single accent touch on the leading glyph carries the identity.

Long repository names truncated at ~21 characters with no way to read the rest. A tighter gap offsets the alignment slot, the disclosure chevron drops to 14px, and the sidebar widens 260 to 280. Names now truncate at ~24 and carry a `title` with the full string. The sidebar ellipsizes rather than clipping, so the fixed width was the binding constraint.

`h-14` was the only asserted height in the sidebar and it was spent on static branding; it is now content-derived, and "Repositories" loses its separator since a section takes a label or a rule, not both. The theme control was a full-width bordered track on its own line, making a once-per-session control the tallest thing in the footer; it moves onto the version row as the compact variant. It was also unreachable on mobile and at the 56px collapsed width, and its selected state now comes from the `dark` class written before first paint, so the first painted frame is correct instead of showing neither option selected.

The layout fell back to `[]` on a rejected fetch, so an unreachable API rendered the exact first-run "add your first repo" invitation. Rejection and emptiness are now distinct and the sidebar says which happened.

`mobile-nav` gets all of the same. Both shells render from `nav-items.ts`, and letting their row styles drift is how they stop looking like one product.

## Verification

Both packages type-check, `packages/ui`'s suite passes, `packages/web` lints and builds, and every touched route was loaded against a local server.