### PR TITLE
fix(tests): list the composed refactoring tables in the model table check

### DIFF
--- a/tests/unit/persistence/test_models.py
+++ b/tests/unit/persistence/test_models.py
@@ -319,6 +319,8 @@ def test_base_includes_all_models():
         "health_file_metrics",
         "health_snapshots",
         "refactoring_suggestions",
+        "refactoring_opportunities",
+        "refactoring_summaries",
         "performance_opportunities",
         "performance_summaries",
         "coverage_files",


### PR DESCRIPTION
`test_base_includes_all_models` asserts an exact match between
`Base.metadata.tables` and a hardcoded set of table names. #1992 added the
`RefactoringOpportunity` and `RefactoringSummary` models without adding
`refactoring_opportunities` and `refactoring_summaries` to that set, so the
test failed on Python 3.11, 3.12 and 3.13, turning CI red on main.

**What changed:** the two table names are added to the expected set.

**Behavior:** no production change. The models were already registered on
`Base`; only the test's list was stale.

**Verification:** `tests/unit/persistence/test_models.py` passes (25 tests),
`ruff check` clean.
