### PR TITLE
refactor(ingestion): collapse _derive_exports dead branch and clarify LanguageConfig metadata

### DIFF
--- a/packages/core/src/repowise/core/ingestion/language_configs.py
+++ b/packages/core/src/repowise/core/ingestion/language_configs.py
@@ -39,10 +39,10 @@ class LanguageConfig:
     # Maps tree-sitter node type → our canonical SymbolKind string
     symbol_node_types: dict[str, str]
 
-    # tree-sitter node types that carry import information (doc purposes)
+    # tree-sitter node types that carry import information (descriptive metadata; not read at runtime)
     import_node_types: list[str]
 
-    # tree-sitter node types that export symbols (doc purposes)
+    # tree-sitter node types that export symbols (descriptive metadata; not read at runtime)
     export_node_types: list[str]
 
     # (name: str, modifier_texts: list[str]) → "public" | "private" | ...
@@ -372,7 +372,7 @@ LANGUAGE_CONFIGS: dict[str, LanguageConfig] = {
             # flagged as a follow-up, not attempted here.
             "declType": "class",
             "declProc": "function",  # signature only (interface decl / forward decl)
-            "defProc": "function",   # full definition with body
+            "defProc": "function",  # full definition with body
             # Matches C#'s choice for the same concept (property_declaration ->
             # "variable"). Rust is the one language that keeps fields under a
             # distinct "property" kind; everywhere else a field and a callable
@@ -381,7 +381,7 @@ LANGUAGE_CONFIGS: dict[str, LanguageConfig] = {
             "declProp": "variable",
         },
         import_node_types=["declUses"],
-        export_node_types=[],       # Pascal has no explicit re-export syntax
+        export_node_types=[],  # Pascal has no explicit re-export syntax
         # No pascal_visibility exists yet. Pascal visibility is per-*section*
         # (`strict private`/`protected`/`public`/`published` governs every
         # declaration until the next section keyword, i.e. extractors/

--- a/packages/core/src/repowise/core/ingestion/parser.py
+++ b/packages/core/src/repowise/core/ingestion/parser.py
@@ -1056,7 +1056,7 @@ class ASTParser:
             else []
         )
         heritage = extract_heritage(matches, config, file_info, src)
-        exports = self._derive_exports(symbols, config, src)
+        exports = self._derive_exports(symbols, config)
         export_aliases = ts_export_aliases(src) if lang in _TS_JS_LANGUAGES else {}
         docstring = extract_module_docstring(root, src, lang)
         type_refs = self._extract_type_refs(matches, src, lang)
@@ -2038,11 +2038,14 @@ class ASTParser:
         self,
         symbols: list[Symbol],
         config: LanguageConfig,
-        src: str,
     ) -> list[str]:
-        """Derive the list of exported names from parsed symbols."""
-        if config.export_node_types:
-            return [s.name for s in symbols if s.visibility == "public" and s.parent_name is None]
+        """Derive the list of exported names from parsed symbols.
+
+        Note on TS/JS: export visibility is resolved upstream during symbol
+        extraction by ``refine_ts_visibility()``, which demotes non-exported
+        declarations to private. This expression relies on that classification to
+        filter top-level public symbols accurately for TS/JS.
+        """
         return [s.name for s in symbols if s.visibility == "public" and s.parent_name is None]
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Collapsed redundant `if config.export_node_types:` branch in `ASTParser._derive_exports()` to a single return statement.
- Dropped unused `src` parameter from `_derive_exports()` and updated its call site in `parser.py`.
- Added docstring explaining that TS/JS export visibility is resolved upstream by `refine_ts_visibility()`, and updated `language_configs.py` comments to clarify `import_node_types` and `export_node_types` are descriptive metadata not read at runtime.

## Related Issues

Closes #1999

## Test Plan

- [x] Tests pass (`uv run pytest tests/unit/ingestion` — 2,803 passed)
- [x] Lint passes (`uv run ruff check .` and `uv run ruff format --check .`)

## Checklist

- [x] My code follows the project's code style
- [x] All existing tests still pass
- [x] I have updated documentation if needed
