### PR TITLE
fix(cli): render a refactoring step whose plan falls outside the limit

### DIFF
--- a/packages/cli/src/repowise/cli/commands/health_cmd/refactoring_targets.py
+++ b/packages/cli/src/repowise/cli/commands/health_cmd/refactoring_targets.py
@@ -377,7 +377,13 @@ def _plan_detail_console(p: dict) -> list[str]:
     extractions appeared three times in three places and the reader had to
     reassemble it. The detail itself was the good part and is unchanged; it is
     the grouping that went.
+
+    Empty when the step's plan is not in the rendered set: composition runs over
+    every suggestion while the plan list is truncated to ``limit``, so a step can
+    outrank its own plan's detail.
     """
+    if not p:
+        return []
     kind = p["refactoring_type"]
     pl = p.get("plan") or {}
     ev = p.get("evidence") or {}
@@ -449,7 +455,9 @@ def _plan_detail_console(p: dict) -> list[str]:
 
 
 def _plan_detail_md(p: dict) -> list[str]:
-    """The same detail, as Markdown lines."""
+    """The same detail, as Markdown lines. Empty for a plan outside the limit."""
+    if not p:
+        return []
     kind = p["refactoring_type"]
     pl = p.get("plan") or {}
     ev = p.get("evidence") or {}

--- a/tests/unit/cli/test_refactoring_targets_render.py
+++ b/tests/unit/cli/test_refactoring_targets_render.py
@@ -148,3 +148,33 @@ def test_helper_site_falls_back_when_a_legacy_row_has_no_directory(capsys):
     legacy = _extract_helper({"module": "ui", "directory": None})
     _render_refactoring_targets([], [], [legacy], fmt="md")
     assert "near `ui`" in capsys.readouterr().out
+
+
+def _extract_method(i: int) -> RefactoringSuggestion:
+    """One plan per file, so composition yields one step per file."""
+    return RefactoringSuggestion(
+        refactoring_type="extract_method",
+        file_path=f"m{i}.py",
+        target_symbol=f"f{i}",
+        line_start=10,
+        line_end=30,
+        plan={"span": {"start": 10, "end": 30}, "suggested_name": f"_f{i}_part"},
+        evidence={"ccn_removed": 6, "slice_nloc": 20},
+        impact_delta=float(i),
+        effort_bucket="S",
+        blast_radius={"scope": "local"},
+        confidence="high",
+    )
+
+
+def test_a_step_whose_plan_falls_outside_the_limit_still_renders(capsys):
+    """Composition runs over every suggestion; the plan list is truncated.
+
+    So a step can outrank its own plan's detail, and the detail lookup hands
+    the renderer an empty dict. It used to dereference that and raise
+    ``KeyError: 'refactoring_type'``, taking the whole command down.
+    """
+    suggestions = [_extract_method(i) for i in range(25)]
+    for fmt in ("console", "md"):
+        _render_refactoring_targets([], [], suggestions, fmt=fmt, limit=3)
+        assert capsys.readouterr().out


### PR DESCRIPTION
`health --refactoring-targets` crashed with `KeyError: 'refactoring_type'` on this
repository, printing a partial table and exiting 1.

Opportunities are composed over every stored suggestion, but the plan list they
look their detail up in is truncated to `limit`. A step can therefore outrank its
own plan's detail, and the lookup hands the renderer the empty dict its caller
already passes as the miss case:

```python
for line in _plan_detail_console(plan_by_id.get(s.plan_id, {})):
```

Both the console and Markdown renderers dereferenced that immediately rather than
honouring it. A step whose plan is outside the rendered set now contributes no
detail lines.

## Verification

The new case in `tests/unit/cli/test_refactoring_targets_render.py` reproduces
the production failure exactly (25 suggestions, `limit=3`) and raises the same
`KeyError` against the unfixed renderers. The file's 8 cases pass.

End to end on this repository the command now exits 0 and renders 3,024 lines,
including the previously unreachable unattached-observations section.
