### PR TITLE
fix(update): keep full dry runs read-only

### DIFF
--- a/packages/cli/src/repowise/cli/commands/update_cmd/command.py
+++ b/packages/cli/src/repowise/cli/commands/update_cmd/command.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import sys
 import time
 from enum import StrEnum
+from pathlib import Path
 from typing import Any
 
 import click
@@ -408,6 +409,35 @@ class UpdateOutcome(StrEnum):
     DRY_RUN = "dry_run"  # dry run, nothing written
 
 
+def _render_full_upgrade_dry_run(
+    repo_path: Path,
+    *,
+    provider_name: str | None,
+    model: str | None,
+) -> None:
+    """Describe a full upgrade without resolving providers or touching the store."""
+    state = load_state(repo_path)
+    config = load_config(repo_path)
+
+    planned_provider = (
+        provider_name or config.get("provider") or state.get("provider") or "auto-detect"
+    )
+    planned_model = model or config.get("model") or state.get("model") or "provider default"
+    current_git_tier = str(state.get("git_tier") or "essential").upper()
+    recorded_pages = state.get("total_pages")
+    page_label = f"{recorded_pages:,}" if isinstance(recorded_pages, int) else "unknown"
+
+    console.print("[yellow]Dry run — full upgrade plan:[/yellow]")
+    console.print(
+        f"  Provider: [cyan]{planned_provider}[/cyan] / [cyan]{planned_model}[/cyan]"
+    )
+    console.print(
+        f"  Git tier: [cyan]{current_git_tier}[/cyan] -> [cyan]FULL[/cyan]"
+    )
+    console.print(f"  Pages currently recorded: [cyan]{page_label}[/cyan]")
+    console.print("  The whole-repository wiki would be generated. No changes made.")
+
+
 def _renderer_inputs(repo_path):
     """The (language, style fingerprint, style template dir) a file page uses.
 
@@ -666,6 +696,22 @@ def run_update(
     # incremental change-detection so the normal `repowise update` flow below
     # is byte-for-byte unchanged. ---
     if full:
+        if dry_run:
+            _render_full_upgrade_dry_run(
+                repo_path,
+                provider_name=provider_name,
+                model=model,
+            )
+            if emitter is not None:
+                emitter.done(
+                    ok=True,
+                    pages_generated=0,
+                    cost_usd=0.0,
+                    duration_s=time.monotonic() - start,
+                    outcome=UpdateOutcome.DRY_RUN.value,
+                )
+            return UpdateOutcome.DRY_RUN
+
         from repowise.cli.commands.upgrade_flow import upgrade_to_full
 
         if emitter is not None:

--- a/tests/unit/cli/test_update_full_dry_run.py
+++ b/tests/unit/cli/test_update_full_dry_run.py
@@ -1,0 +1,160 @@
+"""Regression coverage for ``update --full --dry-run`` (issue #1996)."""
+
+from __future__ import annotations
+
+import json
+from io import StringIO
+from pathlib import Path
+from typing import Any
+
+import click
+import pytest
+from rich.console import Console
+
+from repowise.cli.commands.update_cmd import command as update_cmd
+from repowise.cli.helpers import CommandTarget
+
+
+def _prepare_repo(repo: Path) -> Path:
+    repowise_dir = repo / ".repowise"
+    repowise_dir.mkdir(parents=True)
+    state_path = repowise_dir / "state.json"
+    state_path.write_text(
+        json.dumps(
+            {
+                "git_tier": "essential",
+                "total_pages": 42,
+                "provider": "state-provider",
+                "model": "state-model",
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    (repowise_dir / "config.yaml").write_text(
+        "provider: config-provider\nmodel: config-model\n",
+        encoding="utf-8",
+    )
+    return state_path
+
+
+def _patch_boundary(monkeypatch: pytest.MonkeyPatch, repo: Path) -> None:
+    monkeypatch.setattr(update_cmd, "configure_cli_logging", lambda **_kwargs: None)
+    monkeypatch.setattr(
+        update_cmd,
+        "resolve_command_target",
+        lambda **_kwargs: CommandTarget(mode="single", repo_path=repo),
+    )
+    monkeypatch.setattr(
+        "repowise.cli.commands.workspace_cmd.inherit_workspace_distill_verdict",
+        lambda _repo_path: None,
+    )
+
+
+def _run(repo: Path, *, dry_run: bool, progress: str = "rich") -> update_cmd.UpdateOutcome:
+    return update_cmd.run_update(
+        path=str(repo),
+        provider_name=None,
+        model=None,
+        since=None,
+        reasoning=None,
+        cascade_budget=None,
+        dry_run=dry_run,
+        workspace=False,
+        no_workspace=True,
+        repo_alias=None,
+        full=True,
+        progress=progress,
+    )
+
+
+def test_full_dry_run_preserves_state_and_never_dispatches_upgrade(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    state_path = _prepare_repo(repo)
+    state_before = state_path.read_bytes()
+    _patch_boundary(monkeypatch, repo)
+
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(
+        "repowise.cli.commands.upgrade_flow.upgrade_to_full",
+        lambda *_args, **kwargs: calls.append(kwargs),
+    )
+    output = StringIO()
+    monkeypatch.setattr(
+        update_cmd,
+        "console",
+        Console(file=output, force_terminal=False, color_system=None),
+    )
+
+    outcome = _run(repo, dry_run=True)
+
+    assert outcome is update_cmd.UpdateOutcome.DRY_RUN
+    assert calls == []
+    assert state_path.read_bytes() == state_before
+    assert not (repo / ".repowise" / ".update.lock").exists()
+    assert not (repo / ".repowise" / ".update.pending").exists()
+    rendered = output.getvalue()
+    assert "config-provider / config-model" in rendered
+    assert "ESSENTIAL -> FULL" in rendered
+    assert "Pages currently recorded: 42" in rendered
+    assert "No changes made" in rendered
+
+
+def test_full_dry_run_emits_dry_run_machine_outcome(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    _prepare_repo(repo)
+    _patch_boundary(monkeypatch, repo)
+    monkeypatch.setattr(update_cmd, "silence_logs_for_machine_output", lambda: None)
+
+    events: list[tuple[str, dict[str, Any]]] = []
+
+    class _Emitter:
+        def start(self, **kwargs: Any) -> None:
+            events.append(("start", kwargs))
+
+        def done(self, **kwargs: Any) -> None:
+            events.append(("done", kwargs))
+
+    monkeypatch.setattr(update_cmd, "JsonProgressEmitter", _Emitter)
+
+    with click.Context(click.Command("test")):
+        outcome = _run(repo, dry_run=True, progress="json")
+
+    assert outcome is update_cmd.UpdateOutcome.DRY_RUN
+    assert events[-1][0] == "done"
+    assert events[-1][1]["outcome"] == update_cmd.UpdateOutcome.DRY_RUN.value
+    assert events[-1][1]["pages_generated"] == 0
+
+
+def test_full_without_dry_run_still_dispatches_upgrade(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    _prepare_repo(repo)
+    _patch_boundary(monkeypatch, repo)
+
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(
+        "repowise.cli.commands.upgrade_flow.upgrade_to_full",
+        lambda *_args, **kwargs: calls.append(kwargs),
+    )
+
+    outcome = _run(repo, dry_run=False)
+
+    assert outcome is update_cmd.UpdateOutcome.REGENERATED
+    assert calls == [
+        {
+            "provider_name": None,
+            "model": None,
+            "reasoning": None,
+            "concurrency": 10,
+            "yes": False,
+        }
+    ]

--- a/tests/unit/cli/test_update_full_dry_run.py
+++ b/tests/unit/cli/test_update_full_dry_run.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import sqlite3
 from io import StringIO
 from pathlib import Path
 from typing import Any
@@ -35,7 +36,25 @@ def _prepare_repo(repo: Path) -> Path:
         "provider: config-provider\nmodel: config-model\n",
         encoding="utf-8",
     )
+    # Seed every mutable marker/store that the full-upgrade path could touch.
+    # A dry-run must preserve existing state too, not merely avoid creating
+    # these files when they are absent.
+    (repowise_dir / ".update.lock").write_text("held-by-another-update\n", encoding="utf-8")
+    (repowise_dir / ".update.pending").write_text("{\"head\": \"sentinel\"}\n", encoding="utf-8")
+    with sqlite3.connect(repowise_dir / "wiki.db") as connection:
+        connection.execute("CREATE TABLE sentinel (value TEXT NOT NULL)")
+        connection.execute("INSERT INTO sentinel VALUES (?)", ("existing-index",))
     return state_path
+
+
+def _snapshot_repowise_tree(repo: Path) -> dict[str, bytes]:
+    """Capture all files in the persisted index, including hidden markers."""
+    repowise_dir = repo / ".repowise"
+    return {
+        str(path.relative_to(repowise_dir)): path.read_bytes()
+        for path in repowise_dir.rglob("*")
+        if path.is_file()
+    }
 
 
 def _patch_boundary(monkeypatch: pytest.MonkeyPatch, repo: Path) -> None:
@@ -73,8 +92,8 @@ def test_full_dry_run_preserves_state_and_never_dispatches_upgrade(
     tmp_path: Path,
 ) -> None:
     repo = tmp_path / "repo"
-    state_path = _prepare_repo(repo)
-    state_before = state_path.read_bytes()
+    _prepare_repo(repo)
+    persisted_before = _snapshot_repowise_tree(repo)
     _patch_boundary(monkeypatch, repo)
 
     calls: list[dict[str, Any]] = []
@@ -93,9 +112,7 @@ def test_full_dry_run_preserves_state_and_never_dispatches_upgrade(
 
     assert outcome is update_cmd.UpdateOutcome.DRY_RUN
     assert calls == []
-    assert state_path.read_bytes() == state_before
-    assert not (repo / ".repowise" / ".update.lock").exists()
-    assert not (repo / ".repowise" / ".update.pending").exists()
+    assert _snapshot_repowise_tree(repo) == persisted_before
     rendered = output.getvalue()
     assert "config-provider / config-model" in rendered
     assert "ESSENTIAL -> FULL" in rendered


### PR DESCRIPTION
## Summary

- guard `update --full --dry-run` before dispatching `upgrade_to_full`, preventing index and lock mutations
- render the planned provider/model, git-tier promotion, and recorded page count from persisted config/state
- return and emit `dry_run`, while preserving the existing non-dry-run upgrade path

## Related Issues

Fixes #1996

## Test Plan

- [x] `uv run pytest -q tests/unit/cli/test_*update*.py tests/unit/cli/test_full_upgrade_lock.py` (162 passed)
- [x] `uv run pytest -q tests/integration/test_cli.py` (43 passed)
- [x] `uv run ruff check packages/cli/src/repowise/cli/commands/update_cmd/command.py tests/unit/cli/test_update_full_dry_run.py`
- [x] `git diff --check`

## Checklist

- [x] My code follows the project's code style
- [x] I have added tests for new functionality
- [x] All relevant existing tests pass
- [x] Documentation is not needed for this bug fix