### PR TITLE
fix(performance): solve the loop-carried must-def analysis to a fixpoint

### DIFF
--- a/packages/core/src/repowise/core/analysis/health/perf/promotion.py
+++ b/packages/core/src/repowise/core/analysis/health/perf/promotion.py
@@ -239,36 +239,81 @@ def _must_defined_before_block(
     """Variables guaranteed written before each loop block, within one iteration.
 
     A forward *must* (intersection) analysis over the loop's blocks, treating the
-    header as the iteration start (nothing defined yet) and ignoring the back-edge
-    - so it measures what a single pass from the header definitely writes before a
-    given block. With back-edges removed the loop subgraph is a DAG whose block-id
-    order is a valid topological order, so one pass in id order reaches the
-    fixpoint. A use whose variable is in this set was redefined this iteration and
-    cannot read a previous one.
+    header as the iteration start (nothing defined yet) and ignoring the
+    back-edge, so it measures what a single pass from the header definitely
+    writes before a given block. A use whose variable is in this set was
+    redefined this iteration and cannot read a previous one.
+
+    Solved as a worklist fixpoint rather than one sweep in block-id order. Id
+    order is *not* a topological order of the loop DAG: ``_build_if`` allocates
+    the join block before either arm, so a join's id is lower than the ids of
+    the predecessors flowing into it. A single ordered pass therefore reached
+    joins before their arms and, with the arms' results still missing, collapsed
+    every join to "nothing is definitely defined". Any ``if`` or ``try`` that
+    assigned before the awaited call made the whole loop unprovable, which is a
+    false refusal rather than an unsafe promotion, but it refused a large share
+    of ordinary loops.
+
+    Direction matters for soundness. The lattice descends from "everything" to
+    the fixpoint, so a partially solved state is *larger* than the answer, and a
+    larger must-set promotes more. The iteration therefore runs to convergence
+    or, if it somehow does not converge inside the bound, reports nothing as
+    definitely defined, which can only refuse.
     """
     defs_in_block: dict[int, frozenset[str]] = {}
     for bid in loop_blocks:
         bdu = def_use.block(bid)
         defs_in_block[bid] = frozenset(d.var for d in bdu.defs) if bdu is not None else frozenset()
 
-    defined_in: dict[int, frozenset[str]] = {}
-    defined_out: dict[int, frozenset[str]] = {}
-    for block in cfg.blocks:  # emission (id) order
-        bid = block.id
-        if bid not in loop_blocks:
-            continue
-        if bid == header_id:
-            din: frozenset[str] = frozenset()
-        else:
-            pred_outs = [
-                defined_out[p]
-                for p in block.predecessors
-                if p in loop_blocks and p in defined_out and not _is_back_edge(cfg, p, bid)
-            ]
-            din = frozenset.intersection(*pred_outs) if pred_outs else frozenset()
-        defined_in[bid] = din
-        defined_out[bid] = din | defs_in_block[bid]
-    return defined_in
+    # Only a variable the loop writes can ever be must-defined, since the header
+    # starts empty and the transfer only ever adds this block's own defs.
+    universe: frozenset[str] = frozenset().union(*defs_in_block.values())
+    if not universe:
+        return dict.fromkeys(loop_blocks, frozenset())
+
+    preds: dict[int, tuple[int, ...]] = {
+        bid: tuple(
+            p
+            for p in cfg.block(bid).predecessors
+            if p in loop_blocks and not _is_back_edge(cfg, p, bid)
+        )
+        for bid in loop_blocks
+    }
+
+    defined_in: dict[int, frozenset[str]] = dict.fromkeys(loop_blocks, frozenset())
+    defined_out: dict[int, frozenset[str]] = dict.fromkeys(loop_blocks, universe)
+    defined_out[header_id] = defs_in_block[header_id]
+
+    ordered = sorted(loop_blocks)
+    # Descending a lattice of height |universe| over |blocks| cells, so this is
+    # a generous ceiling on a monotone iteration, not a tuning parameter.
+    for _round in range((len(universe) + 1) * len(ordered) + 1):
+        changed = False
+        for bid in ordered:
+            if bid == header_id:
+                din: frozenset[str] = frozenset()
+            else:
+                # A handler is entered by an exception that may have escaped any
+                # statement of the protected region, including its first, so it
+                # inherits what was defined *before* that region rather than
+                # after it. The CFG draws one edge from the region's entry block
+                # and the whole ``try`` body usually sits in that block, so
+                # reading the predecessor's exit state here would count
+                # assignments the exception may have skipped.
+                entry_state = cfg.block(bid).kind == "handler"
+                pred_states = [
+                    defined_in[p] if entry_state else defined_out[p] for p in preds[bid]
+                ]
+                # No in-loop forward predecessor means the block is not reachable
+                # from the header within one iteration; claim nothing for it.
+                din = frozenset.intersection(*pred_states) if pred_states else frozenset()
+            dout = din | defs_in_block[bid]
+            if din != defined_in[bid] or dout != defined_out[bid]:
+                defined_in[bid], defined_out[bid] = din, dout
+                changed = True
+        if not changed:
+            return defined_in
+    return dict.fromkeys(loop_blocks, frozenset())
 
 
 def _is_back_edge(cfg: CFG, src: int, dst: int) -> bool:

--- a/tests/unit/health/test_perf_promotion.py
+++ b/tests/unit/health/test_perf_promotion.py
@@ -178,6 +178,153 @@ def test_running_dependency_across_iterations_is_carried():
     )
 
 
+# -- branch joins ---------------------------------------------------------
+
+
+def test_definition_on_every_branch_is_independent():
+    """Every path through the ``if`` writes ``key`` before the await reads it.
+
+    The must-def analysis has to reach a fixpoint over the loop to see this:
+    the join block is emitted before either arm, so its id is lower than the
+    ids of the blocks flowing into it and one pass in id order cannot see them.
+    """
+    assert _independent(
+        """
+        async def run(items):
+            out = []
+            for item in items:
+                if item.ok:
+                    key = item.a
+                else:
+                    key = item.b
+                out.append(await fetch(key))  # HIT
+            return out
+        """,
+        "HIT",
+    )
+
+
+def test_definition_on_every_nested_branch_is_independent():
+    assert _independent(
+        """
+        async def run(items):
+            for item in items:
+                if item.a:
+                    if item.b:
+                        key = 1
+                    else:
+                        key = 2
+                else:
+                    key = 3
+                r = await fetch(key)  # HIT
+        """,
+        "HIT",
+    )
+
+
+def test_definition_on_only_one_branch_is_carried():
+    # ``key`` is unwritten on the else path, so the read there takes the
+    # previous iteration's value. That is a carry and must refuse.
+    assert not _independent(
+        """
+        async def run(items):
+            for item in items:
+                if item.ok:
+                    key = item.id
+                r = await fetch(key)  # HIT
+        """,
+        "HIT",
+    )
+
+
+def test_definition_only_inside_a_nested_loop_is_carried():
+    # The inner loop may run zero times, so ``key`` is not definitely written.
+    assert not _independent(
+        """
+        async def run(items):
+            for item in items:
+                for sub in item.parts:
+                    key = sub.id
+                r = await fetch(key)  # HIT
+        """,
+        "HIT",
+    )
+
+
+def test_an_exception_may_skip_the_assignment_it_precedes():
+    """A handler is entered by an exception that may have escaped anything.
+
+    The CFG draws one edge from the protected region's entry block, and the
+    whole ``try`` body usually sits in that block, so the handler must inherit
+    what was defined *before* the region. Reading the block's exit state would
+    count the very assignment the exception skipped.
+    """
+    # ``except`` leaves ``key`` unwritten, so the read there takes the previous
+    # iteration's value: a carry.
+    assert not _independent(
+        """
+        async def run(items):
+            for item in items:
+                try:
+                    key = item.id
+                except AttributeError:
+                    pass
+                r = await fetch(key)  # HIT
+        """,
+        "HIT",
+    )
+    # Both paths write it, so the read is intra-iteration on either.
+    assert _independent(
+        """
+        async def run(items):
+            for item in items:
+                try:
+                    key = item.id
+                except AttributeError:
+                    key = 0
+                r = await fetch(key)  # HIT
+        """,
+        "HIT",
+    )
+
+
+def test_finally_does_not_hide_a_partial_assignment():
+    # The handler path reaches the finally block too, so a variable written
+    # only on the happy path is still not definitely written after it.
+    assert not _independent(
+        """
+        async def run(items):
+            for item in items:
+                try:
+                    key = item.id
+                except AttributeError:
+                    pass
+                finally:
+                    pass
+                r = await fetch(key)  # HIT
+        """,
+        "HIT",
+    )
+
+
+def test_an_except_handler_can_carry_a_dependence():
+    # The handler reads the accumulator the previous iteration wrote.
+    assert not _independent(
+        """
+        async def run(items):
+            prev = None
+            for item in items:
+                try:
+                    key = item.id
+                except AttributeError:
+                    key = prev
+                r = await fetch(key)  # HIT
+                prev = r
+        """,
+        "HIT",
+    )
+
+
 # -- degrade-to-silence ---------------------------------------------------
 
 


### PR DESCRIPTION
## Why

`serial_await_in_loop` is the only marker in the corpus that survived hand-labelling, at 81% production, and the only one that can produce a proven fix. Just 16 of its 49 rows passed the `dataflow_verified` gate, so two thirds of the one strategy that works were dropped to `investigate`.

The cause is a bug, not a conservative choice. `_must_defined_before_block` documented its own key assumption:

> With back-edges removed the loop subgraph is a DAG whose block-id order is a valid topological order, so one pass in id order reaches the fixpoint.

That is false for a branch. `_build_if` allocates the join block **before** either arm, so a join's id is lower than the ids of the blocks flowing into it. The single ordered pass reached joins before their arms, found their results missing, dropped them from the intersection, and collapsed the join to "nothing is definitely defined". Any `if`, `elif` or `try` that assigned before the awaited call made the whole loop unprovable.

Confirmed directly before touching anything:

```
True    baseline, no branch
False   if/else defines before the await     <- should be True
False   try/except defines before the await  <- should be True
False   accumulator carry                     (correctly refused)
False   cursor carry                          (correctly refused)
```

## What changed

**A worklist fixpoint replaces the single sweep.** Direction matters for soundness: the lattice descends from "everything" toward the answer, so a partially solved state is *larger* than the fixpoint, and a larger must-set promotes more. The iteration runs to convergence or reports nothing as definitely defined, which can only refuse.

**A latent unsoundness in the old sweep is closed.** Its predecessor filter dropped any predecessor not yet computed, so the intersection was taken over a subset and could exceed the true must-set. It held only because the surviving low-id predecessor happened to dominate, which was undocumented and fragile.

**The CFG's exception optimism is handled.** Exposing the join arms surfaced a separate problem: the handler edge leaves the protected region's *entry block*, and the whole `try` body normally sits in that block, so a handler looked like it ran after the body's assignments rather than possibly instead of them. A variable assigned only on the happy path read as definitely assigned. Handlers now inherit their predecessors' **entry** state rather than their exit state.

That last one was caught by the adversarial probe, not by the existing tests. A first attempt refused every loop containing a handler; that was sound but cost 3 real promotions, so it was replaced with the precise rule.

## Soundness

The invariant this file states is that the proof may only ever refuse, never invent independence. 18 adversarial shapes, all as expected:

| refuses (carried or unprovable) | promotes (genuinely independent) |
|---|---|
| definition on only one branch | definition on every branch |
| `if` with no `else` | definition on every nested branch |
| `elif` chain with no final `else` | `break` before the definition |
| definition only inside a nested loop | `continue` before the definition |
| accumulator behind a branch | `try`/`except` where both paths assign |
| both arms define, then a real carry | `try`/`finally`, no `except` |
| nested `if`, one inner path misses | `try`/`except`/`finally`, both assign |
| `try` assigns, `except` does not | await inside the `try` body |
| `try`/`except`/`finally`, only `try` assigns | |
| `except` handler reads the accumulator | |

## Measured

Roo-Code holds all 49 corpus `serial_await_in_loop` rows, so one reindex measures this exactly.

| | before | after |
|---|---|---|
| `plan_ready` | 16 | **19** |
| `investigate` | 33 | **30** |
| total rows | 49 | 49 |
| all open opportunities | 249 | 249 |

No new rows, no opportunity identity changed, nothing lost. Corpus-wide proven goes from 16 to 19 of 644.

All three newly proven loops were opened and read:

- `src/services/command/commands.ts:299` reads each scanned command file, `await fs.readFile(resolvedPath)` over a destructured loop item.
- `src/core/webview/ClineProvider.ts:1796` removes each task directory, path derived per iteration.
- `src/core/task-persistence/TaskHistoryStore.ts:340,349` per-item history migration against a per-item path.

All three are genuine independent-await sequences with no accumulator and no cross-iteration state.

## Validation

- `tests/unit/health` promotion, dataflow, opportunity, identity-contract and golden-corpus suites: 176 passed, including `test_perf_identity_contract` (promotion must not renumber opportunities) and `test_perf_corpus_golden`.
- Full `tests/unit/health`: 1388 passed. 28 failures, identical in set and count to the same suite on `main`, all from tree-sitter grammars absent in this environment (shell, sql, dart).
- `ruff check`: clean.
- Six new tests cover the branch-join cases and the exception rule, including the shapes that must still refuse.

Corpus stores were backed up before reindexing and restored afterwards, verified back at 644 open opportunities.

## Scope

This is the `if`/`try` join fix only. The other known bail-outs stay: the check still covers the whole loop rather than the backward slice of the awaited expression, intra-block ordering is still line-based rather than index-based, and field, global and alias state remain deliberately out of scope. Widening those is separate work and the last must stay closed.
