### PR TITLE
fix(ui): align the opportunity row columns below the lg breakpoint

### DIFF
--- a/packages/ui/src/refactoring/opportunity-rows.tsx
+++ b/packages/ui/src/refactoring/opportunity-rows.tsx
@@ -74,7 +74,11 @@ const EFFORT_WORD: Record<string, string> = {
  * only cell whose content has no natural width.
  */
 const GRID =
-  "grid grid-cols-[minmax(0,1fr)_auto] gap-x-5 gap-y-2 px-3 " +
+  // Below `lg` the first track is fixed rather than `1fr` against an `auto`
+  // sibling: each row is its own grid, so an `auto` second track sized to its
+  // own row and left the labels on a ragged edge, wrapping the type mid-phrase
+  // on the wider rows only.
+  "grid grid-cols-[8.5rem_minmax(0,1fr)] gap-x-5 gap-y-2 px-3 " +
   "lg:grid-cols-[116px_minmax(0,1fr)_150px_104px_96px_32px]";
 
 export function OpportunityRows({


### PR DESCRIPTION
Below `lg` the opportunity row grid paired a `1fr` track with an `auto` one:

```
grid-cols-[minmax(0,1fr)_auto]
```

Every row is its own grid, so the `auto` track sized to that row's own content
and the `1fr` track took whatever was left. Rows therefore disagreed about where
their columns started, and on the wider rows the squeezed first track broke the
refactoring type across two lines mid-phrase ("Extract" / "Method") while
narrower rows kept it on one.

The first track is a fixed width below `lg` now, so every row starts its labels
and its values at the same place. The `lg` grid and every desktop width are
unchanged.

## Verification

Checked by eye at 390, 1200, 1440 and 2048, in both themes, against a real
582-opportunity board. The 390 stacked layout now aligns row to row; 1200/1440/
2048 are pixel-identical to before, which is expected since only the sub-`lg`
track list moved.

Gates: 1,520 shared UI tests, 45 VS Code webview tests, type-check clean across
all workspaces, contrast 74 pairs 0 failures. The no-raw-hex gate reports the
same four pre-existing lines in `refactoring/` as it does on `main`; this adds
none.
