### PR TITLE
fix(ui): band the workspace health score on the same ladder the repo pages use

### DIFF
--- a/packages/ui/__tests__/overview/repo-rows.test.tsx
+++ b/packages/ui/__tests__/overview/repo-rows.test.tsx
@@ -63,20 +63,33 @@ describe("RepoRows", () => {
     expect(screen.getByText("—")).toBeTruthy();
   });
 
-  it("bands the score on the canonical three-band ladder", () => {
+  it("bands the score on the same five-step ladder the repo pages use", () => {
     render(
       <RepoRows
         repos={[
           row({ id: "a", name: "alpha", health: 9.1 }),
-          row({ id: "b", name: "beta", health: 5.0 }),
-          row({ id: "c", name: "gamma", health: 3.0 }),
+          row({ id: "b", name: "beta", health: 7.4 }),
+          row({ id: "c", name: "gamma", health: 5.0 }),
+          row({ id: "d", name: "delta", health: 3.6 }),
+          row({ id: "e", name: "epsilon", health: 3.0 }),
         ]}
       />,
     );
 
-    expect(screen.getByText("Healthy")).toBeTruthy();
-    expect(screen.getByText("Warning")).toBeTruthy();
-    expect(screen.getByText("Alert")).toBeTruthy();
+    expect(screen.getByText("Excellent")).toBeTruthy();
+    expect(screen.getByText("Good")).toBeTruthy();
+    expect(screen.getByText("Fair")).toBeTruthy();
+    expect(screen.getByText("Needs work")).toBeTruthy();
+    expect(screen.getByText("Critical")).toBeTruthy();
+  });
+
+  // The bug this guards: 7.4 read amber "Warning" in the workspace list and
+  // green "Good" the moment you opened the same repo.
+  it("reads a mid-seven score green, as the repo overview does", () => {
+    render(<RepoRows repos={[row({ health: 7.4 })]} />);
+
+    expect(screen.getByText("Good")).toBeTruthy();
+    expect(screen.queryByText("Warning")).toBeNull();
   });
 
   it("does not quote figures for a repo that was never indexed", () => {

--- a/packages/ui/src/overview/repo-rows.tsx
+++ b/packages/ui/src/overview/repo-rows.tsx
@@ -1,8 +1,7 @@
 import * as React from "react";
-import { bandForScore, HEALTH_BAND_LABEL } from "@repowise-dev/types/health";
 import type { RepoIndexStatus } from "@repowise-dev/types/repos";
-import { healthInk } from "../health/tokens";
 import { formatNumber, formatRelativeTime } from "../lib/format";
+import { healthBand } from "./health-lede";
 import { RepoAvatar } from "./repo-avatar";
 
 export interface RepoRow {
@@ -101,10 +100,11 @@ function figuresFor(repo: RepoRow): string[] {
  * the ribbon above it.
  *
  * Health leads the right-hand column because it is the figure that decides
- * which repo you open. It is painted on `bandForScore`, the canonical three
- * bands, rather than the five-step `healthBand` reading: that one belongs to a
- * lede, where nothing adjacent contradicts it, and a column of rows is the
- * case where two ladders visibly disagree.
+ * which repo you open. It is painted on the five-step `healthBand`, the same
+ * reading the repo overview and the code health page use, so the number that
+ * sends you into a repo means there what it meant here. This row previously
+ * used the three-band `bandForScore`, which made one repo read amber in the
+ * list and green the moment you opened it.
  */
 export function RepoRows({ repos, LinkComponent, actionsFor }: RepoRowsProps) {
   const A = LinkComponent ?? "a";
@@ -115,7 +115,7 @@ export function RepoRows({ repos, LinkComponent, actionsFor }: RepoRowsProps) {
       {repos.map((repo) => {
         const figures = figuresFor(repo);
         const actions = actionsFor?.(repo);
-        const band = repo.health === null ? null : bandForScore(repo.health);
+        const band = repo.health === null ? null : healthBand(repo.health);
 
         return (
           <li key={repo.id} className="group">
@@ -177,15 +177,15 @@ export function RepoRows({ repos, LinkComponent, actionsFor }: RepoRowsProps) {
                     <>
                       <p
                         className="mt-1 text-[22px] font-semibold leading-none tabular-nums"
-                        style={{ color: healthInk(repo.health) }}
+                        style={{ color: band.color }}
                       >
                         {repo.health.toFixed(1)}
                       </p>
                       <p
                         className="mt-1 text-[11px]"
-                        style={{ color: healthInk(repo.health) }}
+                        style={{ color: band.color }}
                       >
-                        {HEALTH_BAND_LABEL[band]}
+                        {band.label}
                       </p>
                     </>
                   )}


### PR DESCRIPTION
## What

The workspace list painted each repository's health with `bandForScore`, the three-band ladder where Healthy starts at 8.0. The repository overview and the code health page both read the five-step `healthBand`, where Good starts at 6.5.

A repository scoring 7.4 therefore read amber "Warning" in the list and green "Good" the moment you opened it. That is the one comparison the list exists to support.

## How

Point `RepoRows` at `healthBand`, so the figure that decides which repository you open means the same thing on both sides of the click.

`bandForScore` is untouched and still backs the file, treemap, KPI and security surfaces.

## Verification

`packages/ui` suite green. The row test now pins all five steps, plus a regression case asserting a mid-seven score reads green rather than amber.