### PR TITLE
fix(ui): lift the chat dock only where the graph controls are actually under it

### DIFF
--- a/packages/web/src/components/chat/repository-chat-dock.test.tsx
+++ b/packages/web/src/components/chat/repository-chat-dock.test.tsx
@@ -28,11 +28,24 @@ vi.mock("./repository-chat-provider", () => ({
 }));
 
 describe("RepositoryChatDock", () => {
-  it("clears the full graph control stack", () => {
+  it("clears the full graph control stack on the Map tab", () => {
     expect(REPOSITORY_GRAPH_DOCK_INSET).toBe("12.5rem");
+    // No `?view=` is the Map tab's landing state, and both graph scopes are it.
     expect(getRepositoryDockCollisionInset("architecture")).toBe("12.5rem");
-    expect(getRepositoryDockCollisionInset("graph")).toBe("12.5rem");
+    expect(getRepositoryDockCollisionInset("architecture", "communities")).toBe("12.5rem");
+    expect(getRepositoryDockCollisionInset("architecture", "files")).toBe("12.5rem");
     expect(getRepositoryDockCollisionInset("health")).toBeUndefined();
+  });
+
+  it("does not lift the dock where nothing is under it", () => {
+    // The Knowledge Graph anchors its only control bottom-LEFT, and these
+    // Architecture tabs render tables with no canvas. Lifting the pill 200px
+    // on any of them is dead space.
+    expect(getRepositoryDockCollisionInset("graph")).toBeUndefined();
+    expect(getRepositoryDockCollisionInset("architecture", "coupling")).toBeUndefined();
+    expect(getRepositoryDockCollisionInset("architecture", "packages")).toBeUndefined();
+    expect(getRepositoryDockCollisionInset("architecture", "symbols")).toBeUndefined();
+    expect(getRepositoryDockCollisionInset("architecture", "deps")).toBeUndefined();
   });
 
   it("does not mount duplicate chat UI on the full chat route", () => {

--- a/packages/web/src/components/chat/repository-chat-dock.tsx
+++ b/packages/web/src/components/chat/repository-chat-dock.tsx
@@ -2,7 +2,7 @@
 
 import useSWR from "swr";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { ChatDock, getArtifactSourceTarget } from "@repowise-dev/ui/chat";
 import { getProviders } from "@/lib/api/providers";
 import { setConversationArtifactPinned } from "@/lib/api/chat";
@@ -15,10 +15,30 @@ import { useRepositoryChat } from "./repository-chat-provider";
 // five controls and spacing). Keep a small measured clearance above it.
 export const REPOSITORY_GRAPH_DOCK_INSET = "12.5rem";
 
-export function getRepositoryDockCollisionInset(kind: string) {
-  return kind === "architecture" || kind === "graph"
-    ? REPOSITORY_GRAPH_DOCK_INSET
-    : undefined;
+/** Architecture `?view=` values that render a table, not the Sigma canvas.
+ *  `deps` is the legacy spelling of `packages`. Absent or unrecognised means
+ *  the Map tab, which is the default landing view. */
+const ARCHITECTURE_VIEWS_WITHOUT_CANVAS = new Set([
+  "coupling",
+  "packages",
+  "symbols",
+  "deps",
+]);
+
+/**
+ * Lift the dock only where something is actually beneath it.
+ *
+ * The clearance exists for exactly one element: Sigma's zoom/fit/layout stack,
+ * anchored bottom-right on Architecture's Map tab. It used to key off the chat
+ * context kind alone, which raised the pill 200px on two surfaces with nothing
+ * under it — the Knowledge Graph, whose only bottom-anchored control sits
+ * bottom-LEFT, and Architecture's Coupling, Third-party and Symbols tabs,
+ * which render tables and mount no canvas at all.
+ */
+export function getRepositoryDockCollisionInset(kind: string, view?: string) {
+  if (kind !== "architecture") return undefined;
+  if (view && ARCHITECTURE_VIEWS_WITHOUT_CANVAS.has(view)) return undefined;
+  return REPOSITORY_GRAPH_DOCK_INSET;
 }
 
 export function RepositoryChatDock() {
@@ -35,6 +55,7 @@ type RepositoryChatValue = ReturnType<typeof useRepositoryChat>;
 
 function ConnectedRepositoryChatDock({ chat }: { chat: RepositoryChatValue }) {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const { data: providers } = useSWR(
     `providers:${chat.repoId}`,
     () => getProviders(chat.repoId),
@@ -42,7 +63,10 @@ function ConnectedRepositoryChatDock({ chat }: { chat: RepositoryChatValue }) {
   );
   const anyConfigured =
     providers === undefined || providers.providers.some((provider) => provider.configured);
-  const collisionInset = getRepositoryDockCollisionInset(chat.pageContext.kind);
+  const collisionInset = getRepositoryDockCollisionInset(
+    chat.pageContext.kind,
+    searchParams.get("view") ?? undefined,
+  );
 
   return (
     <ChatDock


### PR DESCRIPTION
## What

The dock reserves a 200px bottom clearance for one element: Sigma's zoom / fit / layout stack, anchored bottom-right on Architecture's Map tab. The clearance was keyed on the chat context kind alone, so it also fired on every other surface sharing that kind and lifted the pill off the bottom of two that have nothing beneath it.

- Knowledge Graph renders `ZoomCanvas`, whose only bottom-anchored control is bottom-left. The clearance there was dead space.
- Architecture's Coupling, Third-party and Symbols tabs render tables and mount no canvas, yet share the route's kind.

## How

Key the clearance on the resolved `?view=` as well, so it applies on the Map tab and nowhere else. The legacy `/c4`, `/graph` and `/zoom` spellings are redirects and never mount a dock, so they need no handling.

## Verification

Measured against a running dev server: `knowledge-graph`, `?view=coupling` and `?view=symbols` report a 1rem offset; Architecture's Map still reports 12.5rem. Unit tests cover both the Map cases and the four that must not lift.