### PR TITLE
fix(ui): settle the dark overlay plane and the wells nested inside it

### DIFF
--- a/packages/ui/src/brand.ts
+++ b/packages/ui/src/brand.ts
@@ -45,7 +45,7 @@ export const LIGHT = {
 export const DARK = {
   bgRoot: "#0e0e0f",
   bgSurface: "#141416",
-  bgElevated: "#1c1c1f",
+  bgElevated: "#191a1c",
   bgInset: "#0a0a0b",
   textPrimary: "#f2f2f3",
   textSecondary: "#b4b4b9",

--- a/packages/ui/src/chat/chat-dock.tsx
+++ b/packages/ui/src/chat/chat-dock.tsx
@@ -296,7 +296,7 @@ export function ChatDock({
       <aside
         style={dockOffsetStyle}
         aria-label="Repository chat"
-        className="fixed inset-x-3 bottom-[max(var(--chat-dock-bottom-offset),env(safe-area-inset-bottom))] z-[calc(var(--z-toast)-1)] mx-auto w-auto max-w-[640px] rounded-2xl border border-[var(--color-border-default)] bg-[var(--color-bg-overlay)] px-3 pb-3 pt-2 shadow-[var(--shadow-lg)] sm:inset-x-auto sm:right-[max(1rem,env(safe-area-inset-right))] sm:w-[min(420px,calc(100vw-2rem))]"
+        className="[--color-bg-inset:var(--color-bg-inset-on-overlay)] fixed inset-x-3 bottom-[max(var(--chat-dock-bottom-offset),env(safe-area-inset-bottom))] z-[calc(var(--z-toast)-1)] mx-auto w-auto max-w-[640px] rounded-2xl border border-[var(--color-border-default)] bg-[var(--color-bg-overlay)] px-3 pb-3 pt-2 shadow-[var(--shadow-lg)] sm:inset-x-auto sm:right-[max(1rem,env(safe-area-inset-right))] sm:w-[min(420px,calc(100vw-2rem))]"
       >
         <div className="flex min-w-0 items-center gap-1">
           <p className="min-w-0 flex-1 truncate pl-1 text-xs text-[var(--color-text-tertiary)]">
@@ -388,7 +388,7 @@ export function ChatDock({
           onInteractOutside={(event) => {
             if (!isMobile) event.preventDefault();
           }}
-          className="fixed inset-x-0 bottom-0 z-[var(--z-modal)] flex h-[min(88dvh,760px)] flex-col overflow-hidden rounded-t-2xl border-t border-[var(--color-border-default)] bg-[var(--color-bg-overlay)] pb-[env(safe-area-inset-bottom)] shadow-[var(--shadow-xl)] outline-none md:inset-x-auto md:bottom-[max(var(--chat-dock-bottom-offset),env(safe-area-inset-bottom))] md:right-[max(1rem,env(safe-area-inset-right))] md:w-[min(520px,calc(100vw-2rem))] md:rounded-2xl md:border xl:w-[min(580px,calc(100vw-2rem))]"
+          className="[--color-bg-inset:var(--color-bg-inset-on-overlay)] fixed inset-x-0 bottom-0 z-[var(--z-modal)] flex h-[min(88dvh,760px)] flex-col overflow-hidden rounded-t-2xl border-t border-[var(--color-border-default)] bg-[var(--color-bg-overlay)] pb-[env(safe-area-inset-bottom)] shadow-[var(--shadow-xl)] outline-none md:inset-x-auto md:bottom-[max(var(--chat-dock-bottom-offset),env(safe-area-inset-bottom))] md:right-[max(1rem,env(safe-area-inset-right))] md:w-[min(520px,calc(100vw-2rem))] md:rounded-2xl md:border xl:w-[min(580px,calc(100vw-2rem))]"
         >
           <DialogPrimitive.Title className="sr-only">
             Repository chat

--- a/packages/ui/src/ui/dialog.tsx
+++ b/packages/ui/src/ui/dialog.tsx
@@ -34,7 +34,11 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-[var(--z-modal)] grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border border-[var(--color-border-default)] bg-[var(--color-bg-overlay)] p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] rounded-xl",
+        // A dialog is a floating plane, so any well nested inside it recesses
+      // from the modal rather than from the page. Rebinding the token here
+      // rather than in each body means a code block, prompt preview or command
+      // output inside a dialog needs no styling of its own.
+      "[--color-bg-inset:var(--color-bg-inset-on-overlay)] fixed left-[50%] top-[50%] z-[var(--z-modal)] grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border border-[var(--color-border-default)] bg-[var(--color-bg-overlay)] p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] rounded-xl",
         className,
       )}
       {...props}

--- a/packages/ui/styles/globals.css
+++ b/packages/ui/styles/globals.css
@@ -73,6 +73,10 @@
   --color-bg-elevated: #fbf4ee;
   --color-bg-overlay: #ffffff;
   --color-bg-inset: #f4eae1;
+  /* A well measured from the overlay plane rather than from root. Light mode
+     needs no separate value: overlay is white, so the same warm inset already
+     recesses correctly inside a dialog. See the dark block for why it exists. */
+  --color-bg-inset-on-overlay: #f4eae1;
 
   /* Borders — plum-tinted hairlines */
   --color-border-default: rgba(88, 67, 108, 0.12);
@@ -399,12 +403,27 @@
      three panels, recessed between two lighter ones — a trench, which is the
      opposite of how a reading UI should stack. And near-black gives the accent
      and the semantic colours somewhere to go: the same #f59520 that looked
-     muddy on graphite carries on this ground. */
+     muddy on graphite carries on this ground.
+
+     Elevated and overlay used to sit at #1c1c1f and #26262a. Overlay four
+     steps clear of root made every dialog and the chat dock read as a light
+     grey card floating on a near-black app rather than as the same material
+     lifted. They are compressed here so the ramp still climbs monotonically
+     but a modal reads as a raised plane, not a different palette.
+
+     `inset` stays below root: a code well recessed into the page is correct,
+     and that is where most of them are. It is wrong only when the well is
+     nested inside a floating panel, where dropping from overlay to #0a0a0b is
+     a cliff and the box reads as pure black. `inset-on-overlay` is that same
+     recess measured from the overlay plane instead of from root; dialogs
+     repoint `--color-bg-inset` at it so a well inside a modal sits just under
+     the modal rather than under the page. */
   --color-bg-root: #0e0e0f;
   --color-bg-surface: #141416;
-  --color-bg-elevated: #1c1c1f;
-  --color-bg-overlay: #26262a;
+  --color-bg-elevated: #191a1c;
+  --color-bg-overlay: #1f1f23;
   --color-bg-inset: #0a0a0b;
+  --color-bg-inset-on-overlay: #141417;
 
   /* Neutral hairlines so card / sidebar / table edges read on the gray base.
      Lighter than before: the same alpha reads considerably louder against
@@ -492,7 +511,7 @@
      These are literals rather than var() references because the canvas
      renderer reads them into WebGL, but they have to move with the surface
      ramp or the cards float above a ground that has dropped beneath them. */
-  --color-zoom-card-fill: #1c1c1f; /* leaf card (bg-elevated) */
+  --color-zoom-card-fill: #191a1c; /* leaf card (bg-elevated) */
   --color-zoom-card-fill-2: #141416; /* container card (bg-surface) */
   --color-zoom-card-text: #f2f2f3;
   --color-zoom-card-border: rgba(255, 255, 255, 0.10);


### PR DESCRIPTION
## What

Two complaints, one cause, and it is in the tokens rather than in any component. Dialogs and the chat dock already use the tokens the plane ladder prescribes and override no colours.

The dark ramp ran:

```
root #0e0e0f   surface #141416   elevated #1c1c1f   overlay #26262a   inset #0a0a0b
```

Overlay sat four steps clear of root, so every dialog and the chat panel read as a light grey card on a near-black app rather than the same material lifted. Separately, a well inside one of those panels dropped from `#26262a` to `#0a0a0b`, a 28-point cliff, so a generated prompt or code block rendered as pure black.

## How

Compress elevated and overlay to `#191a1c` and `#1f1f23`. The ramp still climbs monotonically, but a modal reads as a raised plane instead of a different palette.

Add `--color-bg-inset-on-overlay`, the same recess measured from the overlay plane, and rebind `--color-bg-inset` to it on the dialog primitive and the chat panels. A code block, prompt preview or command output inside them now recesses from the panel rather than from the page, with no per-body styling. `--color-bg-inset` is unchanged for wells on the page, which is where most of them are.

The two non-CSS mirrors of the ramp move in the same change: `brand.ts` `bgElevated`, and the zoom canvas's WebGL card fill literal.

## Verification

`packages/ui` suite green, including the token drift check. Values confirmed in the served stylesheet in both themes.