### PR TITLE
feat(ui): give the AI prompt modal hairlines instead of a filled well

### DIFF
--- a/packages/ui/src/health/ai-prompt-modal.tsx
+++ b/packages/ui/src/health/ai-prompt-modal.tsx
@@ -110,26 +110,35 @@ export function AiPromptModal({
         </DialogHeader>
 
         <div className="space-y-4">
-          <div className="space-y-2">
-            <p className="font-mono text-[10px] uppercase tracking-wider text-[var(--color-text-tertiary)]">
-              Target agent
-            </p>
-            <div className="w-fit">
-              <ViewToggle
-                value={flavor}
-                options={FLAVORS.map((f) => ({ value: f.value, label: f.label }))}
-                onChange={setFlavor}
-              />
+          {/* Full-bleed hairlines rather than a bordered, filled well. The
+              prompt is the thing you opened this to read, not an object you
+              can select or act on, so it does not earn a container — and a
+              second plane inside a floating panel is one plane too many. The
+              rules run to the modal's edge (`-mx-6` against its `p-6`) so they
+              read as the page's section dividers do, rather than as a box that
+              happens to have lost its sides. */}
+          <div className="-mx-6 divide-y divide-[var(--color-border-default)] border-y border-[var(--color-border-default)]">
+            <div className="space-y-2 px-6 py-4">
+              <p className="font-mono text-[10px] uppercase tracking-wider text-[var(--color-text-tertiary)]">
+                Target agent
+              </p>
+              <div className="w-fit">
+                <ViewToggle
+                  value={flavor}
+                  options={FLAVORS.map((f) => ({ value: f.value, label: f.label }))}
+                  onChange={setFlavor}
+                />
+              </div>
+              <p className="text-xs leading-snug text-[var(--color-text-tertiary)]">
+                {FLAVORS.find((f) => f.value === flavor)?.hint}
+              </p>
             </div>
-            <p className="text-xs leading-snug text-[var(--color-text-tertiary)]">
-              {FLAVORS.find((f) => f.value === flavor)?.hint}
-            </p>
-          </div>
 
-          <div className="rounded-md border border-[var(--color-border-default)] bg-[var(--color-bg-inset)] max-h-[420px] overflow-y-auto">
-            <pre className="px-3 py-2 font-mono text-xs leading-relaxed text-[var(--color-text-primary)] whitespace-pre-wrap break-words">
-              {prompt}
-            </pre>
+            <div className="max-h-[420px] overflow-y-auto px-6 py-4">
+              <pre className="font-mono text-xs leading-relaxed text-[var(--color-text-primary)] whitespace-pre-wrap break-words">
+                {prompt}
+              </pre>
+            </div>
           </div>
 
           <div className="flex flex-wrap items-center justify-between gap-2 text-xs text-[var(--color-text-tertiary)]">


### PR DESCRIPTION
## What

The generated prompt sat in a bordered box on `--color-bg-inset`. A container teaches the reader that the thing inside can be selected, opened or acted on, and this one cannot: it is the text you opened the modal to read. Nesting a second filled plane inside a floating panel also gave the modal three grounds in six inches of vertical space.

## How

Separate the regions with a rule and space, as the pages do. The hairlines run to the modal's edge (`-mx-6` against the dialog's `p-6`) so they read as section dividers rather than a box that lost its sides, and the prompt sits directly on the modal plane.

Lands on all 13 `AiPromptModal` call sites.

## Verification

`packages/ui` suite green. Checked in both themes, including the scrolling case for a long prompt.