### PR TITLE
feat(ui): let the Ask Repowise dock be dismissed, and brought back from settings

### DIFF
--- a/packages/ui/src/chat/chat-dock.tsx
+++ b/packages/ui/src/chat/chat-dock.tsx
@@ -126,6 +126,11 @@ export interface ChatDockProps {
   onSend: (text: string, context?: ChatContext) => void | Promise<void>;
   onCancel: () => void;
   suppressed?: boolean;
+  /** Hide the dock entirely. The host owns the preference and where it is
+   *  stored: this component's own persisted state is keyed per conversation,
+   *  so a visibility choice kept there would reset on the next new chat.
+   *  Omit to render no dismiss control at all. */
+  onDismiss?: () => void;
   modelSelectorSlot?: ReactNode;
   historySlot?: ReactNode;
   sendDisabled?: boolean;
@@ -159,6 +164,7 @@ export function ChatDock({
   onSend,
   onCancel,
   suppressed = false,
+  onDismiss,
   modelSelectorSlot,
   historySlot,
   sendDisabled = false,
@@ -248,7 +254,7 @@ export function ChatDock({
     return (
       <div
         style={dockOffsetStyle}
-        className="fixed bottom-[max(var(--chat-dock-bottom-offset),env(safe-area-inset-bottom))] right-[max(1rem,env(safe-area-inset-right))] z-[calc(var(--z-toast)-1)]"
+        className="group/dock fixed bottom-[max(var(--chat-dock-bottom-offset),env(safe-area-inset-bottom))] right-[max(1rem,env(safe-area-inset-right))] z-[calc(var(--z-toast)-1)]"
       >
         <button
           ref={minimizedButtonRef}
@@ -284,6 +290,22 @@ export function ChatDock({
             </span>
           )}
         </button>
+        {onDismiss && (
+          /* Quiet until wanted: the dismiss is the kind of control you look
+             for only once you are already annoyed, and a permanent second
+             button on the pill would make the thing louder to solve the
+             complaint that it is too loud. Focusable while transparent, so
+             the keyboard path is not gated on hover. */
+          <button
+            type="button"
+            onClick={onDismiss}
+            aria-label="Hide Ask Repowise"
+            title="Hide Ask Repowise. Bring it back in Settings."
+            className="absolute -right-1 -top-1 flex h-5 w-5 items-center justify-center rounded-full border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] text-[var(--color-text-tertiary)] opacity-0 shadow-[var(--shadow-md)] transition-opacity hover:text-[var(--color-text-primary)] focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent-primary)] group-hover/dock:opacity-100 motion-reduce:transition-none"
+          >
+            <X className="h-3 w-3" />
+          </button>
+        )}
         <span className="sr-only" role="status" aria-live="polite">
           {statusText ?? ""}
         </span>
@@ -327,6 +349,18 @@ export function ChatDock({
           >
             <Minus className="h-4 w-4" />
           </Button>
+          {onDismiss && (
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8"
+              onClick={onDismiss}
+              aria-label="Hide Ask Repowise"
+              title="Hide Ask Repowise. Bring it back in Settings."
+            >
+              <X className="h-4 w-4" />
+            </Button>
+          )}
         </div>
         {activeContext && activeContext.kind !== "repository" && (
           <ChatContextIndicator

--- a/packages/web/src/components/chat/repository-chat-dock.tsx
+++ b/packages/web/src/components/chat/repository-chat-dock.tsx
@@ -10,6 +10,8 @@ import { pageHref } from "@/lib/utils/page-href";
 import { ModelSelector } from "./model-selector";
 import { ConversationHistory } from "./conversation-history";
 import { useRepositoryChat } from "./repository-chat-provider";
+import { useChatDockHidden } from "./use-chat-dock-hidden";
+import { setChatDockHidden } from "@/lib/config";
 
 // Sigma's worst-case bottom-right stack is ~197px tall (layout status plus
 // five controls and spacing). Keep a small measured clearance above it.
@@ -23,10 +25,16 @@ export function getRepositoryDockCollisionInset(kind: string) {
 
 export function RepositoryChatDock() {
   const chat = useRepositoryChat();
+  const hidden = useChatDockHidden();
 
   // The full chat page already renders this controller's complete transcript.
   // Keep the dock out of both the visual and accessibility trees there.
   if (chat.pageContext.kind === "chat") return null;
+
+  // Bail before the connected component rather than passing `suppressed`: that
+  // prop returns null from inside ChatDock, which means the provider fetch and
+  // the dock's own state still run for something nobody can see.
+  if (hidden) return null;
 
   return <ConnectedRepositoryChatDock chat={chat} />;
 }
@@ -76,6 +84,7 @@ function ConnectedRepositoryChatDock({ chat }: { chat: RepositoryChatValue }) {
           : `/repos/${chat.repoId}/chat`,
       )}
       {...(collisionInset ? { collisionInset } : {})}
+      onDismiss={() => setChatDockHidden(true)}
       sendDisabled={!anyConfigured}
       sendDisabledReason={
         <span>

--- a/packages/web/src/components/chat/use-chat-dock-hidden.test.tsx
+++ b/packages/web/src/components/chat/use-chat-dock-hidden.test.tsx
@@ -1,0 +1,66 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { render, screen, act, cleanup } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { config, setChatDockHidden } from "@/lib/config";
+import { useChatDockHidden } from "./use-chat-dock-hidden";
+
+function Probe() {
+  return <span>{useChatDockHidden() ? "hidden" : "shown"}</span>;
+}
+
+describe("useChatDockHidden", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  // This config wires no RTL auto-cleanup, so without this each test inherits
+  // the previous test's mounted probe and every query finds two of everything.
+  afterEach(cleanup);
+
+  it("shows the dock when nothing has been stored", () => {
+    render(<Probe />);
+    expect(screen.getByText("shown")).toBeTruthy();
+  });
+
+  it("reads a stored preference after mount", () => {
+    config.setChatDockHidden(true);
+    render(<Probe />);
+    expect(screen.getByText("hidden")).toBeTruthy();
+  });
+
+  it("reacts to a change made in this tab", () => {
+    // The bug this guards: `localStorage` fires `storage` only in OTHER tabs,
+    // so without the custom event the settings toggle and the dock disagree
+    // until a reload.
+    render(<Probe />);
+    expect(screen.getByText("shown")).toBeTruthy();
+
+    act(() => setChatDockHidden(true));
+    expect(screen.getByText("hidden")).toBeTruthy();
+
+    act(() => setChatDockHidden(false));
+    expect(screen.getByText("shown")).toBeTruthy();
+  });
+
+  it("reacts to a change made in another tab", () => {
+    render(<Probe />);
+
+    act(() => {
+      config.setChatDockHidden(true);
+      window.dispatchEvent(new StorageEvent("storage"));
+    });
+
+    expect(screen.getByText("hidden")).toBeTruthy();
+  });
+
+  it("survives a round trip through storage", () => {
+    // An unset key must read as shown, not as an empty-string surprise.
+    expect(config.getChatDockHidden()).toBe(false);
+    config.setChatDockHidden(true);
+    expect(config.getChatDockHidden()).toBe(true);
+    config.setChatDockHidden(false);
+    expect(config.getChatDockHidden()).toBe(false);
+  });
+});

--- a/packages/web/src/components/chat/use-chat-dock-hidden.ts
+++ b/packages/web/src/components/chat/use-chat-dock-hidden.ts
@@ -1,0 +1,34 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { CHAT_DOCK_VISIBILITY_EVENT, config } from "@/lib/config";
+
+/**
+ * Whether the "Ask Repowise" dock is hidden, kept in step with the settings
+ * toggle without a reload.
+ *
+ * Starts `false` and reads the stored value after mount rather than during
+ * render: `localStorage` does not exist on the server, so seeding from it
+ * directly would make the server and the first client render disagree and
+ * flash the dock away on hydration.
+ *
+ * Two listeners, because they cover different cases. `storage` fires only in
+ * OTHER tabs, so it keeps a second window honest; the custom event covers the
+ * tab that made the change, where `storage` stays silent.
+ */
+export function useChatDockHidden(): boolean {
+  const [hidden, setHidden] = useState(false);
+
+  useEffect(() => {
+    const sync = () => setHidden(config.getChatDockHidden());
+    sync();
+    window.addEventListener(CHAT_DOCK_VISIBILITY_EVENT, sync);
+    window.addEventListener("storage", sync);
+    return () => {
+      window.removeEventListener(CHAT_DOCK_VISIBILITY_EVENT, sync);
+      window.removeEventListener("storage", sync);
+    };
+  }, []);
+
+  return hidden;
+}

--- a/packages/web/src/components/settings/display-section.tsx
+++ b/packages/web/src/components/settings/display-section.tsx
@@ -15,18 +15,21 @@ import {
   SaveIndicator,
   type SaveState,
 } from "@repowise-dev/ui/settings";
+import { Switch } from "@repowise-dev/ui/ui/switch";
 import { DEFAULT_WEEKEND_PRESET, WEEKEND_PRESETS } from "@repowise-dev/ui/stats";
-import { config } from "@/lib/config";
+import { config, setChatDockHidden } from "@/lib/config";
 
 /** Reader-local display preferences for the stats surfaces. */
 export function DisplaySection() {
   const [weekend, setWeekend] = useState(DEFAULT_WEEKEND_PRESET.id);
+  const [dockShown, setDockShown] = useState(true);
   const [saveState, setSaveState] = useState<SaveState>("idle");
   const savedTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Read after mount so SSR and the first client render agree.
   useEffect(() => {
     setWeekend(config.getWeekend() || DEFAULT_WEEKEND_PRESET.id);
+    setDockShown(!config.getChatDockHidden());
   }, []);
 
   useEffect(
@@ -36,18 +39,30 @@ export function DisplaySection() {
     [],
   );
 
-  function handleChange(v: string) {
-    setWeekend(v);
-    config.setWeekend(v);
+  function markSaved() {
     setSaveState("saved");
     if (savedTimer.current) clearTimeout(savedTimer.current);
     savedTimer.current = setTimeout(() => setSaveState("idle"), 2000);
   }
 
+  function handleChange(v: string) {
+    setWeekend(v);
+    config.setWeekend(v);
+    markSaved();
+  }
+
+  function handleDockChange(shown: boolean) {
+    setDockShown(shown);
+    // Goes through the helper, not `config` directly: the dock is mounted on a
+    // different route and needs the event to notice.
+    setChatDockHidden(!shown);
+    markSaved();
+  }
+
   return (
     <OverviewSection
       title="Display"
-      description="How stats are presented in this browser. Nothing here changes the index."
+      description="What this browser shows and how it presents it. Nothing here changes the index."
       action={<SaveIndicator state={saveState} />}
     >
       <SettingsRows>
@@ -67,6 +82,16 @@ export function DisplaySection() {
               ))}
             </SelectContent>
           </Select>
+        </SettingsRow>
+        <SettingsRow
+          label="Ask Repowise"
+          hint="The chat pill in the bottom-right of every repository page. Hiding it does not affect the full chat page."
+        >
+          <Switch
+            checked={dockShown}
+            onCheckedChange={handleDockChange}
+            aria-label="Show the Ask Repowise chat pill"
+          />
         </SettingsRow>
       </SettingsRows>
     </OverviewSection>

--- a/packages/web/src/lib/config.ts
+++ b/packages/web/src/lib/config.ts
@@ -11,6 +11,7 @@ const KEYS = {
   model: "repowise_default_model",
   embedder: "repowise_embedder",
   weekend: "repowise_weekend",
+  chatDockHidden: "repowise_chat_dock_hidden",
 } as const;
 
 function read(key: string): string {
@@ -46,4 +47,23 @@ export const config = {
   /** Weekend-days preset id; "" means unset, which resolves to Sat/Sun. */
   getWeekend: () => read(KEYS.weekend),
   setWeekend: (v: string) => write(KEYS.weekend, v),
+
+  /** Whether the "Ask Repowise" dock is hidden. Lives here rather than in the
+   *  dock's own persisted state, which is keyed per repo AND per conversation
+   *  and would therefore forget the choice on the next new chat. Default is
+   *  shown, so an unset value reads as false. */
+  getChatDockHidden: () => read(KEYS.chatDockHidden) === "1",
+  setChatDockHidden: (v: boolean) => write(KEYS.chatDockHidden, v ? "1" : ""),
 };
+
+/** Fires when the dock's visibility changes in this tab. `localStorage` only
+ *  notifies OTHER tabs via `storage`, so without this the dock and the settings
+ *  toggle would not agree until a reload. */
+export const CHAT_DOCK_VISIBILITY_EVENT = "repowise:chat-dock-visibility";
+
+export function setChatDockHidden(hidden: boolean): void {
+  config.setChatDockHidden(hidden);
+  if (typeof window !== "undefined") {
+    window.dispatchEvent(new Event(CHAT_DOCK_VISIBILITY_EVENT));
+  }
+}


### PR DESCRIPTION
## What

The dock had a three-step ladder with no bottom rung. Both the compact panel's minus and the expanded panel's X are labelled "Minimize" and only return you to the pill, so the pill itself was unconditional on every repository page. The X in particular reads as close and does not close.

`ChatDock` already declared a `suppressed` prop that returns null, and no host passed it.

## How

Add an `onDismiss` callback, a control on the pill that stays transparent until hover or focus, and an explicit Hide beside Minimize in the compact header. A permanent second button on the pill would make it louder in order to answer the complaint that it is too loud, so the affordance appears when someone is already looking for it while remaining tab-reachable.

The preference lives in `config.ts`, not in the dock's own persisted state: that key is scoped per repository and per conversation, so a visibility choice stored there would be forgotten by the next new conversation.

The host returns before the connected component rather than passing `suppressed` down. `suppressed` returns null from inside `ChatDock`, by which point the provider fetch and the dock's own state have already run for something nobody can see.

Restoring it is a switch in Settings, Display. `localStorage` fires `storage` only in other tabs, so a custom event covers the tab that made the change; both are listened for, which also keeps a second window honest.

## Verification

`packages/web` suite green, with five cases over the persistence: the unset default, a stored value read after mount, a change made in this tab, a change made in another tab, and the storage round trip.