### PR TITLE
fix(persistence): give the coverage migration its own revision id

### DIFF
--- a/packages/core/alembic/versions/0060_coverage_mapping_partial.py
+++ b/packages/core/alembic/versions/0060_coverage_mapping_partial.py
@@ -10,8 +10,8 @@ a property of the whole delete-then-insert ingest, so it lives on the table
 Local SQLite stores get the column from the model via ``init_db``'s additive
 schema reconciler; this migration covers the managed Postgres ones.
 
-Revision ID: 0056
-Revises: 0055
+Revision ID: 0060
+Revises: 0059
 Create Date: 2026-08-28
 """
 
@@ -23,8 +23,8 @@ import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers
-revision: str = "0056"
-down_revision: str | None = "0055"
+revision: str = "0060"
+down_revision: str | None = "0059"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 


### PR DESCRIPTION
## What

Two migrations declare `revision = "0056"` with `down_revision = "0055"`:

- `0056_chat_conversation_refinement.py` (#1960, merged 28 August)
- `0056_coverage_mapping_partial.py` (#1955, merged 30 August from a branch cut before the first landed)

`0057` revises `"0056"`, which is no longer a single revision. Alembic resolves one of the two and strands the other as a second head, which breaks two things at once:

- `upgrade head` raises `Multiple head revisions are present for given argument 'head'`
- the migration alembic drops from the chain never runs, so `conversations` reaches head without `pinned` or `deleted_at`

Both failures are live on `main`:

```
FAILED tests/unit/persistence/test_refactoring_opportunity_store.py::test_the_migration_and_the_model_declare_the_same_shape
FAILED tests/unit/server/test_chat_stream_terminal_event.py::test_conversation_refinement_migration_upgrades_sqlite
```

## How

Renumber the coverage migration to `0060` on top of `0059`, and leave the chat migration at `0056`.

That is the order the two were actually applied in: `0056` has been the chat migration in every store migrated since 28 August, and both existing references to the id mean that one — the downgrade target in `test_performance_materialization` and the upgrade target in `test_chat_stream_terminal_event`. `mapping_partial` touches `coverage_files` alone, so nothing between `0056` and `0059` depends on where it sits.

## Verification

`alembic` reports a single head at `0060` and no duplicate-revision warning. The two named tests pass, along with `tests/unit/persistence` (688), `tests/unit/pipeline` and `tests/unit/health/test_coverage_discovery.py` (148).