### PR TITLE
fix(tests): stop `serve` pinning one database for the rest of the session

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 import pytest
@@ -75,6 +76,37 @@ def _no_real_editor_setup():
     mp.setenv("REPOWISE_SKIP_EDITOR_SETUP", "1")
     yield
     mp.undo()
+
+
+@pytest.fixture(autouse=True)
+def _isolate_db_url_env():
+    """Stop one test's database URL from redirecting every later test.
+
+    ``resolve_db_url`` checks ``REPOWISE_DB_URL`` / ``REPOWISE_DATABASE_URL``
+    *before* the explicit ``repo_path`` it is handed, so whatever holds those
+    variables decides where every index write in the process lands.
+
+    ``serve_cmd`` assigns ``REPOWISE_DB_URL`` directly on ``os.environ`` when it
+    finds a ``.repowise/`` beside the cwd, which is right for a real ``serve``
+    process and wrong inside pytest: a test that drives the real ``serve``
+    command in-process leaves the *developer's own* database pinned for the
+    rest of the session, and every later test that indexes a ``tmp_path``
+    fixture repo writes its rows there instead of into its own store. That is
+    how a suite run leaves hundreds of ``repo`` rows, pointing at temp
+    directories, in the checkout you are working in.
+
+    Snapshot and restore rather than pin a value: a test that sets its own URL
+    must keep working, and one that sets none must still fall through to
+    ``<repo>/.repowise/wiki.db``. Only the leak across the test boundary is
+    closed.
+    """
+    saved = {k: os.environ.get(k) for k in ("REPOWISE_DB_URL", "REPOWISE_DATABASE_URL")}
+    yield
+    for key, value in saved.items():
+        if value is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = value
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/cli/test_serve_db_url_isolation.py
+++ b/tests/unit/cli/test_serve_db_url_isolation.py
@@ -1,0 +1,93 @@
+"""`repowise serve` must not pin one database for the rest of a pytest session.
+
+``serve_cmd`` assigns ``REPOWISE_DB_URL`` straight onto ``os.environ`` when a
+``.repowise/`` sits beside the cwd. That is right for a real ``serve``: it is
+one process that serves one store and exits. Inside pytest it is not. Many
+commands share a process, ``resolve_db_url`` consults the environment *before*
+the ``repo_path`` it is handed, and a raw assignment is not undone by anything.
+
+A suite run therefore wrote hundreds of `repo` rows into the developer's own
+``.repowise/wiki.db``, each pointing at a temp fixture directory, and every
+later test that indexed a ``tmp_path`` repo silently measured that database
+instead of its own.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+from click.testing import CliRunner
+
+from repowise.cli.commands import serve_cmd
+
+SENTINEL = "sqlite+aiosqlite:///:memory:"
+
+
+@pytest.fixture
+def stub_serve(monkeypatch) -> None:
+    """Everything `serve` would really do, except touching the database."""
+    monkeypatch.setattr("uvicorn.run", lambda _app, **_kwargs: None)
+    monkeypatch.setattr(serve_cmd, "_load_local_provider_config", lambda: None)
+    monkeypatch.setattr(serve_cmd, "_setup_embedder", lambda: None)
+    monkeypatch.setattr(serve_cmd, "_serve_lock_path", lambda: None)
+    monkeypatch.setattr(serve_cmd, "_find_free_port", lambda _host, port, _label: port)
+    monkeypatch.delenv("REPOWISE_API_KEY", raising=False)
+    monkeypatch.setenv("REPOWISE_HOST", "127.0.0.1")
+
+
+def test_serve_leaves_a_db_url_the_caller_chose_alone(
+    stub_serve: None, monkeypatch, tmp_path
+) -> None:
+    """Auto-detect fills a gap; it must never overrule an explicit choice.
+
+    This is also the shape the fix in ``test_serve_host_env`` relies on: set
+    the variable and the branch is skipped, so ``monkeypatch`` owns the
+    cleanup rather than the command leaking a raw assignment.
+    """
+    (tmp_path / ".repowise").mkdir()
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("REPOWISE_DB_URL", SENTINEL)
+
+    result = CliRunner().invoke(serve_cmd.serve_command, ["--no-ui"])
+
+    assert result.exit_code == 0, result.output
+    assert os.environ["REPOWISE_DB_URL"] == SENTINEL
+
+
+def test_serve_adopts_the_local_store_when_nothing_is_set(
+    stub_serve: None, monkeypatch, tmp_path
+) -> None:
+    """The behaviour that makes the guard necessary, pinned so it stays known.
+
+    Asserting the cleanup from inside this test would prove nothing: the
+    assignment is still live here by design. The test that follows is where it
+    has to be gone.
+    """
+    (tmp_path / ".repowise").mkdir()
+    monkeypatch.chdir(tmp_path)
+    # Deliberately NOT monkeypatch.delenv. monkeypatch records whatever it
+    # touches and restores it at teardown, which would clean up the leak for
+    # us and make this test prove nothing. The real bug happened precisely
+    # because no monkeypatch ever recorded this variable, so the command's raw
+    # assignment had nothing to undo it. Reproduce that: clear it unrecorded
+    # and leave the restoring to the guard under test.
+    os.environ.pop("REPOWISE_DB_URL", None)
+
+    result = CliRunner().invoke(serve_cmd.serve_command, ["--no-ui"])
+
+    assert result.exit_code == 0, result.output
+    assert tmp_path.name in os.environ["REPOWISE_DB_URL"]
+
+
+def test_the_previous_test_did_not_leak_its_db_url() -> None:
+    """The regression itself, and the reason this is a second test function.
+
+    The bug was invisible within the test that caused it and only ever showed
+    up in whatever ran next, so a second assertion in the test above could not
+    have caught it. Ordering is the assertion: pytest runs a module's tests in
+    definition order, and no random-ordering plugin is installed here.
+
+    What restores the variable is the autouse guard in ``tests/conftest.py``.
+    """
+    assert "REPOWISE_DB_URL" not in os.environ

--- a/tests/unit/cli/test_serve_host_env.py
+++ b/tests/unit/cli/test_serve_host_env.py
@@ -31,6 +31,13 @@ def stub_serve(monkeypatch) -> dict:
     # No real sockets: the port probe is not what these tests are about.
     monkeypatch.setattr(serve_cmd, "_find_free_port", lambda _host, port, _label: port)
     monkeypatch.delenv("REPOWISE_API_KEY", raising=False)
+    # The command auto-detects `./.repowise/wiki.db` and assigns
+    # REPOWISE_DB_URL straight onto os.environ. Under CliRunner the cwd is the
+    # developer's own checkout, and a raw assignment outlives the test, so
+    # every later test that indexes a tmp_path repo wrote into it. Setting the
+    # variable here skips that branch and hands the cleanup to monkeypatch,
+    # exactly as REPOWISE_HOST is handled below.
+    monkeypatch.setenv("REPOWISE_DB_URL", "sqlite+aiosqlite:///:memory:")
     # setenv, not delenv: the command assigns REPOWISE_HOST, and only a
     # monkeypatch that recorded the variable will unset it again afterwards.
     monkeypatch.setenv("REPOWISE_HOST", "127.0.0.1")


### PR DESCRIPTION
## What

`serve_cmd` assigns `REPOWISE_DB_URL` straight onto `os.environ` when it finds a `.repowise/` beside the cwd. That is correct for a real `serve`: one process, one store, then it exits. Inside pytest it is not. Many commands share a process, `resolve_db_url` consults the environment *before* the `repo_path` it is handed, and a raw assignment is undone by nothing.

`tests/unit/cli/test_serve_host_env.py` drives the real `serve` in-process through `CliRunner` with no isolated filesystem, so `Path.cwd()` is the developer's own checkout and `.repowise/` is right there. Its `stub_serve` patches uvicorn, the provider config, the embedder, the lock path and the port probe, but not that branch.

Every test collected afterwards that indexes a `tmp_path` fixture repo therefore writes its rows into the developer's live `wiki.db` rather than its own. On the machine this was found on that is 692 `repositories` rows, each pointing at a temp directory, in the database `serve` then lists in the UI. It also makes any measurement taken off that store after a suite run suspect, since the pipeline's stale-row prune runs against it too.

This is test-only. Every shipped path resolves the database from an explicit `repo_path`, each CLI invocation is its own process, and `serve` never indexes.

## How

Two changes, because either alone leaves a gap:

- `stub_serve` sets `REPOWISE_DB_URL`, which skips the branch and hands cleanup to `monkeypatch`. The fixture already does exactly this for `REPOWISE_HOST`, with a comment noting that only a monkeypatch which recorded the variable will unset it again. The database variable had been missed.
- An autouse fixture in `tests/conftest.py` snapshots and restores `REPOWISE_DB_URL` and `REPOWISE_DATABASE_URL` around every test, so the next omission cannot escape the test that makes it. It restores rather than pins: a test that sets its own URL keeps working, and one that sets none still falls through to `<repo>/.repowise/wiki.db`.

## Verification

The regression test reproduces the leak the way it happened. It clears the variable with a raw `os.environ.pop` rather than `monkeypatch.delenv`, because monkeypatch records what it touches and would restore it for us, which is what made the original bug invisible from inside the test that caused it. The assertion therefore lives in a *following* test.

Checked both ways: with the guard disabled the third test fails, and passes again with it enabled. `tests/unit/cli` is otherwise unchanged.