### PR TITLE
release: v0.47.0 — composed refactoring opportunities, contextual chat, explained coupling

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "name": "repowise",
       "source": "./plugins/claude-code",
       "description": "Codebase intelligence for Claude Code. Indexes your repo into five layers (Graph, Git, Docs, Decisions, Code Health) and gives Claude deep understanding of architecture, ownership, hotspots, decisions, and defect risk — fewer greps, fewer file reads, lower cost per query.",
-      "version": "0.46.0",
+      "version": "0.47.0",
       "category": "productivity",
       "keywords": [
         "codebase",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.47.0] — 2026-08-30
+
+The headline this cycle is that Code Health stops handing you observations and starts handing you work. Performance findings compose into per-file opportunities with a real lifecycle, served from a materialized read model so the web page, the CLI and the agent surface cannot disagree about what one opportunity is. Alongside it, a contextual chat dock that can read the indexed repository and keep its artifacts, coupling that says whether two files *should* change together rather than just that they did, and an architecture view that finally does something useful with external dependencies.
+
+### Added
+
+- **Contextual repository chat.** Ask a question about the repo from a persistent dock that follows you across pages, with a conversation lifecycle and a durable artifact workspace so the things a conversation produces outlive it (#1949, #1951, #1960, #1964). The dock can be dismissed and brought back from settings (#2017).
+- **Refactoring opportunities are composed, not listed.** The Refactoring board showed detector outputs, so a file with fifteen of them filled the screen fifteen times and the reader reassembled "this file needs work". Board rows, the structural field, the drawer, the CLI and the VS Code list now read one composed opportunity per file: its steps in dependency-safe order, how many are mechanical, and whether they address what is actually costing the file most (#1988, #1998). Plans gained a versioned identity and a lifecycle, and triage is one request (#1986).
+- **The Performance tab is a queue of causes**, not a list of observations: what to change, why it ranks there, and the evidence behind it, projected from a materialized read model with server-side filters, counts, ordering and paging (#1981, #1985). Production, Tooling, Test and Unclassified stay separate, each with its own count including zero, and the performance lens joined the one Galaxy view (#1987).
+- **Coupling says whether files *should* change together.** A co-change pair is now graded by whether the graph can explain it, filterable by that verdict, and openable as a pair with the matching `edge_type` shown, so "explained" says whether an import or a framework binding accounts for it (#1972, #1973, #1975).
+- **External dependencies are a real view.** Bounded per-package summaries, a dependency explorer, and focused package relationships in the architecture view (#1942, #1943, #1946).
+- **Local OpenAI-compatible gateways** are supported as a provider, for LM Studio, vLLM and friends (#1822).
+
+### Changed
+
+- **`get_change_risk` leads with what the change made worse.** The response now opens with a `directive` (status, headline, reasons, next actions) and a `health_delta` of the findings the change introduced or resolved, ahead of the percentile and the diff-shape drivers (#1980). Every previous field is still there; the ordering and the lede changed. The Claude Code plugin's `change-review` skill is updated to match.
+- **A repeated-cost cause is named by the caller that repeats the work**, not only the sink that pays for it, so a shared infrastructure helper no longer merges unrelated workflows, and execution context gained `unknown` instead of defaulting an unclassifiable file to production (#1978). The opportunity queue defaults to production context (#2003).
+- **`HEALTH_ANALYZER_VERSION` is 7.** An existing index re-scores health on its next update rather than waiting out the decay timer; it does not force a re-index. `STORE_FORMAT_VERSION` and `PARSER_SCHEMA_VERSION` are unchanged.
+- **`repowise` starts faster.** The per-call CLI startup floor is cut (#1833), and an update walks the repo once rather than once per worker (#1926).
+- **A refactoring plan the gates cannot prove behaviour-preserving is suppressed** rather than offered (#1984).
+- Loading motion moved from the box to the region, the sidebar's scale and rhythm were reworked, the AI prompt modal uses hairlines instead of a filled well, and model work has its own accent instead of borrowing orange and green (#1993, #1994, #1995, #2015, #2016).
+
+### Fixed
+
+- **Performance analysis**: the loop-carried must-def analysis is solved to a fixpoint rather than to one pass (#2009), and the hot-path gate requires centrality before it fires (#2007).
+- **Dead code**: JSX prop-guard dead code is detected (#1570), and unused-export confidence is clamped when a dynamic use cannot be resolved (#1959).
+- **Ingestion**: three-part qualified calls resolve (#1920), C++ export-macro forward declarations parse (#1913), and Pascal dead-code false positives are resolved with type kinds disambiguated (#1675).
+- **MCP**: `get_why` trims its lanes before dropping them and names what the answer rests on (#1954, #1963), guided tour steps are renumbered after dedup (#1889), path search supports trailing globs (#1881), and a workspace query prefers the most-specific repo (#1865).
+- **Security scanning** no longer reports `RegExp.exec`, and catches the constant secret form it was missing (#1947).
+- **Coverage**: the Tests tab answers for files a partial report never named (#1805), and severe path-mapping loss is flagged instead of being treated as success (#1955).
+- **Health persistence**: a full index is stamped with its commit and composed after governance (#2001), and the derived queues are rebuilt whenever the findings are replaced (#2000).
+- **Config and workspace**: broken repo config is surfaced instead of silently falling back to defaults (#1958), workspace updates are single-flight (#1834), DB identity resolves on delegated worktree updates (#841), and `codex_cli` is in the server's provider catalog (#1953).
+- **Chat**: GPT-5.6 function tools work against OpenAI (#1950).
+- The coupling tab no longer crashes the page and names files unambiguously (#1965), the workspace health score is banded on the same ladder the repo pages use (#2012), the chat dock lifts only where the graph controls are actually under it (#2013), the dark overlay plane and its nested wells settle (#2014), the opportunity row columns align below the `lg` breakpoint (#2010), a refactoring step whose plan falls outside the limit renders (#2004), and the coverage migration has its own revision id (#2019).
+
+### Documentation
+
+- The security scan is documented, floor and all (#1948).
+
+---
+
 ## [0.46.0] — 2026-08-27
 
 The headline this cycle is cross-repo contracts becoming a surface you can use rather than a graph the indexer knew about. A workspace now recognises routes once and serves them to both producers and consumers, binds each contract to a real symbol id, reads request schemas off handler signatures, and gives the whole thing a front door in the UI and over REST. Alongside it the MCP tool surface got a shared response ceiling with recoverable pagination, so no tool can silently truncate an answer with no way back, and the C++, Rust, Java and TypeScript call graphs each lost a class of wrong edge.

--- a/packages/cli/src/repowise/cli/__init__.py
+++ b/packages/cli/src/repowise/cli/__init__.py
@@ -16,4 +16,4 @@ from repowise.cli._stdio import _ensure_utf8_stdio
 # is already UTF-8.
 _ensure_utf8_stdio()
 
-__version__ = "0.46.0"
+__version__ = "0.47.0"

--- a/packages/core/src/repowise/core/__init__.py
+++ b/packages/core/src/repowise/core/__init__.py
@@ -6,4 +6,4 @@ generation engine. This is the heart of repowise — all other packages depend o
 Namespace package: repowise.core is part of the repowise namespace.
 """
 
-__version__ = "0.46.0"
+__version__ = "0.47.0"

--- a/packages/core/src/repowise/core/upgrade/_data/CHANGELOG.md
+++ b/packages/core/src/repowise/core/upgrade/_data/CHANGELOG.md
@@ -9,6 +9,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.47.0] — 2026-08-30
+
+The headline this cycle is that Code Health stops handing you observations and starts handing you work. Performance findings compose into per-file opportunities with a real lifecycle, served from a materialized read model so the web page, the CLI and the agent surface cannot disagree about what one opportunity is. Alongside it, a contextual chat dock that can read the indexed repository and keep its artifacts, coupling that says whether two files *should* change together rather than just that they did, and an architecture view that finally does something useful with external dependencies.
+
+### Added
+
+- **Contextual repository chat.** Ask a question about the repo from a persistent dock that follows you across pages, with a conversation lifecycle and a durable artifact workspace so the things a conversation produces outlive it (#1949, #1951, #1960, #1964). The dock can be dismissed and brought back from settings (#2017).
+- **Refactoring opportunities are composed, not listed.** The Refactoring board showed detector outputs, so a file with fifteen of them filled the screen fifteen times and the reader reassembled "this file needs work". Board rows, the structural field, the drawer, the CLI and the VS Code list now read one composed opportunity per file: its steps in dependency-safe order, how many are mechanical, and whether they address what is actually costing the file most (#1988, #1998). Plans gained a versioned identity and a lifecycle, and triage is one request (#1986).
+- **The Performance tab is a queue of causes**, not a list of observations: what to change, why it ranks there, and the evidence behind it, projected from a materialized read model with server-side filters, counts, ordering and paging (#1981, #1985). Production, Tooling, Test and Unclassified stay separate, each with its own count including zero, and the performance lens joined the one Galaxy view (#1987).
+- **Coupling says whether files *should* change together.** A co-change pair is now graded by whether the graph can explain it, filterable by that verdict, and openable as a pair with the matching `edge_type` shown, so "explained" says whether an import or a framework binding accounts for it (#1972, #1973, #1975).
+- **External dependencies are a real view.** Bounded per-package summaries, a dependency explorer, and focused package relationships in the architecture view (#1942, #1943, #1946).
+- **Local OpenAI-compatible gateways** are supported as a provider, for LM Studio, vLLM and friends (#1822).
+
+### Changed
+
+- **`get_change_risk` leads with what the change made worse.** The response now opens with a `directive` (status, headline, reasons, next actions) and a `health_delta` of the findings the change introduced or resolved, ahead of the percentile and the diff-shape drivers (#1980). Every previous field is still there; the ordering and the lede changed. The Claude Code plugin's `change-review` skill is updated to match.
+- **A repeated-cost cause is named by the caller that repeats the work**, not only the sink that pays for it, so a shared infrastructure helper no longer merges unrelated workflows, and execution context gained `unknown` instead of defaulting an unclassifiable file to production (#1978). The opportunity queue defaults to production context (#2003).
+- **`HEALTH_ANALYZER_VERSION` is 7.** An existing index re-scores health on its next update rather than waiting out the decay timer; it does not force a re-index. `STORE_FORMAT_VERSION` and `PARSER_SCHEMA_VERSION` are unchanged.
+- **`repowise` starts faster.** The per-call CLI startup floor is cut (#1833), and an update walks the repo once rather than once per worker (#1926).
+- **A refactoring plan the gates cannot prove behaviour-preserving is suppressed** rather than offered (#1984).
+- Loading motion moved from the box to the region, the sidebar's scale and rhythm were reworked, the AI prompt modal uses hairlines instead of a filled well, and model work has its own accent instead of borrowing orange and green (#1993, #1994, #1995, #2015, #2016).
+
+### Fixed
+
+- **Performance analysis**: the loop-carried must-def analysis is solved to a fixpoint rather than to one pass (#2009), and the hot-path gate requires centrality before it fires (#2007).
+- **Dead code**: JSX prop-guard dead code is detected (#1570), and unused-export confidence is clamped when a dynamic use cannot be resolved (#1959).
+- **Ingestion**: three-part qualified calls resolve (#1920), C++ export-macro forward declarations parse (#1913), and Pascal dead-code false positives are resolved with type kinds disambiguated (#1675).
+- **MCP**: `get_why` trims its lanes before dropping them and names what the answer rests on (#1954, #1963), guided tour steps are renumbered after dedup (#1889), path search supports trailing globs (#1881), and a workspace query prefers the most-specific repo (#1865).
+- **Security scanning** no longer reports `RegExp.exec`, and catches the constant secret form it was missing (#1947).
+- **Coverage**: the Tests tab answers for files a partial report never named (#1805), and severe path-mapping loss is flagged instead of being treated as success (#1955).
+- **Health persistence**: a full index is stamped with its commit and composed after governance (#2001), and the derived queues are rebuilt whenever the findings are replaced (#2000).
+- **Config and workspace**: broken repo config is surfaced instead of silently falling back to defaults (#1958), workspace updates are single-flight (#1834), DB identity resolves on delegated worktree updates (#841), and `codex_cli` is in the server's provider catalog (#1953).
+- **Chat**: GPT-5.6 function tools work against OpenAI (#1950).
+- The coupling tab no longer crashes the page and names files unambiguously (#1965), the workspace health score is banded on the same ladder the repo pages use (#2012), the chat dock lifts only where the graph controls are actually under it (#2013), the dark overlay plane and its nested wells settle (#2014), the opportunity row columns align below the `lg` breakpoint (#2010), a refactoring step whose plan falls outside the limit renders (#2004), and the coverage migration has its own revision id (#2019).
+
+### Documentation
+
+- The security scan is documented, floor and all (#1948).
+
+---
+
 ## [0.46.0] — 2026-08-27
 
 The headline this cycle is cross-repo contracts becoming a surface you can use rather than a graph the indexer knew about. A workspace now recognises routes once and serves them to both producers and consumers, binds each contract to a real symbol id, reads request schemas off handler signatures, and gives the whole thing a front door in the UI and over REST. Alongside it the MCP tool surface got a shared response ceiling with recoverable pagination, so no tool can silently truncate an answer with no way back, and the C++, Rust, Java and TypeScript call graphs each lost a class of wrong edge.

--- a/packages/server/src/repowise/server/__init__.py
+++ b/packages/server/src/repowise/server/__init__.py
@@ -7,4 +7,4 @@ Provides:
     - Background job scheduler (APScheduler)
 """
 
-__version__ = "0.46.0"
+__version__ = "0.47.0"

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "repowise",
   "description": "Codebase intelligence for Claude Code. Indexes your codebase into five layers (Graph, Git, Docs, Decisions, Code Health) and exposes them through ten task-shaped MCP tools — so Claude understands architecture, ownership, hotspots, why code is built the way it is, and where the defect risk lives.",
-  "version": "0.46.0",
+  "version": "0.47.0",
   "author": {
     "name": "Repowise",
     "email": "hello@repowise.dev",

--- a/plugins/claude-code/CHANGELOG.md
+++ b/plugins/claude-code/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to the Repowise Claude Code plugin are documented here.
 
+## 0.47.0
+
+### Changed
+- The `change-review` skill leads with `get_change_risk`'s `directive` and
+  `health_delta` — what the change made worse — before the percentile and the
+  diff-shape drivers, matching the reordered response (#1980). It also names
+  `directive.status: unknown` alongside `warning` as the "matched no files"
+  signal, and distinguishes the per-change directive from `get_risk`'s per-file
+  one.
+- No hook change this cycle: `hooks.json` still mirrors `claude_config.py`, and
+  every tool named in a command or skill is one the server lists.
+
 ## 0.46.0
 
 ### Changed

--- a/plugins/claude-code/skills/change-review/SKILL.md
+++ b/plugins/claude-code/skills/change-review/SKILL.md
@@ -22,7 +22,8 @@ Two complementary risk signals, use both:
   score with drivers (lines added/deleted, files, directories, subsystems,
   change entropy, author familiarity). No LLM, no network. Prefer this in-MCP
   tool; it takes a revspec and diffs server-side, so you never shell out. Lead
-  with `risk_percentile` (this change ranked against sampled recent commits),
+  with `directive` and `health_delta` — what the change actually made worse.
+  Then `risk_percentile` (this change ranked against sampled recent commits),
   summarized by `review_priority` and `classification`. `score` is calibrated
   per single commit, so a PR-sized change reads high by construction, and
   `fallback_band` appears only when there was no baseline to rank against.
@@ -38,15 +39,18 @@ Two complementary risk signals, use both:
 get_change_risk(revspec="main..HEAD")   # HEAD, a commit SHA, or base..head
 ```
 
-Read `risk_percentile` and the top drivers: a high score from large diffusion
-(many dirs/subsystems) or low author familiarity tells you where to look
-hardest. `extensions=[".py", ".ts"]` counts only certain file types;
-`exclude_patterns=["tests/"]` omits paths. A `warning` field means the revspec
-or filters matched no files, so an all-zero score there is not a clean bill of
-health. The equivalent from a terminal is `repowise risk <revspec>` (add
-`--ext .py,.ts` or `--format json`).
+Read `directive` first: `status`, a `headline` naming what got worse, the
+`reasons` behind it and `next_actions` to run. `health_delta` carries the
+findings the change introduced or resolved. Then `risk_percentile` and the top
+drivers: a high score from large diffusion (many dirs/subsystems) or low author
+familiarity tells you where to look hardest. `extensions=[".py", ".ts"]` counts
+only certain file types; `exclude_patterns=["tests/"]` omits paths. A `warning`
+field, or a `directive.status` of `unknown`, means the revspec or filters
+matched no files, so an all-zero score there is not a clean bill of health. The
+equivalent from a terminal is `repowise risk <revspec>` (add `--ext .py,.ts` or
+`--format json`).
 
-## Then drill into the directive block
+## Then drill into the per-file directive
 
 Call `get_risk` in **PR mode** by passing the changed files:
 
@@ -54,7 +58,8 @@ Call `get_risk` in **PR mode** by passing the changed files:
 get_risk(targets=<changed files>, changed_files=<same changed files>)
 ```
 
-The response carries a `directive` block — read it first, it's a few short lists:
+The response carries its own `directive` block, per file rather than per change
+(distinct from `get_change_risk`'s) — read it first, it's a few short lists:
 
 - **`may_break`** — files/symbols that import their way to what changed but are
   *not* in the diff. Reachability, not a diff: it says these depend on the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "repowise"
-version = "0.46.0"
+version = "0.47.0"
 description = "The codebase intelligence layer for your AI coding agent — dependency graph, git history, dead code, decisions, and code health, exposed over MCP"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/server.json
+++ b/server.json
@@ -8,12 +8,12 @@
     "source": "github"
   },
   "websiteUrl": "https://www.repowise.dev",
-  "version": "0.46.0",
+  "version": "0.47.0",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "repowise",
-      "version": "0.46.0",
+      "version": "0.47.0",
       "transport": {
         "type": "stdio"
       },

--- a/uv.lock
+++ b/uv.lock
@@ -3051,7 +3051,7 @@ wheels = [
 
 [[package]]
 name = "repowise"
-version = "0.46.0"
+version = "0.47.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Version bump to 0.47.0 plus the changelog. Cut from `main` at f079f7f.

## What's in it

Code Health stops handing you observations and starts handing you work: performance findings compose into per-file opportunities with a real lifecycle, served from a materialized read model so the web page, the CLI and the agent surface cannot disagree about what one opportunity is. Alongside it, a contextual chat dock over the indexed repository, coupling that says whether two files *should* change together, and a real external-dependency view in architecture.

## What this branch changes

- Version bumped in `pyproject.toml`, the three package `__init__` constants, `uv.lock`, `server.json` (twice) and both Claude Code plugin manifests.
- `docs/CHANGELOG.md` gains the 0.47.0 section, resynced to the bundled copy under `packages/core/.../upgrade/_data/`.
- Plugin parity: the `change-review` skill led with `risk_percentile`, but #1980 reordered `get_change_risk` to open with `directive` and `health_delta`. The skill now reads the response in the order the tool returns it, names `directive.status: unknown` alongside `warning` as the "matched no files" signal, and distinguishes the per-change directive from `get_risk`'s per-file one.

`HEALTH_ANALYZER_VERSION` was already moved 6 -> 7 this cycle by #1978, so an existing index re-scores health on its next update. `STORE_FORMAT_VERSION` and `PARSER_SCHEMA_VERSION` are unchanged — no re-index is forced.

## Test plan

- [x] `tests/unit/test_release_manifests.py` and `tests/unit/upgrade/test_bundled_changelog_sync.py` pass (9 passed)
- [x] No stale `0.46.0` string in any versioned manifest
- [x] `uv build --wheel` produces `repowise-0.47.0-py3-none-any.whl` with 37 CLI command modules, 19 tree-sitter `.scm` queries and 36 Jinja templates
- [x] `npm ci && npm run build --workspace packages/web` succeeds; standalone `server.js` emitted, workspace-package code present in the compiled route chunks
- [x] Cold `init` of a real repo against this tree, keyless `--no-prose` (174 files, 1,217 symbols, 188 pages, 17s, 0 tokens) and with prose (188 pages, 9 model-written, 0 artifacts rejected)
- [x] All ten single-repo MCP tools answer over stdio against that index; every tool name in the plugin is one the server lists
- [ ] Tag `v0.47.0` on `main` after merge and watch `publish.yml`
- [ ] Publish `server.json` to the MCP registry once PyPI has the wheel
- [ ] Install from PyPI into a throwaway venv and index a real repo cold