### PR TITLE
release(vscode): v0.10.0 — composed refactoring opportunities and the health map

### DIFF
--- a/packages/vscode/CHANGELOG.md
+++ b/packages/vscode/CHANGELOG.md
@@ -7,6 +7,46 @@ is the minimum server version it checks against.
 This file starts at 0.7.0. Earlier releases are described in the repository's
 release history.
 
+## 0.10.0
+
+The refactoring view stops listing detector outputs and starts listing work.
+One row per file, its steps in dependency-safe order, how many of them are
+mechanical, and a lifecycle you can move it through. The health dashboard gains
+the performance lens on the same map.
+
+**Requires repowise 0.47.0 or newer.** The dashboard reads `/health/map` and the
+refactoring view reads `/refactoring/opportunities`, neither of which an earlier
+server serves, so the status bar flags an older one and asks you to upgrade with
+`pip install --upgrade repowise`.
+
+### Refactoring
+
+- A file appears once, as a composed opportunity, rather than once per finding
+  it triggered. The row carries its step count, how many steps are mechanical,
+  and whether the plan addresses what is actually costing the file most.
+- Opening a row loads its steps and evidence on demand, and the AI prompt is
+  built for the opportunity rather than for a single plan.
+- A plan the gates cannot prove behaviour-preserving is suppressed rather than
+  offered (#1984).
+- Opportunity row columns align below the narrow breakpoint, which is most of
+  the time in a side panel.
+
+### Health
+
+- The dashboard reads the health map, so the performance lens sits on the same
+  view as the rest of health instead of beside it.
+- A repeated-cost cause is named by the caller that repeats the work, not only
+  the sink that pays for it, so a shared helper no longer merges unrelated
+  workflows.
+
+### Shared UI
+
+- Loading motion moved from the box to the region, so a panel resolves as one
+  thing rather than a grid of independently twitching cards.
+- The dark overlay plane and the wells nested inside it settle, model work has
+  its own accent instead of borrowing orange and green, and the AI prompt modal
+  uses hairlines instead of a filled well.
+
 ## 0.9.0
 
 Mostly a rebuild. The webviews compile the shared Repowise UI at build time, so

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "repowise",
   "displayName": "Repowise",
   "description": "Know what your change breaks before you push. Health signals, architecture maps, and refactoring plans in your editor, and the same intelligence for your AI agent via MCP. Local and free.",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "publisher": "repowise-dev",
   "license": "AGPL-3.0-or-later",
   "homepage": "https://www.repowise.dev",

--- a/packages/vscode/src/constants.ts
+++ b/packages/vscode/src/constants.ts
@@ -16,8 +16,13 @@ export const CONFIG_SECTION = "repowise";
  * 0.43.0: the risk panel leads with `fix_history`, which no earlier server
  * sends. `RiskRangeResponse.fix_history` is a required field and the panel
  * dereferences it, so an older server would throw rather than degrade.
+ *
+ * 0.47.0: the health dashboard reads `/health/map` and the refactoring view
+ * reads `/refactoring/opportunities`, neither of which exists earlier. The
+ * dashboard awaits the map alongside the overview and trend in one `Promise.all`,
+ * so a 404 there fails the whole view rather than dropping one panel.
  */
-export const MIN_SERVER_VERSION = "0.45.0";
+export const MIN_SERVER_VERSION = "0.47.0";
 
 /** Command ids contributed by the extension, mirrored from package.json. */
 export const Commands = {


### PR DESCRIPTION
Extension version bump to 0.10.0, on its own version line. Cut from `main` at 83a925f.

## Why now

The webviews compile `@repowise-dev/ui` into the VSIX at build time, so shared-component work reaches extension users only on a rebuild. Eighteen commits touched webview-consumed subpaths since `vscode-v0.9.0` — refactoring, health, graph and the shared primitives — and the extension source itself moved in three of them.

## What changes

- **The refactoring view lists work, not detector output.** One row per file as a composed opportunity, with its step count, how many steps are mechanical, and whether the plan addresses what is actually costing the file most. Steps and evidence load on open; the AI prompt is built for the opportunity rather than a single plan.
- **The health dashboard reads the health map**, so the performance lens sits on the same view as the rest of health.
- Rebundled shared UI: region-level loading motion, the settled dark overlay plane, the model-work accent, and hairlines on the AI prompt modal.

## MIN_SERVER_VERSION 0.45.0 -> 0.47.0

A hard floor, not a preference. The dashboard reads `/health/map` and the refactoring view reads `/refactoring/opportunities`; neither route exists before 0.47.0. The dashboard awaits the map alongside the overview and trend in a single `Promise.all`, so a 404 there fails the whole view rather than dropping one panel. The status bar flags an older server and points at `pip install --upgrade repowise`. repowise 0.47.0 is on PyPI.

## Test plan

- [x] `npm run type-check --workspace packages/vscode`
- [x] `npm run build --workspace packages/vscode` — host bundle 130.5 KB against a 300 KB budget
- [x] `npm run build:webview --workspace packages/vscode` — built; largest lazy chunk is ELK at 1.44 MB (440 KB gzipped), shared by the graph and C4 views, unchanged from 0.9.0
- [x] `npm run test:webview --workspace packages/vscode` — 45 passed across 12 files
- [x] `npm run test --workspace packages/vscode` — electron smoke, 4 passing
- [x] `npm run package --workspace packages/vscode` — `repowise-0.10.0.vsix`, 162 files, 2.24 MB
- [ ] Clean-profile VSIX install smoke test: walkthrough, diagnostics and gutter heat, a dashboard renders, MCP tools listed in agent mode
- [ ] Fork check in Cursor via the `.vscode/mcp.json` fallback
- [ ] Tag `vscode-v0.10.0` after merge to trigger `publish-vscode.yml`
- [ ] Confirm the Marketplace and Open VSX listings render