### PR TITLE
fix(plugins): render the change-review skill from its shared source

### DIFF
--- a/plugins/codex/skills/change-review/SKILL.md
+++ b/plugins/codex/skills/change-review/SKILL.md
@@ -17,7 +17,8 @@ Two complementary risk signals, use both:
   score with drivers (lines added/deleted, files, directories, subsystems,
   change entropy, author familiarity). No LLM, no network. Prefer this in-MCP
   tool; it takes a revspec and diffs server-side, so you never shell out. Lead
-  with `risk_percentile` (this change ranked against sampled recent commits),
+  with `directive` and `health_delta` — what the change actually made worse.
+  Then `risk_percentile` (this change ranked against sampled recent commits),
   summarized by `review_priority` and `classification`. `score` is calibrated
   per single commit, so a PR-sized change reads high by construction, and
   `fallback_band` appears only when there was no baseline to rank against.
@@ -33,15 +34,18 @@ Two complementary risk signals, use both:
 get_change_risk(revspec="main..HEAD")   # HEAD, a commit SHA, or base..head
 ```
 
-Read `risk_percentile` and the top drivers: a high score from large diffusion
-(many dirs/subsystems) or low author familiarity tells you where to look
-hardest. `extensions=[".py", ".ts"]` counts only certain file types;
-`exclude_patterns=["tests/"]` omits paths. A `warning` field means the revspec
-or filters matched no files, so an all-zero score there is not a clean bill of
-health. The equivalent from a terminal is `repowise risk <revspec>` (add
-`--ext .py,.ts` or `--format json`).
+Read `directive` first: `status`, a `headline` naming what got worse, the
+`reasons` behind it and `next_actions` to run. `health_delta` carries the
+findings the change introduced or resolved. Then `risk_percentile` and the top
+drivers: a high score from large diffusion (many dirs/subsystems) or low author
+familiarity tells you where to look hardest. `extensions=[".py", ".ts"]` counts
+only certain file types; `exclude_patterns=["tests/"]` omits paths. A `warning`
+field, or a `directive.status` of `unknown`, means the revspec or filters
+matched no files, so an all-zero score there is not a clean bill of health. The
+equivalent from a terminal is `repowise risk <revspec>` (add `--ext .py,.ts` or
+`--format json`).
 
-## Then drill into the directive block
+## Then drill into the per-file directive
 
 Call `get_risk` in **PR mode** by passing the changed files:
 
@@ -49,7 +53,8 @@ Call `get_risk` in **PR mode** by passing the changed files:
 get_risk(targets=<changed files>, changed_files=<same changed files>)
 ```
 
-The response carries a `directive` block — read it first, it's a few short lists:
+The response carries its own `directive` block, per file rather than per change
+(distinct from `get_change_risk`'s) — read it first, it's a few short lists:
 
 - **`may_break`** — files/symbols that import their way to what changed but are
   *not* in the diff. Reachability, not a diff: it says these depend on the

--- a/plugins/shared/skills/change-review.md
+++ b/plugins/shared/skills/change-review.md
@@ -30,7 +30,8 @@ Two complementary risk signals, use both:
   score with drivers (lines added/deleted, files, directories, subsystems,
   change entropy, author familiarity). No LLM, no network. Prefer this in-MCP
   tool; it takes a revspec and diffs server-side, so you never shell out. Lead
-  with `risk_percentile` (this change ranked against sampled recent commits),
+  with `directive` and `health_delta` — what the change actually made worse.
+  Then `risk_percentile` (this change ranked against sampled recent commits),
   summarized by `review_priority` and `classification`. `score` is calibrated
   per single commit, so a PR-sized change reads high by construction, and
   `fallback_band` appears only when there was no baseline to rank against.
@@ -46,15 +47,18 @@ Two complementary risk signals, use both:
 get_change_risk(revspec="main..HEAD")   # HEAD, a commit SHA, or base..head
 ```
 
-Read `risk_percentile` and the top drivers: a high score from large diffusion
-(many dirs/subsystems) or low author familiarity tells you where to look
-hardest. `extensions=[".py", ".ts"]` counts only certain file types;
-`exclude_patterns=["tests/"]` omits paths. A `warning` field means the revspec
-or filters matched no files, so an all-zero score there is not a clean bill of
-health. The equivalent from a terminal is `repowise risk <revspec>` (add
-`--ext .py,.ts` or `--format json`).
+Read `directive` first: `status`, a `headline` naming what got worse, the
+`reasons` behind it and `next_actions` to run. `health_delta` carries the
+findings the change introduced or resolved. Then `risk_percentile` and the top
+drivers: a high score from large diffusion (many dirs/subsystems) or low author
+familiarity tells you where to look hardest. `extensions=[".py", ".ts"]` counts
+only certain file types; `exclude_patterns=["tests/"]` omits paths. A `warning`
+field, or a `directive.status` of `unknown`, means the revspec or filters
+matched no files, so an all-zero score there is not a clean bill of health. The
+equivalent from a terminal is `repowise risk <revspec>` (add `--ext .py,.ts` or
+`--format json`).
 
-## Then drill into the directive block
+## Then drill into the per-file directive
 
 Call `get_risk` in **PR mode** by passing the changed files:
 
@@ -62,7 +66,8 @@ Call `get_risk` in **PR mode** by passing the changed files:
 get_risk(targets=<changed files>, changed_files=<same changed files>)
 ```
 
-The response carries a `directive` block — read it first, it's a few short lists:
+The response carries its own `directive` block, per file rather than per change
+(distinct from `get_change_risk`'s) — read it first, it's a few short lists:
 
 - **`may_break`** — files/symbols that import their way to what changed but are
   *not* in the diff. Reachability, not a diff: it says these depend on the


### PR DESCRIPTION
Fixes the red `main` after v0.47.0. `tests/unit/cli/test_plugin_content.py` fails on two cases: the `change-review` golden and the idempotency check.

## What happened

`plugins/claude-code/skills/change-review/SKILL.md` is generated from `plugins/shared/skills/change-review.md` by `scripts/gen_plugin_content.py`. The v0.47.0 release edited the rendered file directly, so it drifted from its source.

The edit itself was correct and is unchanged here. #1980 reordered `get_change_risk` to open with `directive` and `health_delta`, while the skill still said to lead with `risk_percentile`. Moving that edit into the shared source and regenerating reproduces the Claude Code copy byte for byte — `git status` shows no change to it.

## What the drift was hiding

The Codex sibling never got the fix. `plugins/codex/skills/change-review/SKILL.md` still told agents to lead with `risk_percentile` and described `warning` as the only "matched no files" signal. Regenerating from the shared source fixes both hosts at once, which is what the generator exists for.

## Scope

No published artifact is affected. The wheel contains no plugin files, and the only plugin content the CLI ships as package data is `codex_prompts`, rendered from `plugins/shared/commands/` — commands, not skills — so it is untouched.

## Test plan

- [x] `pytest tests/unit/cli/test_plugin_content.py` — 56 passed (was 2 failed)
- [x] `python scripts/gen_plugin_content.py --check` — up to date
- [x] `plugins/claude-code/skills/change-review/SKILL.md` is byte-identical to what shipped, confirming the shared source now says what the rendered file said