### PR TITLE
docs(ui): stop claiming the theme toggle is shared with hosted

### DIFF
--- a/packages/ui/src/shared/theme-toggle.tsx
+++ b/packages/ui/src/shared/theme-toggle.tsx
@@ -3,10 +3,16 @@
 /**
  * ThemeToggle — shared segmented Light / Dark control.
  *
- * Canonical implementation consumed by both `packages/web` and the hosted
- * frontend so the toggle UX stays identical across surfaces. Relies on
- * `next-themes` (a peer dependency of consumers) for state + persistence;
- * this component just calls `setTheme()`.
+ * Used by `packages/web`. Relies on `next-themes` (a peer dependency of
+ * consumers) for state + persistence; this component just calls `setTheme()`.
+ *
+ * It is NOT currently shared with the hosted frontend, which this comment used
+ * to claim. That app renders a single icon button of its own instead, because
+ * a bordered two-option track costs roughly 70px of chrome to express a binary
+ * choice. That fork is deliberate and is meant to land here rather than stay
+ * where it is: it is the newer design, and it carries a focus ring and a
+ * reduced-motion guard this one lacks. Until it does, the two surfaces do not
+ * match, and saying otherwise here is how the divergence went unnoticed.
  *
  * Deliberately two-state — no "System" option (product decision: keep the
  * choice explicit). Consumers set `enableSystem={false}` on their provider;


### PR DESCRIPTION
`packages/ui/src/shared/theme-toggle.tsx` opens by describing itself as the

> Canonical implementation consumed by both `packages/web` and the hosted frontend so the toggle UX stays identical across surfaces.

Only the first half of that is true. The hosted app imports a local single-button toggle of its own and has done for a while, so the two surfaces do not match.

The comment is a good part of why that went unnoticed. A shared component that names its consumers is exactly the thing you check before assuming parity, and this one named a consumer it does not have.

This replaces the claim with what is actually there, and records that the hosted control is the newer design (it carries a focus ring and a reduced-motion guard this one lacks) and is meant to land here rather than stay forked.

Comment only. No behaviour change, no API change.