### PR TITLE
fix(ingestion): resolve a package language tie by name, not walk order

### DIFF
--- a/packages/core/src/repowise/core/ingestion/traverser.py
+++ b/packages/core/src/repowise/core/ingestion/traverser.py
@@ -1243,7 +1243,13 @@ def _scan_package_dir(
         pass
     language: LanguageTag = "unknown"
     if counts:
-        language = max(counts, key=lambda k: counts[k])  # type: ignore[assignment]
+        # Tie-break by name, not by insertion order. counts is populated in
+        # walk order and walk_repo does not sort dirnames, so a bare
+        # max handed an exact tie returned whichever language the filesystem
+        # happened to yield first — a different answer on different machines,
+        # and on the same machine after an unrelated file was added. Highest
+        # count wins; equal counts resolve to the alphabetically first name.
+        language = min(counts, key=lambda k: (-counts[k], k))  # type: ignore[assignment]
     return language, sorted(entry_points)
 
 

--- a/tests/unit/ingestion/test_traverser.py
+++ b/tests/unit/ingestion/test_traverser.py
@@ -1226,10 +1226,11 @@ class TestPackageScanPruning:
         pkg = self._pkg(tmp_path, "node_modules/\n")  # dist/ deliberately tracked
         dist = pkg / "dist"
         dist.mkdir()
-        # Outnumber the one real source rather than tie with it: `walk_repo`
-        # does not sort dirnames, so on a tie `max(counts, key=...)` returns
-        # whichever language the filesystem happened to yield first. That made
-        # this pass locally and fail on CI.
+        # Outnumber the one real source rather than tie with it, so this test
+        # asserts pruning and not tie-breaking. Ties are now resolved by name
+        # (see test_an_exact_language_tie_does_not_depend_on_walk_order); before
+        # that they followed filesystem order, which is what made this pass
+        # locally and fail on CI.
         for i in range(5):
             (dist / f"chunk{i}.js").write_text("var a=1;\n", encoding="utf-8")
 
@@ -1240,6 +1241,49 @@ class TestPackageScanPruning:
         pruned, _ = _scan_package_dir(pkg, tmp_path, is_pruned=tv.dir_chain_skipped)
         assert unpruned == "javascript"
         assert pruned == "typescript"
+
+    def test_an_exact_language_tie_does_not_depend_on_walk_order(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A tie must resolve the same way whatever order the filesystem yields.
+
+        counts is built in walk order and walk_repo does not sort
+        dirnames, so a bare max returned whichever tied language came
+        first — machine-dependent, and unstable on one machine as unrelated
+        files are added. Drive both orders through the same package and require
+        one answer.
+        """
+        # Built by hand rather than via _pkg: that helper ships a src/index.ts,
+        # which makes typescript win outright and there is no tie left to test.
+        (tmp_path / ".gitignore").write_text("", encoding="utf-8")
+        pkg = tmp_path / "pkg"
+        pkg.mkdir()
+        (pkg / "package.json").write_text('{"name": "p"}', encoding="utf-8")
+        (pkg / "a.js").write_text("var a=1;\n", encoding="utf-8")
+        (pkg / "b.ts").write_text("const b: number = 1;\n", encoding="utf-8")
+
+        # ``_scan_package_dir`` imports walk_repo inside the function body, so
+        # the patch has to land on the source module, not on the traverser.
+        from repowise.core import fs_walk
+
+        real_walk = fs_walk.walk_repo
+
+        def walk_in(order: list[str]):
+            def _walk(directory, **kwargs):
+                for dirpath, dirnames, filenames in real_walk(directory, **kwargs):
+                    known = [f for f in order if f in filenames]
+                    rest = [f for f in filenames if f not in order]
+                    yield dirpath, dirnames, known + rest
+
+            return _walk
+
+        monkeypatch.setattr(fs_walk, "walk_repo", walk_in(["a.js", "b.ts"]))
+        js_first, _ = _scan_package_dir(pkg, tmp_path, is_pruned=_never_pruned)
+
+        monkeypatch.setattr(fs_walk, "walk_repo", walk_in(["b.ts", "a.js"]))
+        ts_first, _ = _scan_package_dir(pkg, tmp_path, is_pruned=_never_pruned)
+
+        assert js_first == ts_first
 
     def test_a_package_with_nothing_indexed_reports_unknown(self, tmp_path: Path) -> None:
         """The one shape where the answer gets smaller rather than sharper."""


### PR DESCRIPTION
## What

A package's primary language is nondeterministic when two languages tie on file count. The same commit can produce a different `primary_language` on two machines, and adding one unrelated file can flip it on the same machine.

## Root cause

`_scan_package_dir` in `packages/core/src/repowise/core/ingestion/traverser.py` counts files per language and picks the winner with:

```python
language = max(counts, key=lambda k: counts[k])
```

`max()` returns the first maximal element in iteration order. `counts` is a dict populated in walk order, and `walk_repo` (`packages/core/src/repowise/core/fs_walk.py`) does not sort `dirnames` before descending, so iteration order is filesystem order. On an exact tie the winner is whichever language the filesystem happened to yield first.

This is already documented in the suite. `test_a_committed_build_dir_is_excluded_too` deliberately outnumbers rather than ties, with a comment explaining why: *"`walk_repo` does not sort dirnames, so on a tie `max(counts, key=...)` returns whichever language the filesystem happened to yield first. That made this pass locally and fail on CI."*

## Changes

- Tie-break by name: `min(counts, key=lambda k: (-counts[k], k))`. Highest count still wins; equal counts resolve to the alphabetically first language.
- The comment in `test_a_committed_build_dir_is_excluded_too` now points at the new test rather than describing an open bug. Its outnumber-don't-tie construction stays, since that test is about pruning.

## Related Issues

No open issue tracks this. Found while investigating a flaky test of my own whose package language differed between a local run and CI; the tie-break turned out to be the cause. Filing an issue first seemed like ceremony for a defect this contained, but happy to open one if you would prefer it tracked.

## Tests

`test_an_exact_language_tie_does_not_depend_on_walk_order` drives one package (one `.js`, one `.ts`) through `_scan_package_dir` twice, patching `walk_repo` to yield the files in each order, and requires one answer.

It fails on unpatched main:

```
E     - typescript
E     + javascript
```

Ingestion suite: 2804 passed, 5 skipped, 1 xfailed. Full unit suite: 15623 passed, 13 skipped, 3 xfailed.

Three failures in the full run are pre-existing and unrelated — `test_integration_writes_match_baseline`, `test_a_rebased_branch_in_the_history_falls_back`, and `test_the_episode_is_dated_from_the_session_not_the_index` fail identically on `4a810833` with this branch stashed.

## Rejected alternatives

Sorting `dirnames` in `walk_repo` would make traversal deterministic and fix this as a side effect, but it changes iteration order for every consumer of the walk to fix one caller's undefined tie-break. `max()` having no defined tie behaviour is the actual defect, and it is worth fixing where it is, so a future caller that ties does not reintroduce this.


## A note on the health bot

`TestPackageScanPruning` picks up an LCOM4=2 finding from the new test — its methods now split into two cohesion groups. The gate passes. I left the test in that class deliberately: it belongs beside the pruning tests it shares `_scan_package_dir` and `_never_pruned` with, and splitting one test into its own class to move a cohesion metric seemed worse than the metric. Happy to move it if you disagree.
