### PR TITLE
docs(init): document --resume and expand its help text (#113)

### DIFF
--- a/README.md
+++ b/README.md
@@ -618,6 +618,21 @@ already rendered from structure at index time.
 Or pick the provider for the first index directly with `repowise init --provider
 gemini|anthropic|openai`.
 
+**Resuming an interrupted index.** If `init` is interrupted (timeout, crash,
+Ctrl+C), re-run it with `--resume` and it continues from where it stopped —
+pages already written to the vector store are skipped, and only the missing
+ones are generated:
+
+```bash
+repowise init . --resume
+```
+
+`--resume` is a safe no-op on a fully indexed repo, so it is the right thing to
+reach for whenever a long run is cut short. It works because pages are written
+to LanceDB incrementally, while the SQL `generation_jobs` row only finalizes at
+the end — a hard interrupt can leave LanceDB ahead of SQL, and `--resume` is
+the supported recovery path (`repowise doctor` flags the drift).
+
 **3. Connect your agent.** Step 2 already did this for Claude Code: `init`
 writes a repo-root `.mcp.json` unconditionally and, unless you passed
 `--no-editor-setup`, also registers repowise with `~/.claude/settings.json`.

--- a/packages/cli/src/repowise/cli/commands/init_cmd/command.py
+++ b/packages/cli/src/repowise/cli/commands/init_cmd/command.py
@@ -436,7 +436,15 @@ def _run_generation_phase(
     "--dry-run", is_flag=True, default=False, help="Show generation plan without running."
 )
 @click.option("--yes", "-y", is_flag=True, default=False, help="Skip cost confirmation prompt.")
-@click.option("--resume", is_flag=True, default=False, help="Resume from last checkpoint.")
+@click.option(
+    "--resume",
+    is_flag=True,
+    default=False,
+    help=(
+        "Skip pages already generated in the vector store and continue from "
+        "where a previous run stopped. Safe no-op on a fully indexed repo."
+    ),
+)
 @click.option(
     "--force", is_flag=True, default=False, help="Regenerate all pages, ignoring existing."
 )


### PR DESCRIPTION
Closes #113.

**Problem:** `--resume` exists (checkpoint controller) but is undocumented — an interrupted 8-hour `init` looks like a total loss.

**Changes:**
1. README: "Resuming an interrupted index" subsection under the init usage section — one paragraph + the snippet, per the greenlight.
2. `init --help`: `--resume` text expanded from "Resume from last checkpoint." to explain the vector-store skip semantics and the safe no-op on a fully indexed repo.
3. Failure-mode note: pages are written to LanceDB incrementally while the SQL `generation_jobs` row finalizes only at the end, so a hard interrupt can leave LanceDB ahead of SQL — `--resume` is the supported recovery path and `repowise doctor` flags the drift.

**Verified:** `repowise init --help` renders the new text; CLI command tests pass (31). CLI_REFERENCE.md already documents `--resume` fully — no change needed there.