### PR TITLE
feat(helm): add official Helm chart for Kubernetes deployment (#49)

### DIFF
--- a/charts/repowise/Chart.yaml
+++ b/charts/repowise/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v2
+name: repowise
+description: Repowise — codebase intelligence for developers and AI. Deploys the API server and web UI from the official Docker image.
+type: application
+version: 0.1.0
+appVersion: "0.47.0"
+keywords:
+  - repowise
+  - codebase
+  - intelligence
+  - mcp
+home: https://repowise.dev
+sources:
+  - https://github.com/repowise-dev/repowise
+maintainers:
+  - name: repowise-dev
+    url: https://github.com/repowise-dev

--- a/charts/repowise/README.md
+++ b/charts/repowise/README.md
@@ -1,0 +1,137 @@
+# repowise Helm Chart
+
+Deploy [Repowise](https://repowise.dev) — codebase intelligence for developers
+and AI — on Kubernetes. The chart runs the official Docker image
+(`docker/Dockerfile`), mapping the same environment variables and volume
+mounts into k8s-native resources.
+
+## Quick start
+
+```bash
+helm install repowise ./charts/repowise \
+  --set secret.repowiseApiKey="$(openssl rand -hex 16)"
+```
+
+This gives you:
+
+- The API server (port 7337) and web UI (port 3000) in one pod
+- SQLite on a 10Gi PVC at `/data` (the project's default store)
+- Liveness/readiness probes against the unauthenticated `/health` endpoint
+- A generated Secret for `REPOWISE_API_KEY` and any LLM provider keys
+
+Port-forward to reach it:
+
+```bash
+kubectl port-forward svc/repowise 7337:7337 3000:3000
+```
+
+## Configuration
+
+### API keys
+
+Keys are mounted from a Secret — never bake them into `values.yaml` in
+version control. Either let the chart generate one:
+
+```yaml
+secret:
+  createSecret: true
+  repowiseApiKey: "..."        # required for external access
+  anthropicApiKey: "sk-ant-..."  # only set what you use
+  openaiApiKey: ""
+  geminiApiKey: ""
+```
+
+or reference an existing Secret you manage yourself:
+
+```yaml
+secret:
+  createSecret: false
+  existingSecret: my-repowise-secret
+```
+
+The referenced Secret must carry the same key names (`REPOWISE_API_KEY`,
+`ANTHROPIC_API_KEY`, ...).
+
+### Persistence
+
+**SQLite (default)** — a PVC is created and mounted at `/data`:
+
+```yaml
+persistence:
+  enabled: true
+  storageClass: ""      # cluster default
+  size: 10Gi
+```
+
+**PostgreSQL (opt-in)** — set `postgresql.enabled: true` and the chart
+switches `REPOWISE_DB_URL` to a PostgreSQL DSN and stops using the SQLite
+PVC. Bring your own server:
+
+```yaml
+postgresql:
+  enabled: true
+  host: my-postgres.default.svc
+  port: 5432
+  database: repowise
+  user: repowise
+  existingSecret: pg-credentials   # key: password
+```
+
+### Indexed repositories
+
+Mount repositories read-only, mirroring `docker-compose.yml`. Each entry
+becomes a read-only volume at `/repos/<name>`:
+
+```yaml
+repos:
+  - name: my-repo
+    hostPath: /srv/repos/my-repo
+  - name: other-repo
+    pvc: my-repo-pvc
+```
+
+### Ingress
+
+```yaml
+ingress:
+  enabled: true
+  className: nginx
+  hosts:
+    - host: repowise.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - hosts: [repowise.example.com]
+      secretName: repowise-tls
+```
+
+### Embedder
+
+```yaml
+env:
+  REPOWISE_EMBEDDER: mock   # mock (default, keyless), openai, ollama, ...
+  extra:
+    OLLAMA_HOST: http://ollama.default.svc:11434
+```
+
+### Resources
+
+```yaml
+resources:
+  requests:
+    cpu: 500m
+    memory: 512Mi
+  limits:
+    cpu: "2"
+    memory: 2Gi
+```
+
+## Notes
+
+- **Replicas are pinned to 1.** Repowise keeps its state in the SQLite file
+  and the vector store on the PVC; a second replica would race on the same
+  volume. Scale out by indexing more repos, not by replicating the pod.
+- **`REPOWISE_API_KEY` is required for external access.** Without it the API
+  only answers from inside the cluster (the entrypoint warns on startup).
+- **Probes** hit `/health`, which is deliberately unauthenticated.

--- a/charts/repowise/templates/NOTES.txt
+++ b/charts/repowise/templates/NOTES.txt
@@ -1,0 +1,13 @@
+Repowise deployed!
+
+Get the API URL:
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "repowise.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 7337:7337
+
+The API is at http://127.0.0.1:7337 and the web UI at http://127.0.0.1:3000.
+
+{{- if not .Values.secret.repowiseApiKey }}
+WARNING: REPOWISE_API_KEY is not set. The API is only usable from inside the
+cluster. Set secret.repowiseApiKey (or provide an existing Secret) for
+external access.
+{{- end }}

--- a/charts/repowise/templates/_helpers.tpl
+++ b/charts/repowise/templates/_helpers.tpl
@@ -1,0 +1,57 @@
+{{- define "repowise.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "repowise.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "repowise.labels" -}}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/name: {{ include "repowise.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{- define "repowise.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "repowise.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{- define "repowise.secretName" -}}
+{{- if .Values.secret.existingSecret }}
+{{- .Values.secret.existingSecret }}
+{{- else }}
+{{- include "repowise.fullname" . }}-secret
+{{- end }}
+{{- end }}
+
+{{- define "repowise.dbUrl" -}}
+{{- if .Values.postgresql.enabled }}
+{{- $host := default (printf "%s-postgresql" .Release.Name) .Values.postgresql.host }}
+{{- $passwordKey := .Values.postgresql.secretKey }}
+{{- printf "postgresql+asyncpg://%s:$(REPOWISE_DB_PASSWORD)@%s:%d/%s" .Values.postgresql.user $host (int .Values.postgresql.port) .Values.postgresql.database }}
+{{- else }}
+{{- printf "sqlite+aiosqlite:////data/wiki.db" }}
+{{- end }}
+{{- end }}
+
+{{- define "repowise.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "repowise.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/repowise/templates/deployment.yaml
+++ b/charts/repowise/templates/deployment.yaml
@@ -1,0 +1,123 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "repowise.fullname" . }}
+  labels:
+    {{- include "repowise.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "repowise.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "repowise.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "repowise.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: repowise
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: api
+              containerPort: 7337
+              protocol: TCP
+            - name: web
+              containerPort: 3000
+              protocol: TCP
+          env:
+            - name: REPOWISE_DB_URL
+              value: {{ include "repowise.dbUrl" . | quote }}
+            - name: REPOWISE_EMBEDDER
+              value: {{ .Values.env.REPOWISE_EMBEDDER | quote }}
+            - name: REPOWISE_HOST
+              value: "0.0.0.0"
+            - name: PORT_BACKEND
+              value: "7337"
+            - name: PORT_FRONTEND
+              value: "3000"
+            {{- if .Values.postgresql.enabled }}
+            - name: REPOWISE_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.postgresql.existingSecret | default (include "repowise.fullname" . | printf "%s-secret") }}
+                  key: {{ .Values.postgresql.secretKey }}
+            {{- end }}
+            {{- range $key, $value := .Values.env.extra }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+          envFrom:
+            - secretRef:
+                name: {{ include "repowise.secretName" . }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.livenessProbe.path }}
+              port: {{ .Values.livenessProbe.port }}
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.readinessProbe.path }}
+              port: {{ .Values.readinessProbe.port }}
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          volumeMounts:
+            - name: data
+              mountPath: /data
+            {{- range .Values.repos }}
+            - name: repo-{{ .name }}
+              mountPath: /repos/{{ .name }}
+              readOnly: true
+            {{- end }}
+      volumes:
+        - name: data
+          {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "repowise.fullname" . }}-data
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        {{- range .Values.repos }}
+        - name: repo-{{ .name }}
+          {{- if .hostPath }}
+          hostPath:
+            path: {{ .hostPath }}
+            type: Directory
+          {{- else }}
+          persistentVolumeClaim:
+            claimName: {{ .pvc }}
+          {{- end }}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/repowise/templates/ingress.yaml
+++ b/charts/repowise/templates/ingress.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "repowise.fullname" . }}
+  labels:
+    {{- include "repowise.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- toYaml .Values.ingress.tls | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "repowise.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/repowise/templates/pvc.yaml
+++ b/charts/repowise/templates/pvc.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.persistence.enabled (not .Values.postgresql.enabled) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "repowise.fullname" . }}-data
+  labels:
+    {{- include "repowise.labels" . | nindent 4 }}
+  {{- with .Values.persistence.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode }}
+  {{- if .Values.persistence.storageClass }}
+  storageClassName: {{ .Values.persistence.storageClass }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+{{- end }}

--- a/charts/repowise/templates/secret.yaml
+++ b/charts/repowise/templates/secret.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.secret.createSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "repowise.fullname" . }}-secret
+  labels:
+    {{- include "repowise.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{- if .Values.secret.anthropicApiKey }}
+  ANTHROPIC_API_KEY: {{ .Values.secret.anthropicApiKey | quote }}
+  {{- end }}
+  {{- if .Values.secret.openaiApiKey }}
+  OPENAI_API_KEY: {{ .Values.secret.openaiApiKey | quote }}
+  {{- end }}
+  {{- if .Values.secret.geminiApiKey }}
+  GEMINI_API_KEY: {{ .Values.secret.geminiApiKey | quote }}
+  {{- end }}
+  {{- if .Values.secret.repowiseApiKey }}
+  REPOWISE_API_KEY: {{ .Values.secret.repowiseApiKey | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/repowise/templates/service.yaml
+++ b/charts/repowise/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "repowise.fullname" . }}
+  labels:
+    {{- include "repowise.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: api
+      protocol: TCP
+      name: api
+    - port: {{ .Values.service.webPort }}
+      targetPort: web
+      protocol: TCP
+      name: web
+  selector:
+    {{- include "repowise.selectorLabels" . | nindent 4 }}

--- a/charts/repowise/templates/serviceaccount.yaml
+++ b/charts/repowise/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "repowise.serviceAccountName" . }}
+  labels:
+    {{- include "repowise.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/repowise/values.yaml
+++ b/charts/repowise/values.yaml
@@ -1,0 +1,140 @@
+# Default values for repowise.
+# This is a YAML-formatted file. Declare variables to be passed into your templates.
+
+image:
+  repository: repowise/repowise
+  tag: ""
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+
+nameOverride: ""
+fullnameOverride: ""
+
+# --- Service ---
+service:
+  type: ClusterIP
+  port: 7337
+  # Web UI port (frontend). The container runs both servers; expose the UI
+  # through a second Service when you need it (see README).
+  webPort: 3000
+
+# --- Ingress ---
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: repowise.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+
+# --- Persistence ---
+# Default: SQLite on a PVC mounted at /data, matching the rest of the project.
+# PostgreSQL is opt-in via postgresql.enabled.
+persistence:
+  enabled: true
+  storageClass: ""
+  size: 10Gi
+  accessMode: ReadWriteOnce
+  annotations: {}
+
+# --- PostgreSQL (opt-in) ---
+# When enabled, REPOWISE_DB_URL is set to the PostgreSQL DSN and the SQLite
+# PVC is not used. Bring your own server or deploy one via a subchart.
+postgresql:
+  enabled: false
+  host: ""
+  port: 5432
+  database: repowise
+  user: repowise
+  # Password is taken from the secret referenced by existingSecret, or
+  # generated when createSecret is true.
+  existingSecret: ""
+  secretKey: password
+  createSecret: true
+
+# --- Secrets ---
+# API keys are mounted from a Secret, never baked into values.
+# Create one yourself and set existingSecret, or let the chart generate it
+# from the values below (createSecret: true).
+secret:
+  createSecret: true
+  existingSecret: ""
+  # LLM provider keys (only set what you use)
+  anthropicApiKey: ""
+  openaiApiKey: ""
+  geminiApiKey: ""
+  # API key for repowise itself (required for non-loopback access)
+  repowiseApiKey: ""
+
+# --- Environment ---
+env:
+  # Embedder: mock (default, keyless), openai, ollama, ...
+  REPOWISE_EMBEDDER: mock
+  # Extra environment variables (e.g. OLLAMA_HOST)
+  extra: {}
+
+# --- Resources ---
+resources:
+  requests:
+    cpu: 500m
+    memory: 512Mi
+  limits:
+    cpu: "2"
+    memory: 2Gi
+
+# --- Probes ---
+# The API exposes an unauthenticated /health endpoint; probes hit it.
+livenessProbe:
+  path: /health
+  port: 7337
+  initialDelaySeconds: 30
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 3
+
+readinessProbe:
+  path: /health
+  port: 7337
+  initialDelaySeconds: 10
+  periodSeconds: 5
+  timeoutSeconds: 3
+  failureThreshold: 3
+
+# --- ServiceAccount ---
+serviceAccount:
+  create: true
+  name: ""
+  annotations: {}
+
+# --- Pod ---
+podAnnotations: {}
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
+  fsGroup: 1000
+
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: false
+  capabilities:
+    drop:
+      - ALL
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+# --- Repos to index ---
+# Mount indexed repositories read-only, mirroring docker-compose.
+# Each entry: {name, hostPath} or {name, pvc, subPath}
+repos: []
+#  - name: my-repo
+#    hostPath: /srv/repos/my-repo
+#  - name: other-repo
+#    pvc: my-repo-pvc
+#    subPath: ""


### PR DESCRIPTION
## What

Fixes #49. Official Helm chart for Kubernetes deployment, per the constraints in the thread.

## Root cause

No first-class Kubernetes deployment path existed — docker-compose was the only orchestration story, and it doesn't cover PVC lifecycle, Secret management, or probes.

## Changes

- **SQLite + PVC by default** — matches the project's store; PostgreSQL is opt-in via `postgresql.enabled` (switches `REPOWISE_DB_URL` to a DSN, suppresses the SQLite PVC).
- **API keys via Secret refs** — chart generates a Secret from values or references an existing one; nothing baked into the Deployment.
- **Probes hit `/health`** — the unauthenticated liveness/readiness endpoint.
- **Built on the existing `docker/Dockerfile` image** — no new image; same env vars and volume mounts as docker-compose, mapped to k8s resources.
- Repos mount read-only at `/repos/<name>` (hostPath or PVC), mirroring docker-compose.
- Replicas pinned to 1 with a note: the SQLite file and vector store live on the PVC, so a second replica would race on the same volume.

**Structure:** `charts/repowise/` — Chart.yaml, values.yaml, templates (Deployment, Service, PVC, Secret, Ingress, ServiceAccount, NOTES), README with config reference.

## Tests

- `helm lint` clean; `helm template` renders correctly for both the SQLite default and PostgreSQL opt-in paths, and with ingress enabled.

Note: `test_plugin_content` is red on main itself (v0.47.0 release bug, unrelated to this PR).
