### PR TITLE
fix(cli): resolve --embedder auto through the repo pin

### DIFF
--- a/packages/cli/src/repowise/cli/commands/reindex_cmd.py
+++ b/packages/cli/src/repowise/cli/commands/reindex_cmd.py
@@ -48,7 +48,7 @@ async def _reindex(repo_path, embedder_name: str, batch_size: int) -> None:
     from sqlalchemy import select
     from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
-    from repowise.cli.providers.embedders import build_embedder
+    from repowise.cli.providers.embedders import build_embedder, resolve_embedder_for_repo
     from repowise.core.persistence.database import create_engine, init_db
     from repowise.core.persistence.models import Page
     from repowise.core.providers.embedding.base import MockEmbedder
@@ -56,9 +56,16 @@ async def _reindex(repo_path, embedder_name: str, batch_size: int) -> None:
     # --- Resolve embedder ---
     requested_embedder = embedder_name
     if embedder_name == "auto":
-        from repowise.cli.commands.init_cmd import _resolve_embedder
-
-        embedder_name = _resolve_embedder(None)
+        # Resolve through the repo, not the environment. `_resolve_embedder(None)`
+        # reads REPOWISE_EMBEDDER and API keys only, so `auto` never saw the
+        # `embedder` pin in config.yaml despite this flag's help text promising
+        # "env vars / config". A repo pinned to a keyless embedder therefore
+        # aborted with "No real embedder available", and a repo pinned to one
+        # embedder in a shell exporting a different provider's key had its table
+        # REWRITTEN by that other provider — the exact writer/reader split
+        # `resolve_embedder_for_repo` was added to prevent, and one this command
+        # is on the writing side of.
+        embedder_name = resolve_embedder_for_repo(repo_path)
 
     embedder_impl = build_embedder(embedder_name, repo_path)
     if isinstance(embedder_impl, MockEmbedder) and requested_embedder != "mock":

--- a/packages/cli/src/repowise/cli/commands/reindex_cmd.py
+++ b/packages/cli/src/repowise/cli/commands/reindex_cmd.py
@@ -54,7 +54,6 @@ async def _reindex(repo_path, embedder_name: str, batch_size: int) -> None:
     from repowise.core.providers.embedding.base import MockEmbedder
 
     # --- Resolve embedder ---
-    requested_embedder = embedder_name
     if embedder_name == "auto":
         # Resolve through the repo, not the environment. `_resolve_embedder(None)`
         # reads REPOWISE_EMBEDDER and API keys only, so `auto` never saw the
@@ -68,7 +67,13 @@ async def _reindex(repo_path, embedder_name: str, batch_size: int) -> None:
         embedder_name = resolve_embedder_for_repo(repo_path)
 
     embedder_impl = build_embedder(embedder_name, repo_path)
-    if isinstance(embedder_impl, MockEmbedder) and requested_embedder != "mock":
+    # Guard on the RESOLVED name, not the flag. `mock` reached here two ways:
+    # asked for, or fallen back to because nothing else was configured. Only the
+    # second is an error. Now that `auto` reads the pin, `embedder: mock` in
+    # config.yaml is a third way, and it is as deliberate as passing the flag —
+    # comparing against `requested_embedder` would abort a repo that is pinned
+    # to mock on purpose.
+    if isinstance(embedder_impl, MockEmbedder) and embedder_name != "mock":
         console.print(
             "[red]No real embedder available. Set a real embedder key, configure Ollama, or pass --embedder mock for test vectors.[/red]"
         )

--- a/tests/unit/cli/test_reindex_cmd.py
+++ b/tests/unit/cli/test_reindex_cmd.py
@@ -206,3 +206,36 @@ async def test_reindex_auto_honours_the_repo_pinned_embedder(
         await reindex_cmd._reindex(tmp_path, "auto", batch_size=20)
 
     assert built["name"] == "ollama"
+
+
+async def test_reindex_does_not_abort_on_a_deliberately_pinned_mock_embedder(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    """`embedder: mock` in config.yaml is a choice, not a missing embedder.
+
+    The abort exists for the fallback case — nothing configured, so build_embedder
+    quietly hands back a MockEmbedder and a real reindex would write meaningless
+    vectors. A repo that pins mock has said what it wants, the same as passing
+    --embedder mock, and must not be treated as unconfigured.
+    """
+    db_url = f"sqlite+aiosqlite:///{tmp_path / 'wiki.db'}"
+    (tmp_path / ".repowise").mkdir(parents=True, exist_ok=True)
+    (tmp_path / ".repowise" / "config.yaml").write_text(
+        "embedder: mock\n", encoding="utf-8"
+    )
+
+    monkeypatch.delenv("REPOWISE_EMBEDDER", raising=False)
+    monkeypatch.setattr(reindex_cmd, "get_db_url_for_repo", lambda _repo_path: db_url)
+    monkeypatch.setattr(
+        "repowise.core.persistence.database.create_engine", lambda _url: _DummyEngine()
+    )
+
+    async def fake_init_db(_engine: object) -> None:
+        return None
+
+    monkeypatch.setattr("repowise.core.persistence.database.init_db", fake_init_db)
+    monkeypatch.setattr("sqlalchemy.ext.asyncio.async_sessionmaker", _sessionmaker)
+
+    # No Abort: reaches the normal empty-database path and returns.
+    await reindex_cmd._reindex(tmp_path, "auto", batch_size=20)

--- a/tests/unit/cli/test_reindex_cmd.py
+++ b/tests/unit/cli/test_reindex_cmd.py
@@ -160,3 +160,49 @@ async def test_reindex_aborts_when_every_item_failed(
 
     with pytest.raises(click.Abort):
         await reindex_cmd._reindex(tmp_path, "openai", batch_size=20)
+
+
+async def test_reindex_auto_honours_the_repo_pinned_embedder(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    """`--embedder auto` must read config.yaml's pin, not just the environment.
+
+    The pin is what wrote the vector table, so it is what must rewrite it. When
+    `auto` resolved from env vars alone, a repo pinned to one embedder in a
+    shell exporting another provider's key had its table rewritten by that other
+    provider, leaving every reader — which does honour the pin — querying
+    vectors of the wrong width.
+    """
+    db_url = f"sqlite+aiosqlite:///{tmp_path / 'wiki.db'}"
+    (tmp_path / ".repowise").mkdir(parents=True, exist_ok=True)
+    (tmp_path / ".repowise" / "config.yaml").write_text(
+        "embedder: ollama\n", encoding="utf-8"
+    )
+
+    built: dict[str, str] = {}
+
+    def fake_build_embedder(name: str, _repo_path: object):
+        built["name"] = name
+        raise click.Abort()
+
+    # REPOWISE_EMBEDDER legitimately outranks the pin, so a test about pin
+    # precedence has to clear it or it is asserting the wrong rule. It is also
+    # genuinely leaked into this process by
+    # test_embedder_resolution.py::test_the_reader_prefers_the_repo_pin, whose
+    # `monkeypatch.delenv(..., raising=False)` records nothing when the variable
+    # is already absent — so the value the production code then sets has no
+    # saved state to restore and survives into later tests.
+    monkeypatch.delenv("REPOWISE_EMBEDDER", raising=False)
+    # An unrelated provider key exported in the environment. Before the fix this
+    # is what `auto` resolved to, silently overriding the repo's own pin.
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setattr(reindex_cmd, "get_db_url_for_repo", lambda _repo_path: db_url)
+    monkeypatch.setattr(
+        "repowise.cli.providers.embedders.build_embedder", fake_build_embedder
+    )
+
+    with pytest.raises(click.Abort):
+        await reindex_cmd._reindex(tmp_path, "auto", batch_size=20)
+
+    assert built["name"] == "ollama"


### PR DESCRIPTION
## What

`repowise reindex` ignores the repo's pinned embedder. `--embedder auto` — the default — resolves from the environment only, so a repo with `embedder: ollama` in `config.yaml` aborts with:

```
No real embedder available. Set a real embedder key, configure Ollama, or pass --embedder mock for test vectors.
```

`--embedder ollama` then works, which is the tell that the pin was fine and only the resolution was wrong.

## Root cause

`reindex_cmd._reindex` resolves `auto` via `_resolve_embedder(None)`, which reads `REPOWISE_EMBEDDER` and provider API keys. It never consults `config.yaml`, despite the `--embedder` help text saying *"'auto' detects from env vars / config."*

`resolve_embedder_for_repo` already exists for this, and its docstring states the invariant plainly:

> The pinned `embedder` in `config.yaml` is what wrote the table, so it is what can query it. Readers used to resolve from the environment while writers read the pin, which is how a repo indexed keyless ends up queried with whatever API key happens to be exported: the 1536-wide query vector finds nothing in an 8-wide table, and search just returns nothing.

`reindex` is on the *writing* side of exactly that split, and was resolving from the environment.

## Consequences

- A repo pinned to a keyless embedder cannot reindex without restating the pin on the command line.
- Worse, and silent: a repo pinned to one embedder, reindexed in a shell exporting a different provider's key, has its table **rewritten** by that other provider. Every reader honours the pin, so they then query vectors of the wrong width and search returns nothing — with no error at write time.

## Related Issues

No open issue tracks this. Hit it directly: a repo pinned to `embedder: ollama` refused to reindex, and `--embedder ollama` on the same repo worked, which is what pointed at resolution rather than configuration.

## Changes

`auto` now resolves through `resolve_embedder_for_repo(repo_path)`. `REPOWISE_EMBEDDER` still wins, since that is the documented escape hatch after a manual re-embed; the pin now takes precedence over ambient API keys instead of losing to them.

## Tests

`test_reindex_auto_honours_the_repo_pinned_embedder` writes `embedder: ollama` to a repo, exports an unrelated `OPENAI_API_KEY`, and asserts the embedder built is the pinned one.

On unpatched main:

```
E   AssertionError: assert 'openai' == 'ollama'
```

CLI suite: 2253 passed, 1 skipped, 2 xfailed. `test_integration_writes_match_baseline` fails both with and without this branch — it compares against a Windows baseline (`AppData/Roaming/...` vs `Library/Application Support/...`) and is unrelated.

## One thing worth flagging separately

The new test clears `REPOWISE_EMBEDDER` explicitly. That is correct on its own terms, since the variable outranks the pin and a test about pin precedence must control it — but it is also load-bearing, because the variable leaks between tests today.

`test_embedder_resolution.py::test_the_reader_prefers_the_repo_pin` calls `monkeypatch.delenv("REPOWISE_EMBEDDER", raising=False)` and then invokes `serve_cmd._load_local_provider_config()`, which sets that variable in `os.environ`. When the variable is already absent, `delenv(raising=False)` records nothing, so monkeypatch has no saved state to restore and the value the production code set survives into every later test in the process. It is observable directly:

```
pytest tests/unit/cli/test_embedder_resolution.py tests/unit/cli/test_reindex_cmd.py
```

I have not fixed that here — it is a separate concern from this command and I did not want to widen the diff. Happy to send a follow-up if you would like one.


## Follow-up commit

Addresses @sloemo01's review note about the mock pin. The abort guard compared the resolved embedder against the flag the user typed, so once `auto` read the pin, a repo with `embedder: mock` resolved to mock and was then rejected as unconfigured. `mock` reaches that guard two ways — asked for, or fallen back to when nothing is configured — and only the second is an error. The guard now tests the resolved name, and `requested_embedder` is gone with it.

`test_reindex_does_not_abort_on_a_deliberately_pinned_mock_embedder` covers it, and fails against the previous guard.

Also ran the three suites the health bot flagged as importing the changed file — `test_dead_code_integration.py`, `test_persistence.py`, `test_mock_provider.py`: 51 passed.
