### PR TITLE
feat(cli): add --verbose to augment, wired to configure_cli_logging (#930)

### DIFF
--- a/docs/reference/CLI_REFERENCE.md
+++ b/docs/reference/CLI_REFERENCE.md
@@ -1650,6 +1650,11 @@ To remove a single agent rather than all of them, use
 
 Hook-driven context enrichment engine. Not meant to be called manually, invoked by Claude Code and Codex hooks installed during `repowise init`. Claude Code uses it for search-result enrichment, stale-wiki checks, and decision injection: session start gets the standing decisions relevant to the session's working set (relevance-ranked, hard token cap, silent when nothing clears the floor), and editing a governed file gets a one-line "governed by" notice once per session per decision. Codex uses it for `SessionStart` and `PostToolUse` lifecycle guidance. Shown decisions are recorded in `.repowise/sessions/sessions.db` so the next `repowise update` can judge whether the guidance was followed or contradicted and adjust decision staleness.
 
+| Flag | Meaning |
+|---|---|
+| `--client` | Hook client marker: `codex`. Codex lifecycle hooks pass this explicitly. |
+| `--verbose`, `-v` | Show debug logs from the hook pipeline. |
+
 ### `repowise-augment` / `repowise-rewrite`
 
 Two separate console scripts (not `repowise` subcommands) installed alongside the CLI: `repowise-augment` is an import-isolated entry point for the Claude Code/Codex augment hooks above; `repowise-rewrite` backs the Distill command-rewrite hook (`repowise hook rewrite install`). Neither is meant to be run by hand.

--- a/packages/cli/src/repowise/cli/commands/augment_cmd/command.py
+++ b/packages/cli/src/repowise/cli/commands/augment_cmd/command.py
@@ -93,6 +93,7 @@ from pathlib import Path
 
 import click
 
+from repowise.cli._setup import configure_cli_logging
 from repowise.cli.agent_adapters import adapter_for
 
 from ._shared import HookResult, as_result
@@ -135,8 +136,16 @@ def _adapter(client: str | None):
     default=None,
     help="Hook client marker. Codex lifecycle hooks pass this explicitly.",
 )
-def augment_command(client: str | None = None) -> None:
+@click.option(
+    "--verbose",
+    "-v",
+    is_flag=True,
+    default=False,
+    help="Show debug logs from the hook pipeline.",
+)
+def augment_command(client: str | None = None, verbose: bool = False) -> None:
     """Enrich AI agent tool calls with codebase graph context (hook mode)."""
+    configure_cli_logging(verbose=verbose)
     try:
         _run_augment(client=client)
     except (SystemExit, KeyboardInterrupt):

--- a/tests/unit/cli/test_augment_cmd_logging.py
+++ b/tests/unit/cli/test_augment_cmd_logging.py
@@ -1,0 +1,42 @@
+"""Tests for logging setup at the ``augment`` command boundary."""
+
+from __future__ import annotations
+
+import pytest
+from click.testing import CliRunner
+
+from repowise.cli.commands.augment_cmd import command as augment_cmd
+from repowise.cli.main import cli
+
+
+@pytest.mark.parametrize(
+    ("extra_args", "expected_verbose"),
+    [([], False), (["--verbose"], True), (["-v"], True)],
+)
+def test_augment_configures_logging_before_hook_work(
+    monkeypatch: pytest.MonkeyPatch,
+    extra_args: list[str],
+    expected_verbose: bool,
+) -> None:
+    events: list[tuple[str, object]] = []
+
+    def fake_configure_cli_logging(*, verbose: bool = False) -> None:
+        events.append(("logging", verbose))
+
+    def fake_run_augment(*, client: str | None = None) -> None:
+        events.append(("run", client))
+
+    monkeypatch.setattr(augment_cmd, "configure_cli_logging", fake_configure_cli_logging)
+    monkeypatch.setattr(augment_cmd, "_run_augment", fake_run_augment)
+
+    result = CliRunner().invoke(cli, ["augment", *extra_args])
+
+    assert result.exit_code == 0
+    assert events == [("logging", expected_verbose), ("run", None)]
+
+
+def test_augment_help_lists_verbose() -> None:
+    result = CliRunner().invoke(cli, ["augment", "--help"])
+
+    assert result.exit_code == 0
+    assert "--verbose" in result.output


### PR DESCRIPTION
The `augment` slice of #930 — the last long-running command without a `--verbose` flag.

**Changes:**
- `--verbose`/`-v` on `repowise augment`, calling `configure_cli_logging(verbose=verbose)` before any hook work — mirroring the reindex/export/restyle/claude-md/watch/coverage/health/workspace slices.
- Tests: quiet/verbose/`-v` forwarding through `CliRunner` (asserting logging is configured before `_run_augment`), plus help-text coverage.
- CLI reference: flag table for the augment section.

**Verified:** 48 augment-related tests pass. Note: the `test_plugin_content` CI failure is pre-existing on main (v0.47.0 release hand-edited a generated plugin file without regenerating from `plugins/shared/`) — unrelated to this change.