### PR TITLE
fix(health): stamp analyzed_commit in every remaining metric writer (#1864)

### DIFF
--- a/packages/cli/src/repowise/cli/commands/health_cmd/persist.py
+++ b/packages/cli/src/repowise/cli/commands/health_cmd/persist.py
@@ -129,6 +129,7 @@ def _persist_health(repo_path: object, *, report: object) -> None:
         save_health_metrics,
         save_health_snapshot,
     )
+    from repowise.core.workspace.update import get_head_commit
 
     async def _do() -> None:
         url = get_db_url_for_repo(repo_path)
@@ -145,7 +146,12 @@ def _persist_health(repo_path: object, *, report: object) -> None:
                 return
             repo_id = repo.id
 
-            await save_health_metrics(session, repo_id, list(getattr(report, "metrics", []) or []))
+            await save_health_metrics(
+                session,
+                repo_id,
+                list(getattr(report, "metrics", []) or []),
+                analyzed_commit=get_head_commit(repo_path),
+            )
             findings = list(getattr(report, "findings", []) or [])
             if findings:
                 await save_health_findings(session, repo_id, findings)

--- a/packages/cli/src/repowise/cli/commands/upgrade_flow.py
+++ b/packages/cli/src/repowise/cli/commands/upgrade_flow.py
@@ -349,6 +349,7 @@ async def _run_upgrade(
             save_health_snapshot,
         )
         from repowise.core.pipeline.orchestrator import _run_health_analysis
+        from repowise.core.workspace.update import get_head_commit
 
         health_report = await _run_health_analysis(
             graph_builder,
@@ -359,7 +360,12 @@ async def _run_upgrade(
         )
         if health_report is not None:
             async with get_session(sf) as session:
-                await save_health_metrics(session, repo_id, health_report.metrics or [])
+                await save_health_metrics(
+                    session,
+                    repo_id,
+                    health_report.metrics or [],
+                    analyzed_commit=get_head_commit(repo_path),
+                )
                 if health_report.findings:
                     await save_health_findings(session, repo_id, health_report.findings)
                 kpis = health_report.kpis or {}

--- a/packages/core/src/repowise/core/persistence/_interfaces/_analysis.py
+++ b/packages/core/src/repowise/core/persistence/_interfaces/_analysis.py
@@ -166,7 +166,11 @@ class AnalysisIndexStore(ABC):
 
     @abstractmethod
     async def save_health_metrics(
-        self, repository_id: str, metrics: list[Any]
+        self,
+        repository_id: str,
+        metrics: list[Any],
+        *,
+        analyzed_commit: str | None = None,
     ) -> None: ...
 
     @abstractmethod

--- a/packages/core/src/repowise/core/persistence/stores/_sql_analysis.py
+++ b/packages/core/src/repowise/core/persistence/stores/_sql_analysis.py
@@ -188,9 +188,15 @@ class _SqlAnalysisMixin(AnalysisIndexStore):
         await crud.save_health_findings(self._session, repository_id, findings)
 
     async def save_health_metrics(
-        self, repository_id: str, metrics: list[Any]
+        self,
+        repository_id: str,
+        metrics: list[Any],
+        *,
+        analyzed_commit: str | None = None,
     ) -> None:
-        await crud.save_health_metrics(self._session, repository_id, metrics)
+        await crud.save_health_metrics(
+            self._session, repository_id, metrics, analyzed_commit=analyzed_commit
+        )
 
     async def upsert_health_findings(
         self,

--- a/tests/unit/cli/test_health_persist_analyzed_commit.py
+++ b/tests/unit/cli/test_health_persist_analyzed_commit.py
@@ -8,8 +8,6 @@ cannot report stale health data. This pins the ``repowise health`` writer.
 
 from __future__ import annotations
 
-import pytest
-
 from repowise.cli.commands.health_cmd import persist as health_persist
 
 
@@ -51,9 +49,10 @@ def test_persist_health_stamps_analyzed_commit(tmp_path, monkeypatch) -> None:
         return _FakeRepo()
 
     class _FakeReport:
-        metrics = []
-        findings = []
-        kpis = {}
+        def __init__(self) -> None:
+            self.metrics: list = []
+            self.findings: list = []
+            self.kpis: dict = {}
 
     monkeypatch.setattr(
         "repowise.core.persistence.crud.save_health_metrics", _fake_save_health_metrics

--- a/tests/unit/cli/test_health_persist_analyzed_commit.py
+++ b/tests/unit/cli/test_health_persist_analyzed_commit.py
@@ -1,0 +1,96 @@
+"""Regression: every health metric writer must stamp analyzed_commit (#1864).
+
+The full pipeline, the update re-score, ``repowise health`` persistence and
+the fast-index upgrade pass all recompute health; each must record the commit
+it analyzed against, or the table fills with NULL provenance and get_health
+cannot report stale health data. This pins the ``repowise health`` writer.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from repowise.cli.commands.health_cmd import persist as health_persist
+
+
+def test_persist_health_stamps_analyzed_commit(tmp_path, monkeypatch) -> None:
+    """``repowise health`` persistence must pass the live HEAD as
+    analyzed_commit, not leave the metric rows NULL (issue #1864)."""
+    import git as gitpython
+
+    # A real repo with one commit; get_head_commit reads it off disk.
+    repo = gitpython.Repo.init(tmp_path)
+    with repo.config_writer() as cw:
+        cw.set_value("user", "name", "Alice")
+        cw.set_value("user", "email", "alice@example.com")
+    (tmp_path / "a.py").write_text("x = 1\n")
+    repo.index.add(["a.py"])
+    repo.index.commit("feat: add a")
+    live_head = repo.head.commit.hexsha
+    repo.close()
+
+    recorded: dict = {}
+
+    async def _fake_save_health_metrics(session, repository_id, metrics, **kwargs):
+        recorded["commit"] = kwargs.get("analyzed_commit")
+
+    class _FakeRepo:
+        id = "repo-1"
+
+    class _FakeSession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+        async def commit(self):
+            return None
+
+    async def _fake_get_repository_by_path(session, local_path):
+        return _FakeRepo()
+
+    class _FakeReport:
+        metrics = []
+        findings = []
+        kpis = {}
+
+    monkeypatch.setattr(
+        "repowise.core.persistence.crud.save_health_metrics", _fake_save_health_metrics
+    )
+    monkeypatch.setattr(
+        "repowise.core.persistence.crud.get_repository_by_path",
+        _fake_get_repository_by_path,
+    )
+    async def _fake_save_health_findings(*a, **k):
+        return None
+
+    async def _fake_save_health_snapshot(*a, **k):
+        return None
+
+    monkeypatch.setattr(
+        "repowise.core.persistence.crud.save_health_findings",
+        _fake_save_health_findings,
+    )
+    monkeypatch.setattr(
+        "repowise.core.persistence.crud.save_health_snapshot",
+        _fake_save_health_snapshot,
+    )
+    monkeypatch.setattr(
+        "repowise.cli.helpers.get_db_url_for_repo", lambda p: "sqlite:///:memory:"
+    )
+    async def _fake_reconcile(url):
+        return None
+
+    monkeypatch.setattr(
+        "repowise.cli.helpers.reconcile_schema_best_effort", _fake_reconcile
+    )
+    monkeypatch.setattr("repowise.core.persistence.create_engine", lambda url: object())
+    monkeypatch.setattr(
+        "repowise.core.persistence.create_session_factory", lambda engine: object()
+    )
+    monkeypatch.setattr("repowise.core.persistence.get_session", lambda sf: _FakeSession())
+
+    health_persist._persist_health(tmp_path, report=_FakeReport())
+
+    assert recorded["commit"] == live_head


### PR DESCRIPTION
Closes #1864 (first complete slice — metric provenance; findings/snapshots left out per the scoping).

**Writers fixed** (all still called `save_health_metrics` without a commit, so a full re-score could replace the table with entirely NULL provenance):
1. `repowise health` persistence — `health_cmd/persist.py`
2. Fast-index upgrade health pass — `upgrade_flow.py`
3. The update re-score already stamps via `save_full_health_report` (from #1800)

**Abstraction:** `analyzed_commit` threaded through the `IndexStore` interface and the SQL adapter so the abstraction cannot silently drop the commit.

**Preserved:** NULL for legacy rows and unreadable/non-git checkouts — no backfill of old rows with current HEAD (would invent provenance).

**Regression test:** `test_persist_health_stamps_analyzed_commit` — a real repo, `repowise health` persistence, asserts the live HEAD lands as `analyzed_commit`. Verified it **fails on the pre-fix code** (sabotage run) and passes with the fix.

Note: the `test_plugin_content` CI failure is pre-existing on main (v0.47.0 release hand-edited a generated plugin file) — unrelated to this change.