### PR TITLE
fix(update): show live progress and persist incrementally on --full (#1709)

### DIFF
--- a/packages/cli/src/repowise/cli/commands/upgrade_flow.py
+++ b/packages/cli/src/repowise/cli/commands/upgrade_flow.py
@@ -69,6 +69,7 @@ def _gate_cost(
             COST_GATE_USD,
             cost_gate_declined,
             format_cost,
+            structural_page_summary,
         )
         from repowise.core.cost_estimator import build_generation_plan, estimate_cost
 
@@ -80,6 +81,9 @@ def _gate_cost(
 
     pages = sum(p.count for p in plans)
     console.print(f"Estimated: [bold]{pages}[/bold] pages, [bold]{format_cost(est)}[/bold].")
+    structural = structural_page_summary(plans)
+    if structural:
+        console.print(f"  [dim]{structural}[/dim]")
 
     # Nothing to ask on a run that cannot be asked. Without this the confirm
     # reads EOF, raises, and the caller reports a successful run that generated
@@ -197,7 +201,7 @@ async def _run_upgrade(
         upsert_pages_from_generated,
         upsert_repository,
     )
-    from repowise.core.pipeline import rehydrate_graph_builder, run_generation
+    from repowise.core.pipeline import rehydrate_graph_builder
 
     url = get_db_url_for_repo(repo_path)
     engine = create_engine(url)
@@ -266,21 +270,52 @@ async def _run_upgrade(
     except Exception as exc:
         console.print(f"[yellow]Embedding skipped: {exc}[/yellow]")
 
-    generated_pages = await run_generation(
-        repo_path=repo_path,
-        parsed_files=parsed_files,
-        source_map=source_map,
-        graph_builder=graph_builder,
-        repo_structure=repo_structure,
-        git_meta_map=git_meta_map,
-        llm_client=provider,
-        embedder=embedder,
-        vector_store=vector_store,
-        concurrency=config.max_concurrency,
-        progress=None,
-        cost_tracker=cost_tracker,
-        generation_config=config,
+    # Generate with init's persistence wrapper: pages are written to the DB the
+    # instant each one completes (so a Ctrl-C loses at most the in-flight page,
+    # not the whole run), prior pages are reused from the store, and the
+    # progress bar the user expected to see actually advances. The old path
+    # passed ``progress=None`` and buffered every page in memory until the end —
+    # hour eight of a long run showed a dead screen and an interrupt cost the
+    # entire run (issue #1709).
+    from rich.progress import BarColumn, Progress, SpinnerColumn, TextColumn, TimeElapsedColumn
+
+    from repowise.cli.commands.init_cmd._generation_persist import (
+        run_generation_with_persistence,
     )
+    from repowise.cli.ui import (
+        BRAND_STYLE,
+        OK,
+        OWL_SPINNER,
+        MaybeCountColumn,
+        RichProgressCallback,
+    )
+
+    with Progress(
+        SpinnerColumn(spinner_name=OWL_SPINNER, style=BRAND_STYLE),
+        TextColumn("[progress.description]{task.description}"),
+        BarColumn(),
+        MaybeCountColumn(),
+        TimeElapsedColumn(),
+        TextColumn(f"[{OK}]${{task.fields[cost]:.3f}}[/]"),
+        console=console,
+    ) as upgrade_progress:
+        gen_callback = RichProgressCallback(upgrade_progress, console)
+        generated_pages = await run_generation_with_persistence(
+            repo_path=repo_path,
+            repo_name=repo_path.name,
+            parsed_files=parsed_files,
+            source_map=source_map,
+            graph_builder=graph_builder,
+            repo_structure=repo_structure,
+            git_meta_map=git_meta_map,
+            llm_client=provider,
+            embedder=embedder,
+            vector_store=vector_store,
+            concurrency=config.max_concurrency,
+            progress=gen_callback,
+            cost_tracker=cost_tracker,
+            generation_config=config,
+        )
 
     # Flush buffered cost rows now generation is done (best-effort).
     await cost_tracker.flush()

--- a/tests/unit/cli/test_full_upgrade_progress.py
+++ b/tests/unit/cli/test_full_upgrade_progress.py
@@ -1,0 +1,51 @@
+"""``repowise update --full`` must show progress and persist incrementally (#1709).
+
+The full-upgrade path used to pass ``progress=None`` into generation (no-ops
+every progress callback — a long run showed a dead screen) and buffered every
+page in memory until the end (a Ctrl-C at hour eight cost the whole run). It
+now routes through init's ``run_generation_with_persistence`` wrapper, which
+gives progress, incremental per-page saves and resume.
+
+The wrapper call lives inside an async closure that needs real DB/graph
+objects, so like the strict-branch guards in test_coverage_cmd.py this is a
+structural pin: it asserts the call site names the persistence wrapper with a
+real progress callback, and can only fail if someone restores the old
+buffered ``progress=None`` path.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+from repowise.cli.commands import upgrade_flow
+
+
+def _upgrade_source() -> str:
+    return inspect.getsource(upgrade_flow._run_upgrade)
+
+
+def test_full_upgrade_uses_the_persistence_wrapper() -> None:
+    src = _upgrade_source()
+
+    assert "run_generation_with_persistence" in src, (
+        "the full upgrade must route generation through init's persistence "
+        "wrapper so pages are saved as they complete"
+    )
+
+
+def test_full_upgrade_passes_a_real_progress_callback() -> None:
+    src = _upgrade_source()
+
+    assert "RichProgressCallback" in src, (
+        "the full upgrade must attach a live progress bar, not progress=None"
+    )
+    # The callback is wired to the same rich Progress init uses.
+    assert "Progress(" in src
+
+
+def test_full_upgrade_estimate_names_structural_pages() -> None:
+    src = inspect.getsource(upgrade_flow._gate_cost)
+
+    # The estimate line must call the summary that says most pages never reach
+    # a model — otherwise "3661 pages" reads as 3661 model calls.
+    assert "structural_page_summary" in src


### PR DESCRIPTION
## What

Fixes #1709 — the reporting/safety halves of Raghav's diagnosis.

## Root cause

- `update --full` passed `progress=None` into generation — every progress callback no-oped, so a long run showed a dead screen while the local model sat pinned for hours.
- Every page was buffered in memory and written once at the end — a Ctrl-C at hour eight cost the entire run (the issue's real question: is aborting safe?).
- The estimate line never called `structural_page_summary()`, so "3661 pages" read as 3661 model calls when ~98 of them are.

## Changes

1. Generation now routes through `run_generation_with_persistence` (init's wrapper): pages are written to the DB the instant each completes, prior pages are reused from the store, and a real Rich progress bar advances. Interrupting now loses at most the in-flight page.
2. The estimate line calls `structural_page_summary()`, printing the "N more pages rendered from the code itself, no model, no cost" breakdown.

## Tests

Regression guards (structural, mirroring the strict-branch pins in test_coverage_cmd.py): the call site must use the persistence wrapper, a live `RichProgressCallback`, and the structural summary — all three fail on the pre-fix code (verified via sabotage run).

Note: `test_plugin_content` is red on main itself (v0.47.0 release bug, unrelated to this PR).
