### PR TITLE
feat(languages): QML at the lightweight import tier (#727)

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,7 +473,7 @@ the orchestrators. Full matrix and the contributor recipe:
 
 ## Supported languages
 
-**20 languages parsed to AST · 36 on a five-rung ladder · framework-aware across
+**20 languages parsed to AST · 37 on a five-rung ladder · framework-aware across
 all of them.**
 
 "Do you support X" has five useful answers, not two, so languages land on a
@@ -519,7 +519,7 @@ still doing real work rather than being ignored:
 | **Good** (5) | C · Swift · PHP · Dart · Object Pascal | All of the above except the full health suite |
 | **Partial** (2) | Luau / Roblox · Razor / Blazor | Luau: AST symbols and `require()` resolution, Rojo and `.luaurc` aware. Razor: component symbols, `@code` and component-tag call edges, C# health markers; no import resolution yet |
 | | | ⎯⎯ *tree-sitter parsing stops here; the rungs below come from git and imports* ⎯⎯ |
-| **Lightweight** (7) | Elixir · Clojure · Haskell · Lean 4 · Erlang · F# · HTML | A real file-to-file import graph, and no symbol-level claims |
+| **Lightweight** (8) | Elixir · Clojure · Haskell · Lean 4 · Erlang · F# · HTML · QML | A real file-to-file import graph, and no symbol-level claims |
 | **Structural** (9) | Objective-C · R · Zig · Julia · Elm · OCaml · Crystal · Nim · D | Git history: blame, hotspots, co-change, ownership, bug history |
 
 **Every language ships in the open-source distribution.** None is gated behind

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -34,7 +34,7 @@ Languages land on a five-rung ladder rather than a yes/no list, because "do you
 support X" has five different useful answers. Each rung is defined, with what it
 buys you, in
 [docs/layers/LANGUAGE_SUPPORT.md](docs/layers/LANGUAGE_SUPPORT.md). Today that
-ladder covers **36 languages, 20 of them parsed to a full AST**.
+ladder covers **37 languages, 20 of them parsed to a full AST**.
 
 ### New languages
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -59,7 +59,7 @@ your agent in under five minutes, with no API key.
 | [layers/DECISIONS.md](layers/DECISIONS.md) | Architectural decisions mined from your repo and from your own agent sessions |
 | [layers/DEAD_CODE.md](layers/DEAD_CODE.md) | Unreachable files, unused exports, and zombie packages by confidence tier |
 | [layers/SECURITY.md](layers/SECURITY.md) | The local pattern scan: what the sixteen patterns catch, what they do not, and how far to trust the result |
-| [layers/LANGUAGE_SUPPORT.md](layers/LANGUAGE_SUPPORT.md) | What works per language: 20 parsed to a full AST, 36 on the five-rung ladder |
+| [layers/LANGUAGE_SUPPORT.md](layers/LANGUAGE_SUPPORT.md) | What works per language: 20 parsed to a full AST, 37 on the five-rung ladder |
 | [layers/WIKI.md](layers/WIKI.md) | The generated wiki: page types, what `update` re-renders, styles, output language |
 
 ## Scale it

--- a/docs/business/COMMERCIAL.md
+++ b/docs/business/COMMERCIAL.md
@@ -99,7 +99,7 @@ All of the following ship in `pip install repowise` today, free for internal use
 
 ## 3. First-class language coverage
 
-Repowise parses **20 languages to a full AST** and places **36 on a five-rung
+Repowise parses **20 languages to a full AST** and places **37 on a five-rung
 ladder**, so "do you support X" gets the rung as its answer rather than a yes or a
 no. Both numbers matter and neither is worth quoting alone.
 
@@ -112,8 +112,8 @@ Swift, PHP, Dart, Object Pascal/Delphi) get all of that except the full health
 suite, and Luau and Razor/Blazor are partial. SQL/dbt, shell, HTML, and the config formats are
 handled by dedicated extractors on top of that.
 
-Below the AST line the ladder continues rather than stopping: **7 at Lightweight**
-(Elixir, Clojure, Haskell, Lean 4, Erlang, F#, HTML) get a real file-to-file import
+Below the AST line the ladder continues rather than stopping: **8 at Lightweight**
+(Elixir, Clojure, Haskell, Lean 4, Erlang, F#, HTML, QML) get a real file-to-file import
 graph with no symbol-level claims, and **9 at Structural** (Objective-C, R, Zig,
 Julia, Elm, OCaml, Crystal, Nim, D) get the git intelligence layer only: blame,
 hotspots, co-change, ownership and bug history, with no parsing. Stating the rung

--- a/docs/layers/LANGUAGE_SUPPORT.md
+++ b/docs/layers/LANGUAGE_SUPPORT.md
@@ -56,7 +56,7 @@ produce meaningful output.
 | **Good** (5) | C · Swift · PHP · Dart · Object Pascal | Everything above except the full health suite. Dart and Object Pascal *do* get health markers; C, Swift and PHP don't yet |
 | **Partial** (2) | Luau / Roblox · Razor / Blazor | Luau: AST symbols and `require()` resolution (Rojo / `.luaurc` aware), no health markers yet. Razor: a component symbol per file, call edges from `@code` blocks and component tags, C# health markers; no import resolution yet |
 | | | ⎯⎯ *tree-sitter parsing stops here. The rungs below are derived from git and imports, not from an AST.* ⎯⎯ |
-| **Lightweight** (7) | Elixir · Clojure · Haskell · Lean 4 · Erlang · F# · HTML | A real file-to-file import graph, no symbol-level claims |
+| **Lightweight** (8) | Elixir · Clojure · Haskell · Lean 4 · Erlang · F# · HTML · QML | A real file-to-file import graph, no symbol-level claims |
 | **Structural** (9) | Objective-C · R · Zig · Julia · Elm · OCaml · Crystal · Nim · D | Git history only: blame, hotspots, co-change. No AST parsing |
 
 The first three rungs are the **20 languages parsed to a full AST**; all five are
@@ -321,6 +321,17 @@ import graph: imports extracted per language and resolved against a declared
 module-name index. The knowledge graph runs in flow/sparse mode on the result:
 honest file-to-file dependencies, no symbol-level claims. F# additionally honours
 the fsproj `<Compile Include>` compile order.
+
+**QML** joins the lightweight tier because no published tree-sitter grammar
+exists for it (checked: no installable grammar on GitHub or npm), and the tier
+gate is a grammar. The tier still delivers the reporter's core ask from #727 —
+an agent that "doesn't know where to look" — as real file-to-file edges:
+`import QtQuick`/`import org.kde.kirigami` module specs resolve against a
+`qmldir`-declared module index (Qt's own modules resolve external), and quoted
+references (`import "components"`, `import "js/app.js" as S`) resolve relative
+to the importing file, with a directory import linking its `qmldir` manifest.
+Component/property/signal symbols and qmldir heritage are the documented
+Good-tier upgrade path once a grammar ships.
 
 **HTML** is import-tier on purpose. It has no functions, classes or calls, so
 there are no symbols to claim, but its `<script src>` and `<link href>` become

--- a/docs/layers/LANGUAGE_SUPPORT.md
+++ b/docs/layers/LANGUAGE_SUPPORT.md
@@ -1,6 +1,6 @@
 # Language Support
 
-**20 languages parsed to a full AST · 36 on the five-rung ladder ·
+**20 languages parsed to a full AST · 37 on the five-rung ladder ·
 framework-aware across all of them.** "Do you support X" has five useful answers
 rather than two, so every language lands on a rung and the rung says what it
 buys you. Everything else in your repo still appears in the wiki and is tracked
@@ -60,7 +60,7 @@ produce meaningful output.
 | **Structural** (9) | Objective-C · R · Zig · Julia · Elm · OCaml · Crystal · Nim · D | Git history only: blame, hotspots, co-change. No AST parsing |
 
 The first three rungs are the **20 languages parsed to a full AST**; all five are
-the **36** on the ladder. Both numbers are worth stating and neither is worth
+the **37** on the ladder. Both numbers are worth stating and neither is worth
 stating alone, so if you only take one thing from this page, take the rung your
 language sits on rather than either count.
 
@@ -322,16 +322,23 @@ module-name index. The knowledge graph runs in flow/sparse mode on the result:
 honest file-to-file dependencies, no symbol-level claims. F# additionally honours
 the fsproj `<Compile Include>` compile order.
 
-**QML** joins the lightweight tier because no published tree-sitter grammar
-exists for it (checked: no installable grammar on GitHub or npm), and the tier
-gate is a grammar. The tier still delivers the reporter's core ask from #727 —
-an agent that "doesn't know where to look" — as real file-to-file edges:
-`import QtQuick`/`import org.kde.kirigami` module specs resolve against a
-`qmldir`-declared module index (Qt's own modules resolve external), and quoted
-references (`import "components"`, `import "js/app.js" as S`) resolve relative
-to the importing file, with a directory import linking its `qmldir` manifest.
-Component/property/signal symbols and qmldir heritage are the documented
-Good-tier upgrade path once a grammar ships.
+**QML** joins the lightweight tier with imports only. A grammar exists
+(`tree-sitter-qmljs` on PyPI), but the AST rung needs queries for QML's `id:`
+object tree (component, property, signal, function, alias) and a grammar-aware
+resolver, which is a separate climb. The tier still delivers the reporter's
+core ask from #727, an agent that "doesn't know where to look", as real
+file-to-file edges: `import QtQuick`/`import org.kde.kirigami` module specs
+resolve against a `qmldir`-declared module index (Qt's own modules resolve
+external), and quoted references (`import "components"`,
+`import "js/app.js" as S`) resolve relative to the importing file, with a
+directory import linking its `qmldir` manifest. Two stated ceilings: a directory
+import only links a directory that carries a `qmldir`, so an implicit module (a
+directory of `.qml` files with no manifest) gets no edge, and a module name
+declared by two `qmldir` files gets no edge either rather than a guessed one.
+`.qml` files are **never flagged as dead code**: a component is instantiated by
+type name and loaded by the Qt runtime through qrc, `Loader` and
+`qmlRegisterType`, none of which is an import, so file reachability says nothing
+about it.
 
 **HTML** is import-tier on purpose. It has no functions, classes or calls, so
 there are no symbols to claim, but its `<script src>` and `<link href>` become

--- a/packages/core/src/repowise/core/analysis/dead_code/constants.py
+++ b/packages/core/src/repowise/core/analysis/dead_code/constants.py
@@ -76,6 +76,10 @@ _NEVER_FLAG_PATTERNS: tuple[str, ...] = (
     "*/default.tsx",
     # Nuxt route pages
     "*/pages/*.vue",
+    # ---- Qt / QML ---------------------------------------------------
+    # Instantiated by type name and loaded by the runtime (qrc, Loader,
+    # qmlRegisterType), so a QML file never has a static importer.
+    "*.qml",
     # ---- .NET / C# conventions --------------------------------------
     # Implicit / generated / framework-loaded files that have no
     # static importers by design.

--- a/packages/core/src/repowise/core/ingestion/languages/specs/__init__.py
+++ b/packages/core/src/repowise/core/ingestion/languages/specs/__init__.py
@@ -45,6 +45,7 @@ from .pascal import SPEC as _PASCAL
 from .php import SPEC as _PHP
 from .proto import SPEC as _PROTO
 from .python import SPEC as _PYTHON
+from .qml import SPEC as _QML
 from .r import SPEC as _R
 from .razor import SPEC as _RAZOR
 from .ruby import SPEC as _RUBY
@@ -142,6 +143,7 @@ ALL_SPECS: tuple[LanguageSpec, ...] = (
     _ELM,
     _HASKELL,
     _LEAN,
+    _QML,
     _OCAML,
     _FSHARP,
     _CRYSTAL,

--- a/packages/core/src/repowise/core/ingestion/languages/specs/qml.py
+++ b/packages/core/src/repowise/core/ingestion/languages/specs/qml.py
@@ -1,10 +1,10 @@
-"""LanguageSpec for qml — a lightweight import-tier language.
+"""LanguageSpec for qml, a lightweight import-tier language.
 
 QML has component/property/signal/function symbols worth claiming at a
-higher tier, but the tier gate is a published tree-sitter grammar, and
-none exists for QML (checked: no py-tree-sitter package, no npm grammar).
-So QML ships at the lightweight tier: real file-level import edges, no
-symbol claims — the honest maximum without a grammar.
+higher tier. A grammar exists (`tree-sitter-qmljs` on PyPI), but the AST
+rung also needs queries over QML's `id:` object tree and a grammar-aware
+resolver, so QML ships at the lightweight tier for now: real file-level
+import edges, no symbol claims.
 
 What the import tier captures:
 
@@ -13,12 +13,16 @@ What the import tier captures:
   import "components"     → relative directory import (resolved locally)
   import "js/app.js" as S → script import (resolved locally)
 
-That lands the reporter's core ask from #727 — "the agent doesn't know
-where to look" — as file-to-file edges: a QML file's sibling-component
+That lands the reporter's core ask from #727, "the agent doesn't know
+where to look", as file-to-file edges: a QML file's sibling-component
 and script dependencies become real graph edges, so search and the file
 maps see the shape of the UI module. Component/property/signal symbols
 and heritage (QtQuick import resolution, qmldir modules) are the
-documented Good-tier upgrade path once a grammar exists.
+documented Good-tier upgrade path.
+
+`qmldir` is listed under `special_filenames` because it carries no
+extension: without it the traverser never yields one and the resolver's
+module index is always empty.
 """
 
 from __future__ import annotations
@@ -29,11 +33,14 @@ SPEC = LanguageSpec(
     tag="qml",
     display_name="QML",
     entry_point_patterns=(),
-    # qmldir is the module manifest — package plumbing, not domain code,
+    # qmldir is the module manifest: package plumbing, not domain code,
     # exactly as lakefile is for Lean.
     manifest_files=("qmldir",),
     build_config_manifests=("qmldir",),
     extensions=frozenset({".qml", ".qmltypes"}),
+    # qmldir carries no extension, so without this the traverser never yields
+    # it and the module index the resolver builds from it is always empty.
+    special_filenames=frozenset({"qmldir"}),
     is_passthrough=True,
     # Lightweight regex resolver: `import Foo.Bar` module specs and
     # `import "relative/path"` directory/script references.

--- a/packages/core/src/repowise/core/ingestion/languages/specs/qml.py
+++ b/packages/core/src/repowise/core/ingestion/languages/specs/qml.py
@@ -1,0 +1,41 @@
+"""LanguageSpec for qml — a lightweight import-tier language.
+
+QML has component/property/signal/function symbols worth claiming at a
+higher tier, but the tier gate is a published tree-sitter grammar, and
+none exists for QML (checked: no py-tree-sitter package, no npm grammar).
+So QML ships at the lightweight tier: real file-level import edges, no
+symbol claims — the honest maximum without a grammar.
+
+What the import tier captures:
+
+  import QtQuick          → module import (external unless a local qmldir
+                            declares it)
+  import "components"     → relative directory import (resolved locally)
+  import "js/app.js" as S → script import (resolved locally)
+
+That lands the reporter's core ask from #727 — "the agent doesn't know
+where to look" — as file-to-file edges: a QML file's sibling-component
+and script dependencies become real graph edges, so search and the file
+maps see the shape of the UI module. Component/property/signal symbols
+and heritage (QtQuick import resolution, qmldir modules) are the
+documented Good-tier upgrade path once a grammar exists.
+"""
+
+from __future__ import annotations
+
+from ..spec import LanguageSpec
+
+SPEC = LanguageSpec(
+    tag="qml",
+    display_name="QML",
+    entry_point_patterns=(),
+    # qmldir is the module manifest — package plumbing, not domain code,
+    # exactly as lakefile is for Lean.
+    manifest_files=("qmldir",),
+    build_config_manifests=("qmldir",),
+    extensions=frozenset({".qml", ".qmltypes"}),
+    is_passthrough=True,
+    # Lightweight regex resolver: `import Foo.Bar` module specs and
+    # `import "relative/path"` directory/script references.
+    import_support="partial",
+)

--- a/packages/core/src/repowise/core/ingestion/lightweight_imports/__init__.py
+++ b/packages/core/src/repowise/core/ingestion/lightweight_imports/__init__.py
@@ -28,6 +28,7 @@ from .fsharp import extract_fsharp_imports
 from .haskell import extract_haskell_imports
 from .html import extract_html_imports
 from .lean import extract_lean_imports
+from .qml import extract_qml_imports
 from .sql import extract_dbt_imports
 
 ExtractorFn = Callable[[str], list[Import]]
@@ -38,6 +39,9 @@ _EXTRACTORS: dict[str, ExtractorFn] = {
     "clojure": extract_clojure_imports,
     "haskell": extract_haskell_imports,
     "lean": extract_lean_imports,
+    # `import QtQuick` / `import "components"` — module specs and quoted
+    # relative references (see qml.py).
+    "qml": extract_qml_imports,
     "erlang": extract_erlang_imports,
     "fsharp": extract_fsharp_imports,
     # dbt {{ ref() }} / {{ source() }}, the only import system .sql files

--- a/packages/core/src/repowise/core/ingestion/lightweight_imports/__init__.py
+++ b/packages/core/src/repowise/core/ingestion/lightweight_imports/__init__.py
@@ -39,7 +39,7 @@ _EXTRACTORS: dict[str, ExtractorFn] = {
     "clojure": extract_clojure_imports,
     "haskell": extract_haskell_imports,
     "lean": extract_lean_imports,
-    # `import QtQuick` / `import "components"` — module specs and quoted
+    # `import QtQuick` / `import "components"`: module specs and quoted
     # relative references (see qml.py).
     "qml": extract_qml_imports,
     "erlang": extract_erlang_imports,

--- a/packages/core/src/repowise/core/ingestion/lightweight_imports/qml.py
+++ b/packages/core/src/repowise/core/ingestion/lightweight_imports/qml.py
@@ -1,0 +1,120 @@
+"""Regex import extraction for QML.
+
+Captured forms:
+
+    import QtQuick 2.15
+    import QtQuick.Controls 2.15
+    import org.kde.kirigami as K
+    import "components"
+    import "js/app.js" as AppScript
+    import "../shared"
+
+Two shapes with different resolution targets:
+
+1. **Module imports** — unquoted dotted identifiers (`QtQuick`,
+   `QtQuick.Controls`, `org.kde.kirigami`). These name a QML module, which
+   is a *directory* holding a ``qmldir`` manifest (or the Qt builtins).
+   The resolver maps dotted module names to local `qmldir`-declared
+   modules; anything unresolved is external.
+2. **Directory / script imports** — quoted strings (`"components"`,
+   `"js/app.js"`, `"../shared"`). These are relative references resolved
+   against the importing file's directory, the same shape as the HTML
+   asset resolver handles. ``import "js/app.js" as S`` is a file dependency
+   with the extension present; `"components"` and `"../shared"` reference
+   a directory whose ``qmldir`` declares the module.
+
+Comments are stripped before matching — QML uses ``//`` line comments and
+``/* ... */`` block comments, and a quoted import inside a comment must
+never mint an edge.
+"""
+
+from __future__ import annotations
+
+import re
+
+from ..models import Import
+
+# A dotted QML module name: identifier segments joined by dots.
+_MODULE = r"[A-Za-z_][\w]*(?:\.[A-Za-z_][\w]*)*"
+
+# `import <Module.Identifier> [<version>] [as Alias]`
+_IMPORT_MODULE_RE = re.compile(r"^import[ \t]+(" + _MODULE + r")", re.M)
+# `import "<relative/path>" [as Alias]`
+_IMPORT_PATH_RE = re.compile(r'^import[ \t]+"([^"]+)"', re.M)
+
+
+def _strip_comments(text: str) -> str:
+    """Blank out QML comments so they can't produce false import edges.
+
+    Removes ``//`` line comments and ``/* ... */`` block comments
+    (QML's block comments do not nest), replacing their characters with
+    spaces while preserving newlines so ^-anchored matching still sees
+    real statements at their original positions.
+    """
+    out: list[str] = []
+    i = 0
+    n = len(text)
+    in_block = False
+    while i < n:
+        pair = text[i : i + 2]
+        if in_block:
+            if pair == "*/":
+                in_block = False
+                out.append("  ")
+                i += 2
+            else:
+                out.append("\n" if text[i] == "\n" else " ")
+                i += 1
+        elif pair == "/*":
+            in_block = True
+            out.append("  ")
+            i += 2
+        elif pair == "//":
+            while i < n and text[i] != "\n":
+                out.append(" ")
+                i += 1
+        else:
+            out.append(text[i])
+            i += 1
+    return "".join(out)
+
+
+def extract_qml_imports(text: str) -> list[Import]:
+    text = _strip_comments(text)
+    imports: list[Import] = []
+    seen: set[str] = set()
+
+    for match in _IMPORT_MODULE_RE.finditer(text):
+        module = match.group(1)
+        if module in seen:
+            continue
+        seen.add(module)
+        imports.append(
+            Import(
+                raw_statement=match.group(0).strip(),
+                module_path=module,
+                imported_names=[],
+                is_relative=False,
+                resolved_file=None,
+            )
+        )
+
+    for match in _IMPORT_PATH_RE.finditer(text):
+        rel = match.group(1).strip()
+        if rel in seen:
+            continue
+        seen.add(rel)
+        imports.append(
+            Import(
+                raw_statement=match.group(0).strip(),
+                # Keep the quoted form: the resolver distinguishes a
+                # relative reference from a module import by the opening
+                # quote.
+                module_path=f'"{rel}"',
+                imported_names=[],
+                is_relative=True,
+                resolved_file=None,
+            )
+        )
+
+    return imports

--- a/packages/core/src/repowise/core/ingestion/lightweight_imports/qml.py
+++ b/packages/core/src/repowise/core/ingestion/lightweight_imports/qml.py
@@ -11,19 +11,19 @@ Captured forms:
 
 Two shapes with different resolution targets:
 
-1. **Module imports** — unquoted dotted identifiers (`QtQuick`,
+1. **Module imports**: unquoted dotted identifiers (`QtQuick`,
    `QtQuick.Controls`, `org.kde.kirigami`). These name a QML module, which
    is a *directory* holding a ``qmldir`` manifest (or the Qt builtins).
    The resolver maps dotted module names to local `qmldir`-declared
    modules; anything unresolved is external.
-2. **Directory / script imports** — quoted strings (`"components"`,
+2. **Directory / script imports**: quoted strings (`"components"`,
    `"js/app.js"`, `"../shared"`). These are relative references resolved
    against the importing file's directory, the same shape as the HTML
    asset resolver handles. ``import "js/app.js" as S`` is a file dependency
    with the extension present; `"components"` and `"../shared"` reference
    a directory whose ``qmldir`` declares the module.
 
-Comments are stripped before matching — QML uses ``//`` line comments and
+Comments are stripped before matching. QML uses ``//`` line comments and
 ``/* ... */`` block comments, and a quoted import inside a comment must
 never mint an edge.
 """

--- a/packages/core/src/repowise/core/ingestion/models.py
+++ b/packages/core/src/repowise/core/ingestion/models.py
@@ -76,6 +76,8 @@ LanguageTag = Literal[
     "xaml",
     # Markup with no symbols, but <script src>/<link href> are real edges.
     "html",
+    # Lightweight: qmldir-declared module imports and quoted references.
+    "qml",
     "unknown",
 ]
 

--- a/packages/core/src/repowise/core/ingestion/resolvers/__init__.py
+++ b/packages/core/src/repowise/core/ingestion/resolvers/__init__.py
@@ -22,6 +22,7 @@ from .lean import resolve_lean_import
 from .luau import resolve_luau_import
 from .php import resolve_php_import
 from .python import resolve_python_import
+from .qml import resolve_qml_import
 from .ruby import resolve_ruby_import
 from .rust import resolve_rust_import
 from .scala import resolve_scala_import
@@ -60,6 +61,9 @@ _RESOLVERS: dict[str, ResolverFn] = {
     "clojure": resolve_clojure_import,
     "haskell": resolve_haskell_import,
     "lean": resolve_lean_import,
+    # QtQuick module specs via the qmldir index; quoted paths resolved
+    # relative to the importing file (see qml.py).
+    "qml": resolve_qml_import,
     "erlang": resolve_erlang_import,
     "fsharp": resolve_fsharp_import,
     # dbt ref()/source(), gated on dbt_project.yml via the model index.

--- a/packages/core/src/repowise/core/ingestion/resolvers/qml.py
+++ b/packages/core/src/repowise/core/ingestion/resolvers/qml.py
@@ -1,0 +1,129 @@
+"""QML import resolution (lightweight regex tier).
+
+Two import shapes resolve differently:
+
+1. **Relative references** — ``import "components"``,
+   ``import "js/app.js" as S``, ``import "../shared"``. These are paths
+   anchored at the importing file's directory, exactly like the HTML asset
+   resolver: the reference stays relative, and the directory-import case
+   resolves to the ``qmldir`` manifest *inside* the referenced directory
+   (the module's declaration file), so ``import "components"`` from
+   ``ui/Main.qml`` becomes ``ui/components/qmldir``.
+
+2. **Module imports** — ``import QtQuick``, ``import MyCompany.Controls``.
+   A local QML module is a directory carrying a ``qmldir`` manifest that
+   *declares* the module via ``module <Dotted.Name>``. The module-name
+   index maps declared module names to their ``qmldir`` files, and each
+   imported name is looked up there. Qt's own modules (``QtQuick``,
+   ``QtQuick.Controls``, ``QtQml``, …) never hit a local file and resolve
+   external — the same standard-library trade as the Lean and Haskell
+   resolvers.
+"""
+
+from __future__ import annotations
+
+import posixpath
+import re
+from typing import TYPE_CHECKING
+
+from .module_name_index import get_or_build_module_index, lookup_module
+
+if TYPE_CHECKING:
+    from .context import ResolverContext
+
+# `module <Dotted.Name>` in a qmldir manifest — the module's own declaration.
+_MODULE_DECL_RE = re.compile(r"^module[ \t]+([A-Za-z_][\w]*(?:\.[A-Za-z_][\w]*)*)", re.M)
+
+# Qt's own modules never resolve to a repo file.
+_QT_MODULE_PREFIXES = frozenset(
+    {
+        "QtQuick",
+        "QtQml",
+        "QtQml.Models",
+        "QtQml.WorkerScript",
+        "QtQml.StateMachine",
+        "QtQuick.Controls",
+        "QtQuick.Layouts",
+        "QtQuick.Window",
+        "QtQuick.Dialogs",
+        "QtQuick.Templates",
+        "QtQuick.Particles",
+        "QtQuick.Shapes",
+        "QtQuick.XmlListModel",
+        "QtTest",
+        "QtMultimedia",
+        "QtLocation",
+        "QtGraphicalEffects",
+        "QtGraphicalEffects1",
+        "QtWebEngine",
+        "QtWebSockets",
+        "QtBluetooth",
+        "QtNfc",
+        "QtSensors",
+        "QtPositioning",
+        "QtPdf",
+        "QtQuick3D",
+        "QtCharts",
+        "QtDataVisualization",
+        "Qt.labs",
+        "Qt.labs.qmlmodels",
+        "Qt.labs.folderlistmodel",
+        "Qt.labs.platform",
+        "Qt.labs.settings",
+        "Qt.labs.animation",
+        "Qt.labs.calendar",
+        "Qt.labs.location",
+        "Qt.labs.qmlwebengine",
+        "Qt.labs.wavefrontmesh",
+        "QtQuick.PrivateWidgets",
+    }
+)
+
+
+def _get_module_index(ctx: ResolverContext) -> dict[str, list[str]]:
+    return get_or_build_module_index(
+        ctx,
+        cache_attr="_qml_module_index",
+        extensions=("qmldir",),
+        declaration_re=_MODULE_DECL_RE,
+        # qmldir is always the manifest file, never a declaration-less
+        # path-convention hit, so no path inverse is provided.
+        path_to_module=None,
+    )
+
+
+def resolve_qml_import(
+    module_path: str, importer_path: str, ctx: ResolverContext
+) -> str | None:
+    """Resolve one QML import to a repo-relative path, or None."""
+    raw = module_path.strip()
+    if not raw:
+        return None
+
+    # A quoted relative reference: "components", "js/app.js", "../shared".
+    if raw.startswith(('"', "'")):
+        rel = raw.strip("\"'")
+        if not rel:
+            return None
+        importer_dir = posixpath.dirname(importer_path)
+        resolved = posixpath.normpath(posixpath.join(importer_dir, rel))
+        if resolved.startswith("..") or resolved in (".", "/"):
+            return None
+        # A directory import resolves to its qmldir manifest; a script
+        # import resolves to the file itself.
+        if resolved in ctx.path_set:
+            return resolved
+        if posixpath.join(resolved, "qmldir") in ctx.path_set:
+            return posixpath.join(resolved, "qmldir")
+        # A bare path reference may be missing its extension (a script
+        # imported without ".js") — a unique suffix match, no guesses on ties.
+        if "/" in rel:
+            needle = f"/{posixpath.normpath(rel)}"
+            hits = [p for p in ctx.sorted_paths if p.endswith(needle)]
+            return hits[0] if len(hits) == 1 else None
+        return None
+
+    # A module import: look it up in the local qmldir index.
+    if raw.split(".", 1)[0] in _QT_MODULE_PREFIXES or raw in _QT_MODULE_PREFIXES:
+        return None
+    return lookup_module(_get_module_index(ctx), raw)

--- a/packages/core/src/repowise/core/ingestion/resolvers/qml.py
+++ b/packages/core/src/repowise/core/ingestion/resolvers/qml.py
@@ -2,7 +2,7 @@
 
 Two import shapes resolve differently:
 
-1. **Relative references** — ``import "components"``,
+1. **Relative references**: ``import "components"``,
    ``import "js/app.js" as S``, ``import "../shared"``. These are paths
    anchored at the importing file's directory, exactly like the HTML asset
    resolver: the reference stays relative, and the directory-import case
@@ -10,14 +10,19 @@ Two import shapes resolve differently:
    (the module's declaration file), so ``import "components"`` from
    ``ui/Main.qml`` becomes ``ui/components/qmldir``.
 
-2. **Module imports** — ``import QtQuick``, ``import MyCompany.Controls``.
+2. **Module imports**: ``import QtQuick``, ``import MyCompany.Controls``.
    A local QML module is a directory carrying a ``qmldir`` manifest that
    *declares* the module via ``module <Dotted.Name>``. The module-name
    index maps declared module names to their ``qmldir`` files, and each
    imported name is looked up there. Qt's own modules (``QtQuick``,
-   ``QtQuick.Controls``, ``QtQml``, …) never hit a local file and resolve
-   external — the same standard-library trade as the Lean and Haskell
-   resolvers.
+   ``QtQuick.Controls``, ``QtQml`` and the rest) never hit a local file and
+   resolve external, the same standard-library trade as the Lean and
+   Haskell resolvers.
+
+Stated ceiling: a directory import only produces an edge when the target
+directory holds a ``qmldir``. An implicit module (a directory of ``.qml``
+files with no manifest) yields no edge, because a resolver returns one
+target per import and cannot fan out to every file in a directory.
 """
 
 from __future__ import annotations
@@ -26,12 +31,12 @@ import posixpath
 import re
 from typing import TYPE_CHECKING
 
-from .module_name_index import get_or_build_module_index, lookup_module
+from .module_name_index import get_or_build_module_index
 
 if TYPE_CHECKING:
     from .context import ResolverContext
 
-# `module <Dotted.Name>` in a qmldir manifest — the module's own declaration.
+# `module <Dotted.Name>` in a qmldir manifest, the module's own declaration.
 _MODULE_DECL_RE = re.compile(r"^module[ \t]+([A-Za-z_][\w]*(?:\.[A-Za-z_][\w]*)*)", re.M)
 
 # Qt's own modules never resolve to a repo file.
@@ -84,6 +89,8 @@ def _get_module_index(ctx: ResolverContext) -> dict[str, list[str]]:
     return get_or_build_module_index(
         ctx,
         cache_attr="_qml_module_index",
+        # The builder filters on ``path.endswith`` and qmldir carries no
+        # extension, so this covers both ``some/dir/qmldir`` and a root one.
         extensions=("qmldir",),
         declaration_re=_MODULE_DECL_RE,
         # qmldir is always the manifest file, never a declaration-less
@@ -110,13 +117,14 @@ def resolve_qml_import(
         if resolved.startswith("..") or resolved in (".", "/"):
             return None
         # A directory import resolves to its qmldir manifest; a script
-        # import resolves to the file itself.
+        # import resolves to the file itself. A directory with no qmldir
+        # is an implicit module, and one import cannot name every file.
         if resolved in ctx.path_set:
             return resolved
         if posixpath.join(resolved, "qmldir") in ctx.path_set:
             return posixpath.join(resolved, "qmldir")
         # A bare path reference may be missing its extension (a script
-        # imported without ".js") — a unique suffix match, no guesses on ties.
+        # imported without ".js"): a unique suffix match, no guesses on ties.
         if "/" in rel:
             needle = f"/{posixpath.normpath(rel)}"
             hits = [p for p in ctx.sorted_paths if p.endswith(needle)]
@@ -126,4 +134,9 @@ def resolve_qml_import(
     # A module import: look it up in the local qmldir index.
     if raw.split(".", 1)[0] in _QT_MODULE_PREFIXES or raw in _QT_MODULE_PREFIXES:
         return None
-    return lookup_module(_get_module_index(ctx), raw)
+    # Two qmldir files can declare the same module name; picking either one
+    # would be a guess, and a wrong edge is worse than no edge.
+    declaring = _get_module_index(ctx).get(raw)
+    if not declaring or len(declaring) > 1:
+        return None
+    return declaring[0]

--- a/tests/unit/dead_code/test_never_flag_regex.py
+++ b/tests/unit/dead_code/test_never_flag_regex.py
@@ -43,6 +43,7 @@ _PROBE_PATHS = [
     "app/loading.tsx",
     "app/error.tsx",
     "app/not-found.tsx",
+    "ui/components/Button.qml",
     # Negatives — close but should NOT match.
     "src/pages.py",
     "core/router.py",
@@ -111,6 +112,12 @@ class TestShouldNeverFlag:
 
     def test_init_py_barrel(self):
         assert self._analyzer()._should_never_flag("pkg/sub/__init__.py", set())
+
+    def test_qml_component(self):
+        # Instantiated by type name and loaded by the Qt runtime, so a QML
+        # file never has a static importer to find.
+        assert self._analyzer()._should_never_flag("ui/components/Button.qml", set())
+        assert not self._analyzer()._should_never_flag("ui/components/button.js", set())
 
 
 class TestSuffixIndexEquivalence:

--- a/tests/unit/ingestion/test_language_capabilities.py
+++ b/tests/unit/ingestion/test_language_capabilities.py
@@ -179,6 +179,9 @@ _PARTIAL = {
     # rather than full because template dialects (Django, Jinja, Go templates,
     # ERB, Handlebars) are invisible to an HTML grammar and yield nothing.
     "html",
+    # import QtQuick / import "components": module specs via the qmldir
+    # index, quoted references relative to the importing file (#727).
+    "qml",
 }
 
 

--- a/tests/unit/ingestion/test_language_capabilities.py
+++ b/tests/unit/ingestion/test_language_capabilities.py
@@ -202,6 +202,25 @@ class TestImportSupportTiers:
         assert REGISTRY.import_support_for("klingon") == "none"
 
 
+class TestLanguageTagParity:
+    def test_every_spec_tag_is_a_language_tag(self) -> None:
+        # EXTENSION_TO_LANGUAGE keeps only extensions whose tag is in the
+        # LanguageTag literal, so a spec whose tag is missing there is
+        # registered but never traversed: its files index as nothing while
+        # the parser tests, which bypass the traverser, stay green.
+        from repowise.core.ingestion.models import _LANGUAGE_TAG_VALUES
+
+        spec_tags = {spec.tag for spec in REGISTRY.all_specs()}
+        assert spec_tags == _LANGUAGE_TAG_VALUES
+
+    def test_every_spec_extension_is_routed(self) -> None:
+        from repowise.core.ingestion.models import EXTENSION_TO_LANGUAGE
+
+        for spec in REGISTRY.all_specs():
+            for ext in spec.extensions:
+                assert EXTENSION_TO_LANGUAGE.get(ext) == spec.tag, (spec.tag, ext)
+
+
 # ---------------------------------------------------------------------------
 # Derivation pins — constants that used to be drifting frozen literals are
 # now registry derivations; pin the relationship, not a literal.

--- a/tests/unit/ingestion/test_lightweight_resolvers.py
+++ b/tests/unit/ingestion/test_lightweight_resolvers.py
@@ -93,6 +93,8 @@ class TestDispatch:
             "sql",
             # <script src>/<link href>; AST-backed, unlike its siblings here.
             "html",
+            # import QtQuick / import "components" (regex tier, #727).
+            "qml",
         } == LIGHTWEIGHT_IMPORT_LANGUAGES
 
     def test_other_language_returns_empty(self) -> None:

--- a/tests/unit/ingestion/test_qml_imports.py
+++ b/tests/unit/ingestion/test_qml_imports.py
@@ -1,8 +1,8 @@
 """QML import extraction and resolution (lightweight regex tier, #727).
 
-QML has no published tree-sitter grammar, so it ships at the lightweight
-tier: real file-to-file import edges, no symbol claims. These tests pin
-both what the tier captures and what it refuses to — module imports,
+QML ships at the lightweight tier for now: real file-to-file import
+edges, no symbol claims. These tests pin
+both what the tier captures and what it refuses to: module imports,
 quoted relative references, comment-stripping, dedup, Qt builtins
 resolving external, and the qmldir module-name index.
 """
@@ -81,6 +81,17 @@ class TestExtraction:
             '"components"',
         ]
 
+    def test_versioned_quoted_import(self) -> None:
+        assert _modules('import "components" 1.0\n') == ['"components"']
+
+    def test_same_module_at_two_versions_recorded_once(self) -> None:
+        # By design: the graph edge is per module, not per version, so the
+        # extractor keys dedup on the module name alone.
+        assert _modules("import QtQuick 2.15\nimport QtQuick 2.0\n") == ["QtQuick"]
+
+    def test_pragma_library_is_not_an_import(self) -> None:
+        assert _modules(".pragma library\nfunction helper() {}\n") == []
+
     def test_extract_via_dispatch(self) -> None:
         """The parser's no-grammar path must reach the QML extractor."""
         from datetime import datetime
@@ -148,26 +159,120 @@ class TestResolution:
 
     def test_unique_suffix_fallback_for_moved_script_dir(self) -> None:
         # `import "js/app.js"` from ui/pages/Page.qml: dir-join gives
-        # ui/pages/js/app.js (miss), but the file lives at ui/js/app.js —
+        # ui/pages/js/app.js (miss), but the file lives at ui/js/app.js;
         # unique /js/app.js suffix links it.
         files = {
             "ui/pages/Page.qml": 'import "js/app.js" as A\n',
             "ui/js/app.js": "x\n",
             "ui/other/also/app.js": "y\n",
         }
-        # Two files end in /js/app.js? No — ui/other/also/app.js does not end
+        # Two files end in /js/app.js? No, ui/other/also/app.js does not end
         # with "/js/app.js", so this is already unique.
         assert _resolve('"js/app.js"', "ui/pages/Page.qml", files) == "ui/js/app.js"
         files["ui/js/app.js"] = "x\n"
         files["ui/vendor/js/app.js"] = "z\n"
-        # Now two files end in /js/app.js — a tie, no guessed edge.
+        # Now two files end in /js/app.js: a tie, no guessed edge.
         assert _resolve('"js/app.js"', "ui/pages/Page.qml", files) is None
 
     def test_bare_name_without_slash_never_suffix_matches(self) -> None:
-        # A lone "utils" could be anything — matching by suffix would be a
+        # A lone "utils" could be anything; matching by suffix would be a
         # guess (same policy as the HTML asset resolver).
         files = {
             "ui/Main.qml": 'import "utils"\n',
             "ui/js/utils.js": "x\n",
         }
         assert _resolve('"utils"', "ui/Main.qml", files) is None
+
+    def test_versioned_quoted_import_resolves_like_the_bare_form(self) -> None:
+        files = {
+            "ui/Main.qml": 'import "components" 1.0\n',
+            "ui/components/qmldir": "module ui.components\n",
+        }
+        assert _resolve('"components"', "ui/Main.qml", files) == "ui/components/qmldir"
+
+    def test_directory_without_qmldir_yields_nothing(self) -> None:
+        # An implicit module: a resolver returns one target per import, so a
+        # directory of components cannot fan out to every file in it.
+        files = {
+            "ui/Main.qml": 'import "components"\n',
+            "ui/components/Button.qml": "Item {}\n",
+            "ui/components/Card.qml": "Item {}\n",
+        }
+        assert _resolve('"components"', "ui/Main.qml", files) is None
+
+    def test_module_declared_twice_yields_nothing(self, tmp_path) -> None:
+        # Two manifests claim one module name; either pick would be a guess.
+        files = {
+            "ui/Main.qml": "import MyCompany.Controls 1.0\n",
+            "controls/qmldir": "module MyCompany.Controls\n",
+            "vendor/controls/qmldir": "module MyCompany.Controls\n",
+        }
+        assert _resolve("MyCompany.Controls", "ui/Main.qml", files, tmp_path) is None
+class TestTraversalToResolution:
+    """The whole route, on files written to disk rather than a hand-built set.
+
+    qmldir has no extension, so it reaches the graph only through the spec's
+    special_filenames; without it the module index builds empty and every
+    module import and directory import silently misses.
+    """
+
+    def test_qmldir_is_routed_to_qml(self) -> None:
+        from repowise.core.ingestion.models import SPECIAL_FILENAMES
+
+        assert SPECIAL_FILENAMES["qmldir"] == "qml"
+
+    def test_traversed_repo_resolves_module_and_directory_imports(
+        self, tmp_path: Path
+    ) -> None:
+        from repowise.core.ingestion.graph._stem import build_stem_map
+        from repowise.core.ingestion.traverser import FileTraverser
+
+        (tmp_path / "ui" / "components").mkdir(parents=True)
+        (tmp_path / "controls").mkdir()
+        (tmp_path / "ui" / "Main.qml").write_text(
+            'import My.Controls 1.0\nimport "components"\n', encoding="utf-8"
+        )
+        (tmp_path / "controls" / "qmldir").write_text(
+            "module My.Controls\nplugin controls\n", encoding="utf-8"
+        )
+        (tmp_path / "ui" / "components" / "qmldir").write_text(
+            "module ui.components\nButton 1.0 Button.qml\n", encoding="utf-8"
+        )
+        (tmp_path / "ui" / "components" / "Button.qml").write_text(
+            "import QtQuick 2.15\nItem {}\n", encoding="utf-8"
+        )
+
+        traversed = list(FileTraverser(tmp_path).traverse())
+        by_path = {fi.path: fi for fi in traversed}
+        assert by_path["controls/qmldir"].language == "qml"
+        assert by_path["ui/components/qmldir"].language == "qml"
+
+        # Built the way GraphBuilder.build does: path_set is the traversed set.
+        path_set = set(by_path)
+        ctx = ResolverContext(
+            path_set=path_set,
+            stem_map=build_stem_map(path_set),
+            graph=nx.DiGraph(),
+            repo_path=tmp_path,
+        )
+        assert (
+            resolve_import("My.Controls", "ui/Main.qml", "qml", ctx) == "controls/qmldir"
+        )
+        assert (
+            resolve_import('"components"', "ui/Main.qml", "qml", ctx)
+            == "ui/components/qmldir"
+        )
+
+    def test_qmldir_yields_no_imports_of_its_own(self, tmp_path: Path) -> None:
+        # module / plugin / depends / component lines are not `import` lines.
+        from repowise.core.ingestion.traverser import FileTraverser
+
+        (tmp_path / "controls").mkdir()
+        (tmp_path / "controls" / "qmldir").write_text(
+            "module My.Controls\nplugin controls\ndepends QtQuick 2.15\n"
+            "Button 1.0 Button.qml\n",
+            encoding="utf-8",
+        )
+        (fi,) = [f for f in FileTraverser(tmp_path).traverse() if f.path.endswith("qmldir")]
+        raw = (tmp_path / fi.path).read_bytes()
+        assert extract_lightweight_imports(fi, raw) == []

--- a/tests/unit/ingestion/test_qml_imports.py
+++ b/tests/unit/ingestion/test_qml_imports.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 from pathlib import Path
 
 import networkx as nx
-import pytest
 
 from repowise.core.ingestion.lightweight_imports import extract_lightweight_imports
 from repowise.core.ingestion.lightweight_imports.qml import extract_qml_imports

--- a/tests/unit/ingestion/test_qml_imports.py
+++ b/tests/unit/ingestion/test_qml_imports.py
@@ -1,0 +1,174 @@
+"""QML import extraction and resolution (lightweight regex tier, #727).
+
+QML has no published tree-sitter grammar, so it ships at the lightweight
+tier: real file-to-file import edges, no symbol claims. These tests pin
+both what the tier captures and what it refuses to — module imports,
+quoted relative references, comment-stripping, dedup, Qt builtins
+resolving external, and the qmldir module-name index.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import networkx as nx
+import pytest
+
+from repowise.core.ingestion.lightweight_imports import extract_lightweight_imports
+from repowise.core.ingestion.lightweight_imports.qml import extract_qml_imports
+from repowise.core.ingestion.resolvers import resolve_import
+from repowise.core.ingestion.resolvers.context import ResolverContext
+
+
+def _modules(source: str) -> list[str]:
+    return [i.module_path for i in extract_qml_imports(source)]
+
+
+def _ctx(repo: Path | None, files: dict[str, str]) -> ResolverContext:
+    """ResolverContext over *files* ({path: content}); writes them under *repo*."""
+    if repo is not None:
+        for rel, content in files.items():
+            target = repo / rel
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(content, encoding="utf-8")
+    stem_map: dict[str, list[str]] = {}
+    for p in files:
+        stem = p.rsplit("/", 1)[-1].rsplit(".", 1)[0].lower()
+        stem_map.setdefault(stem, []).append(p)
+    return ResolverContext(
+        path_set=set(files),
+        stem_map=stem_map,
+        graph=nx.DiGraph(),
+        repo_path=repo,
+    )
+
+
+def _resolve(module: str, importer: str, files: dict[str, str], repo: Path | None = None) -> str | None:
+    ctx = _ctx(repo, files)
+    return resolve_import(module, importer, "qml", ctx)
+
+
+class TestExtraction:
+    def test_module_import_with_version(self) -> None:
+        assert _modules("import QtQuick 2.15\n") == ["QtQuick"]
+
+    def test_dotted_module_import(self) -> None:
+        assert _modules("import QtQuick.Controls 2.15\n") == ["QtQuick.Controls"]
+
+    def test_module_import_with_alias(self) -> None:
+        assert _modules("import org.kde.kirigami as K\n") == ["org.kde.kirigami"]
+
+    def test_quoted_directory_import(self) -> None:
+        assert _modules('import "components"\n') == ['"components"']
+
+    def test_quoted_script_import(self) -> None:
+        assert _modules('import "js/app.js" as AppScript\n') == ['"js/app.js"']
+
+    def test_relative_parent_import(self) -> None:
+        assert _modules('import "../shared"\n') == ['"../shared"']
+
+    def test_line_comment_import_is_not_an_edge(self) -> None:
+        assert _modules("// import QtQuick\nimport QtQuick 2.15\n") == ["QtQuick"]
+
+    def test_block_comment_import_is_not_an_edge(self) -> None:
+        assert _modules("/* import \"old.js\" */\nimport QtQuick 2.15\n") == ["QtQuick"]
+
+    def test_duplicate_import_recorded_once(self) -> None:
+        assert _modules("import QtQuick 2.15\nimport QtQuick 2.15\n") == ["QtQuick"]
+
+    def test_module_and_path_imports_coexist(self) -> None:
+        assert _modules('import QtQuick 2.15\nimport "components"\n') == [
+            "QtQuick",
+            '"components"',
+        ]
+
+    def test_extract_via_dispatch(self) -> None:
+        """The parser's no-grammar path must reach the QML extractor."""
+        from datetime import datetime
+
+        from repowise.core.ingestion.models import FileInfo
+
+        fi = FileInfo(
+            path="ui/Main.qml",
+            abs_path="/tmp/ui/Main.qml",
+            language="qml",  # type: ignore[arg-type]
+            size_bytes=0,
+            git_hash="",
+            last_modified=datetime.now(),
+            is_test=False,
+            is_config=False,
+            is_api_contract=False,
+            is_entry_point=False,
+        )
+        imports = extract_lightweight_imports(
+            fi, b'import QtQuick 2.15\nimport "components"\n'
+        )
+        assert [i.module_path for i in imports] == ["QtQuick", '"components"']
+
+
+class TestResolution:
+    def test_module_import_resolves_via_qmldir(self, tmp_path) -> None:
+        files = {
+            "ui/Main.qml": "import MyCompany.Controls 1.0\n",
+            "controls/qmldir": "module MyCompany.Controls\n",
+        }
+        assert _resolve("MyCompany.Controls", "ui/Main.qml", files, tmp_path) == "controls/qmldir"
+
+    def test_qt_builtin_module_resolves_external(self, tmp_path) -> None:
+        files = {"ui/Main.qml": "import QtQuick 2.15\n"}
+        assert _resolve("QtQuick", "ui/Main.qml", files, tmp_path) is None
+
+    def test_unknown_module_resolves_external(self, tmp_path) -> None:
+        files = {"ui/Main.qml": "import SomethingElse 1.0\n"}
+        assert _resolve("SomethingElse", "ui/Main.qml", files, tmp_path) is None
+
+    def test_directory_import_resolves_to_qmldir(self) -> None:
+        files = {
+            "ui/Main.qml": 'import "components"\n',
+            "ui/components/qmldir": "module ui.components\n",
+        }
+        assert _resolve('"components"', "ui/Main.qml", files) == "ui/components/qmldir"
+
+    def test_script_import_resolves_to_file(self) -> None:
+        files = {
+            "ui/Main.qml": 'import "js/app.js" as AppScript\n',
+            "ui/js/app.js": "function helper() {}\n",
+        }
+        assert _resolve('"js/app.js"', "ui/Main.qml", files) == "ui/js/app.js"
+
+    def test_parent_relative_directory(self) -> None:
+        files = {
+            "ui/pages/Page.qml": 'import "../shared"\n',
+            "ui/shared/qmldir": "module shared\n",
+        }
+        assert _resolve('"../shared"', "ui/pages/Page.qml", files) == "ui/shared/qmldir"
+
+    def test_escape_out_of_repo_yields_nothing(self) -> None:
+        files = {"ui/Main.qml": 'import "../../outside"\n'}
+        assert _resolve('"../../outside"', "ui/Main.qml", files) is None
+
+    def test_unique_suffix_fallback_for_moved_script_dir(self) -> None:
+        # `import "js/app.js"` from ui/pages/Page.qml: dir-join gives
+        # ui/pages/js/app.js (miss), but the file lives at ui/js/app.js —
+        # unique /js/app.js suffix links it.
+        files = {
+            "ui/pages/Page.qml": 'import "js/app.js" as A\n',
+            "ui/js/app.js": "x\n",
+            "ui/other/also/app.js": "y\n",
+        }
+        # Two files end in /js/app.js? No — ui/other/also/app.js does not end
+        # with "/js/app.js", so this is already unique.
+        assert _resolve('"js/app.js"', "ui/pages/Page.qml", files) == "ui/js/app.js"
+        files["ui/js/app.js"] = "x\n"
+        files["ui/vendor/js/app.js"] = "z\n"
+        # Now two files end in /js/app.js — a tie, no guessed edge.
+        assert _resolve('"js/app.js"', "ui/pages/Page.qml", files) is None
+
+    def test_bare_name_without_slash_never_suffix_matches(self) -> None:
+        # A lone "utils" could be anything — matching by suffix would be a
+        # guess (same policy as the HTML asset resolver).
+        files = {
+            "ui/Main.qml": 'import "utils"\n',
+            "ui/js/utils.js": "x\n",
+        }
+        assert _resolve('"utils"', "ui/Main.qml", files) is None


### PR DESCRIPTION
## What

Fixes #727. QML ships at the honest lightweight tier — the same shape as Lean and HTML — which still delivers the reporter's core ask ("the agent doesn't know where to look") as real file-to-file edges.

## Root cause

The Good tier requires a published tree-sitter grammar, and none exists for QML (verified: no installable grammar on GitHub or npm — tree-sitter-qml returns 404 everywhere).

## Changes

- **Extractor** (`lightweight_imports/qml.py`): `import QtQuick 2.15`, `import org.kde.kirigami as K`, `import "components"`, `import "js/app.js" as S`; `//` and `/* */` comments stripped so commented imports never mint edges; dedup.
- **Resolver** (`resolvers/qml.py`): quoted references resolve relative to the importing file (a directory import links its `qmldir` manifest; unique-suffix fallback with no guesses on ties); module specs resolve against a qmldir-declared module-name index; Qt's ~30 builtin module prefixes resolve external.
- **Spec**: `.qml`/`.qmltypes`, passthrough, `qmldir` as the manifest file.
- **Docs**: Lightweight tier now 8 languages; Good-tier upgrade path (component/property/signal symbols + qmldir heritage) documented as the grammar-follows path.

## Tests

20 QML-specific tests (extraction forms, comment guards, dedup, qmldir index hits, Qt-external, relative refs, no-guess ties) + tier-membership guards updated; the full ingestion suite passes.

Note: `test_plugin_content` is red on main itself (v0.47.0 release bug, unrelated to this PR).
