### PR TITLE
feat(mcp): add set_finding_status — the durable write half of findings triage (#1535)

### DIFF
--- a/docs/agent/INTEGRATIONS.md
+++ b/docs/agent/INTEGRATIONS.md
@@ -73,10 +73,10 @@ name for a host at this tier, which is the point of the tier.
 
 ## The MCP surface
 
-repowise registers **seventeen MCP tools**. A single-repo server advertises **ten**
+repowise registers **eighteen MCP tools**. A single-repo server advertises **ten**
 of them by default, and workspace mode adds one more automatically for **eleven**. A
-further **six** are off by default, enabled through the `mcp.tools` config block or
-`--tools +name`. The `lean` profile trims the default surface to **six** tools
+further **seven** are off by default, enabled through the `mcp.tools` config block
+or `--tools +name`. The `lean` profile trims the default surface to **six** tools
 (seven in workspace mode) for agents on a tight context budget.
 
 Per-tool detail: [MCP_TOOLS.md](MCP_TOOLS.md).

--- a/docs/agent/MCP_TOOLS.md
+++ b/docs/agent/MCP_TOOLS.md
@@ -2,7 +2,7 @@
 
 repowise exposes a curated set of tools via the [Model Context Protocol](https://modelcontextprotocol.io) (MCP). These tools give AI coding assistants (Claude Code, Codex, Cursor, Cline, Windsurf) structured access to your codebase intelligence: dependency graph, git history, documentation, and architectural decisions.
 
-17 tools are registered in total. A single-repo server advertises 10 by default: exactly the canonical tools. Workspace mode adds the `list_repos` discovery utility, for 11. 6 specialist tools are opt-in where eligible. The surface is configurable; see [Configuring the tool surface](#configuring-the-tool-surface).
+18 tools are registered in total. A single-repo server advertises 10 by default: exactly the canonical tools. Workspace mode adds the `list_repos` discovery utility, for 11. 7 specialist tools are opt-in where eligible. The surface is configurable; see [Configuring the tool surface](#configuring-the-tool-surface).
 
 **Start the MCP server:**
 
@@ -35,13 +35,14 @@ repowise mcp --transport sse --port 7338 # legacy SSE transport
 **Workspace discovery utility (default in workspace mode, 1)**
 [list_repos](#list_repos)
 
-**Opt-in specialists (6; workspace eligibility still applies)**
+**Opt-in specialists (7; workspace eligibility still applies)**
 [get_architecture](#get_architecture) &middot;
 [get_blast_radius](#get_blast_radius) &middot;
 [get_dependency_path](#get_dependency_path) &middot;
 [get_execution_flows](#get_execution_flows) &middot;
 [generate_refactoring_code](#generate_refactoring_code) &middot;
-[get_conformance](#get_conformance)
+[get_conformance](#get_conformance) &middot;
+[set_finding_status](#set_finding_status)
 
 Also see [Configuring the tool surface](#configuring-the-tool-surface), [Reversible truncation](#reversible-truncation-_metaomitted) and [Unrecognised arguments](#unrecognised-arguments-ignored_arguments).
 
@@ -1156,6 +1157,28 @@ Turns one structured refactoring plan from `get_health(include=["refactoring"])`
 
 ```
 generate_refactoring_code(suggestion_id="a1b2c3d4")
+```
+
+#### `set_finding_status`
+
+Records a durable disposition on one refactoring plan — the write half of the findings triage loop. `get_health(include=["refactoring"])` and the generated task prompts ask an agent to flag false positives, but until this tool there was nowhere to record that verdict from inside the agent loop. The status is stored on the plan row, and the analyzer's finalizer never re-emits a `false_positive` plan, so the triage survives every later run.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `suggestion_id` | string | Yes | The `id` or `public_id` of a plan from `get_health(include=["refactoring"])` |
+| `status` | string | Yes | One of `open`, `acknowledged`, `resolved`, `false_positive` |
+| `repo` | string | No | *(workspace only)* Target repo alias |
+| `reason` | string | No | Free-text audit note stored on the row (defaults to `"agent"`) |
+
+- `false_positive` — the plan is wrong for this repository; it is never re-emitted on future runs.
+- `acknowledged` — real, but the team is consciously not acting now; stays visible, stops counting as unheard.
+- `resolved` — the change landed (or the code moved on); a person-resolved plan stays resolved even if the detector still fires.
+- `open` — reset a prior decision.
+
+**When to use:** After `get_health(include=["refactoring"])` surfaces a plan you have judged, so the verdict becomes durable state instead of a one-off remark.
+
+```
+set_finding_status(suggestion_id="a1b2c3d4", status="false_positive", reason="false alarm: the class is a DTO")
 ```
 
 ---

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -356,7 +356,7 @@ repowise mcp --transport streamable-http
 repowise mcp --transport sse
 ```
 
-Exposes 17 registered MCP tools (11 advertised by default in single-repo mode:
+Exposes 18 registered MCP tools (11 advertised by default in single-repo mode:
 ten flagship tools plus `list_repos`) for querying wiki pages, symbols, the
 dependency graph, git analytics, ownership data, hotspots, dead code findings,
 code health, change risk, and decision intelligence. Full surface:

--- a/packages/cli/src/repowise/cli/commands/mcp_cmd.py
+++ b/packages/cli/src/repowise/cli/commands/mcp_cmd.py
@@ -133,7 +133,7 @@ def mcp_command(
 
     Exposes a curated set of tools for querying the repowise wiki via the MCP
     protocol: ten by default in single-repo mode, plus one more by default
-    in workspace mode. Six more are opt-in via ``--tools`` or the
+    in workspace mode. Seven more are opt-in via ``--tools`` or the
     ``mcp.tools`` config block. Supports stdio
     (for Claude Code, Codex, Cursor), streamable HTTP, and legacy SSE
     transports.

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -11,7 +11,7 @@ FastAPI REST API, webhook handlers, MCP server, and background job scheduler for
 | Component | Description |
 |-----------|-------------|
 | **REST API** | FastAPI application with full CRUD for repos, pages (with version history), symbols, jobs, git analytics, dead code, decisions, graph intelligence, blast radius, costs, knowledge map, security findings, providers, chat, CLAUDE.md generation, and multi-repo workspace |
-| **MCP Server** | 17 registered MCP tools (10 advertised by default in single-repo mode: the canonical set) for AI coding assistants (Claude Code, Cursor, Cline) |
+| **MCP Server** | 18 registered MCP tools (10 advertised by default in single-repo mode: the canonical set) for AI coding assistants (Claude Code, Cursor, Cline) |
 | **Webhooks** | GitHub and GitLab push event handlers — trigger sync jobs automatically on push |
 | **Scheduler** | APScheduler background jobs — polling fallback (auto-syncs diverged repos), stale page detection |
 

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -232,9 +232,9 @@ Job progress events (`JobProgressEvent`) carry: `event` type, `file` currently b
 
 ## MCP Server
 
-repowise registers 17 MCP tools and advertises **10 by default** in single-repo
+repowise registers 18 MCP tools and advertises **10 by default** in single-repo
 mode (10 advertised by default, exactly the canonical set). Workspace mode adds
-`list_repos`; six specialist tools are opt-in where eligible. See
+`list_repos`; seven specialist tools are opt-in where eligible. See
 [`docs/agent/MCP_TOOLS.md`](../../docs/agent/MCP_TOOLS.md).
 Start the MCP server via:
 

--- a/packages/server/src/repowise/server/mcp_server/__init__.py
+++ b/packages/server/src/repowise/server/mcp_server/__init__.py
@@ -52,6 +52,7 @@ from repowise.server.mcp_server import _state
 #: imports; individually they are what a single-tool consumer pays for.
 _TOOL_MODULES: dict[str, str] = {
     "generate_refactoring_code": "tool_refactoring",
+    "set_finding_status": "tool_findings",
     "get_answer": "tool_answer",
     "get_architecture": "tool_architecture",
     "get_blast_radius": "tool_blast_radius",

--- a/packages/server/src/repowise/server/mcp_server/_budget/contracts.py
+++ b/packages/server/src/repowise/server/mcp_server/_budget/contracts.py
@@ -316,6 +316,20 @@ _CONTRACTS: dict[str, ResponseBudgetContract] = {
         expansion_argument=None,
         protected=("suggestion_id", "resolved", "error"),
     ),
+    # Same shape as generate_refactoring_code: a small fixed write response
+    # whose fields are all load-bearing. No shed order — nothing to rank.
+    "set_finding_status": ResponseBudgetContract(
+        "blocks",
+        expansion_argument=None,
+        protected=(
+            "id",
+            "public_id",
+            "status",
+            "status_reason",
+            "status_changed_at",
+            "note",
+        ),
+    ),
 }
 
 

--- a/packages/server/src/repowise/server/mcp_server/tool_findings.py
+++ b/packages/server/src/repowise/server/mcp_server/tool_findings.py
@@ -1,0 +1,117 @@
+"""MCP tool: set_finding_status — record a disposition on a refactoring plan.
+
+The missing write half of the findings lifecycle (#1535). ``get_health``
+surfaces refactoring plans read-only, and the generated task prompts tell an
+agent to "flag false positives" — but until now there was nowhere to flag
+them *to* from inside the agent loop. This tool closes the loop: an agent
+that judged a plan wrong records ``false_positive`` (or ``acknowledged`` /
+``resolved``), and the finalizer ("finalize_refactoring_suggestions") never
+re-emits a ``false_positive`` plan, so the triage is durable across runs —
+the same suppression the REST PATCH path gives the web UI.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from repowise.core.persistence.crud import (
+    get_refactoring_suggestion,
+    get_refactoring_suggestions,
+    update_refactoring_suggestion_status,
+)
+from repowise.core.persistence.database import get_session
+from repowise.core.registry import mcp_tool_registry as mcp
+from repowise.server.mcp_server._helpers import _get_repo, _resolve_repo_context
+from repowise.server.mcp_server._meta import build_meta as _build_meta
+
+# One triage vocabulary for every layer (shared with health findings and the
+# REST PATCH surface) — see crud/analysis/refactoring.py.
+ALLOWED_STATUSES = ("open", "acknowledged", "resolved", "false_positive")
+
+
+@mcp.tool(
+    default=False,
+    tier="specialist",
+    surface_order=235,
+    trust_kind="user",
+    artifact_type="finding",
+    presentation="status",
+    safety="mutating",
+)
+async def set_finding_status(
+    suggestion_id: str,
+    status: str,
+    repo: str | None = None,
+    reason: str = "agent",
+) -> dict[str, Any]:
+    """Record a durable disposition on one refactoring plan.
+
+    The write side of the findings triage loop: after reviewing a plan from
+    ``get_health(include=["refactoring"])`` (use the plan's ``id`` or its
+    content-derived ``public_id``), record what you decided so the judgment
+    survives every later analysis run.
+
+    - ``false_positive`` — the plan is wrong for this repository; it is
+      never re-emitted on future runs (the analyzer's finalizer suppresses
+      the kernel), so a wrong suggestion stops coming back instead of being
+      re-proposed forever.
+    - ``acknowledged`` — real, but the team is consciously not acting now;
+      stays visible, stops counting as unheard.
+    - ``resolved`` — the change landed (or the code moved on); a plan a
+      person resolved stays resolved even if the detector still fires.
+    - ``open`` — reset a prior decision.
+
+    ``reason`` is a free-text note stored on the row for audit. Returns the
+    new status and its timestamp; raises on an unknown status or an id that
+    does not belong to this repository.
+    """
+    if status not in ALLOWED_STATUSES:
+        raise ValueError(
+            f"unknown finding status: {status!r}; expected one of {ALLOWED_STATUSES}"
+        )
+
+    ctx = await _resolve_repo_context(repo)
+    async with get_session(ctx.session_factory) as session:
+        repository = await _get_repo(session)
+        row = await get_refactoring_suggestion(session, repository.id, suggestion_id)
+        if row is None:
+            # Same fallback as generate_refactoring_code: a deep link may carry
+            # the display id ("<alias> <file>:<symbol>") rather than a storage
+            # or content id — match it against the rendered plan ids.
+            from repowise.server.mcp_server.tool_health import _refactoring_plan_id
+
+            candidates = await get_refactoring_suggestions(session, repository.id)
+            row = next(
+                (
+                    candidate
+                    for candidate in candidates
+                    if _refactoring_plan_id(candidate, ctx.alias or repository.name)
+                    == suggestion_id
+                ),
+                None,
+            )
+        if row is None:
+            raise ValueError(
+                f"refactoring plan not found: {suggestion_id!r} (in this repository)"
+            )
+        updated = await update_refactoring_suggestion_status(
+            session, repository.id, row.id, status, reason=reason
+        )
+        await session.commit()
+
+    return {
+        "id": updated.id,
+        "public_id": updated.public_id,
+        "status": updated.status,
+        "status_reason": updated.status_reason,
+        "status_changed_at": updated.status_changed_at.isoformat()
+        if updated.status_changed_at
+        else None,
+        "note": (
+            "Recorded. A false_positive plan will not be re-emitted by "
+            "future analysis runs."
+            if status == "false_positive"
+            else "Recorded."
+        ),
+        "_meta": _build_meta(repository=repository),
+    }

--- a/tests/fixtures/mcp/tool_response_shapes.json
+++ b/tests/fixtures/mcp/tool_response_shapes.json
@@ -1,1718 +1,1718 @@
 {
- "get_answer": {
-  "_meta": {
-   "cached": null,
-   "contract_version": null,
-   "embedder_degraded": null,
-   "index_age_days": null,
-   "indexed_commit": null,
-   "projection": {
-    "recovery": {
-     "arguments": {
-      "include": [
-       null
-      ],
-      "question": null
-     },
-     "tool": null
-    }
-   },
-   "timing_ms": null
-  },
-  "answer": null,
-  "candidates_emitted": null,
-  "candidates_reduced_reason": null,
-  "candidates_total": null,
-  "citations": [
-   null
-  ],
-  "confidence": null,
-  "fallback_targets_emitted": null,
-  "fallback_targets_reduced_reason": null,
-  "fallback_targets_total": null,
-  "flow_path": [
-   null
-  ],
-  "next_action_hint": null,
-  "note": null,
-  "quotes": [
-   {
-    "lines": [
-     null
-    ],
-    "path": null,
-    "quote": null
-   }
-  ],
-  "quotes_emitted": null,
-  "quotes_reduced_reason": null,
-  "quotes_total": null,
-  "retrieval_quality": null
- },
- "get_architecture": {
-  "_meta": {
-   "analysis_commits": {
-    "backend": null,
-    "frontend": null,
-    "repowise": null
-   },
-   "analysis_timestamp": null,
-   "contract_version": null,
-   "embedder_degraded": null
-  },
-  "architecture_type": null,
-  "conformance_violations": null,
-  "core_members": [
-   null
-  ],
-  "core_members_truncated": null,
-  "core_ratio": null,
-  "core_size": null,
-  "cycle_count": null,
-  "node_count": null,
-  "propagation_cost_pct": null,
-  "role_breakdown": {
-   "control": null,
-   "core": null,
-   "peripheral": null,
-   "shared": null
-  },
-  "score": null,
-  "summary": null
- },
- "get_blast_radius": {
-  "_meta": {
-   "analysis_commits": {
-    "backend": null,
-    "frontend": null,
-    "repowise": null
-   },
-   "analysis_timestamp": null,
-   "contract_version": null,
-   "embedder_degraded": null
-  },
-  "behavioral_count": null,
-  "impact_score_semantics": {
-   "authoritative_for_change_review": null,
-   "calibration": {
-    "status": null
-   },
-   "field": null,
-   "kind": null,
-   "measures": null,
-   "range": {
-    "maximum": null,
-    "minimum": null
-   },
-   "runtime_breakage_probability": null,
-   "unit": null
-  },
-  "impacted": [],
-  "impacted_repos": [],
-  "impacted_truncated": null,
-  "max_distance": null,
-  "structural_count": null,
-  "summary": null,
-  "target_repos": [],
-  "targets": [],
-  "total_impacted": null,
-  "unresolved_targets": [
-   null
-  ]
- },
- "get_change_risk": {
-  "_meta": {
-   "contract_version": null,
-   "embedder_degraded": null,
-   "index_age_days": null,
-   "indexed_commit": null,
-   "omitted": {
-    "refs": [
-     null
-    ],
-    "restore": null,
-    "tokens": null
-   },
-   "source": null,
-   "timing_ms": null
-  },
-  "change_shape": {
-   "classification": null,
-   "diagnostics_via": null,
-   "fallback_band": null,
-   "is_fix": null,
-   "measures": null,
-   "review_priority": null,
-   "risk_percentile": null,
-   "score": null
-  },
-  "classification": null,
-  "directive": {
-   "headline": null,
-   "next_actions": [
-    null
-   ],
-   "reasons": [
-    null
-   ],
-   "status": null
-  },
-  "exclude_patterns": [],
-  "fallback_band": null,
-  "fix_history": {
-   "available": null,
-   "density": null,
-   "files": [
-    {
-     "churn": null,
-     "fix_pressure": null,
-     "path": null
-    }
-   ],
-   "percentile": null
-  },
-  "health_delta": {
-   "analyzer": {
-    "analyzer_version": null,
-    "performance_model_version": null,
-    "rules_fingerprint": null
-   },
-   "base": {
-    "kind": null,
-    "ref": null,
-    "sha": null
-   },
-   "basis": null,
-   "by_dimension": {},
-   "by_severity": {},
-   "explanation": null,
-   "findings_emitted": null,
-   "findings_total": null,
-   "head": {
-    "kind": null,
-    "ref": null,
-    "sha": null
-   },
-   "introduced": null,
-   "limits": [
-    null
-   ],
-   "resolved": null,
-   "scope": {
-    "analyzed": null,
-    "changed": null,
-    "eligible": null,
-    "failed": null,
-    "skipped": null
-   },
-   "skipped": {
-    "by_reason": {
-     "not_health_analyzable": null
-    },
-    "total": null
-   },
-   "status": null,
-   "top_findings": [],
-   "worsened": null
-  },
-  "impacted_tests": {
-   "basis": null,
-   "line_coverage": {
-    "covered": [],
-    "no_coverage_data": [],
-    "stale_test_candidates": [],
-    "untested_changes": []
-   },
-   "map_present": null,
-   "status": null,
-   "summary": null,
-   "tests_to_run": [
-    null
-   ],
-   "total": null,
-   "truncated": null
-  },
-  "is_fix": null,
-  "omission_marker": null,
-  "prior_fixes": {
-   "changed_lines_in_fixed_files": null,
-   "files": [
-    {
-     "changed_lines": null,
-     "file_path": null,
-     "fix_count": null,
-     "last_fix_days_ago": null,
-     "overlapping_lines": null,
-     "share_of_change": null
-    }
-   ],
-   "files_with_fixes": null,
-   "line_overlap": null,
-   "summary": null,
-   "total_fixes": null,
-   "truncated": null
-  },
-  "ref": null,
-  "review_priority": null,
-  "risk_percentile": null,
-  "score": null,
-  "working_tree": null
- },
- "get_conformance": {
-  "_meta": {
-   "analysis_commits": {
-    "backend": null,
-    "frontend": null,
-    "repowise": null
-   },
-   "analysis_timestamp": null,
-   "contract_version": null,
-   "embedder_degraded": null
-  },
-  "checked_at": null,
-  "cycle_count": null,
-  "cycles": [
-   {
-    "edge_ids": [
-     null
-    ],
-    "length": null,
-    "nodes": [
-     null
-    ]
-   }
-  ],
-  "cycles_truncated": null,
-  "rules_evaluated": null,
-  "summary": null,
-  "total_cycles": null,
-  "violation_count": null,
-  "violations": [],
-  "violations_truncated": null
- },
- "get_context": {
-  "_meta": {
-   "contract_version": null,
-   "embedder_degraded": null,
-   "index_age_days": null,
-   "indexed_commit": null,
-   "timing_ms": null
-  },
-  "targets": {
-   "<path>": {
-    "_call_graph_note": null,
-    "architectural_layer": {
-     "description": null,
-     "name": null,
-     "role": null
-    },
-    "callers": [
-     {
-      "file": null,
-      "imports": null,
-      "inbound_calls": null
-     }
-    ],
-    "docs": {
-     "summary": null,
-     "symbols": [
-      {
-       "kind": null,
-       "line": null,
-       "name": null,
-       "signature": null,
-       "symbol_id": null
-      }
-     ],
-     "symbols_truncated": {
-      "hint": null,
-      "shown": null,
-      "total": null
-     },
-     "title": null
-    },
-    "episodes": null,
-    "fix_history": {
-     "bug_magnet": null,
-     "fix_count": null,
-     "last_fix_days_ago": null
-    },
-    "freshness": {
-     "confidence_score": null,
-     "freshness_status": null,
-     "is_stale": null
-    },
-    "hotspot": null,
-    "parent_page": {
-     "section": null,
-     "target_path": null,
-     "title": null
-    },
-    "path": null,
-    "skeleton": {
-     "bodies_kept": [],
-     "full_tokens": null,
-     "mode": null,
-     "pct_of_full": null,
-     "text": null,
-     "tokens": null,
-     "verified": null
-    },
-    "target": null,
-    "type": null
-   }
-  }
- },
- "get_dead_code": {
-  "_meta": {
-   "contract_version": null,
-   "embedder_degraded": null,
-   "index_age_days": null,
-   "indexed_commit": null,
-   "omitted": {
-    "refs": [
-     null
-    ],
-    "restore": null,
-    "tokens": null
-   }
-  },
-  "impact": {
-   "recommendation": null,
-   "safe_lines_reclaimable": null,
-   "total_lines_reclaimable": null
-  },
-  "limit_note": null,
-  "omission_marker": null,
-  "summary": {
-   "by_kind": {
-    "unreachable_file": null,
-    "unused_export": null,
-    "unused_internal": null,
-    "zombie_package": null
-   },
-   "deletable_lines": null,
-   "filtered_findings": null,
-   "safe_to_delete_count": null,
-   "total_findings": null
-  },
-  "tiers": {
-   "high": {
-    "count": null,
-    "description": null,
-    "findings": [
-     {
-      "age_days": null,
-      "commit_count_90d": null,
-      "confidence": null,
-      "end_line": null,
-      "file_path": null,
-      "id": null,
-      "kind": null,
-      "last_commit_at": null,
-      "last_meaningful_change": null,
-      "lines": null,
-      "primary_owner": null,
-      "reason": null,
-      "repository": null,
-      "risk_factors": [],
-      "safe_to_delete": null,
-      "start_line": null,
-      "symbol_kind": null,
-      "symbol_name": null
-     }
-    ],
-    "lines": null,
-    "safe_count": null,
-    "truncated": null
-   },
-   "low": {
-    "count": null,
-    "description": null,
-    "findings": [
-     {
-      "age_days": null,
-      "commit_count_90d": null,
-      "confidence": null,
-      "end_line": null,
-      "file_path": null,
-      "id": null,
-      "kind": null,
-      "last_commit_at": null,
-      "last_meaningful_change": null,
-      "lines": null,
-      "primary_owner": null,
-      "reason": null,
-      "repository": null,
-      "risk_factors": [
-       null
-      ],
-      "safe_to_delete": null,
-      "start_line": null,
-      "symbol_kind": null,
-      "symbol_name": null
-     }
-    ],
-    "lines": null,
-    "safe_count": null,
-    "truncated": null
-   },
-   "medium": {
-    "count": null,
-    "description": null,
-    "findings": [
-     {
-      "age_days": null,
-      "commit_count_90d": null,
-      "confidence": null,
-      "end_line": null,
-      "file_path": null,
-      "id": null,
-      "kind": null,
-      "last_commit_at": null,
-      "last_meaningful_change": null,
-      "lines": null,
-      "primary_owner": null,
-      "reason": null,
-      "repository": null,
-      "risk_factors": [
-       null
-      ],
-      "safe_to_delete": null,
-      "start_line": null,
-      "symbol_kind": null,
-      "symbol_name": null
-     }
-    ],
-    "lines": null,
-    "safe_count": null,
-    "truncated": null
-   }
-  }
- },
- "get_dependency_path": {
-  "distance": null,
-  "explanation": null,
-  "path": [],
-  "visual_context": {
-   "bridge_suggestions": [
-    {
-     "node": null,
-     "pagerank": null
-    }
-   ],
-   "community": {
-    "same_community": null,
-    "source_community": null,
-    "target_community": null
-   },
-   "disconnected": null,
-   "nearest_common_ancestors": [
-    {
-     "distance_from_source": null,
-     "distance_from_target": null,
-     "node": null
-    }
-   ],
-   "reverse_path": {
-    "distance": null,
-    "exists": null,
-    "note": null,
-    "path": [
-     null
-    ]
-   },
-   "shared_neighbors": [
-    null
-   ],
-   "suggestion": null
-  }
- },
- "get_execution_flows": {
-  "_meta": {
-   "contract_version": null,
-   "embedder_degraded": null,
-   "hint": null,
-   "timing_ms": null
-  },
-  "flows": [
-   {
-    "communities_visited": [
-     null
-    ],
-    "crosses_community": null,
-    "depth": null,
-    "entry_point": null,
-    "entry_point_name": null,
-    "entry_point_score": null,
-    "termination": null,
-    "trace": [
-     null
-    ],
-    "trace_via": [
-     null
-    ]
-   }
-  ],
-  "total_entry_points": null
- },
- "get_health": {
-  "_meta": {
-   "contract_version": null,
-   "embedder_degraded": null,
-   "health_analysis": {
-    "analyzed_at": null,
-    "analyzed_commit": null,
-    "analyzed_commits_distinct": null,
-    "live_verification": {
-     "basis": null,
-     "source_bytes_verified": null
-    },
-    "recomputed_this_call": null,
-    "refresh": {
-     "command": null,
-     "precondition": null,
-     "required_before_comparison": null
-    },
-    "source": null,
-    "status": null
-   },
-   "health_analyzed_at": null,
-   "health_analyzed_commit": null,
-   "health_analyzed_commits_distinct": null,
-   "health_semantics": {
-    "percentiles": {
-     "direction": null,
-     "freshness": null,
-     "population": null,
-     "public_raw_scale": null,
-     "stored_scale": null
-    },
-    "weighted_deficit_points": {
-     "denominator": null,
-     "direction": null,
-     "interpretation": null,
-     "numerator": null,
-     "scale": {
-      "maximum": null,
-      "minimum": null,
-      "normalized": null
-     },
-     "unit": null
-    }
-   },
-   "index_age_days": null,
-   "indexed_commit": null,
-   "timing_ms": null
-  },
-  "directive": {
-   "fix_first": null,
-   "next_action": null,
-   "plan_addresses_reason": null,
-   "plan_note": null,
-   "plan_via": null,
-   "reason": null,
-   "recovers_points": null,
-   "recovers_points_compatibility": {
-    "deprecated": null,
-    "equivalent_value": null,
-    "replacement": null
-   },
-   "recovers_weighted_deficit_points": null,
-   "share_of_repo_gap_pct": null,
-   "then": [
-    null
-   ],
-   "then_emitted": null,
-   "then_total": null
-  },
-  "distribution": {
-   "bands": {
-    "alert": {
-     "files": null,
-     "nloc": null,
-     "pct": null
-    },
-    "healthy": {
-     "files": null,
-     "nloc": null,
-     "pct": null
-    },
-    "warning": {
-     "files": null,
-     "nloc": null,
-     "pct": null
-    }
-   },
-   "total_files": null,
-   "total_nloc": null
-  },
-  "gap_analysis": {
-   "files_below_target": null,
-   "files_for_half_gap": null,
-   "files_to_reach_target": null,
-   "target_score": null,
-   "weighted_gap_points": null,
-   "weighted_gross_gap_points": null
-  },
-  "high_leverage_files": [
-   {
-    "branch_coverage_pct": null,
-    "file_path": null,
-    "has_test_file": null,
-    "is_test": null,
-    "line_coverage_pct": null,
-    "maintainability_score": null,
-    "max_ccn": null,
-    "max_nesting": null,
-    "module": null,
-    "nloc": null,
-    "performance_score": null,
-    "primary_biomarker": null,
-    "primary_reason": null,
-    "score": null,
-    "share_of_repo_gap_pct": null,
-    "total_deduction": null,
-    "weighted_deficit": null
-   }
-  ],
-  "high_leverage_files_emitted": null,
-  "high_leverage_files_reduced_reason": null,
-  "high_leverage_files_total": null,
-  "kpis": {
-   "average_health": null,
-   "average_health_code_only": null,
-   "average_health_unweighted": null,
-   "average_health_weighting": null,
-   "band": null,
-   "file_count": null,
-   "hotspot_health": null,
-   "maintainability_average": null,
-   "non_code_files": null,
-   "performance_analyzed_files": null,
-   "performance_average": null,
-   "performance_coverage_pct": null,
-   "performance_covered_files": null,
-   "performance_findings": null,
-   "performance_findings_density_per_10k_loc": null,
-   "performance_skipped_files": null,
-   "performance_unsupported_languages": [
-    null
-   ],
-   "performance_unsupported_languages_emitted": null,
-   "performance_unsupported_languages_total": null,
-   "worst_performer_path": null,
-   "worst_performer_score": null
-  },
-  "mode": null,
-  "performance_directive": {
-   "advisory_total": null,
-   "affected_call_sites_total": null,
-   "boundary_kind": null,
-   "execution_context": null,
-   "file_path": null,
-   "investigate_total": null,
-   "next_action": {
-    "arguments": {
-     "opportunity_id": null
-    },
-    "tool": null
-   },
-   "observations_total": null,
-   "opportunities_total": null,
-   "opportunity_id": null,
-   "performance_model_version": null,
-   "plan_ready_total": null,
-   "plan_reason": null,
-   "plan_state": null,
-   "prerequisites": [],
-   "prerequisites_emitted": null,
-   "prerequisites_total": null,
-   "status": null,
-   "title": null,
-   "why_ranked": [
-    {
-     "factor": null,
-     "points": null,
-     "value": null
-    }
-   ],
-   "why_ranked_emitted": null,
-   "why_ranked_total": null
-  },
-  "performance_opportunities": [
-   {
-    "actionability_reason": null,
-    "actionability_state": null,
-    "affected_call_sites_total": null,
-    "affected_files_total": null,
-    "biomarker_type": null,
-    "biomarker_types": [
-     null
-    ],
-    "biomarker_types_emitted": null,
-    "biomarker_types_total": null,
-    "boundary_kind": null,
-    "confidence": null,
-    "evidence": [
-     {
-      "biomarker_type": null,
-      "file_path": null,
-      "finding_id": null,
-      "function_name": null,
-      "line_end": null,
-      "line_start": null,
-      "path": [],
-      "path_emitted": null,
-      "path_total": null,
-      "provenance": null,
-      "reason": null
-     }
-    ],
-    "evidence_emitted": null,
-    "evidence_total": null,
-    "evidence_truncated": null,
-    "execution_context": null,
-    "facets": {
-     "actionability_confidence": null,
-     "amplification": null,
-     "change_risk": null,
-     "exposure": null,
-     "leverage": null
-    },
-    "file_path": null,
-    "fix": {
-     "rationale": null,
-     "safety": null,
-     "strategy": null
-    },
-    "intervention_symbol": null,
-    "observations_total": null,
-    "opportunity_id": null,
-    "performance_model_version": null,
-    "plan_id": null,
-    "plan_reason": null,
-    "plan_reference": null,
-    "plan_status": null,
-    "prerequisites": [],
-    "prerequisites_emitted": null,
-    "prerequisites_total": null,
-    "provenance": null,
-    "rank_factors": {
-     "affected_call_sites": null,
-     "boundary_kind": null,
-     "entry_reachability": null,
-     "execution_context": null,
-     "multiplier_shape": null,
-     "provenance": null
-    },
-    "rank_position": null,
-    "rank_score": null,
-    "reliable_entry_reachability": null,
-    "resource_fingerprints": [],
-    "resource_fingerprints_emitted": null,
-    "resource_fingerprints_total": null,
-    "shared_path_suffix": [],
-    "shared_path_suffix_emitted": null,
-    "shared_path_suffix_total": null,
-    "terminal_sink": null,
-    "why_ranked": [
-     {
-      "factor": null,
-      "points": null,
-      "value": null
-     }
-    ],
-    "why_ranked_emitted": null,
-    "why_ranked_total": null
-   }
-  ],
-  "performance_opportunities_emitted": null,
-  "performance_opportunities_reduced_reason": null,
-  "performance_opportunities_total": null,
-  "performance_summary": {
-   "actionability": {
-    "advisory": null,
-    "investigate": null,
-    "plan_ready": null
-   },
-   "analyzed_commit": null,
-   "boundary": {
-    "db": null,
-    "filesystem": null,
-    "network": null,
-    "none": null,
-    "subprocess": null
-   },
-   "context": {
-    "production": null
-   },
-   "facets": {
-    "actionability": [
-     {
-      "total": null,
-      "value": null
-     }
-    ],
-    "actionability_emitted": null,
-    "actionability_total": null,
-    "boundary": [
-     {
-      "total": null,
-      "value": null
-     }
-    ],
-    "boundary_emitted": null,
-    "boundary_total": null,
-    "confidence": [
-     {
-      "total": null,
-      "value": null
-     }
-    ],
-    "confidence_emitted": null,
-    "confidence_total": null,
-    "context": [
-     {
-      "total": null,
-      "value": null
-     }
-    ],
-    "context_emitted": null,
-    "context_total": null,
-    "plan_state": [
-     {
-      "total": null,
-      "value": null
-     }
-    ],
-    "plan_state_emitted": null,
-    "plan_state_total": null
-   },
-   "materialized_model_version": null,
-   "next_call": null,
-   "performance_model_version": null,
-   "repository_total": null,
-   "status": null,
-   "total": null,
-   "with_plan_total": null
-  },
-  "recommendation_lede": {
-   "next_call": null,
-   "performance_lead": {
-    "affected_call_sites_total": null,
-    "boundary_kind": null,
-    "execution_context": null,
-    "intervention_symbol": null,
-    "opportunity_id": null,
-    "rank_score": null
-   },
-   "performance_opportunities_total": null,
-   "performance_plan_id": null,
-   "performance_plan_reason": null,
-   "recommendation_lead": {
-    "benefit": null,
-    "cost": null,
-    "file_path": null,
-    "id": null,
-    "leverage": null,
-    "rank_score": null,
-    "refactoring_type": null,
-    "risk": null,
-    "target_symbol": null
-   },
-   "refactoring_plans_total": null
-  },
-  "recovery": {
-   "high_leverage_files": {
-    "call": null,
-    "remaining": null
-   },
-   "performance_opportunities": {
-    "call": null,
-    "remaining": null
-   },
-   "refactoring_opportunities": {
-    "call": null,
-    "remaining": null
-   },
-   "refactoring_plans": {
-    "call": null,
-    "remaining": null
-   }
-  },
-  "refactoring_directive": {
-   "addresses_primary_problem": null,
-   "confidence": null,
-   "effort_bucket": null,
-   "fix_first": null,
-   "judgment_steps": null,
-   "lead_refactoring_type": null,
-   "mechanical_steps": null,
-   "next_action": {
-    "arguments": {
-     "opportunity_id": null
-    },
-    "tool": null
-   },
-   "opportunities_total": null,
-   "opportunity_id": null,
-   "reason": null,
-   "recovers_health_points": null,
-   "status": null,
-   "steps": null
-  },
-  "refactoring_opportunities": [
-   {
-    "addresses_primary_problem": null,
-    "affected_files_total": null,
-    "confidence": null,
-    "dependents": null,
-    "effort_bucket": null,
-    "evidence_total": null,
-    "file_nloc": null,
-    "file_path": null,
-    "judgment_steps": null,
-    "lead_biomarker": null,
-    "lead_refactoring_type": null,
-    "mechanical_steps": null,
-    "opportunity_id": null,
-    "queue_position": null,
-    "rank_factors": {
-     "benefit": null,
-     "cost": null,
-     "mechanical_share": null,
-     "primary_problem": null,
-     "risk": null
-    },
-    "rank_position": null,
-    "rank_score": null,
-    "recoverable_health": null,
-    "refactoring_model_version": null,
-    "status": null,
-    "step_count": null,
-    "steps": [
-     {
-      "applicability": {
-       "classification": null,
-       "facts": {
-        "affected_file_count": null,
-        "blast_size": null,
-        "callers": null,
-        "confidence": null,
-        "cross_file": null,
-        "framework_registration": null
-       },
-       "reasons": [
-        null
-       ],
-       "reasons_emitted": null,
-       "reasons_total": null,
-       "unknowns": [
-        null
-       ],
-       "unknowns_emitted": null,
-       "unknowns_total": null
+  "get_answer": {
+    "_meta": {
+      "cached": null,
+      "contract_version": null,
+      "embedder_degraded": null,
+      "index_age_days": null,
+      "indexed_commit": null,
+      "projection": {
+        "recovery": {
+          "arguments": {
+            "include": [
+              null
+            ],
+            "question": null
+          },
+          "tool": null
+        }
       },
+      "timing_ms": null
+    },
+    "answer": null,
+    "candidates_emitted": null,
+    "candidates_reduced_reason": null,
+    "candidates_total": null,
+    "citations": [
+      null
+    ],
+    "confidence": null,
+    "fallback_targets_emitted": null,
+    "fallback_targets_reduced_reason": null,
+    "fallback_targets_total": null,
+    "flow_path": [
+      null
+    ],
+    "next_action_hint": null,
+    "note": null,
+    "quotes": [
+      {
+        "lines": [
+          null
+        ],
+        "path": null,
+        "quote": null
+      }
+    ],
+    "quotes_emitted": null,
+    "quotes_reduced_reason": null,
+    "quotes_total": null,
+    "retrieval_quality": null
+  },
+  "get_architecture": {
+    "_meta": {
+      "analysis_commits": {
+        "backend": null,
+        "frontend": null,
+        "repowise": null
+      },
+      "analysis_timestamp": null,
+      "contract_version": null,
+      "embedder_degraded": null
+    },
+    "architecture_type": null,
+    "conformance_violations": null,
+    "core_members": [
+      null
+    ],
+    "core_members_truncated": null,
+    "core_ratio": null,
+    "core_size": null,
+    "cycle_count": null,
+    "node_count": null,
+    "propagation_cost_pct": null,
+    "role_breakdown": {
+      "control": null,
+      "core": null,
+      "peripheral": null,
+      "shared": null
+    },
+    "score": null,
+    "summary": null
+  },
+  "get_blast_radius": {
+    "_meta": {
+      "analysis_commits": {
+        "backend": null,
+        "frontend": null,
+        "repowise": null
+      },
+      "analysis_timestamp": null,
+      "contract_version": null,
+      "embedder_degraded": null
+    },
+    "behavioral_count": null,
+    "impact_score_semantics": {
+      "authoritative_for_change_review": null,
+      "calibration": {
+        "status": null
+      },
+      "field": null,
+      "kind": null,
+      "measures": null,
+      "range": {
+        "maximum": null,
+        "minimum": null
+      },
+      "runtime_breakage_probability": null,
+      "unit": null
+    },
+    "impacted": [],
+    "impacted_repos": [],
+    "impacted_truncated": null,
+    "max_distance": null,
+    "structural_count": null,
+    "summary": null,
+    "target_repos": [],
+    "targets": [],
+    "total_impacted": null,
+    "unresolved_targets": [
+      null
+    ]
+  },
+  "get_change_risk": {
+    "_meta": {
+      "contract_version": null,
+      "embedder_degraded": null,
+      "index_age_days": null,
+      "indexed_commit": null,
+      "omitted": {
+        "refs": [
+          null
+        ],
+        "restore": null,
+        "tokens": null
+      },
+      "source": null,
+      "timing_ms": null
+    },
+    "change_shape": {
+      "classification": null,
+      "diagnostics_via": null,
+      "fallback_band": null,
+      "is_fix": null,
+      "measures": null,
+      "review_priority": null,
+      "risk_percentile": null,
+      "score": null
+    },
+    "classification": null,
+    "directive": {
+      "headline": null,
+      "next_actions": [
+        null
+      ],
+      "reasons": [
+        null
+      ],
+      "status": null
+    },
+    "exclude_patterns": [],
+    "fallback_band": null,
+    "fix_history": {
+      "available": null,
+      "density": null,
+      "files": [
+        {
+          "churn": null,
+          "fix_pressure": null,
+          "path": null
+        }
+      ],
+      "percentile": null
+    },
+    "health_delta": {
+      "analyzer": {
+        "analyzer_version": null,
+        "performance_model_version": null,
+        "rules_fingerprint": null
+      },
+      "base": {
+        "kind": null,
+        "ref": null,
+        "sha": null
+      },
+      "basis": null,
+      "by_dimension": {},
+      "by_severity": {},
+      "explanation": null,
+      "findings_emitted": null,
+      "findings_total": null,
+      "head": {
+        "kind": null,
+        "ref": null,
+        "sha": null
+      },
+      "introduced": null,
+      "limits": [
+        null
+      ],
+      "resolved": null,
+      "scope": {
+        "analyzed": null,
+        "changed": null,
+        "eligible": null,
+        "failed": null,
+        "skipped": null
+      },
+      "skipped": {
+        "by_reason": {
+          "not_health_analyzable": null
+        },
+        "total": null
+      },
+      "status": null,
+      "top_findings": [],
+      "worsened": null
+    },
+    "impacted_tests": {
+      "basis": null,
+      "line_coverage": {
+        "covered": [],
+        "no_coverage_data": [],
+        "stale_test_candidates": [],
+        "untested_changes": []
+      },
+      "map_present": null,
+      "status": null,
+      "summary": null,
+      "tests_to_run": [
+        null
+      ],
+      "total": null,
+      "truncated": null
+    },
+    "is_fix": null,
+    "omission_marker": null,
+    "prior_fixes": {
+      "changed_lines_in_fixed_files": null,
+      "files": [
+        {
+          "changed_lines": null,
+          "file_path": null,
+          "fix_count": null,
+          "last_fix_days_ago": null,
+          "overlapping_lines": null,
+          "share_of_change": null
+        }
+      ],
+      "files_with_fixes": null,
+      "line_overlap": null,
+      "summary": null,
+      "total_fixes": null,
+      "truncated": null
+    },
+    "ref": null,
+    "review_priority": null,
+    "risk_percentile": null,
+    "score": null,
+    "working_tree": null
+  },
+  "get_conformance": {
+    "_meta": {
+      "analysis_commits": {
+        "backend": null,
+        "frontend": null,
+        "repowise": null
+      },
+      "analysis_timestamp": null,
+      "contract_version": null,
+      "embedder_degraded": null
+    },
+    "checked_at": null,
+    "cycle_count": null,
+    "cycles": [
+      {
+        "edge_ids": [
+          null
+        ],
+        "length": null,
+        "nodes": [
+          null
+        ]
+      }
+    ],
+    "cycles_truncated": null,
+    "rules_evaluated": null,
+    "summary": null,
+    "total_cycles": null,
+    "violation_count": null,
+    "violations": [],
+    "violations_truncated": null
+  },
+  "get_context": {
+    "_meta": {
+      "contract_version": null,
+      "embedder_degraded": null,
+      "index_age_days": null,
+      "indexed_commit": null,
+      "timing_ms": null
+    },
+    "targets": {
+      "<path>": {
+        "_call_graph_note": null,
+        "architectural_layer": {
+          "description": null,
+          "name": null,
+          "role": null
+        },
+        "callers": [
+          {
+            "file": null,
+            "imports": null,
+            "inbound_calls": null
+          }
+        ],
+        "docs": {
+          "summary": null,
+          "symbols": [
+            {
+              "kind": null,
+              "line": null,
+              "name": null,
+              "signature": null,
+              "symbol_id": null
+            }
+          ],
+          "symbols_truncated": {
+            "hint": null,
+            "shown": null,
+            "total": null
+          },
+          "title": null
+        },
+        "episodes": null,
+        "fix_history": {
+          "bug_magnet": null,
+          "fix_count": null,
+          "last_fix_days_ago": null
+        },
+        "freshness": {
+          "confidence_score": null,
+          "freshness_status": null,
+          "is_stale": null
+        },
+        "hotspot": null,
+        "parent_page": {
+          "section": null,
+          "target_path": null,
+          "title": null
+        },
+        "path": null,
+        "skeleton": {
+          "bodies_kept": [],
+          "full_tokens": null,
+          "mode": null,
+          "pct_of_full": null,
+          "text": null,
+          "tokens": null,
+          "verified": null
+        },
+        "target": null,
+        "type": null
+      }
+    }
+  },
+  "get_dead_code": {
+    "_meta": {
+      "contract_version": null,
+      "embedder_degraded": null,
+      "index_age_days": null,
+      "indexed_commit": null,
+      "omitted": {
+        "refs": [
+          null
+        ],
+        "restore": null,
+        "tokens": null
+      }
+    },
+    "impact": {
+      "recommendation": null,
+      "safe_lines_reclaimable": null,
+      "total_lines_reclaimable": null
+    },
+    "limit_note": null,
+    "omission_marker": null,
+    "summary": {
+      "by_kind": {
+        "unreachable_file": null,
+        "unused_export": null,
+        "unused_internal": null,
+        "zombie_package": null
+      },
+      "deletable_lines": null,
+      "filtered_findings": null,
+      "safe_to_delete_count": null,
+      "total_findings": null
+    },
+    "tiers": {
+      "high": {
+        "count": null,
+        "description": null,
+        "findings": [
+          {
+            "age_days": null,
+            "commit_count_90d": null,
+            "confidence": null,
+            "end_line": null,
+            "file_path": null,
+            "id": null,
+            "kind": null,
+            "last_commit_at": null,
+            "last_meaningful_change": null,
+            "lines": null,
+            "primary_owner": null,
+            "reason": null,
+            "repository": null,
+            "risk_factors": [],
+            "safe_to_delete": null,
+            "start_line": null,
+            "symbol_kind": null,
+            "symbol_name": null
+          }
+        ],
+        "lines": null,
+        "safe_count": null,
+        "truncated": null
+      },
+      "low": {
+        "count": null,
+        "description": null,
+        "findings": [
+          {
+            "age_days": null,
+            "commit_count_90d": null,
+            "confidence": null,
+            "end_line": null,
+            "file_path": null,
+            "id": null,
+            "kind": null,
+            "last_commit_at": null,
+            "last_meaningful_change": null,
+            "lines": null,
+            "primary_owner": null,
+            "reason": null,
+            "repository": null,
+            "risk_factors": [
+              null
+            ],
+            "safe_to_delete": null,
+            "start_line": null,
+            "symbol_kind": null,
+            "symbol_name": null
+          }
+        ],
+        "lines": null,
+        "safe_count": null,
+        "truncated": null
+      },
+      "medium": {
+        "count": null,
+        "description": null,
+        "findings": [
+          {
+            "age_days": null,
+            "commit_count_90d": null,
+            "confidence": null,
+            "end_line": null,
+            "file_path": null,
+            "id": null,
+            "kind": null,
+            "last_commit_at": null,
+            "last_meaningful_change": null,
+            "lines": null,
+            "primary_owner": null,
+            "reason": null,
+            "repository": null,
+            "risk_factors": [
+              null
+            ],
+            "safe_to_delete": null,
+            "start_line": null,
+            "symbol_kind": null,
+            "symbol_name": null
+          }
+        ],
+        "lines": null,
+        "safe_count": null,
+        "truncated": null
+      }
+    }
+  },
+  "get_dependency_path": {
+    "distance": null,
+    "explanation": null,
+    "path": [],
+    "visual_context": {
+      "bridge_suggestions": [
+        {
+          "node": null,
+          "pagerank": null
+        }
+      ],
+      "community": {
+        "same_community": null,
+        "source_community": null,
+        "target_community": null
+      },
+      "disconnected": null,
+      "nearest_common_ancestors": [
+        {
+          "distance_from_source": null,
+          "distance_from_target": null,
+          "node": null
+        }
+      ],
+      "reverse_path": {
+        "distance": null,
+        "exists": null,
+        "note": null,
+        "path": [
+          null
+        ]
+      },
+      "shared_neighbors": [
+        null
+      ],
+      "suggestion": null
+    }
+  },
+  "get_execution_flows": {
+    "_meta": {
+      "contract_version": null,
+      "embedder_degraded": null,
+      "hint": null,
+      "timing_ms": null
+    },
+    "flows": [
+      {
+        "communities_visited": [
+          null
+        ],
+        "crosses_community": null,
+        "depth": null,
+        "entry_point": null,
+        "entry_point_name": null,
+        "entry_point_score": null,
+        "termination": null,
+        "trace": [
+          null
+        ],
+        "trace_via": [
+          null
+        ]
+      }
+    ],
+    "total_entry_points": null
+  },
+  "get_health": {
+    "_meta": {
+      "contract_version": null,
+      "embedder_degraded": null,
+      "health_analysis": {
+        "analyzed_at": null,
+        "analyzed_commit": null,
+        "analyzed_commits_distinct": null,
+        "live_verification": {
+          "basis": null,
+          "source_bytes_verified": null
+        },
+        "recomputed_this_call": null,
+        "refresh": {
+          "command": null,
+          "precondition": null,
+          "required_before_comparison": null
+        },
+        "source": null,
+        "status": null
+      },
+      "health_analyzed_at": null,
+      "health_analyzed_commit": null,
+      "health_analyzed_commits_distinct": null,
+      "health_semantics": {
+        "percentiles": {
+          "direction": null,
+          "freshness": null,
+          "population": null,
+          "public_raw_scale": null,
+          "stored_scale": null
+        },
+        "weighted_deficit_points": {
+          "denominator": null,
+          "direction": null,
+          "interpretation": null,
+          "numerator": null,
+          "scale": {
+            "maximum": null,
+            "minimum": null,
+            "normalized": null
+          },
+          "unit": null
+        }
+      },
+      "index_age_days": null,
+      "indexed_commit": null,
+      "timing_ms": null
+    },
+    "directive": {
+      "fix_first": null,
+      "next_action": null,
+      "plan_addresses_reason": null,
+      "plan_note": null,
+      "plan_via": null,
+      "reason": null,
+      "recovers_points": null,
+      "recovers_points_compatibility": {
+        "deprecated": null,
+        "equivalent_value": null,
+        "replacement": null
+      },
+      "recovers_weighted_deficit_points": null,
+      "share_of_repo_gap_pct": null,
+      "then": [
+        null
+      ],
+      "then_emitted": null,
+      "then_total": null
+    },
+    "distribution": {
+      "bands": {
+        "alert": {
+          "files": null,
+          "nloc": null,
+          "pct": null
+        },
+        "healthy": {
+          "files": null,
+          "nloc": null,
+          "pct": null
+        },
+        "warning": {
+          "files": null,
+          "nloc": null,
+          "pct": null
+        }
+      },
+      "total_files": null,
+      "total_nloc": null
+    },
+    "gap_analysis": {
+      "files_below_target": null,
+      "files_for_half_gap": null,
+      "files_to_reach_target": null,
+      "target_score": null,
+      "weighted_gap_points": null,
+      "weighted_gross_gap_points": null
+    },
+    "high_leverage_files": [
+      {
+        "branch_coverage_pct": null,
+        "file_path": null,
+        "has_test_file": null,
+        "is_test": null,
+        "line_coverage_pct": null,
+        "maintainability_score": null,
+        "max_ccn": null,
+        "max_nesting": null,
+        "module": null,
+        "nloc": null,
+        "performance_score": null,
+        "primary_biomarker": null,
+        "primary_reason": null,
+        "score": null,
+        "share_of_repo_gap_pct": null,
+        "total_deduction": null,
+        "weighted_deficit": null
+      }
+    ],
+    "high_leverage_files_emitted": null,
+    "high_leverage_files_reduced_reason": null,
+    "high_leverage_files_total": null,
+    "kpis": {
+      "average_health": null,
+      "average_health_code_only": null,
+      "average_health_unweighted": null,
+      "average_health_weighting": null,
+      "band": null,
+      "file_count": null,
+      "hotspot_health": null,
+      "maintainability_average": null,
+      "non_code_files": null,
+      "performance_analyzed_files": null,
+      "performance_average": null,
+      "performance_coverage_pct": null,
+      "performance_covered_files": null,
+      "performance_findings": null,
+      "performance_findings_density_per_10k_loc": null,
+      "performance_skipped_files": null,
+      "performance_unsupported_languages": [
+        null
+      ],
+      "performance_unsupported_languages_emitted": null,
+      "performance_unsupported_languages_total": null,
+      "worst_performer_path": null,
+      "worst_performer_score": null
+    },
+    "mode": null,
+    "performance_directive": {
+      "advisory_total": null,
+      "affected_call_sites_total": null,
+      "boundary_kind": null,
+      "execution_context": null,
+      "file_path": null,
+      "investigate_total": null,
+      "next_action": {
+        "arguments": {
+          "opportunity_id": null
+        },
+        "tool": null
+      },
+      "observations_total": null,
+      "opportunities_total": null,
+      "opportunity_id": null,
+      "performance_model_version": null,
+      "plan_ready_total": null,
+      "plan_reason": null,
+      "plan_state": null,
+      "prerequisites": [],
+      "prerequisites_emitted": null,
+      "prerequisites_total": null,
+      "status": null,
+      "title": null,
+      "why_ranked": [
+        {
+          "factor": null,
+          "points": null,
+          "value": null
+        }
+      ],
+      "why_ranked_emitted": null,
+      "why_ranked_total": null
+    },
+    "performance_opportunities": [
+      {
+        "actionability_reason": null,
+        "actionability_state": null,
+        "affected_call_sites_total": null,
+        "affected_files_total": null,
+        "biomarker_type": null,
+        "biomarker_types": [
+          null
+        ],
+        "biomarker_types_emitted": null,
+        "biomarker_types_total": null,
+        "boundary_kind": null,
+        "confidence": null,
+        "evidence": [
+          {
+            "biomarker_type": null,
+            "file_path": null,
+            "finding_id": null,
+            "function_name": null,
+            "line_end": null,
+            "line_start": null,
+            "path": [],
+            "path_emitted": null,
+            "path_total": null,
+            "provenance": null,
+            "reason": null
+          }
+        ],
+        "evidence_emitted": null,
+        "evidence_total": null,
+        "evidence_truncated": null,
+        "execution_context": null,
+        "facets": {
+          "actionability_confidence": null,
+          "amplification": null,
+          "change_risk": null,
+          "exposure": null,
+          "leverage": null
+        },
+        "file_path": null,
+        "fix": {
+          "rationale": null,
+          "safety": null,
+          "strategy": null
+        },
+        "intervention_symbol": null,
+        "observations_total": null,
+        "opportunity_id": null,
+        "performance_model_version": null,
+        "plan_id": null,
+        "plan_reason": null,
+        "plan_reference": null,
+        "plan_status": null,
+        "prerequisites": [],
+        "prerequisites_emitted": null,
+        "prerequisites_total": null,
+        "provenance": null,
+        "rank_factors": {
+          "affected_call_sites": null,
+          "boundary_kind": null,
+          "entry_reachability": null,
+          "execution_context": null,
+          "multiplier_shape": null,
+          "provenance": null
+        },
+        "rank_position": null,
+        "rank_score": null,
+        "reliable_entry_reachability": null,
+        "resource_fingerprints": [],
+        "resource_fingerprints_emitted": null,
+        "resource_fingerprints_total": null,
+        "shared_path_suffix": [],
+        "shared_path_suffix_emitted": null,
+        "shared_path_suffix_total": null,
+        "terminal_sink": null,
+        "why_ranked": [
+          {
+            "factor": null,
+            "points": null,
+            "value": null
+          }
+        ],
+        "why_ranked_emitted": null,
+        "why_ranked_total": null
+      }
+    ],
+    "performance_opportunities_emitted": null,
+    "performance_opportunities_reduced_reason": null,
+    "performance_opportunities_total": null,
+    "performance_summary": {
+      "actionability": {
+        "advisory": null,
+        "investigate": null,
+        "plan_ready": null
+      },
+      "analyzed_commit": null,
+      "boundary": {
+        "db": null,
+        "filesystem": null,
+        "network": null,
+        "none": null,
+        "subprocess": null
+      },
+      "context": {
+        "production": null
+      },
+      "facets": {
+        "actionability": [
+          {
+            "total": null,
+            "value": null
+          }
+        ],
+        "actionability_emitted": null,
+        "actionability_total": null,
+        "boundary": [
+          {
+            "total": null,
+            "value": null
+          }
+        ],
+        "boundary_emitted": null,
+        "boundary_total": null,
+        "confidence": [
+          {
+            "total": null,
+            "value": null
+          }
+        ],
+        "confidence_emitted": null,
+        "confidence_total": null,
+        "context": [
+          {
+            "total": null,
+            "value": null
+          }
+        ],
+        "context_emitted": null,
+        "context_total": null,
+        "plan_state": [
+          {
+            "total": null,
+            "value": null
+          }
+        ],
+        "plan_state_emitted": null,
+        "plan_state_total": null
+      },
+      "materialized_model_version": null,
+      "next_call": null,
+      "performance_model_version": null,
+      "repository_total": null,
+      "status": null,
+      "total": null,
+      "with_plan_total": null
+    },
+    "recommendation_lede": {
+      "next_call": null,
+      "performance_lead": {
+        "affected_call_sites_total": null,
+        "boundary_kind": null,
+        "execution_context": null,
+        "intervention_symbol": null,
+        "opportunity_id": null,
+        "rank_score": null
+      },
+      "performance_opportunities_total": null,
+      "performance_plan_id": null,
+      "performance_plan_reason": null,
+      "recommendation_lead": {
+        "benefit": null,
+        "cost": null,
+        "file_path": null,
+        "id": null,
+        "leverage": null,
+        "rank_score": null,
+        "refactoring_type": null,
+        "risk": null,
+        "target_symbol": null
+      },
+      "refactoring_plans_total": null
+    },
+    "recovery": {
+      "high_leverage_files": {
+        "call": null,
+        "remaining": null
+      },
+      "performance_opportunities": {
+        "call": null,
+        "remaining": null
+      },
+      "refactoring_opportunities": {
+        "call": null,
+        "remaining": null
+      },
+      "refactoring_plans": {
+        "call": null,
+        "remaining": null
+      }
+    },
+    "refactoring_directive": {
+      "addresses_primary_problem": null,
       "confidence": null,
       "effort_bucket": null,
-      "file_path": null,
-      "finding_ids": [],
-      "finding_ids_emitted": null,
-      "finding_ids_total": null,
-      "impact_delta": null,
-      "line_end": null,
-      "line_start": null,
-      "plan_id": null,
-      "refactoring_type": null,
-      "relocated_by": null,
-      "source_biomarker": null,
-      "target_symbol": null,
-      "validation_profile_id": null
-     }
-    ],
-    "steps_emitted": null,
-    "steps_reduced_reason": null,
-    "steps_total": null,
-    "why_ranked": [
-     {
-      "factor": null,
-      "value": null
-     }
-    ],
-    "why_ranked_emitted": null,
-    "why_ranked_total": null
-   }
-  ],
-  "refactoring_opportunities_emitted": null,
-  "refactoring_opportunities_reduced_reason": null,
-  "refactoring_opportunities_total": null,
-  "refactoring_plans": [
-   {
-    "benefit": null,
-    "blast_radius": {
-     "scope": null
+      "fix_first": null,
+      "judgment_steps": null,
+      "lead_refactoring_type": null,
+      "mechanical_steps": null,
+      "next_action": {
+        "arguments": {
+          "opportunity_id": null
+        },
+        "tool": null
+      },
+      "opportunities_total": null,
+      "opportunity_id": null,
+      "reason": null,
+      "recovers_health_points": null,
+      "status": null,
+      "steps": null
     },
-    "confidence": null,
-    "cost": null,
-    "dependents": null,
-    "effort_bucket": null,
-    "evidence": {
-     "ccn_removed": null,
-     "slice_nloc": null
+    "refactoring_opportunities": [
+      {
+        "addresses_primary_problem": null,
+        "affected_files_total": null,
+        "confidence": null,
+        "dependents": null,
+        "effort_bucket": null,
+        "evidence_total": null,
+        "file_nloc": null,
+        "file_path": null,
+        "judgment_steps": null,
+        "lead_biomarker": null,
+        "lead_refactoring_type": null,
+        "mechanical_steps": null,
+        "opportunity_id": null,
+        "queue_position": null,
+        "rank_factors": {
+          "benefit": null,
+          "cost": null,
+          "mechanical_share": null,
+          "primary_problem": null,
+          "risk": null
+        },
+        "rank_position": null,
+        "rank_score": null,
+        "recoverable_health": null,
+        "refactoring_model_version": null,
+        "status": null,
+        "step_count": null,
+        "steps": [
+          {
+            "applicability": {
+              "classification": null,
+              "facts": {
+                "affected_file_count": null,
+                "blast_size": null,
+                "callers": null,
+                "confidence": null,
+                "cross_file": null,
+                "framework_registration": null
+              },
+              "reasons": [
+                null
+              ],
+              "reasons_emitted": null,
+              "reasons_total": null,
+              "unknowns": [
+                null
+              ],
+              "unknowns_emitted": null,
+              "unknowns_total": null
+            },
+            "confidence": null,
+            "effort_bucket": null,
+            "file_path": null,
+            "finding_ids": [],
+            "finding_ids_emitted": null,
+            "finding_ids_total": null,
+            "impact_delta": null,
+            "line_end": null,
+            "line_start": null,
+            "plan_id": null,
+            "refactoring_type": null,
+            "relocated_by": null,
+            "source_biomarker": null,
+            "target_symbol": null,
+            "validation_profile_id": null
+          }
+        ],
+        "steps_emitted": null,
+        "steps_reduced_reason": null,
+        "steps_total": null,
+        "why_ranked": [
+          {
+            "factor": null,
+            "value": null
+          }
+        ],
+        "why_ranked_emitted": null,
+        "why_ranked_total": null
+      }
+    ],
+    "refactoring_opportunities_emitted": null,
+    "refactoring_opportunities_reduced_reason": null,
+    "refactoring_opportunities_total": null,
+    "refactoring_plans": [
+      {
+        "benefit": null,
+        "blast_radius": {
+          "scope": null
+        },
+        "confidence": null,
+        "cost": null,
+        "dependents": null,
+        "effort_bucket": null,
+        "evidence": {
+          "ccn_removed": null,
+          "slice_nloc": null
+        },
+        "file_nloc": null,
+        "file_path": null,
+        "file_weighted_deficit": null,
+        "id": null,
+        "impact_delta": null,
+        "leverage": null,
+        "line_end": null,
+        "line_start": null,
+        "plan": {
+          "params": [
+            null
+          ],
+          "params_emitted": null,
+          "params_total": null,
+          "returns": [],
+          "returns_emitted": null,
+          "returns_total": null,
+          "span": {
+            "end": null,
+            "start": null
+          },
+          "suggested_name": null
+        },
+        "rank_score": null,
+        "refactoring_type": null,
+        "repository": null,
+        "risk": null,
+        "source_biomarker": null,
+        "target_symbol": null,
+        "validation_profile_id": null
+      }
+    ],
+    "refactoring_plans_emitted": null,
+    "refactoring_plans_reduced_reason": null,
+    "refactoring_plans_status": {
+      "reason": null,
+      "state": null
     },
-    "file_nloc": null,
-    "file_path": null,
-    "file_weighted_deficit": null,
-    "id": null,
-    "impact_delta": null,
-    "leverage": null,
-    "line_end": null,
-    "line_start": null,
-    "plan": {
-     "params": [
+    "refactoring_plans_total": null,
+    "refactoring_summary": {
+      "addresses_primary_problem": {
+        "no": null,
+        "unknown": null,
+        "yes": null
+      },
+      "analyzed_commit": null,
+      "by_confidence": {
+        "high": null,
+        "medium": null
+      },
+      "by_effort": {
+        "L": null,
+        "M": null,
+        "S": null,
+        "XL": null
+      },
+      "by_lead_type": {
+        "break_cycle": null,
+        "extract_class": null,
+        "extract_helper": null,
+        "extract_method": null,
+        "move_method": null,
+        "split_file": null
+      },
+      "by_status": {
+        "open": null
+      },
+      "facets": {
+        "confidence": {
+          "high": null,
+          "medium": null
+        },
+        "effort": {
+          "L": null,
+          "M": null,
+          "S": null,
+          "XL": null
+        },
+        "lead_type": {
+          "break_cycle": null,
+          "extract_class": null,
+          "extract_helper": null,
+          "extract_method": null,
+          "move_method": null,
+          "split_file": null
+        }
+      },
+      "files_total": null,
+      "judgment_steps_total": null,
+      "lead": {
+        "addresses_primary_problem": null,
+        "confidence": null,
+        "effort_bucket": null,
+        "file_path": null,
+        "judgment_steps": null,
+        "lead_biomarker": null,
+        "lead_refactoring_type": null,
+        "mechanical_steps": null,
+        "opportunity_id": null,
+        "recoverable_health": null,
+        "status": null,
+        "step_count": null
+      },
+      "mechanical_steps_total": null,
+      "next_call": null,
+      "opportunities_total": null,
+      "refactoring_model_version": null,
+      "status": null,
+      "steps_total": null,
+      "view": null
+    },
+    "secondary_rankings": {
+      "modules": {
+        "call": null,
+        "total": null
+      },
+      "test_findings": {
+        "call": null,
+        "total": null
+      },
+      "top_findings": {
+        "call": null,
+        "total": null
+      },
+      "worst_files": {
+        "call": null,
+        "total": null
+      }
+    },
+    "suggestion_legend": {
+      "hot_path_sync_io": null,
+      "io_in_loop": null,
+      "nested_loop_with_io": null,
+      "serial_await_in_loop": null
+    },
+    "unknown_include_keys": [
       null
-     ],
-     "params_emitted": null,
-     "params_total": null,
-     "returns": [],
-     "returns_emitted": null,
-     "returns_total": null,
-     "span": {
-      "end": null,
-      "start": null
-     },
-     "suggested_name": null
-    },
-    "rank_score": null,
-    "refactoring_type": null,
-    "repository": null,
-    "risk": null,
-    "source_biomarker": null,
-    "target_symbol": null,
-    "validation_profile_id": null
-   }
-  ],
-  "refactoring_plans_emitted": null,
-  "refactoring_plans_reduced_reason": null,
-  "refactoring_plans_status": {
-   "reason": null,
-   "state": null
-  },
-  "refactoring_plans_total": null,
-  "refactoring_summary": {
-   "addresses_primary_problem": {
-    "no": null,
-    "unknown": null,
-    "yes": null
-   },
-   "analyzed_commit": null,
-   "by_confidence": {
-    "high": null,
-    "medium": null
-   },
-   "by_effort": {
-    "L": null,
-    "M": null,
-    "S": null,
-    "XL": null
-   },
-   "by_lead_type": {
-    "break_cycle": null,
-    "extract_class": null,
-    "extract_helper": null,
-    "extract_method": null,
-    "move_method": null,
-    "split_file": null
-   },
-   "by_status": {
-    "open": null
-   },
-   "facets": {
-    "confidence": {
-     "high": null,
-     "medium": null
-    },
-    "effort": {
-     "L": null,
-     "M": null,
-     "S": null,
-     "XL": null
-    },
-    "lead_type": {
-     "break_cycle": null,
-     "extract_class": null,
-     "extract_helper": null,
-     "extract_method": null,
-     "move_method": null,
-     "split_file": null
-    }
-   },
-   "files_total": null,
-   "judgment_steps_total": null,
-   "lead": {
-    "addresses_primary_problem": null,
-    "confidence": null,
-    "effort_bucket": null,
-    "file_path": null,
-    "judgment_steps": null,
-    "lead_biomarker": null,
-    "lead_refactoring_type": null,
-    "mechanical_steps": null,
-    "opportunity_id": null,
-    "recoverable_health": null,
-    "status": null,
-    "step_count": null
-   },
-   "mechanical_steps_total": null,
-   "next_call": null,
-   "opportunities_total": null,
-   "refactoring_model_version": null,
-   "status": null,
-   "steps_total": null,
-   "view": null
-  },
-  "secondary_rankings": {
-   "modules": {
-    "call": null,
-    "total": null
-   },
-   "test_findings": {
-    "call": null,
-    "total": null
-   },
-   "top_findings": {
-    "call": null,
-    "total": null
-   },
-   "worst_files": {
-    "call": null,
-    "total": null
-   }
-  },
-  "suggestion_legend": {
-   "hot_path_sync_io": null,
-   "io_in_loop": null,
-   "nested_loop_with_io": null,
-   "serial_await_in_loop": null
-  },
-  "unknown_include_keys": [
-   null
-  ],
-  "unknown_include_keys_emitted": null,
-  "unknown_include_keys_total": null,
-  "validation_profiles": [
-   {
-    "affected_files": [
-     null
     ],
-    "affected_files_emitted": null,
-    "affected_files_total": null,
-    "affected_symbols": [
-     null
+    "unknown_include_keys_emitted": null,
+    "unknown_include_keys_total": null,
+    "validation_profiles": [
+      {
+        "affected_files": [
+          null
+        ],
+        "affected_files_emitted": null,
+        "affected_files_total": null,
+        "affected_symbols": [
+          null
+        ],
+        "affected_symbols_emitted": null,
+        "affected_symbols_total": null,
+        "basis": null,
+        "commands": [
+          null
+        ],
+        "commands_emitted": null,
+        "commands_total": null,
+        "id": null,
+        "targets": [
+          {
+            "basis": null,
+            "file_path": null,
+            "tests": [
+              null
+            ],
+            "tests_emitted": null,
+            "tests_total": null,
+            "total": null,
+            "truncated": null,
+            "via": null
+          }
+        ],
+        "targets_emitted": null,
+        "targets_total": null,
+        "tests": [
+          null
+        ],
+        "tests_emitted": null,
+        "tests_reduced_reason": null,
+        "tests_total": null,
+        "total": null,
+        "via": null
+      }
     ],
-    "affected_symbols_emitted": null,
-    "affected_symbols_total": null,
-    "basis": null,
-    "commands": [
-     null
-    ],
-    "commands_emitted": null,
-    "commands_total": null,
-    "id": null,
-    "targets": [
-     {
-      "basis": null,
-      "file_path": null,
-      "tests": [
-       null
+    "validation_profiles_emitted": null,
+    "validation_profiles_total": null
+  },
+  "get_overview": {
+    "_meta": {
+      "contract_version": null,
+      "embedder_degraded": null,
+      "index_age_days": null,
+      "indexed_commit": null,
+      "omitted": {
+        "refs": [
+          null
+        ],
+        "restore": null,
+        "tokens": null
+      }
+    },
+    "architecture": {
+      "layer_order": [
+        null
       ],
-      "tests_emitted": null,
-      "tests_total": null,
-      "total": null,
-      "truncated": null,
-      "via": null
-     }
-    ],
-    "targets_emitted": null,
-    "targets_total": null,
-    "tests": [
-     null
-    ],
-    "tests_emitted": null,
-    "tests_reduced_reason": null,
-    "tests_total": null,
-    "total": null,
-    "via": null
-   }
-  ],
-  "validation_profiles_emitted": null,
-  "validation_profiles_total": null
- },
- "get_overview": {
-  "_meta": {
-   "contract_version": null,
-   "embedder_degraded": null,
-   "index_age_days": null,
-   "indexed_commit": null,
-   "omitted": {
-    "refs": [
-     null
-    ],
-    "restore": null,
-    "tokens": null
-   }
-  },
-  "architecture": {
-   "layer_order": [
-    null
-   ],
-   "layers": [
-    {
-     "file_count": null,
-     "name": null
-    }
-   ],
-   "tour_available": null,
-   "tour_step_count": null
-  },
-  "code_health": {
-   "average_health": null,
-   "band": null,
-   "distribution": {
-    "bands": {
-     "alert": {
-      "files": null,
-      "nloc": null,
-      "pct": null
-     },
-     "healthy": {
-      "files": null,
-      "nloc": null,
-      "pct": null
-     },
-     "warning": {
-      "files": null,
-      "nloc": null,
-      "pct": null
-     }
-    },
-    "total_files": null,
-    "total_nloc": null
-   },
-   "file_count": null,
-   "hotspot_health": null,
-   "open_findings": null,
-   "worst_performer_path": null,
-   "worst_performer_score": null
-  },
-  "content_hint": null,
-  "content_md": null,
-  "entry_points": [
-   null
-  ],
-  "git_health": {
-   "avg_bus_factor": null,
-   "churn_trend": null,
-   "files_git_attributed": null,
-   "files_with_bus_factor_1": null,
-   "hotspot_count": null,
-   "top_churn_modules": [
-    null
-   ]
-  },
-  "key_modules": [
-   {
-    "name": null,
-    "path": null,
-    "section": null
-   }
-  ],
-  "more": null,
-  "omission_marker": null,
-  "title": null,
-  "tool_surface": {
-   "counts": {
-    "default": null,
-    "eligible": null,
-    "enabled": null,
-    "opt_in_available": null,
-    "tiers": {
-     "canonical": null
-    }
-   },
-   "enabled": [
-    null
-   ],
-   "mode": null,
-   "opt_in": [
-    {
-     "description": null,
-     "enabled": null,
-     "name": null
-    }
-   ],
-   "recipes": [
-    {
-     "call": null,
-     "name": null
-    }
-   ],
-   "tools": [
-    {
-     "default": null,
-     "description": null,
-     "name": null,
-     "tier": null
-    }
-   ]
-  }
- },
- "get_risk": {
-  "_meta": {
-   "contract_version": null,
-   "embedder_degraded": null,
-   "index_age_days": null,
-   "indexed_commit": null,
-   "omitted": {
-    "refs": [
-     null
-    ],
-    "restore": null,
-    "tokens": null
-   }
-  },
-  "omission_marker": null,
-  "targets": {
-   "packages/core/src/repowise/core/ingestion/call_resolver.py": {
-    "bus_factor": null,
-    "co_change_partners": [
-     {
-      "direction": null,
-      "evidence_kind": null,
-      "file_path": null,
-      "has_import_link": null,
-      "has_structural_link": null,
-      "last_co_change": null,
-      "provenance": null,
-      "relationship_type": null,
-      "structural_relationship_types": [
-       null
+      "layers": [
+        {
+          "file_count": null,
+          "name": null
+        }
       ],
-      "support": null,
-      "weight": null
-     }
-    ],
-    "co_change_partners_emitted": null,
-    "co_change_partners_omitted": null,
-    "co_change_partners_reduced_reason": null,
-    "co_change_partners_total": null,
-    "co_change_partners_truncated": null,
-    "commit_count_capped": null,
-    "contributor_count": null,
-    "coverage_pct": null,
-    "defect_profile": {
-     "bug_magnet": null,
-     "fix_count": null,
-     "last_fix_days_ago": null,
-     "top_symbols": {
-      "_link_declarations": null,
-      "_merged_symbols_for": null,
-      "_published": null
-     },
-     "window": null
+      "tour_available": null,
+      "tour_step_count": null
     },
-    "dependents_count": null,
-    "episodes": null,
-    "health_score": null,
-    "hotspot_score": null,
-    "is_hotspot": null,
-    "owner_pct": null,
-    "primary_owner": null,
-    "recent_owner": null,
-    "recent_owner_pct": null,
-    "risk_summary": null,
-    "security_signals": [],
-    "target": null,
-    "test_gap": null,
-    "top_biomarkers": [
-     {
-      "biomarker_type": null,
-      "function_name": null,
-      "impact": null,
-      "severity": null
-     }
+    "code_health": {
+      "average_health": null,
+      "band": null,
+      "distribution": {
+        "bands": {
+          "alert": {
+            "files": null,
+            "nloc": null,
+            "pct": null
+          },
+          "healthy": {
+            "files": null,
+            "nloc": null,
+            "pct": null
+          },
+          "warning": {
+            "files": null,
+            "nloc": null,
+            "pct": null
+          }
+        },
+        "total_files": null,
+        "total_nloc": null
+      },
+      "file_count": null,
+      "hotspot_health": null,
+      "open_findings": null,
+      "worst_performer_path": null,
+      "worst_performer_score": null
+    },
+    "content_hint": null,
+    "content_md": null,
+    "entry_points": [
+      null
     ],
-    "trend": null
-   }
-  }
- },
- "get_symbol": {
-  "_meta": {
-   "contract_version": null,
-   "embedder_degraded": null,
-   "index_age_days": null,
-   "indexed_commit": null,
-   "replaced_tokens": null,
-   "timing_ms": null
-  },
-  "continuation": null,
-  "continuation_reference": {
-   "id": null,
-   "kind": null,
-   "path": null,
-   "range": [
-    null
-   ],
-   "repository": null,
-   "source_kind": null,
-   "verification_basis": null
-  },
-  "end_line": null,
-  "file": null,
-  "kind": null,
-  "language": null,
-  "name": null,
-  "note": null,
-  "qualified_name": null,
-  "signature": null,
-  "source": null,
-  "start_line": null,
-  "symbol_end_line": null,
-  "symbol_id": null,
-  "symbol_start_line": null,
-  "truncated": null,
-  "verified": null
- },
- "get_why": {
-  "_meta": {
-   "contract_version": null,
-   "embedder_degraded": null,
-   "index_age_days": null,
-   "indexed_commit": null,
-   "omitted": {
-    "refs": [
-     null
+    "git_health": {
+      "avg_bus_factor": null,
+      "churn_trend": null,
+      "files_git_attributed": null,
+      "files_with_bus_factor_1": null,
+      "hotspot_count": null,
+      "top_churn_modules": [
+        null
+      ]
+    },
+    "key_modules": [
+      {
+        "name": null,
+        "path": null,
+        "section": null
+      }
     ],
-    "restore": null,
-    "tokens": null
-   }
+    "more": null,
+    "omission_marker": null,
+    "title": null,
+    "tool_surface": {
+      "counts": {
+        "default": null,
+        "eligible": null,
+        "enabled": null,
+        "opt_in_available": null,
+        "tiers": {
+          "canonical": null
+        }
+      },
+      "enabled": [
+        null
+      ],
+      "mode": null,
+      "opt_in": [
+        {
+          "description": null,
+          "enabled": null,
+          "name": null
+        }
+      ],
+      "recipes": [
+        {
+          "call": null,
+          "name": null
+        }
+      ],
+      "tools": [
+        {
+          "default": null,
+          "description": null,
+          "name": null,
+          "tier": null
+        }
+      ]
+    }
   },
-  "alignment": {
-   "active_count": null,
-   "deprecated_count": null,
-   "explanation": null,
-   "governing_count": null,
-   "score": null,
-   "sibling_coverage": null,
-   "stale_count": null
+  "get_risk": {
+    "_meta": {
+      "contract_version": null,
+      "embedder_degraded": null,
+      "index_age_days": null,
+      "indexed_commit": null,
+      "omitted": {
+        "refs": [
+          null
+        ],
+        "restore": null,
+        "tokens": null
+      }
+    },
+    "omission_marker": null,
+    "targets": {
+      "packages/core/src/repowise/core/ingestion/call_resolver.py": {
+        "bus_factor": null,
+        "co_change_partners": [
+          {
+            "direction": null,
+            "evidence_kind": null,
+            "file_path": null,
+            "has_import_link": null,
+            "has_structural_link": null,
+            "last_co_change": null,
+            "provenance": null,
+            "relationship_type": null,
+            "structural_relationship_types": [
+              null
+            ],
+            "support": null,
+            "weight": null
+          }
+        ],
+        "co_change_partners_emitted": null,
+        "co_change_partners_omitted": null,
+        "co_change_partners_reduced_reason": null,
+        "co_change_partners_total": null,
+        "co_change_partners_truncated": null,
+        "commit_count_capped": null,
+        "contributor_count": null,
+        "coverage_pct": null,
+        "defect_profile": {
+          "bug_magnet": null,
+          "fix_count": null,
+          "last_fix_days_ago": null,
+          "top_symbols": {
+            "_link_declarations": null,
+            "_merged_symbols_for": null,
+            "_published": null
+          },
+          "window": null
+        },
+        "dependents_count": null,
+        "episodes": null,
+        "health_score": null,
+        "hotspot_score": null,
+        "is_hotspot": null,
+        "owner_pct": null,
+        "primary_owner": null,
+        "recent_owner": null,
+        "recent_owner_pct": null,
+        "risk_summary": null,
+        "security_signals": [],
+        "target": null,
+        "test_gap": null,
+        "top_biomarkers": [
+          {
+            "biomarker_type": null,
+            "function_name": null,
+            "impact": null,
+            "severity": null
+          }
+        ],
+        "trend": null
+      }
+    }
   },
-  "answer_basis": null,
-  "code_rationale": [
-   {
-    "comment": null,
-    "evidence_refs": [
-     {
-      "content_id": null,
+  "get_symbol": {
+    "_meta": {
+      "contract_version": null,
+      "embedder_degraded": null,
+      "index_age_days": null,
+      "indexed_commit": null,
+      "replaced_tokens": null,
+      "timing_ms": null
+    },
+    "continuation": null,
+    "continuation_reference": {
       "id": null,
       "kind": null,
-      "line": null,
       "path": null,
-      "provenance": null,
       "range": [
-       null
+        null
       ],
       "repository": null,
-      "source": null,
-      "source_kind": null,
-      "verification": null,
-      "verification_basis": null
-     }
-    ],
-    "lines": [
-     null
-    ],
-    "matched_terms": [],
-    "path": null,
-    "provenance": null
-   }
-  ],
-  "code_rationale_emitted": null,
-  "code_rationale_omitted": null,
-  "code_rationale_reduced_reason": null,
-  "code_rationale_total": null,
-  "code_rationale_truncated": null,
-  "decisions": [],
-  "episodes": [
-   {
-    "evidence": null,
-    "evidence_refs": [
-     {
-      "commit": null,
-      "id": null,
-      "kind": null,
-      "provenance": null,
-      "repository": null,
-      "source": null,
       "source_kind": null,
       "verification_basis": null
-     }
-    ],
+    },
+    "end_line": null,
+    "file": null,
     "kind": null,
-    "provenance": null,
-    "recorded": null,
-    "scope": [
-     null
-    ],
-    "still_true": null,
-    "subject": null,
-    "tier": null
-   }
-  ],
-  "episodes_emitted": null,
-  "episodes_omitted": null,
-  "episodes_reduced_reason": null,
-  "episodes_total": null,
-  "episodes_truncated": null,
-  "git_archaeology": {
-   "cross_references": [],
-   "file_commits": [
-    {
-     "author": null,
-     "date": null,
-     "evidence_refs": [
-      {
-       "commit": null,
-       "id": null,
-       "kind": null,
-       "provenance": null,
-       "repository": null,
-       "source": null,
-       "source_kind": null,
-       "verification_basis": null
+    "language": null,
+    "name": null,
+    "note": null,
+    "qualified_name": null,
+    "signature": null,
+    "source": null,
+    "start_line": null,
+    "symbol_end_line": null,
+    "symbol_id": null,
+    "symbol_start_line": null,
+    "truncated": null,
+    "verified": null
+  },
+  "get_why": {
+    "_meta": {
+      "contract_version": null,
+      "embedder_degraded": null,
+      "index_age_days": null,
+      "indexed_commit": null,
+      "omitted": {
+        "refs": [
+          null
+        ],
+        "restore": null,
+        "tokens": null
       }
-     ],
-     "message": null,
-     "provenance": null,
-     "sha": null
-    }
-   ],
-   "file_commits_emitted": null,
-   "file_commits_omitted": null,
-   "file_commits_reduced_reason": null,
-   "file_commits_total": null,
-   "file_commits_truncated": null,
-   "git_log": [],
-   "provenance": null,
-   "summary": null,
-   "triggered": null
-  },
-  "mode": null,
-  "omission_marker": null,
-  "origin_story": {
-   "age_days": null,
-   "author_commit_pct": null,
-   "available": null,
-   "contributors": [
-    {
-     "commit_count": null,
-     "email": null,
-     "first_commit_ts": null,
-     "last_commit_ts": null,
-     "name": null
-    }
-   ],
-   "first_commit": null,
-   "key_commits": [
-    {
-     "author": null,
-     "date": null,
-     "evidence_refs": [
+    },
+    "alignment": {
+      "active_count": null,
+      "deprecated_count": null,
+      "explanation": null,
+      "governing_count": null,
+      "score": null,
+      "sibling_coverage": null,
+      "stale_count": null
+    },
+    "answer_basis": null,
+    "code_rationale": [
       {
-       "commit": null,
-       "id": null,
-       "kind": null,
-       "provenance": null,
-       "repository": null,
-       "source": null,
-       "source_kind": null,
-       "verification_basis": null
+        "comment": null,
+        "evidence_refs": [
+          {
+            "content_id": null,
+            "id": null,
+            "kind": null,
+            "line": null,
+            "path": null,
+            "provenance": null,
+            "range": [
+              null
+            ],
+            "repository": null,
+            "source": null,
+            "source_kind": null,
+            "verification": null,
+            "verification_basis": null
+          }
+        ],
+        "lines": [
+          null
+        ],
+        "matched_terms": [],
+        "path": null,
+        "provenance": null
       }
-     ],
-     "message": null,
-     "pr_number": null,
-     "provenance": null,
-     "sha": null
-    }
-   ],
-   "key_commits_emitted": null,
-   "key_commits_omitted": null,
-   "key_commits_reduced_reason": null,
-   "key_commits_total": null,
-   "key_commits_truncated": null,
-   "last_commit": null,
-   "linked_decisions": [],
-   "primary_author": null,
-   "provenance": null,
-   "summary": null,
-   "total_commits": null
-  },
-  "path": null
- },
- "list_repos": {
-  "_meta": {
-   "contract_version": null,
-   "embedder_degraded": null
-  },
-  "default_repo": null,
-  "hint": null,
-  "repos": [
-   {
-    "absolute_path": null,
-    "alias": null,
-    "is_default": null,
-    "path": null
-   }
-  ],
-  "workspace": null,
-  "workspace_root": null
- },
- "search_codebase": {
-  "_meta": {
-   "contract_version": null,
-   "embedder_degraded": null,
-   "index_age_days": null,
-   "indexed_commit": null
-  },
-  "candidates": [
-   {
-    "path": null
-   }
-  ],
-  "results": [
-   {
-    "confidence_score": null,
-    "page_type": null,
-    "relevance_score": null,
-    "snippet": null,
-    "sources": [
-     null
     ],
-    "target_path": null,
-    "title": null
-   }
-  ]
- },
- "set_finding_status": {
-  "_meta": {
-   "contract_version": null,
-   "embedder_degraded": null
+    "code_rationale_emitted": null,
+    "code_rationale_omitted": null,
+    "code_rationale_reduced_reason": null,
+    "code_rationale_total": null,
+    "code_rationale_truncated": null,
+    "decisions": [],
+    "episodes": [
+      {
+        "evidence": null,
+        "evidence_refs": [
+          {
+            "commit": null,
+            "id": null,
+            "kind": null,
+            "provenance": null,
+            "repository": null,
+            "source": null,
+            "source_kind": null,
+            "verification_basis": null
+          }
+        ],
+        "kind": null,
+        "provenance": null,
+        "recorded": null,
+        "scope": [
+          null
+        ],
+        "still_true": null,
+        "subject": null,
+        "tier": null
+      }
+    ],
+    "episodes_emitted": null,
+    "episodes_omitted": null,
+    "episodes_reduced_reason": null,
+    "episodes_total": null,
+    "episodes_truncated": null,
+    "git_archaeology": {
+      "cross_references": [],
+      "file_commits": [
+        {
+          "author": null,
+          "date": null,
+          "evidence_refs": [
+            {
+              "commit": null,
+              "id": null,
+              "kind": null,
+              "provenance": null,
+              "repository": null,
+              "source": null,
+              "source_kind": null,
+              "verification_basis": null
+            }
+          ],
+          "message": null,
+          "provenance": null,
+          "sha": null
+        }
+      ],
+      "file_commits_emitted": null,
+      "file_commits_omitted": null,
+      "file_commits_reduced_reason": null,
+      "file_commits_total": null,
+      "file_commits_truncated": null,
+      "git_log": [],
+      "provenance": null,
+      "summary": null,
+      "triggered": null
+    },
+    "mode": null,
+    "omission_marker": null,
+    "origin_story": {
+      "age_days": null,
+      "author_commit_pct": null,
+      "available": null,
+      "contributors": [
+        {
+          "commit_count": null,
+          "email": null,
+          "first_commit_ts": null,
+          "last_commit_ts": null,
+          "name": null
+        }
+      ],
+      "first_commit": null,
+      "key_commits": [
+        {
+          "author": null,
+          "date": null,
+          "evidence_refs": [
+            {
+              "commit": null,
+              "id": null,
+              "kind": null,
+              "provenance": null,
+              "repository": null,
+              "source": null,
+              "source_kind": null,
+              "verification_basis": null
+            }
+          ],
+          "message": null,
+          "pr_number": null,
+          "provenance": null,
+          "sha": null
+        }
+      ],
+      "key_commits_emitted": null,
+      "key_commits_omitted": null,
+      "key_commits_reduced_reason": null,
+      "key_commits_total": null,
+      "key_commits_truncated": null,
+      "last_commit": null,
+      "linked_decisions": [],
+      "primary_author": null,
+      "provenance": null,
+      "summary": null,
+      "total_commits": null
+    },
+    "path": null
   },
-  "id": null,
-  "note": null,
-  "public_id": null,
-  "status": null,
-  "status_changed_at": null,
-  "status_reason": null
- }
+  "list_repos": {
+    "_meta": {
+      "contract_version": null,
+      "embedder_degraded": null
+    },
+    "default_repo": null,
+    "hint": null,
+    "repos": [
+      {
+        "absolute_path": null,
+        "alias": null,
+        "is_default": null,
+        "path": null
+      }
+    ],
+    "workspace": null,
+    "workspace_root": null
+  },
+  "search_codebase": {
+    "_meta": {
+      "contract_version": null,
+      "embedder_degraded": null,
+      "index_age_days": null,
+      "indexed_commit": null
+    },
+    "candidates": [
+      {
+        "path": null
+      }
+    ],
+    "results": [
+      {
+        "confidence_score": null,
+        "page_type": null,
+        "relevance_score": null,
+        "snippet": null,
+        "sources": [
+          null
+        ],
+        "target_path": null,
+        "title": null
+      }
+    ]
+  },
+  "set_finding_status": {
+    "_meta": {
+      "contract_version": null,
+      "embedder_degraded": null
+    },
+    "id": null,
+    "note": null,
+    "public_id": null,
+    "status": null,
+    "status_changed_at": null,
+    "status_reason": null
+  }
 }

--- a/tests/fixtures/mcp/tool_response_shapes.json
+++ b/tests/fixtures/mcp/tool_response_shapes.json
@@ -1,1706 +1,1718 @@
 {
-  "get_answer": {
-    "_meta": {
-      "cached": null,
-      "contract_version": null,
-      "embedder_degraded": null,
-      "index_age_days": null,
-      "indexed_commit": null,
-      "projection": {
-        "recovery": {
-          "arguments": {
-            "include": [
-              null
-            ],
-            "question": null
-          },
-          "tool": null
-        }
-      },
-      "timing_ms": null
-    },
-    "answer": null,
-    "candidates_emitted": null,
-    "candidates_reduced_reason": null,
-    "candidates_total": null,
-    "citations": [
-      null
-    ],
-    "confidence": null,
-    "fallback_targets_emitted": null,
-    "fallback_targets_reduced_reason": null,
-    "fallback_targets_total": null,
-    "flow_path": [
-      null
-    ],
-    "next_action_hint": null,
-    "note": null,
-    "quotes": [
-      {
-        "lines": [
-          null
-        ],
-        "path": null,
-        "quote": null
-      }
-    ],
-    "quotes_emitted": null,
-    "quotes_reduced_reason": null,
-    "quotes_total": null,
-    "retrieval_quality": null
-  },
-  "get_architecture": {
-    "_meta": {
-      "analysis_commits": {
-        "backend": null,
-        "frontend": null,
-        "repowise": null
-      },
-      "analysis_timestamp": null,
-      "contract_version": null,
-      "embedder_degraded": null
-    },
-    "architecture_type": null,
-    "conformance_violations": null,
-    "core_members": [
-      null
-    ],
-    "core_members_truncated": null,
-    "core_ratio": null,
-    "core_size": null,
-    "cycle_count": null,
-    "node_count": null,
-    "propagation_cost_pct": null,
-    "role_breakdown": {
-      "control": null,
-      "core": null,
-      "peripheral": null,
-      "shared": null
-    },
-    "score": null,
-    "summary": null
-  },
-  "get_blast_radius": {
-    "_meta": {
-      "analysis_commits": {
-        "backend": null,
-        "frontend": null,
-        "repowise": null
-      },
-      "analysis_timestamp": null,
-      "contract_version": null,
-      "embedder_degraded": null
-    },
-    "behavioral_count": null,
-    "impact_score_semantics": {
-      "authoritative_for_change_review": null,
-      "calibration": {
-        "status": null
-      },
-      "field": null,
-      "kind": null,
-      "measures": null,
-      "range": {
-        "maximum": null,
-        "minimum": null
-      },
-      "runtime_breakage_probability": null,
-      "unit": null
-    },
-    "impacted": [],
-    "impacted_repos": [],
-    "impacted_truncated": null,
-    "max_distance": null,
-    "structural_count": null,
-    "summary": null,
-    "target_repos": [],
-    "targets": [],
-    "total_impacted": null,
-    "unresolved_targets": [
-      null
-    ]
-  },
-  "get_change_risk": {
-    "_meta": {
-      "contract_version": null,
-      "embedder_degraded": null,
-      "index_age_days": null,
-      "indexed_commit": null,
-      "omitted": {
-        "refs": [
-          null
-        ],
-        "restore": null,
-        "tokens": null
-      },
-      "source": null,
-      "timing_ms": null
-    },
-    "change_shape": {
-      "classification": null,
-      "diagnostics_via": null,
-      "fallback_band": null,
-      "is_fix": null,
-      "measures": null,
-      "review_priority": null,
-      "risk_percentile": null,
-      "score": null
-    },
-    "classification": null,
-    "directive": {
-      "headline": null,
-      "next_actions": [
-        null
-      ],
-      "reasons": [
-        null
-      ],
-      "status": null
-    },
-    "exclude_patterns": [],
-    "fallback_band": null,
-    "fix_history": {
-      "available": null,
-      "density": null,
-      "files": [
-        {
-          "churn": null,
-          "fix_pressure": null,
-          "path": null
-        }
-      ],
-      "percentile": null
-    },
-    "health_delta": {
-      "analyzer": {
-        "analyzer_version": null,
-        "performance_model_version": null,
-        "rules_fingerprint": null
-      },
-      "base": {
-        "kind": null,
-        "ref": null,
-        "sha": null
-      },
-      "basis": null,
-      "by_dimension": {},
-      "by_severity": {},
-      "explanation": null,
-      "findings_emitted": null,
-      "findings_total": null,
-      "head": {
-        "kind": null,
-        "ref": null,
-        "sha": null
-      },
-      "introduced": null,
-      "limits": [
-        null
-      ],
-      "resolved": null,
-      "scope": {
-        "analyzed": null,
-        "changed": null,
-        "eligible": null,
-        "failed": null,
-        "skipped": null
-      },
-      "skipped": {
-        "by_reason": {
-          "not_health_analyzable": null
-        },
-        "total": null
-      },
-      "status": null,
-      "top_findings": [],
-      "worsened": null
-    },
-    "impacted_tests": {
-      "basis": null,
-      "line_coverage": {
-        "covered": [],
-        "no_coverage_data": [],
-        "stale_test_candidates": [],
-        "untested_changes": []
-      },
-      "map_present": null,
-      "status": null,
-      "summary": null,
-      "tests_to_run": [
-        null
-      ],
-      "total": null,
-      "truncated": null
-    },
-    "is_fix": null,
-    "omission_marker": null,
-    "prior_fixes": {
-      "changed_lines_in_fixed_files": null,
-      "files": [
-        {
-          "changed_lines": null,
-          "file_path": null,
-          "fix_count": null,
-          "last_fix_days_ago": null,
-          "overlapping_lines": null,
-          "share_of_change": null
-        }
-      ],
-      "files_with_fixes": null,
-      "line_overlap": null,
-      "summary": null,
-      "total_fixes": null,
-      "truncated": null
-    },
-    "ref": null,
-    "review_priority": null,
-    "risk_percentile": null,
-    "score": null,
-    "working_tree": null
-  },
-  "get_conformance": {
-    "_meta": {
-      "analysis_commits": {
-        "backend": null,
-        "frontend": null,
-        "repowise": null
-      },
-      "analysis_timestamp": null,
-      "contract_version": null,
-      "embedder_degraded": null
-    },
-    "checked_at": null,
-    "cycle_count": null,
-    "cycles": [
-      {
-        "edge_ids": [
-          null
-        ],
-        "length": null,
-        "nodes": [
-          null
-        ]
-      }
-    ],
-    "cycles_truncated": null,
-    "rules_evaluated": null,
-    "summary": null,
-    "total_cycles": null,
-    "violation_count": null,
-    "violations": [],
-    "violations_truncated": null
-  },
-  "get_context": {
-    "_meta": {
-      "contract_version": null,
-      "embedder_degraded": null,
-      "index_age_days": null,
-      "indexed_commit": null,
-      "timing_ms": null
-    },
-    "targets": {
-      "<path>": {
-        "_call_graph_note": null,
-        "architectural_layer": {
-          "description": null,
-          "name": null,
-          "role": null
-        },
-        "callers": [
-          {
-            "file": null,
-            "imports": null,
-            "inbound_calls": null
-          }
-        ],
-        "docs": {
-          "summary": null,
-          "symbols": [
-            {
-              "kind": null,
-              "line": null,
-              "name": null,
-              "signature": null,
-              "symbol_id": null
-            }
-          ],
-          "symbols_truncated": {
-            "hint": null,
-            "shown": null,
-            "total": null
-          },
-          "title": null
-        },
-        "episodes": null,
-        "fix_history": {
-          "bug_magnet": null,
-          "fix_count": null,
-          "last_fix_days_ago": null
-        },
-        "freshness": {
-          "confidence_score": null,
-          "freshness_status": null,
-          "is_stale": null
-        },
-        "hotspot": null,
-        "parent_page": {
-          "section": null,
-          "target_path": null,
-          "title": null
-        },
-        "path": null,
-        "skeleton": {
-          "bodies_kept": [],
-          "full_tokens": null,
-          "mode": null,
-          "pct_of_full": null,
-          "text": null,
-          "tokens": null,
-          "verified": null
-        },
-        "target": null,
-        "type": null
-      }
-    }
-  },
-  "get_dead_code": {
-    "_meta": {
-      "contract_version": null,
-      "embedder_degraded": null,
-      "index_age_days": null,
-      "indexed_commit": null,
-      "omitted": {
-        "refs": [
-          null
-        ],
-        "restore": null,
-        "tokens": null
-      }
-    },
-    "impact": {
-      "recommendation": null,
-      "safe_lines_reclaimable": null,
-      "total_lines_reclaimable": null
-    },
-    "limit_note": null,
-    "omission_marker": null,
-    "summary": {
-      "by_kind": {
-        "unreachable_file": null,
-        "unused_export": null,
-        "unused_internal": null,
-        "zombie_package": null
-      },
-      "deletable_lines": null,
-      "filtered_findings": null,
-      "safe_to_delete_count": null,
-      "total_findings": null
-    },
-    "tiers": {
-      "high": {
-        "count": null,
-        "description": null,
-        "findings": [
-          {
-            "age_days": null,
-            "commit_count_90d": null,
-            "confidence": null,
-            "end_line": null,
-            "file_path": null,
-            "id": null,
-            "kind": null,
-            "last_commit_at": null,
-            "last_meaningful_change": null,
-            "lines": null,
-            "primary_owner": null,
-            "reason": null,
-            "repository": null,
-            "risk_factors": [],
-            "safe_to_delete": null,
-            "start_line": null,
-            "symbol_kind": null,
-            "symbol_name": null
-          }
-        ],
-        "lines": null,
-        "safe_count": null,
-        "truncated": null
-      },
-      "low": {
-        "count": null,
-        "description": null,
-        "findings": [
-          {
-            "age_days": null,
-            "commit_count_90d": null,
-            "confidence": null,
-            "end_line": null,
-            "file_path": null,
-            "id": null,
-            "kind": null,
-            "last_commit_at": null,
-            "last_meaningful_change": null,
-            "lines": null,
-            "primary_owner": null,
-            "reason": null,
-            "repository": null,
-            "risk_factors": [
-              null
-            ],
-            "safe_to_delete": null,
-            "start_line": null,
-            "symbol_kind": null,
-            "symbol_name": null
-          }
-        ],
-        "lines": null,
-        "safe_count": null,
-        "truncated": null
-      },
-      "medium": {
-        "count": null,
-        "description": null,
-        "findings": [
-          {
-            "age_days": null,
-            "commit_count_90d": null,
-            "confidence": null,
-            "end_line": null,
-            "file_path": null,
-            "id": null,
-            "kind": null,
-            "last_commit_at": null,
-            "last_meaningful_change": null,
-            "lines": null,
-            "primary_owner": null,
-            "reason": null,
-            "repository": null,
-            "risk_factors": [
-              null
-            ],
-            "safe_to_delete": null,
-            "start_line": null,
-            "symbol_kind": null,
-            "symbol_name": null
-          }
-        ],
-        "lines": null,
-        "safe_count": null,
-        "truncated": null
-      }
-    }
-  },
-  "get_dependency_path": {
-    "distance": null,
-    "explanation": null,
-    "path": [],
-    "visual_context": {
-      "bridge_suggestions": [
-        {
-          "node": null,
-          "pagerank": null
-        }
-      ],
-      "community": {
-        "same_community": null,
-        "source_community": null,
-        "target_community": null
-      },
-      "disconnected": null,
-      "nearest_common_ancestors": [
-        {
-          "distance_from_source": null,
-          "distance_from_target": null,
-          "node": null
-        }
-      ],
-      "reverse_path": {
-        "distance": null,
-        "exists": null,
-        "note": null,
-        "path": [
-          null
-        ]
-      },
-      "shared_neighbors": [
-        null
-      ],
-      "suggestion": null
-    }
-  },
-  "get_execution_flows": {
-    "_meta": {
-      "contract_version": null,
-      "embedder_degraded": null,
-      "hint": null,
-      "timing_ms": null
-    },
-    "flows": [
-      {
-        "communities_visited": [
-          null
-        ],
-        "crosses_community": null,
-        "depth": null,
-        "entry_point": null,
-        "entry_point_name": null,
-        "entry_point_score": null,
-        "termination": null,
-        "trace": [
-          null
-        ],
-        "trace_via": [
-          null
-        ]
-      }
-    ],
-    "total_entry_points": null
-  },
-  "get_health": {
-    "_meta": {
-      "contract_version": null,
-      "embedder_degraded": null,
-      "health_analysis": {
-        "analyzed_at": null,
-        "analyzed_commit": null,
-        "analyzed_commits_distinct": null,
-        "live_verification": {
-          "basis": null,
-          "source_bytes_verified": null
-        },
-        "recomputed_this_call": null,
-        "refresh": {
-          "command": null,
-          "precondition": null,
-          "required_before_comparison": null
-        },
-        "source": null,
-        "status": null
-      },
-      "health_analyzed_at": null,
-      "health_analyzed_commit": null,
-      "health_analyzed_commits_distinct": null,
-      "health_semantics": {
-        "percentiles": {
-          "direction": null,
-          "freshness": null,
-          "population": null,
-          "public_raw_scale": null,
-          "stored_scale": null
-        },
-        "weighted_deficit_points": {
-          "denominator": null,
-          "direction": null,
-          "interpretation": null,
-          "numerator": null,
-          "scale": {
-            "maximum": null,
-            "minimum": null,
-            "normalized": null
-          },
-          "unit": null
-        }
-      },
-      "index_age_days": null,
-      "indexed_commit": null,
-      "timing_ms": null
-    },
-    "directive": {
-      "fix_first": null,
-      "next_action": null,
-      "plan_addresses_reason": null,
-      "plan_note": null,
-      "plan_via": null,
-      "reason": null,
-      "recovers_points": null,
-      "recovers_points_compatibility": {
-        "deprecated": null,
-        "equivalent_value": null,
-        "replacement": null
-      },
-      "recovers_weighted_deficit_points": null,
-      "share_of_repo_gap_pct": null,
-      "then": [
-        null
-      ],
-      "then_emitted": null,
-      "then_total": null
-    },
-    "distribution": {
-      "bands": {
-        "alert": {
-          "files": null,
-          "nloc": null,
-          "pct": null
-        },
-        "healthy": {
-          "files": null,
-          "nloc": null,
-          "pct": null
-        },
-        "warning": {
-          "files": null,
-          "nloc": null,
-          "pct": null
-        }
-      },
-      "total_files": null,
-      "total_nloc": null
-    },
-    "gap_analysis": {
-      "files_below_target": null,
-      "files_for_half_gap": null,
-      "files_to_reach_target": null,
-      "target_score": null,
-      "weighted_gap_points": null,
-      "weighted_gross_gap_points": null
-    },
-    "high_leverage_files": [
-      {
-        "branch_coverage_pct": null,
-        "file_path": null,
-        "has_test_file": null,
-        "is_test": null,
-        "line_coverage_pct": null,
-        "maintainability_score": null,
-        "max_ccn": null,
-        "max_nesting": null,
-        "module": null,
-        "nloc": null,
-        "performance_score": null,
-        "primary_biomarker": null,
-        "primary_reason": null,
-        "score": null,
-        "share_of_repo_gap_pct": null,
-        "total_deduction": null,
-        "weighted_deficit": null
-      }
-    ],
-    "high_leverage_files_emitted": null,
-    "high_leverage_files_reduced_reason": null,
-    "high_leverage_files_total": null,
-    "kpis": {
-      "average_health": null,
-      "average_health_code_only": null,
-      "average_health_unweighted": null,
-      "average_health_weighting": null,
-      "band": null,
-      "file_count": null,
-      "hotspot_health": null,
-      "maintainability_average": null,
-      "non_code_files": null,
-      "performance_analyzed_files": null,
-      "performance_average": null,
-      "performance_coverage_pct": null,
-      "performance_covered_files": null,
-      "performance_findings": null,
-      "performance_findings_density_per_10k_loc": null,
-      "performance_skipped_files": null,
-      "performance_unsupported_languages": [
-        null
-      ],
-      "performance_unsupported_languages_emitted": null,
-      "performance_unsupported_languages_total": null,
-      "worst_performer_path": null,
-      "worst_performer_score": null
-    },
-    "mode": null,
-    "performance_directive": {
-      "advisory_total": null,
-      "affected_call_sites_total": null,
-      "boundary_kind": null,
-      "execution_context": null,
-      "file_path": null,
-      "investigate_total": null,
-      "next_action": {
-        "arguments": {
-          "opportunity_id": null
-        },
-        "tool": null
-      },
-      "observations_total": null,
-      "opportunities_total": null,
-      "opportunity_id": null,
-      "performance_model_version": null,
-      "plan_ready_total": null,
-      "plan_reason": null,
-      "plan_state": null,
-      "prerequisites": [],
-      "prerequisites_emitted": null,
-      "prerequisites_total": null,
-      "status": null,
-      "title": null,
-      "why_ranked": [
-        {
-          "factor": null,
-          "points": null,
-          "value": null
-        }
-      ],
-      "why_ranked_emitted": null,
-      "why_ranked_total": null
-    },
-    "performance_opportunities": [
-      {
-        "actionability_reason": null,
-        "actionability_state": null,
-        "affected_call_sites_total": null,
-        "affected_files_total": null,
-        "biomarker_type": null,
-        "biomarker_types": [
-          null
-        ],
-        "biomarker_types_emitted": null,
-        "biomarker_types_total": null,
-        "boundary_kind": null,
-        "confidence": null,
-        "evidence": [
-          {
-            "biomarker_type": null,
-            "file_path": null,
-            "finding_id": null,
-            "function_name": null,
-            "line_end": null,
-            "line_start": null,
-            "path": [],
-            "path_emitted": null,
-            "path_total": null,
-            "provenance": null,
-            "reason": null
-          }
-        ],
-        "evidence_emitted": null,
-        "evidence_total": null,
-        "evidence_truncated": null,
-        "execution_context": null,
-        "facets": {
-          "actionability_confidence": null,
-          "amplification": null,
-          "change_risk": null,
-          "exposure": null,
-          "leverage": null
-        },
-        "file_path": null,
-        "fix": {
-          "rationale": null,
-          "safety": null,
-          "strategy": null
-        },
-        "intervention_symbol": null,
-        "observations_total": null,
-        "opportunity_id": null,
-        "performance_model_version": null,
-        "plan_id": null,
-        "plan_reason": null,
-        "plan_reference": null,
-        "plan_status": null,
-        "prerequisites": [],
-        "prerequisites_emitted": null,
-        "prerequisites_total": null,
-        "provenance": null,
-        "rank_factors": {
-          "affected_call_sites": null,
-          "boundary_kind": null,
-          "entry_reachability": null,
-          "execution_context": null,
-          "multiplier_shape": null,
-          "provenance": null
-        },
-        "rank_position": null,
-        "rank_score": null,
-        "reliable_entry_reachability": null,
-        "resource_fingerprints": [],
-        "resource_fingerprints_emitted": null,
-        "resource_fingerprints_total": null,
-        "shared_path_suffix": [],
-        "shared_path_suffix_emitted": null,
-        "shared_path_suffix_total": null,
-        "terminal_sink": null,
-        "why_ranked": [
-          {
-            "factor": null,
-            "points": null,
-            "value": null
-          }
-        ],
-        "why_ranked_emitted": null,
-        "why_ranked_total": null
-      }
-    ],
-    "performance_opportunities_emitted": null,
-    "performance_opportunities_reduced_reason": null,
-    "performance_opportunities_total": null,
-    "performance_summary": {
-      "actionability": {
-        "advisory": null,
-        "investigate": null,
-        "plan_ready": null
-      },
-      "analyzed_commit": null,
-      "boundary": {
-        "db": null,
-        "filesystem": null,
-        "network": null,
-        "none": null,
-        "subprocess": null
-      },
-      "context": {
-        "production": null
-      },
-      "facets": {
-        "actionability": [
-          {
-            "total": null,
-            "value": null
-          }
-        ],
-        "actionability_emitted": null,
-        "actionability_total": null,
-        "boundary": [
-          {
-            "total": null,
-            "value": null
-          }
-        ],
-        "boundary_emitted": null,
-        "boundary_total": null,
-        "confidence": [
-          {
-            "total": null,
-            "value": null
-          }
-        ],
-        "confidence_emitted": null,
-        "confidence_total": null,
-        "context": [
-          {
-            "total": null,
-            "value": null
-          }
-        ],
-        "context_emitted": null,
-        "context_total": null,
-        "plan_state": [
-          {
-            "total": null,
-            "value": null
-          }
-        ],
-        "plan_state_emitted": null,
-        "plan_state_total": null
-      },
-      "materialized_model_version": null,
-      "next_call": null,
-      "performance_model_version": null,
-      "repository_total": null,
-      "status": null,
-      "total": null,
-      "with_plan_total": null
-    },
-    "recommendation_lede": {
-      "next_call": null,
-      "performance_lead": {
-        "affected_call_sites_total": null,
-        "boundary_kind": null,
-        "execution_context": null,
-        "intervention_symbol": null,
-        "opportunity_id": null,
-        "rank_score": null
-      },
-      "performance_opportunities_total": null,
-      "performance_plan_id": null,
-      "performance_plan_reason": null,
-      "recommendation_lead": {
-        "benefit": null,
-        "cost": null,
-        "file_path": null,
-        "id": null,
-        "leverage": null,
-        "rank_score": null,
-        "refactoring_type": null,
-        "risk": null,
-        "target_symbol": null
-      },
-      "refactoring_plans_total": null
-    },
+ "get_answer": {
+  "_meta": {
+   "cached": null,
+   "contract_version": null,
+   "embedder_degraded": null,
+   "index_age_days": null,
+   "indexed_commit": null,
+   "projection": {
     "recovery": {
-      "high_leverage_files": {
-        "call": null,
-        "remaining": null
-      },
-      "performance_opportunities": {
-        "call": null,
-        "remaining": null
-      },
-      "refactoring_opportunities": {
-        "call": null,
-        "remaining": null
-      },
-      "refactoring_plans": {
-        "call": null,
-        "remaining": null
-      }
+     "arguments": {
+      "include": [
+       null
+      ],
+      "question": null
+     },
+     "tool": null
+    }
+   },
+   "timing_ms": null
+  },
+  "answer": null,
+  "candidates_emitted": null,
+  "candidates_reduced_reason": null,
+  "candidates_total": null,
+  "citations": [
+   null
+  ],
+  "confidence": null,
+  "fallback_targets_emitted": null,
+  "fallback_targets_reduced_reason": null,
+  "fallback_targets_total": null,
+  "flow_path": [
+   null
+  ],
+  "next_action_hint": null,
+  "note": null,
+  "quotes": [
+   {
+    "lines": [
+     null
+    ],
+    "path": null,
+    "quote": null
+   }
+  ],
+  "quotes_emitted": null,
+  "quotes_reduced_reason": null,
+  "quotes_total": null,
+  "retrieval_quality": null
+ },
+ "get_architecture": {
+  "_meta": {
+   "analysis_commits": {
+    "backend": null,
+    "frontend": null,
+    "repowise": null
+   },
+   "analysis_timestamp": null,
+   "contract_version": null,
+   "embedder_degraded": null
+  },
+  "architecture_type": null,
+  "conformance_violations": null,
+  "core_members": [
+   null
+  ],
+  "core_members_truncated": null,
+  "core_ratio": null,
+  "core_size": null,
+  "cycle_count": null,
+  "node_count": null,
+  "propagation_cost_pct": null,
+  "role_breakdown": {
+   "control": null,
+   "core": null,
+   "peripheral": null,
+   "shared": null
+  },
+  "score": null,
+  "summary": null
+ },
+ "get_blast_radius": {
+  "_meta": {
+   "analysis_commits": {
+    "backend": null,
+    "frontend": null,
+    "repowise": null
+   },
+   "analysis_timestamp": null,
+   "contract_version": null,
+   "embedder_degraded": null
+  },
+  "behavioral_count": null,
+  "impact_score_semantics": {
+   "authoritative_for_change_review": null,
+   "calibration": {
+    "status": null
+   },
+   "field": null,
+   "kind": null,
+   "measures": null,
+   "range": {
+    "maximum": null,
+    "minimum": null
+   },
+   "runtime_breakage_probability": null,
+   "unit": null
+  },
+  "impacted": [],
+  "impacted_repos": [],
+  "impacted_truncated": null,
+  "max_distance": null,
+  "structural_count": null,
+  "summary": null,
+  "target_repos": [],
+  "targets": [],
+  "total_impacted": null,
+  "unresolved_targets": [
+   null
+  ]
+ },
+ "get_change_risk": {
+  "_meta": {
+   "contract_version": null,
+   "embedder_degraded": null,
+   "index_age_days": null,
+   "indexed_commit": null,
+   "omitted": {
+    "refs": [
+     null
+    ],
+    "restore": null,
+    "tokens": null
+   },
+   "source": null,
+   "timing_ms": null
+  },
+  "change_shape": {
+   "classification": null,
+   "diagnostics_via": null,
+   "fallback_band": null,
+   "is_fix": null,
+   "measures": null,
+   "review_priority": null,
+   "risk_percentile": null,
+   "score": null
+  },
+  "classification": null,
+  "directive": {
+   "headline": null,
+   "next_actions": [
+    null
+   ],
+   "reasons": [
+    null
+   ],
+   "status": null
+  },
+  "exclude_patterns": [],
+  "fallback_band": null,
+  "fix_history": {
+   "available": null,
+   "density": null,
+   "files": [
+    {
+     "churn": null,
+     "fix_pressure": null,
+     "path": null
+    }
+   ],
+   "percentile": null
+  },
+  "health_delta": {
+   "analyzer": {
+    "analyzer_version": null,
+    "performance_model_version": null,
+    "rules_fingerprint": null
+   },
+   "base": {
+    "kind": null,
+    "ref": null,
+    "sha": null
+   },
+   "basis": null,
+   "by_dimension": {},
+   "by_severity": {},
+   "explanation": null,
+   "findings_emitted": null,
+   "findings_total": null,
+   "head": {
+    "kind": null,
+    "ref": null,
+    "sha": null
+   },
+   "introduced": null,
+   "limits": [
+    null
+   ],
+   "resolved": null,
+   "scope": {
+    "analyzed": null,
+    "changed": null,
+    "eligible": null,
+    "failed": null,
+    "skipped": null
+   },
+   "skipped": {
+    "by_reason": {
+     "not_health_analyzable": null
     },
-    "refactoring_directive": {
-      "addresses_primary_problem": null,
+    "total": null
+   },
+   "status": null,
+   "top_findings": [],
+   "worsened": null
+  },
+  "impacted_tests": {
+   "basis": null,
+   "line_coverage": {
+    "covered": [],
+    "no_coverage_data": [],
+    "stale_test_candidates": [],
+    "untested_changes": []
+   },
+   "map_present": null,
+   "status": null,
+   "summary": null,
+   "tests_to_run": [
+    null
+   ],
+   "total": null,
+   "truncated": null
+  },
+  "is_fix": null,
+  "omission_marker": null,
+  "prior_fixes": {
+   "changed_lines_in_fixed_files": null,
+   "files": [
+    {
+     "changed_lines": null,
+     "file_path": null,
+     "fix_count": null,
+     "last_fix_days_ago": null,
+     "overlapping_lines": null,
+     "share_of_change": null
+    }
+   ],
+   "files_with_fixes": null,
+   "line_overlap": null,
+   "summary": null,
+   "total_fixes": null,
+   "truncated": null
+  },
+  "ref": null,
+  "review_priority": null,
+  "risk_percentile": null,
+  "score": null,
+  "working_tree": null
+ },
+ "get_conformance": {
+  "_meta": {
+   "analysis_commits": {
+    "backend": null,
+    "frontend": null,
+    "repowise": null
+   },
+   "analysis_timestamp": null,
+   "contract_version": null,
+   "embedder_degraded": null
+  },
+  "checked_at": null,
+  "cycle_count": null,
+  "cycles": [
+   {
+    "edge_ids": [
+     null
+    ],
+    "length": null,
+    "nodes": [
+     null
+    ]
+   }
+  ],
+  "cycles_truncated": null,
+  "rules_evaluated": null,
+  "summary": null,
+  "total_cycles": null,
+  "violation_count": null,
+  "violations": [],
+  "violations_truncated": null
+ },
+ "get_context": {
+  "_meta": {
+   "contract_version": null,
+   "embedder_degraded": null,
+   "index_age_days": null,
+   "indexed_commit": null,
+   "timing_ms": null
+  },
+  "targets": {
+   "<path>": {
+    "_call_graph_note": null,
+    "architectural_layer": {
+     "description": null,
+     "name": null,
+     "role": null
+    },
+    "callers": [
+     {
+      "file": null,
+      "imports": null,
+      "inbound_calls": null
+     }
+    ],
+    "docs": {
+     "summary": null,
+     "symbols": [
+      {
+       "kind": null,
+       "line": null,
+       "name": null,
+       "signature": null,
+       "symbol_id": null
+      }
+     ],
+     "symbols_truncated": {
+      "hint": null,
+      "shown": null,
+      "total": null
+     },
+     "title": null
+    },
+    "episodes": null,
+    "fix_history": {
+     "bug_magnet": null,
+     "fix_count": null,
+     "last_fix_days_ago": null
+    },
+    "freshness": {
+     "confidence_score": null,
+     "freshness_status": null,
+     "is_stale": null
+    },
+    "hotspot": null,
+    "parent_page": {
+     "section": null,
+     "target_path": null,
+     "title": null
+    },
+    "path": null,
+    "skeleton": {
+     "bodies_kept": [],
+     "full_tokens": null,
+     "mode": null,
+     "pct_of_full": null,
+     "text": null,
+     "tokens": null,
+     "verified": null
+    },
+    "target": null,
+    "type": null
+   }
+  }
+ },
+ "get_dead_code": {
+  "_meta": {
+   "contract_version": null,
+   "embedder_degraded": null,
+   "index_age_days": null,
+   "indexed_commit": null,
+   "omitted": {
+    "refs": [
+     null
+    ],
+    "restore": null,
+    "tokens": null
+   }
+  },
+  "impact": {
+   "recommendation": null,
+   "safe_lines_reclaimable": null,
+   "total_lines_reclaimable": null
+  },
+  "limit_note": null,
+  "omission_marker": null,
+  "summary": {
+   "by_kind": {
+    "unreachable_file": null,
+    "unused_export": null,
+    "unused_internal": null,
+    "zombie_package": null
+   },
+   "deletable_lines": null,
+   "filtered_findings": null,
+   "safe_to_delete_count": null,
+   "total_findings": null
+  },
+  "tiers": {
+   "high": {
+    "count": null,
+    "description": null,
+    "findings": [
+     {
+      "age_days": null,
+      "commit_count_90d": null,
       "confidence": null,
-      "effort_bucket": null,
-      "fix_first": null,
-      "judgment_steps": null,
-      "lead_refactoring_type": null,
-      "mechanical_steps": null,
-      "next_action": {
-        "arguments": {
-          "opportunity_id": null
-        },
-        "tool": null
-      },
-      "opportunities_total": null,
-      "opportunity_id": null,
-      "reason": null,
-      "recovers_health_points": null,
-      "status": null,
-      "steps": null
-    },
-    "refactoring_opportunities": [
-      {
-        "addresses_primary_problem": null,
-        "affected_files_total": null,
-        "confidence": null,
-        "dependents": null,
-        "effort_bucket": null,
-        "evidence_total": null,
-        "file_nloc": null,
-        "file_path": null,
-        "judgment_steps": null,
-        "lead_biomarker": null,
-        "lead_refactoring_type": null,
-        "mechanical_steps": null,
-        "opportunity_id": null,
-        "queue_position": null,
-        "rank_factors": {
-          "benefit": null,
-          "cost": null,
-          "mechanical_share": null,
-          "primary_problem": null,
-          "risk": null
-        },
-        "rank_position": null,
-        "rank_score": null,
-        "recoverable_health": null,
-        "refactoring_model_version": null,
-        "status": null,
-        "step_count": null,
-        "steps": [
-          {
-            "applicability": {
-              "classification": null,
-              "facts": {
-                "affected_file_count": null,
-                "blast_size": null,
-                "callers": null,
-                "confidence": null,
-                "cross_file": null,
-                "framework_registration": null
-              },
-              "reasons": [
-                null
-              ],
-              "reasons_emitted": null,
-              "reasons_total": null,
-              "unknowns": [
-                null
-              ],
-              "unknowns_emitted": null,
-              "unknowns_total": null
-            },
-            "confidence": null,
-            "effort_bucket": null,
-            "file_path": null,
-            "finding_ids": [],
-            "finding_ids_emitted": null,
-            "finding_ids_total": null,
-            "impact_delta": null,
-            "line_end": null,
-            "line_start": null,
-            "plan_id": null,
-            "refactoring_type": null,
-            "relocated_by": null,
-            "source_biomarker": null,
-            "target_symbol": null,
-            "validation_profile_id": null
-          }
-        ],
-        "steps_emitted": null,
-        "steps_reduced_reason": null,
-        "steps_total": null,
-        "why_ranked": [
-          {
-            "factor": null,
-            "value": null
-          }
-        ],
-        "why_ranked_emitted": null,
-        "why_ranked_total": null
-      }
-    ],
-    "refactoring_opportunities_emitted": null,
-    "refactoring_opportunities_reduced_reason": null,
-    "refactoring_opportunities_total": null,
-    "refactoring_plans": [
-      {
-        "benefit": null,
-        "blast_radius": {
-          "scope": null
-        },
-        "confidence": null,
-        "cost": null,
-        "dependents": null,
-        "effort_bucket": null,
-        "evidence": {
-          "ccn_removed": null,
-          "slice_nloc": null
-        },
-        "file_nloc": null,
-        "file_path": null,
-        "file_weighted_deficit": null,
-        "id": null,
-        "impact_delta": null,
-        "leverage": null,
-        "line_end": null,
-        "line_start": null,
-        "plan": {
-          "params": [
-            null
-          ],
-          "params_emitted": null,
-          "params_total": null,
-          "returns": [],
-          "returns_emitted": null,
-          "returns_total": null,
-          "span": {
-            "end": null,
-            "start": null
-          },
-          "suggested_name": null
-        },
-        "rank_score": null,
-        "refactoring_type": null,
-        "repository": null,
-        "risk": null,
-        "source_biomarker": null,
-        "target_symbol": null,
-        "validation_profile_id": null
-      }
-    ],
-    "refactoring_plans_emitted": null,
-    "refactoring_plans_reduced_reason": null,
-    "refactoring_plans_status": {
-      "reason": null,
-      "state": null
-    },
-    "refactoring_plans_total": null,
-    "refactoring_summary": {
-      "addresses_primary_problem": {
-        "no": null,
-        "unknown": null,
-        "yes": null
-      },
-      "analyzed_commit": null,
-      "by_confidence": {
-        "high": null,
-        "medium": null
-      },
-      "by_effort": {
-        "L": null,
-        "M": null,
-        "S": null,
-        "XL": null
-      },
-      "by_lead_type": {
-        "break_cycle": null,
-        "extract_class": null,
-        "extract_helper": null,
-        "extract_method": null,
-        "move_method": null,
-        "split_file": null
-      },
-      "by_status": {
-        "open": null
-      },
-      "facets": {
-        "confidence": {
-          "high": null,
-          "medium": null
-        },
-        "effort": {
-          "L": null,
-          "M": null,
-          "S": null,
-          "XL": null
-        },
-        "lead_type": {
-          "break_cycle": null,
-          "extract_class": null,
-          "extract_helper": null,
-          "extract_method": null,
-          "move_method": null,
-          "split_file": null
-        }
-      },
-      "files_total": null,
-      "judgment_steps_total": null,
-      "lead": {
-        "addresses_primary_problem": null,
-        "confidence": null,
-        "effort_bucket": null,
-        "file_path": null,
-        "judgment_steps": null,
-        "lead_biomarker": null,
-        "lead_refactoring_type": null,
-        "mechanical_steps": null,
-        "opportunity_id": null,
-        "recoverable_health": null,
-        "status": null,
-        "step_count": null
-      },
-      "mechanical_steps_total": null,
-      "next_call": null,
-      "opportunities_total": null,
-      "refactoring_model_version": null,
-      "status": null,
-      "steps_total": null,
-      "view": null
-    },
-    "secondary_rankings": {
-      "modules": {
-        "call": null,
-        "total": null
-      },
-      "test_findings": {
-        "call": null,
-        "total": null
-      },
-      "top_findings": {
-        "call": null,
-        "total": null
-      },
-      "worst_files": {
-        "call": null,
-        "total": null
-      }
-    },
-    "suggestion_legend": {
-      "hot_path_sync_io": null,
-      "io_in_loop": null,
-      "nested_loop_with_io": null,
-      "serial_await_in_loop": null
-    },
-    "unknown_include_keys": [
-      null
-    ],
-    "unknown_include_keys_emitted": null,
-    "unknown_include_keys_total": null,
-    "validation_profiles": [
-      {
-        "affected_files": [
-          null
-        ],
-        "affected_files_emitted": null,
-        "affected_files_total": null,
-        "affected_symbols": [
-          null
-        ],
-        "affected_symbols_emitted": null,
-        "affected_symbols_total": null,
-        "basis": null,
-        "commands": [
-          null
-        ],
-        "commands_emitted": null,
-        "commands_total": null,
-        "id": null,
-        "targets": [
-          {
-            "basis": null,
-            "file_path": null,
-            "tests": [
-              null
-            ],
-            "tests_emitted": null,
-            "tests_total": null,
-            "total": null,
-            "truncated": null,
-            "via": null
-          }
-        ],
-        "targets_emitted": null,
-        "targets_total": null,
-        "tests": [
-          null
-        ],
-        "tests_emitted": null,
-        "tests_reduced_reason": null,
-        "tests_total": null,
-        "total": null,
-        "via": null
-      }
-    ],
-    "validation_profiles_emitted": null,
-    "validation_profiles_total": null
-  },
-  "get_overview": {
-    "_meta": {
-      "contract_version": null,
-      "embedder_degraded": null,
-      "index_age_days": null,
-      "indexed_commit": null,
-      "omitted": {
-        "refs": [
-          null
-        ],
-        "restore": null,
-        "tokens": null
-      }
-    },
-    "architecture": {
-      "layer_order": [
-        null
-      ],
-      "layers": [
-        {
-          "file_count": null,
-          "name": null
-        }
-      ],
-      "tour_available": null,
-      "tour_step_count": null
-    },
-    "code_health": {
-      "average_health": null,
-      "band": null,
-      "distribution": {
-        "bands": {
-          "alert": {
-            "files": null,
-            "nloc": null,
-            "pct": null
-          },
-          "healthy": {
-            "files": null,
-            "nloc": null,
-            "pct": null
-          },
-          "warning": {
-            "files": null,
-            "nloc": null,
-            "pct": null
-          }
-        },
-        "total_files": null,
-        "total_nloc": null
-      },
-      "file_count": null,
-      "hotspot_health": null,
-      "open_findings": null,
-      "worst_performer_path": null,
-      "worst_performer_score": null
-    },
-    "content_hint": null,
-    "content_md": null,
-    "entry_points": [
-      null
-    ],
-    "git_health": {
-      "avg_bus_factor": null,
-      "churn_trend": null,
-      "files_git_attributed": null,
-      "files_with_bus_factor_1": null,
-      "hotspot_count": null,
-      "top_churn_modules": [
-        null
-      ]
-    },
-    "key_modules": [
-      {
-        "name": null,
-        "path": null,
-        "section": null
-      }
-    ],
-    "more": null,
-    "omission_marker": null,
-    "title": null,
-    "tool_surface": {
-      "counts": {
-        "default": null,
-        "eligible": null,
-        "enabled": null,
-        "opt_in_available": null,
-        "tiers": {
-          "canonical": null
-        }
-      },
-      "enabled": [
-        null
-      ],
-      "mode": null,
-      "opt_in": [
-        {
-          "description": null,
-          "enabled": null,
-          "name": null
-        }
-      ],
-      "recipes": [
-        {
-          "call": null,
-          "name": null
-        }
-      ],
-      "tools": [
-        {
-          "default": null,
-          "description": null,
-          "name": null,
-          "tier": null
-        }
-      ]
-    }
-  },
-  "get_risk": {
-    "_meta": {
-      "contract_version": null,
-      "embedder_degraded": null,
-      "index_age_days": null,
-      "indexed_commit": null,
-      "omitted": {
-        "refs": [
-          null
-        ],
-        "restore": null,
-        "tokens": null
-      }
-    },
-    "omission_marker": null,
-    "targets": {
-      "packages/core/src/repowise/core/ingestion/call_resolver.py": {
-        "bus_factor": null,
-        "co_change_partners": [
-          {
-            "direction": null,
-            "evidence_kind": null,
-            "file_path": null,
-            "has_import_link": null,
-            "has_structural_link": null,
-            "last_co_change": null,
-            "provenance": null,
-            "relationship_type": null,
-            "structural_relationship_types": [
-              null
-            ],
-            "support": null,
-            "weight": null
-          }
-        ],
-        "co_change_partners_emitted": null,
-        "co_change_partners_omitted": null,
-        "co_change_partners_reduced_reason": null,
-        "co_change_partners_total": null,
-        "co_change_partners_truncated": null,
-        "commit_count_capped": null,
-        "contributor_count": null,
-        "coverage_pct": null,
-        "defect_profile": {
-          "bug_magnet": null,
-          "fix_count": null,
-          "last_fix_days_ago": null,
-          "top_symbols": {
-            "_link_declarations": null,
-            "_merged_symbols_for": null,
-            "_published": null
-          },
-          "window": null
-        },
-        "dependents_count": null,
-        "episodes": null,
-        "health_score": null,
-        "hotspot_score": null,
-        "is_hotspot": null,
-        "owner_pct": null,
-        "primary_owner": null,
-        "recent_owner": null,
-        "recent_owner_pct": null,
-        "risk_summary": null,
-        "security_signals": [],
-        "target": null,
-        "test_gap": null,
-        "top_biomarkers": [
-          {
-            "biomarker_type": null,
-            "function_name": null,
-            "impact": null,
-            "severity": null
-          }
-        ],
-        "trend": null
-      }
-    }
-  },
-  "get_symbol": {
-    "_meta": {
-      "contract_version": null,
-      "embedder_degraded": null,
-      "index_age_days": null,
-      "indexed_commit": null,
-      "replaced_tokens": null,
-      "timing_ms": null
-    },
-    "continuation": null,
-    "continuation_reference": {
+      "end_line": null,
+      "file_path": null,
       "id": null,
       "kind": null,
-      "path": null,
-      "range": [
+      "last_commit_at": null,
+      "last_meaningful_change": null,
+      "lines": null,
+      "primary_owner": null,
+      "reason": null,
+      "repository": null,
+      "risk_factors": [],
+      "safe_to_delete": null,
+      "start_line": null,
+      "symbol_kind": null,
+      "symbol_name": null
+     }
+    ],
+    "lines": null,
+    "safe_count": null,
+    "truncated": null
+   },
+   "low": {
+    "count": null,
+    "description": null,
+    "findings": [
+     {
+      "age_days": null,
+      "commit_count_90d": null,
+      "confidence": null,
+      "end_line": null,
+      "file_path": null,
+      "id": null,
+      "kind": null,
+      "last_commit_at": null,
+      "last_meaningful_change": null,
+      "lines": null,
+      "primary_owner": null,
+      "reason": null,
+      "repository": null,
+      "risk_factors": [
+       null
+      ],
+      "safe_to_delete": null,
+      "start_line": null,
+      "symbol_kind": null,
+      "symbol_name": null
+     }
+    ],
+    "lines": null,
+    "safe_count": null,
+    "truncated": null
+   },
+   "medium": {
+    "count": null,
+    "description": null,
+    "findings": [
+     {
+      "age_days": null,
+      "commit_count_90d": null,
+      "confidence": null,
+      "end_line": null,
+      "file_path": null,
+      "id": null,
+      "kind": null,
+      "last_commit_at": null,
+      "last_meaningful_change": null,
+      "lines": null,
+      "primary_owner": null,
+      "reason": null,
+      "repository": null,
+      "risk_factors": [
+       null
+      ],
+      "safe_to_delete": null,
+      "start_line": null,
+      "symbol_kind": null,
+      "symbol_name": null
+     }
+    ],
+    "lines": null,
+    "safe_count": null,
+    "truncated": null
+   }
+  }
+ },
+ "get_dependency_path": {
+  "distance": null,
+  "explanation": null,
+  "path": [],
+  "visual_context": {
+   "bridge_suggestions": [
+    {
+     "node": null,
+     "pagerank": null
+    }
+   ],
+   "community": {
+    "same_community": null,
+    "source_community": null,
+    "target_community": null
+   },
+   "disconnected": null,
+   "nearest_common_ancestors": [
+    {
+     "distance_from_source": null,
+     "distance_from_target": null,
+     "node": null
+    }
+   ],
+   "reverse_path": {
+    "distance": null,
+    "exists": null,
+    "note": null,
+    "path": [
+     null
+    ]
+   },
+   "shared_neighbors": [
+    null
+   ],
+   "suggestion": null
+  }
+ },
+ "get_execution_flows": {
+  "_meta": {
+   "contract_version": null,
+   "embedder_degraded": null,
+   "hint": null,
+   "timing_ms": null
+  },
+  "flows": [
+   {
+    "communities_visited": [
+     null
+    ],
+    "crosses_community": null,
+    "depth": null,
+    "entry_point": null,
+    "entry_point_name": null,
+    "entry_point_score": null,
+    "termination": null,
+    "trace": [
+     null
+    ],
+    "trace_via": [
+     null
+    ]
+   }
+  ],
+  "total_entry_points": null
+ },
+ "get_health": {
+  "_meta": {
+   "contract_version": null,
+   "embedder_degraded": null,
+   "health_analysis": {
+    "analyzed_at": null,
+    "analyzed_commit": null,
+    "analyzed_commits_distinct": null,
+    "live_verification": {
+     "basis": null,
+     "source_bytes_verified": null
+    },
+    "recomputed_this_call": null,
+    "refresh": {
+     "command": null,
+     "precondition": null,
+     "required_before_comparison": null
+    },
+    "source": null,
+    "status": null
+   },
+   "health_analyzed_at": null,
+   "health_analyzed_commit": null,
+   "health_analyzed_commits_distinct": null,
+   "health_semantics": {
+    "percentiles": {
+     "direction": null,
+     "freshness": null,
+     "population": null,
+     "public_raw_scale": null,
+     "stored_scale": null
+    },
+    "weighted_deficit_points": {
+     "denominator": null,
+     "direction": null,
+     "interpretation": null,
+     "numerator": null,
+     "scale": {
+      "maximum": null,
+      "minimum": null,
+      "normalized": null
+     },
+     "unit": null
+    }
+   },
+   "index_age_days": null,
+   "indexed_commit": null,
+   "timing_ms": null
+  },
+  "directive": {
+   "fix_first": null,
+   "next_action": null,
+   "plan_addresses_reason": null,
+   "plan_note": null,
+   "plan_via": null,
+   "reason": null,
+   "recovers_points": null,
+   "recovers_points_compatibility": {
+    "deprecated": null,
+    "equivalent_value": null,
+    "replacement": null
+   },
+   "recovers_weighted_deficit_points": null,
+   "share_of_repo_gap_pct": null,
+   "then": [
+    null
+   ],
+   "then_emitted": null,
+   "then_total": null
+  },
+  "distribution": {
+   "bands": {
+    "alert": {
+     "files": null,
+     "nloc": null,
+     "pct": null
+    },
+    "healthy": {
+     "files": null,
+     "nloc": null,
+     "pct": null
+    },
+    "warning": {
+     "files": null,
+     "nloc": null,
+     "pct": null
+    }
+   },
+   "total_files": null,
+   "total_nloc": null
+  },
+  "gap_analysis": {
+   "files_below_target": null,
+   "files_for_half_gap": null,
+   "files_to_reach_target": null,
+   "target_score": null,
+   "weighted_gap_points": null,
+   "weighted_gross_gap_points": null
+  },
+  "high_leverage_files": [
+   {
+    "branch_coverage_pct": null,
+    "file_path": null,
+    "has_test_file": null,
+    "is_test": null,
+    "line_coverage_pct": null,
+    "maintainability_score": null,
+    "max_ccn": null,
+    "max_nesting": null,
+    "module": null,
+    "nloc": null,
+    "performance_score": null,
+    "primary_biomarker": null,
+    "primary_reason": null,
+    "score": null,
+    "share_of_repo_gap_pct": null,
+    "total_deduction": null,
+    "weighted_deficit": null
+   }
+  ],
+  "high_leverage_files_emitted": null,
+  "high_leverage_files_reduced_reason": null,
+  "high_leverage_files_total": null,
+  "kpis": {
+   "average_health": null,
+   "average_health_code_only": null,
+   "average_health_unweighted": null,
+   "average_health_weighting": null,
+   "band": null,
+   "file_count": null,
+   "hotspot_health": null,
+   "maintainability_average": null,
+   "non_code_files": null,
+   "performance_analyzed_files": null,
+   "performance_average": null,
+   "performance_coverage_pct": null,
+   "performance_covered_files": null,
+   "performance_findings": null,
+   "performance_findings_density_per_10k_loc": null,
+   "performance_skipped_files": null,
+   "performance_unsupported_languages": [
+    null
+   ],
+   "performance_unsupported_languages_emitted": null,
+   "performance_unsupported_languages_total": null,
+   "worst_performer_path": null,
+   "worst_performer_score": null
+  },
+  "mode": null,
+  "performance_directive": {
+   "advisory_total": null,
+   "affected_call_sites_total": null,
+   "boundary_kind": null,
+   "execution_context": null,
+   "file_path": null,
+   "investigate_total": null,
+   "next_action": {
+    "arguments": {
+     "opportunity_id": null
+    },
+    "tool": null
+   },
+   "observations_total": null,
+   "opportunities_total": null,
+   "opportunity_id": null,
+   "performance_model_version": null,
+   "plan_ready_total": null,
+   "plan_reason": null,
+   "plan_state": null,
+   "prerequisites": [],
+   "prerequisites_emitted": null,
+   "prerequisites_total": null,
+   "status": null,
+   "title": null,
+   "why_ranked": [
+    {
+     "factor": null,
+     "points": null,
+     "value": null
+    }
+   ],
+   "why_ranked_emitted": null,
+   "why_ranked_total": null
+  },
+  "performance_opportunities": [
+   {
+    "actionability_reason": null,
+    "actionability_state": null,
+    "affected_call_sites_total": null,
+    "affected_files_total": null,
+    "biomarker_type": null,
+    "biomarker_types": [
+     null
+    ],
+    "biomarker_types_emitted": null,
+    "biomarker_types_total": null,
+    "boundary_kind": null,
+    "confidence": null,
+    "evidence": [
+     {
+      "biomarker_type": null,
+      "file_path": null,
+      "finding_id": null,
+      "function_name": null,
+      "line_end": null,
+      "line_start": null,
+      "path": [],
+      "path_emitted": null,
+      "path_total": null,
+      "provenance": null,
+      "reason": null
+     }
+    ],
+    "evidence_emitted": null,
+    "evidence_total": null,
+    "evidence_truncated": null,
+    "execution_context": null,
+    "facets": {
+     "actionability_confidence": null,
+     "amplification": null,
+     "change_risk": null,
+     "exposure": null,
+     "leverage": null
+    },
+    "file_path": null,
+    "fix": {
+     "rationale": null,
+     "safety": null,
+     "strategy": null
+    },
+    "intervention_symbol": null,
+    "observations_total": null,
+    "opportunity_id": null,
+    "performance_model_version": null,
+    "plan_id": null,
+    "plan_reason": null,
+    "plan_reference": null,
+    "plan_status": null,
+    "prerequisites": [],
+    "prerequisites_emitted": null,
+    "prerequisites_total": null,
+    "provenance": null,
+    "rank_factors": {
+     "affected_call_sites": null,
+     "boundary_kind": null,
+     "entry_reachability": null,
+     "execution_context": null,
+     "multiplier_shape": null,
+     "provenance": null
+    },
+    "rank_position": null,
+    "rank_score": null,
+    "reliable_entry_reachability": null,
+    "resource_fingerprints": [],
+    "resource_fingerprints_emitted": null,
+    "resource_fingerprints_total": null,
+    "shared_path_suffix": [],
+    "shared_path_suffix_emitted": null,
+    "shared_path_suffix_total": null,
+    "terminal_sink": null,
+    "why_ranked": [
+     {
+      "factor": null,
+      "points": null,
+      "value": null
+     }
+    ],
+    "why_ranked_emitted": null,
+    "why_ranked_total": null
+   }
+  ],
+  "performance_opportunities_emitted": null,
+  "performance_opportunities_reduced_reason": null,
+  "performance_opportunities_total": null,
+  "performance_summary": {
+   "actionability": {
+    "advisory": null,
+    "investigate": null,
+    "plan_ready": null
+   },
+   "analyzed_commit": null,
+   "boundary": {
+    "db": null,
+    "filesystem": null,
+    "network": null,
+    "none": null,
+    "subprocess": null
+   },
+   "context": {
+    "production": null
+   },
+   "facets": {
+    "actionability": [
+     {
+      "total": null,
+      "value": null
+     }
+    ],
+    "actionability_emitted": null,
+    "actionability_total": null,
+    "boundary": [
+     {
+      "total": null,
+      "value": null
+     }
+    ],
+    "boundary_emitted": null,
+    "boundary_total": null,
+    "confidence": [
+     {
+      "total": null,
+      "value": null
+     }
+    ],
+    "confidence_emitted": null,
+    "confidence_total": null,
+    "context": [
+     {
+      "total": null,
+      "value": null
+     }
+    ],
+    "context_emitted": null,
+    "context_total": null,
+    "plan_state": [
+     {
+      "total": null,
+      "value": null
+     }
+    ],
+    "plan_state_emitted": null,
+    "plan_state_total": null
+   },
+   "materialized_model_version": null,
+   "next_call": null,
+   "performance_model_version": null,
+   "repository_total": null,
+   "status": null,
+   "total": null,
+   "with_plan_total": null
+  },
+  "recommendation_lede": {
+   "next_call": null,
+   "performance_lead": {
+    "affected_call_sites_total": null,
+    "boundary_kind": null,
+    "execution_context": null,
+    "intervention_symbol": null,
+    "opportunity_id": null,
+    "rank_score": null
+   },
+   "performance_opportunities_total": null,
+   "performance_plan_id": null,
+   "performance_plan_reason": null,
+   "recommendation_lead": {
+    "benefit": null,
+    "cost": null,
+    "file_path": null,
+    "id": null,
+    "leverage": null,
+    "rank_score": null,
+    "refactoring_type": null,
+    "risk": null,
+    "target_symbol": null
+   },
+   "refactoring_plans_total": null
+  },
+  "recovery": {
+   "high_leverage_files": {
+    "call": null,
+    "remaining": null
+   },
+   "performance_opportunities": {
+    "call": null,
+    "remaining": null
+   },
+   "refactoring_opportunities": {
+    "call": null,
+    "remaining": null
+   },
+   "refactoring_plans": {
+    "call": null,
+    "remaining": null
+   }
+  },
+  "refactoring_directive": {
+   "addresses_primary_problem": null,
+   "confidence": null,
+   "effort_bucket": null,
+   "fix_first": null,
+   "judgment_steps": null,
+   "lead_refactoring_type": null,
+   "mechanical_steps": null,
+   "next_action": {
+    "arguments": {
+     "opportunity_id": null
+    },
+    "tool": null
+   },
+   "opportunities_total": null,
+   "opportunity_id": null,
+   "reason": null,
+   "recovers_health_points": null,
+   "status": null,
+   "steps": null
+  },
+  "refactoring_opportunities": [
+   {
+    "addresses_primary_problem": null,
+    "affected_files_total": null,
+    "confidence": null,
+    "dependents": null,
+    "effort_bucket": null,
+    "evidence_total": null,
+    "file_nloc": null,
+    "file_path": null,
+    "judgment_steps": null,
+    "lead_biomarker": null,
+    "lead_refactoring_type": null,
+    "mechanical_steps": null,
+    "opportunity_id": null,
+    "queue_position": null,
+    "rank_factors": {
+     "benefit": null,
+     "cost": null,
+     "mechanical_share": null,
+     "primary_problem": null,
+     "risk": null
+    },
+    "rank_position": null,
+    "rank_score": null,
+    "recoverable_health": null,
+    "refactoring_model_version": null,
+    "status": null,
+    "step_count": null,
+    "steps": [
+     {
+      "applicability": {
+       "classification": null,
+       "facts": {
+        "affected_file_count": null,
+        "blast_size": null,
+        "callers": null,
+        "confidence": null,
+        "cross_file": null,
+        "framework_registration": null
+       },
+       "reasons": [
         null
+       ],
+       "reasons_emitted": null,
+       "reasons_total": null,
+       "unknowns": [
+        null
+       ],
+       "unknowns_emitted": null,
+       "unknowns_total": null
+      },
+      "confidence": null,
+      "effort_bucket": null,
+      "file_path": null,
+      "finding_ids": [],
+      "finding_ids_emitted": null,
+      "finding_ids_total": null,
+      "impact_delta": null,
+      "line_end": null,
+      "line_start": null,
+      "plan_id": null,
+      "refactoring_type": null,
+      "relocated_by": null,
+      "source_biomarker": null,
+      "target_symbol": null,
+      "validation_profile_id": null
+     }
+    ],
+    "steps_emitted": null,
+    "steps_reduced_reason": null,
+    "steps_total": null,
+    "why_ranked": [
+     {
+      "factor": null,
+      "value": null
+     }
+    ],
+    "why_ranked_emitted": null,
+    "why_ranked_total": null
+   }
+  ],
+  "refactoring_opportunities_emitted": null,
+  "refactoring_opportunities_reduced_reason": null,
+  "refactoring_opportunities_total": null,
+  "refactoring_plans": [
+   {
+    "benefit": null,
+    "blast_radius": {
+     "scope": null
+    },
+    "confidence": null,
+    "cost": null,
+    "dependents": null,
+    "effort_bucket": null,
+    "evidence": {
+     "ccn_removed": null,
+     "slice_nloc": null
+    },
+    "file_nloc": null,
+    "file_path": null,
+    "file_weighted_deficit": null,
+    "id": null,
+    "impact_delta": null,
+    "leverage": null,
+    "line_end": null,
+    "line_start": null,
+    "plan": {
+     "params": [
+      null
+     ],
+     "params_emitted": null,
+     "params_total": null,
+     "returns": [],
+     "returns_emitted": null,
+     "returns_total": null,
+     "span": {
+      "end": null,
+      "start": null
+     },
+     "suggested_name": null
+    },
+    "rank_score": null,
+    "refactoring_type": null,
+    "repository": null,
+    "risk": null,
+    "source_biomarker": null,
+    "target_symbol": null,
+    "validation_profile_id": null
+   }
+  ],
+  "refactoring_plans_emitted": null,
+  "refactoring_plans_reduced_reason": null,
+  "refactoring_plans_status": {
+   "reason": null,
+   "state": null
+  },
+  "refactoring_plans_total": null,
+  "refactoring_summary": {
+   "addresses_primary_problem": {
+    "no": null,
+    "unknown": null,
+    "yes": null
+   },
+   "analyzed_commit": null,
+   "by_confidence": {
+    "high": null,
+    "medium": null
+   },
+   "by_effort": {
+    "L": null,
+    "M": null,
+    "S": null,
+    "XL": null
+   },
+   "by_lead_type": {
+    "break_cycle": null,
+    "extract_class": null,
+    "extract_helper": null,
+    "extract_method": null,
+    "move_method": null,
+    "split_file": null
+   },
+   "by_status": {
+    "open": null
+   },
+   "facets": {
+    "confidence": {
+     "high": null,
+     "medium": null
+    },
+    "effort": {
+     "L": null,
+     "M": null,
+     "S": null,
+     "XL": null
+    },
+    "lead_type": {
+     "break_cycle": null,
+     "extract_class": null,
+     "extract_helper": null,
+     "extract_method": null,
+     "move_method": null,
+     "split_file": null
+    }
+   },
+   "files_total": null,
+   "judgment_steps_total": null,
+   "lead": {
+    "addresses_primary_problem": null,
+    "confidence": null,
+    "effort_bucket": null,
+    "file_path": null,
+    "judgment_steps": null,
+    "lead_biomarker": null,
+    "lead_refactoring_type": null,
+    "mechanical_steps": null,
+    "opportunity_id": null,
+    "recoverable_health": null,
+    "status": null,
+    "step_count": null
+   },
+   "mechanical_steps_total": null,
+   "next_call": null,
+   "opportunities_total": null,
+   "refactoring_model_version": null,
+   "status": null,
+   "steps_total": null,
+   "view": null
+  },
+  "secondary_rankings": {
+   "modules": {
+    "call": null,
+    "total": null
+   },
+   "test_findings": {
+    "call": null,
+    "total": null
+   },
+   "top_findings": {
+    "call": null,
+    "total": null
+   },
+   "worst_files": {
+    "call": null,
+    "total": null
+   }
+  },
+  "suggestion_legend": {
+   "hot_path_sync_io": null,
+   "io_in_loop": null,
+   "nested_loop_with_io": null,
+   "serial_await_in_loop": null
+  },
+  "unknown_include_keys": [
+   null
+  ],
+  "unknown_include_keys_emitted": null,
+  "unknown_include_keys_total": null,
+  "validation_profiles": [
+   {
+    "affected_files": [
+     null
+    ],
+    "affected_files_emitted": null,
+    "affected_files_total": null,
+    "affected_symbols": [
+     null
+    ],
+    "affected_symbols_emitted": null,
+    "affected_symbols_total": null,
+    "basis": null,
+    "commands": [
+     null
+    ],
+    "commands_emitted": null,
+    "commands_total": null,
+    "id": null,
+    "targets": [
+     {
+      "basis": null,
+      "file_path": null,
+      "tests": [
+       null
+      ],
+      "tests_emitted": null,
+      "tests_total": null,
+      "total": null,
+      "truncated": null,
+      "via": null
+     }
+    ],
+    "targets_emitted": null,
+    "targets_total": null,
+    "tests": [
+     null
+    ],
+    "tests_emitted": null,
+    "tests_reduced_reason": null,
+    "tests_total": null,
+    "total": null,
+    "via": null
+   }
+  ],
+  "validation_profiles_emitted": null,
+  "validation_profiles_total": null
+ },
+ "get_overview": {
+  "_meta": {
+   "contract_version": null,
+   "embedder_degraded": null,
+   "index_age_days": null,
+   "indexed_commit": null,
+   "omitted": {
+    "refs": [
+     null
+    ],
+    "restore": null,
+    "tokens": null
+   }
+  },
+  "architecture": {
+   "layer_order": [
+    null
+   ],
+   "layers": [
+    {
+     "file_count": null,
+     "name": null
+    }
+   ],
+   "tour_available": null,
+   "tour_step_count": null
+  },
+  "code_health": {
+   "average_health": null,
+   "band": null,
+   "distribution": {
+    "bands": {
+     "alert": {
+      "files": null,
+      "nloc": null,
+      "pct": null
+     },
+     "healthy": {
+      "files": null,
+      "nloc": null,
+      "pct": null
+     },
+     "warning": {
+      "files": null,
+      "nloc": null,
+      "pct": null
+     }
+    },
+    "total_files": null,
+    "total_nloc": null
+   },
+   "file_count": null,
+   "hotspot_health": null,
+   "open_findings": null,
+   "worst_performer_path": null,
+   "worst_performer_score": null
+  },
+  "content_hint": null,
+  "content_md": null,
+  "entry_points": [
+   null
+  ],
+  "git_health": {
+   "avg_bus_factor": null,
+   "churn_trend": null,
+   "files_git_attributed": null,
+   "files_with_bus_factor_1": null,
+   "hotspot_count": null,
+   "top_churn_modules": [
+    null
+   ]
+  },
+  "key_modules": [
+   {
+    "name": null,
+    "path": null,
+    "section": null
+   }
+  ],
+  "more": null,
+  "omission_marker": null,
+  "title": null,
+  "tool_surface": {
+   "counts": {
+    "default": null,
+    "eligible": null,
+    "enabled": null,
+    "opt_in_available": null,
+    "tiers": {
+     "canonical": null
+    }
+   },
+   "enabled": [
+    null
+   ],
+   "mode": null,
+   "opt_in": [
+    {
+     "description": null,
+     "enabled": null,
+     "name": null
+    }
+   ],
+   "recipes": [
+    {
+     "call": null,
+     "name": null
+    }
+   ],
+   "tools": [
+    {
+     "default": null,
+     "description": null,
+     "name": null,
+     "tier": null
+    }
+   ]
+  }
+ },
+ "get_risk": {
+  "_meta": {
+   "contract_version": null,
+   "embedder_degraded": null,
+   "index_age_days": null,
+   "indexed_commit": null,
+   "omitted": {
+    "refs": [
+     null
+    ],
+    "restore": null,
+    "tokens": null
+   }
+  },
+  "omission_marker": null,
+  "targets": {
+   "packages/core/src/repowise/core/ingestion/call_resolver.py": {
+    "bus_factor": null,
+    "co_change_partners": [
+     {
+      "direction": null,
+      "evidence_kind": null,
+      "file_path": null,
+      "has_import_link": null,
+      "has_structural_link": null,
+      "last_co_change": null,
+      "provenance": null,
+      "relationship_type": null,
+      "structural_relationship_types": [
+       null
+      ],
+      "support": null,
+      "weight": null
+     }
+    ],
+    "co_change_partners_emitted": null,
+    "co_change_partners_omitted": null,
+    "co_change_partners_reduced_reason": null,
+    "co_change_partners_total": null,
+    "co_change_partners_truncated": null,
+    "commit_count_capped": null,
+    "contributor_count": null,
+    "coverage_pct": null,
+    "defect_profile": {
+     "bug_magnet": null,
+     "fix_count": null,
+     "last_fix_days_ago": null,
+     "top_symbols": {
+      "_link_declarations": null,
+      "_merged_symbols_for": null,
+      "_published": null
+     },
+     "window": null
+    },
+    "dependents_count": null,
+    "episodes": null,
+    "health_score": null,
+    "hotspot_score": null,
+    "is_hotspot": null,
+    "owner_pct": null,
+    "primary_owner": null,
+    "recent_owner": null,
+    "recent_owner_pct": null,
+    "risk_summary": null,
+    "security_signals": [],
+    "target": null,
+    "test_gap": null,
+    "top_biomarkers": [
+     {
+      "biomarker_type": null,
+      "function_name": null,
+      "impact": null,
+      "severity": null
+     }
+    ],
+    "trend": null
+   }
+  }
+ },
+ "get_symbol": {
+  "_meta": {
+   "contract_version": null,
+   "embedder_degraded": null,
+   "index_age_days": null,
+   "indexed_commit": null,
+   "replaced_tokens": null,
+   "timing_ms": null
+  },
+  "continuation": null,
+  "continuation_reference": {
+   "id": null,
+   "kind": null,
+   "path": null,
+   "range": [
+    null
+   ],
+   "repository": null,
+   "source_kind": null,
+   "verification_basis": null
+  },
+  "end_line": null,
+  "file": null,
+  "kind": null,
+  "language": null,
+  "name": null,
+  "note": null,
+  "qualified_name": null,
+  "signature": null,
+  "source": null,
+  "start_line": null,
+  "symbol_end_line": null,
+  "symbol_id": null,
+  "symbol_start_line": null,
+  "truncated": null,
+  "verified": null
+ },
+ "get_why": {
+  "_meta": {
+   "contract_version": null,
+   "embedder_degraded": null,
+   "index_age_days": null,
+   "indexed_commit": null,
+   "omitted": {
+    "refs": [
+     null
+    ],
+    "restore": null,
+    "tokens": null
+   }
+  },
+  "alignment": {
+   "active_count": null,
+   "deprecated_count": null,
+   "explanation": null,
+   "governing_count": null,
+   "score": null,
+   "sibling_coverage": null,
+   "stale_count": null
+  },
+  "answer_basis": null,
+  "code_rationale": [
+   {
+    "comment": null,
+    "evidence_refs": [
+     {
+      "content_id": null,
+      "id": null,
+      "kind": null,
+      "line": null,
+      "path": null,
+      "provenance": null,
+      "range": [
+       null
       ],
       "repository": null,
+      "source": null,
+      "source_kind": null,
+      "verification": null,
+      "verification_basis": null
+     }
+    ],
+    "lines": [
+     null
+    ],
+    "matched_terms": [],
+    "path": null,
+    "provenance": null
+   }
+  ],
+  "code_rationale_emitted": null,
+  "code_rationale_omitted": null,
+  "code_rationale_reduced_reason": null,
+  "code_rationale_total": null,
+  "code_rationale_truncated": null,
+  "decisions": [],
+  "episodes": [
+   {
+    "evidence": null,
+    "evidence_refs": [
+     {
+      "commit": null,
+      "id": null,
+      "kind": null,
+      "provenance": null,
+      "repository": null,
+      "source": null,
       "source_kind": null,
       "verification_basis": null
-    },
-    "end_line": null,
-    "file": null,
+     }
+    ],
     "kind": null,
-    "language": null,
-    "name": null,
-    "note": null,
-    "qualified_name": null,
-    "signature": null,
-    "source": null,
-    "start_line": null,
-    "symbol_end_line": null,
-    "symbol_id": null,
-    "symbol_start_line": null,
-    "truncated": null,
-    "verified": null
+    "provenance": null,
+    "recorded": null,
+    "scope": [
+     null
+    ],
+    "still_true": null,
+    "subject": null,
+    "tier": null
+   }
+  ],
+  "episodes_emitted": null,
+  "episodes_omitted": null,
+  "episodes_reduced_reason": null,
+  "episodes_total": null,
+  "episodes_truncated": null,
+  "git_archaeology": {
+   "cross_references": [],
+   "file_commits": [
+    {
+     "author": null,
+     "date": null,
+     "evidence_refs": [
+      {
+       "commit": null,
+       "id": null,
+       "kind": null,
+       "provenance": null,
+       "repository": null,
+       "source": null,
+       "source_kind": null,
+       "verification_basis": null
+      }
+     ],
+     "message": null,
+     "provenance": null,
+     "sha": null
+    }
+   ],
+   "file_commits_emitted": null,
+   "file_commits_omitted": null,
+   "file_commits_reduced_reason": null,
+   "file_commits_total": null,
+   "file_commits_truncated": null,
+   "git_log": [],
+   "provenance": null,
+   "summary": null,
+   "triggered": null
   },
-  "get_why": {
-    "_meta": {
-      "contract_version": null,
-      "embedder_degraded": null,
-      "index_age_days": null,
-      "indexed_commit": null,
-      "omitted": {
-        "refs": [
-          null
-        ],
-        "restore": null,
-        "tokens": null
-      }
-    },
-    "alignment": {
-      "active_count": null,
-      "deprecated_count": null,
-      "explanation": null,
-      "governing_count": null,
-      "score": null,
-      "sibling_coverage": null,
-      "stale_count": null
-    },
-    "answer_basis": null,
-    "code_rationale": [
+  "mode": null,
+  "omission_marker": null,
+  "origin_story": {
+   "age_days": null,
+   "author_commit_pct": null,
+   "available": null,
+   "contributors": [
+    {
+     "commit_count": null,
+     "email": null,
+     "first_commit_ts": null,
+     "last_commit_ts": null,
+     "name": null
+    }
+   ],
+   "first_commit": null,
+   "key_commits": [
+    {
+     "author": null,
+     "date": null,
+     "evidence_refs": [
       {
-        "comment": null,
-        "evidence_refs": [
-          {
-            "content_id": null,
-            "id": null,
-            "kind": null,
-            "line": null,
-            "path": null,
-            "provenance": null,
-            "range": [
-              null
-            ],
-            "repository": null,
-            "source": null,
-            "source_kind": null,
-            "verification": null,
-            "verification_basis": null
-          }
-        ],
-        "lines": [
-          null
-        ],
-        "matched_terms": [],
-        "path": null,
-        "provenance": null
+       "commit": null,
+       "id": null,
+       "kind": null,
+       "provenance": null,
+       "repository": null,
+       "source": null,
+       "source_kind": null,
+       "verification_basis": null
       }
-    ],
-    "code_rationale_emitted": null,
-    "code_rationale_omitted": null,
-    "code_rationale_reduced_reason": null,
-    "code_rationale_total": null,
-    "code_rationale_truncated": null,
-    "decisions": [],
-    "episodes": [
-      {
-        "evidence": null,
-        "evidence_refs": [
-          {
-            "commit": null,
-            "id": null,
-            "kind": null,
-            "provenance": null,
-            "repository": null,
-            "source": null,
-            "source_kind": null,
-            "verification_basis": null
-          }
-        ],
-        "kind": null,
-        "provenance": null,
-        "recorded": null,
-        "scope": [
-          null
-        ],
-        "still_true": null,
-        "subject": null,
-        "tier": null
-      }
-    ],
-    "episodes_emitted": null,
-    "episodes_omitted": null,
-    "episodes_reduced_reason": null,
-    "episodes_total": null,
-    "episodes_truncated": null,
-    "git_archaeology": {
-      "cross_references": [],
-      "file_commits": [
-        {
-          "author": null,
-          "date": null,
-          "evidence_refs": [
-            {
-              "commit": null,
-              "id": null,
-              "kind": null,
-              "provenance": null,
-              "repository": null,
-              "source": null,
-              "source_kind": null,
-              "verification_basis": null
-            }
-          ],
-          "message": null,
-          "provenance": null,
-          "sha": null
-        }
-      ],
-      "file_commits_emitted": null,
-      "file_commits_omitted": null,
-      "file_commits_reduced_reason": null,
-      "file_commits_total": null,
-      "file_commits_truncated": null,
-      "git_log": [],
-      "provenance": null,
-      "summary": null,
-      "triggered": null
-    },
-    "mode": null,
-    "omission_marker": null,
-    "origin_story": {
-      "age_days": null,
-      "author_commit_pct": null,
-      "available": null,
-      "contributors": [
-        {
-          "commit_count": null,
-          "email": null,
-          "first_commit_ts": null,
-          "last_commit_ts": null,
-          "name": null
-        }
-      ],
-      "first_commit": null,
-      "key_commits": [
-        {
-          "author": null,
-          "date": null,
-          "evidence_refs": [
-            {
-              "commit": null,
-              "id": null,
-              "kind": null,
-              "provenance": null,
-              "repository": null,
-              "source": null,
-              "source_kind": null,
-              "verification_basis": null
-            }
-          ],
-          "message": null,
-          "pr_number": null,
-          "provenance": null,
-          "sha": null
-        }
-      ],
-      "key_commits_emitted": null,
-      "key_commits_omitted": null,
-      "key_commits_reduced_reason": null,
-      "key_commits_total": null,
-      "key_commits_truncated": null,
-      "last_commit": null,
-      "linked_decisions": [],
-      "primary_author": null,
-      "provenance": null,
-      "summary": null,
-      "total_commits": null
-    },
+     ],
+     "message": null,
+     "pr_number": null,
+     "provenance": null,
+     "sha": null
+    }
+   ],
+   "key_commits_emitted": null,
+   "key_commits_omitted": null,
+   "key_commits_reduced_reason": null,
+   "key_commits_total": null,
+   "key_commits_truncated": null,
+   "last_commit": null,
+   "linked_decisions": [],
+   "primary_author": null,
+   "provenance": null,
+   "summary": null,
+   "total_commits": null
+  },
+  "path": null
+ },
+ "list_repos": {
+  "_meta": {
+   "contract_version": null,
+   "embedder_degraded": null
+  },
+  "default_repo": null,
+  "hint": null,
+  "repos": [
+   {
+    "absolute_path": null,
+    "alias": null,
+    "is_default": null,
     "path": null
+   }
+  ],
+  "workspace": null,
+  "workspace_root": null
+ },
+ "search_codebase": {
+  "_meta": {
+   "contract_version": null,
+   "embedder_degraded": null,
+   "index_age_days": null,
+   "indexed_commit": null
   },
-  "list_repos": {
-    "_meta": {
-      "contract_version": null,
-      "embedder_degraded": null
-    },
-    "default_repo": null,
-    "hint": null,
-    "repos": [
-      {
-        "absolute_path": null,
-        "alias": null,
-        "is_default": null,
-        "path": null
-      }
+  "candidates": [
+   {
+    "path": null
+   }
+  ],
+  "results": [
+   {
+    "confidence_score": null,
+    "page_type": null,
+    "relevance_score": null,
+    "snippet": null,
+    "sources": [
+     null
     ],
-    "workspace": null,
-    "workspace_root": null
+    "target_path": null,
+    "title": null
+   }
+  ]
+ },
+ "set_finding_status": {
+  "_meta": {
+   "contract_version": null,
+   "embedder_degraded": null
   },
-  "search_codebase": {
-    "_meta": {
-      "contract_version": null,
-      "embedder_degraded": null,
-      "index_age_days": null,
-      "indexed_commit": null
-    },
-    "candidates": [
-      {
-        "path": null
-      }
-    ],
-    "results": [
-      {
-        "confidence_score": null,
-        "page_type": null,
-        "relevance_score": null,
-        "snippet": null,
-        "sources": [
-          null
-        ],
-        "target_path": null,
-        "title": null
-      }
-    ]
-  }
+  "id": null,
+  "note": null,
+  "public_id": null,
+  "status": null,
+  "status_changed_at": null,
+  "status_reason": null
+ }
 }

--- a/tests/unit/server/test_tool_findings.py
+++ b/tests/unit/server/test_tool_findings.py
@@ -12,7 +12,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from repowise.server.mcp_server.tool_findings import ALLOWED_STATUSES, set_finding_status
+from repowise.server.mcp_server.tool_findings import set_finding_status
 
 
 class _Row:
@@ -71,9 +71,8 @@ async def test_missing_plan_raises(ctx):
     ), patch(
         "repowise.server.mcp_server.tool_findings.get_refactoring_suggestions",
         new=AsyncMock(return_value=[]),
-    ):
-        with pytest.raises(ValueError, match="refactoring plan not found"):
-            await set_finding_status("absent", "resolved")
+    ), pytest.raises(ValueError, match="refactoring plan not found"):
+        await set_finding_status("absent", "resolved")
 
 
 async def test_write_goes_through_the_shared_writer(ctx):
@@ -105,7 +104,6 @@ async def test_display_id_fallback(ctx):
     """A deep link may carry the display id (\"<alias> <file>:<symbol>\")
     rather than a storage or content id; the tool falls back like
     generate_refactoring_code does."""
-    matched = object()
     with patch(
         "repowise.server.mcp_server.tool_findings.get_refactoring_suggestion",
         new=AsyncMock(return_value=None),

--- a/tests/unit/server/test_tool_findings.py
+++ b/tests/unit/server/test_tool_findings.py
@@ -1,0 +1,124 @@
+"""set_finding_status (MCP) records dispositions through the shared writer.
+
+The CRUD lifecycle is pinned in test_refactoring_lifecycle.py; these tests
+cover the tool layer: it validates the vocabulary, resolves the plan by
+storage id or display id, routes through update_refactoring_suggestion_status
+(the single writer), and surfaces the resulting status.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from repowise.server.mcp_server.tool_findings import ALLOWED_STATUSES, set_finding_status
+
+
+class _Row:
+    def __init__(self, status: str = "false_positive", status_reason: str = "agent"):
+        self.id = "row-1"
+        self.public_id = "plan-1"
+        self.status = status
+        self.status_reason = status_reason
+        self.status_changed_at = None
+
+
+class _Repo:
+    id = "repo-1"
+    name = "acme"
+
+
+@pytest.fixture
+def ctx():
+    """Fake _resolve_repo_context result + session plumbing."""
+    fake_session = AsyncMock()
+    fake_session.__aenter__.return_value = fake_session
+    fake_session.__aexit__.return_value = False
+
+    fake_ctx = type(
+        "Ctx",
+        (),
+        {"session_factory": object(), "alias": "acme", "path": "/tmp/acme"},
+    )()
+
+    with (
+        patch(
+            "repowise.server.mcp_server.tool_findings._resolve_repo_context",
+            new=AsyncMock(return_value=fake_ctx),
+        ),
+        patch(
+            "repowise.server.mcp_server.tool_findings.get_session",
+            side_effect=lambda _f: fake_session,
+        ),
+        patch(
+            "repowise.server.mcp_server.tool_findings._get_repo",
+            new=AsyncMock(return_value=_Repo()),
+        ),
+    ):
+        yield fake_session
+
+
+async def test_unknown_status_raises(ctx):
+    with pytest.raises(ValueError, match=r"unknown finding status: 'bogus'"):
+        await set_finding_status("row-1", "bogus")
+
+
+async def test_missing_plan_raises(ctx):
+    with patch(
+        "repowise.server.mcp_server.tool_findings.get_refactoring_suggestion",
+        new=AsyncMock(return_value=None),
+    ), patch(
+        "repowise.server.mcp_server.tool_findings.get_refactoring_suggestions",
+        new=AsyncMock(return_value=[]),
+    ):
+        with pytest.raises(ValueError, match="refactoring plan not found"):
+            await set_finding_status("absent", "resolved")
+
+
+async def test_write_goes_through_the_shared_writer(ctx):
+    """The tool must route through update_refactoring_suggestion_status — the
+    same writer the REST PATCH and the pipeline use — so a false_positive
+    recorded here is suppressed by the finalizer the same way."""
+    update = AsyncMock(return_value=_Row())
+    with patch(
+        "repowise.server.mcp_server.tool_findings.get_refactoring_suggestion",
+        new=AsyncMock(return_value=_Row()),
+    ), patch(
+        "repowise.server.mcp_server.tool_findings.update_refactoring_suggestion_status",
+        update,
+    ):
+        out = await set_finding_status("row-1", "false_positive", reason="dup of #12")
+
+    update.assert_awaited_once()
+    call = update.await_args.args
+    assert call[1] == "repo-1"  # repo id
+    assert call[2] == "row-1"  # row id
+    assert call[3] == "false_positive"
+    assert update.await_args.kwargs["reason"] == "dup of #12"
+    assert out["status"] == "false_positive"
+    assert out["id"] == "row-1"
+    assert "not be re-emitted" in out["note"]
+
+
+async def test_display_id_fallback(ctx):
+    """A deep link may carry the display id (\"<alias> <file>:<symbol>\")
+    rather than a storage or content id; the tool falls back like
+    generate_refactoring_code does."""
+    matched = object()
+    with patch(
+        "repowise.server.mcp_server.tool_findings.get_refactoring_suggestion",
+        new=AsyncMock(return_value=None),
+    ), patch(
+        "repowise.server.mcp_server.tool_findings.get_refactoring_suggestions",
+        new=AsyncMock(return_value=[_Row()]),
+    ), patch(
+        "repowise.server.mcp_server.tool_health._refactoring_plan_id",
+        new=lambda _c, _alias: "acme a.py:Foo",
+    ), patch(
+        "repowise.server.mcp_server.tool_findings.update_refactoring_suggestion_status",
+        new=AsyncMock(return_value=_Row(status="acknowledged")),
+    ):
+        out = await set_finding_status("acme a.py:Foo", "acknowledged")
+
+    assert out["status"] == "acknowledged"

--- a/website/concepts.md
+++ b/website/concepts.md
@@ -161,7 +161,7 @@ The dependency graph is loaded into memory at server startup for fast traversal.
 
 ## The MCP server
 
-The MCP server sits on top of the persistence layer and exposes everything to AI coding assistants through 17 registered tools: 11 by default in a single repository, 13 by default in workspace mode, and four opt-in tools. It's the primary interface between repowise and Claude Code, Codex, Cursor, Cline, or any other MCP-compatible editor.
+The MCP server sits on top of the persistence layer and exposes everything to AI coding assistants through 18 registered tools: 11 by default in a single repository, 13 by default in workspace mode, and five opt-in tools. It's the primary interface between repowise and Claude Code, Codex, Cursor, Cline, or any other MCP-compatible editor.
 
 When you run `repowise mcp`, the server starts in stdio mode and your editor can begin calling tools. The tools are designed to answer the questions an AI needs to make good decisions about your code — not just "what is this file" but "should I edit it", "why is it structured this way", and "what will break if I change it".
 

--- a/website/index.md
+++ b/website/index.md
@@ -24,7 +24,7 @@ repowise generates and maintains a structured wiki for any codebase. It tracks c
 | **Git intelligence** | Churn hotspots, ownership, bus factor, change patterns |
 | **Dead code detection** | Finds confirmed unused exports, functions, and types |
 | **Decision intelligence** | Captures *why* code is structured the way it is |
-| **MCP server** | 11 default tools (10 flagship + `list_repos`) for AI assistants; 17 registered |
+| **MCP server** | 11 default tools (10 flagship + `list_repos`) for AI assistants; 18 registered |
 | **Web dashboard** | Browse wiki, search, and explore architecture diagrams |
 | **Multi-language** | 16 AST languages (11 Full tier): Python, TypeScript, JavaScript, Go, Rust, Java, C/C++, Kotlin, Ruby, C#, Swift, Scala, PHP, Dart, Shell |
 

--- a/website/mcp-server.md
+++ b/website/mcp-server.md
@@ -22,7 +22,7 @@ Connect repowise to Claude Code, Codex, Cursor, Cline, or any MCP-compatible edi
 
 ## Overview
 
-The MCP (Model Context Protocol) server is how repowise talks to AI coding assistants. It registers 17 tools: a curated 10-tool default surface in a single repository, `list_repos` added by default in workspace mode, and six opt-in specialists subject to mode eligibility. Once connected, your editor's AI can query your codebase wiki for synthesized answers, symbols, docs, ownership, file and change-risk signals, code health, and architectural decisions.
+The MCP (Model Context Protocol) server is how repowise talks to AI coding assistants. It registers 18 tools: a curated 10-tool default surface in a single repository, `list_repos` added by default in workspace mode, and seven opt-in specialists subject to mode eligibility. Once connected, your editor's AI can query your codebase wiki for synthesized answers, symbols, docs, ownership, file and change-risk signals, code health, and architectural decisions.
 
 Start the server with:
 


### PR DESCRIPTION
## What

Fixes #1535 (track 2 — the disposition lifecycle). A new opt-in specialist MCP tool, `set_finding_status` (safety: `mutating`).

## Root cause

#1986 (merged Aug 29) already gave refactoring plans a versioned identity and real lifecycle: stable content-derived `public_id`, the `open|acknowledged|resolved|false_positive` vocabulary, a finalizer that never re-emits `false_positive` plans, and `update_refactoring_suggestion_status` as the single writer. The web UI can PATCH a status. What #1535 still names as missing is the **agent-facing write**: `get_health` and the generated task prompts tell agents to flag false positives, but there was nowhere to record that verdict from inside the agent loop.

## Changes

- Resolves a plan by storage id, content `public_id`, or the display id a deep link carries (same fallback `generate_refactoring_code` uses).
- Writes **only** through `update_refactoring_suggestion_status` — the single lifecycle owner — so a `false_positive` recorded here is suppressed by the finalizer on later runs, exactly like the REST PATCH path. No second writer.
- `reason` is a free-text note stored on the row for audit.
- Statuses: `open`, `acknowledged`, `resolved`, `false_positive`.

## Tests

4 tool-layer tests (vocabulary validation, missing-plan error, shared-writer routing with reason, display-id fallback) — 20 pass with the lifecycle suite. All 27 MCP surface/drift guards pass.

Note: `test_plugin_content` is red on main itself (v0.47.0 release bug, unrelated to this PR).
