### PR TITLE
fix(ui): clarify performance filter counts

### DIFF
--- a/packages/ui/__tests__/health/performance-view.test.tsx
+++ b/packages/ui/__tests__/health/performance-view.test.tsx
@@ -68,7 +68,7 @@ describe("PerformanceView queue", () => {
     render(<PerformanceView adapter={adapter()} />);
     await rows();
     expect(screen.queryByLabelText("Evidence confidence")).toBeNull();
-    expect(screen.getByText("on all 7")).toBeTruthy();
+    expect(screen.getByText("on 7 matching")).toBeTruthy();
   });
 
   it("states the rendered scope, the filtered total, and the repository total", async () => {

--- a/packages/ui/src/health/performance/filters.tsx
+++ b/packages/ui/src/health/performance/filters.tsx
@@ -99,7 +99,7 @@ function SingleValueFact({ facet, only }: { facet: PerformanceFacetKey; only: Pe
       <span className="text-[var(--color-text-secondary)]">
         {facetValueLabel(facet, only.value)}
       </span>{" "}
-      <span className="tabular-nums">on all {only.total.toLocaleString()}</span>
+      <span className="tabular-nums">on {only.total.toLocaleString()} matching</span>
     </p>
   );
 }
@@ -205,4 +205,3 @@ export function ContextHint({ context }: { context: PerformanceContextFilter }) 
     </p>
   );
 }
-

--- a/packages/ui/src/health/performance/states.tsx
+++ b/packages/ui/src/health/performance/states.tsx
@@ -76,8 +76,8 @@ export function FilteredEmpty({ onClear }: { onClear: () => void }) {
         No opportunities match these filters
       </h3>
       <p className="mx-auto mt-2 max-w-[60ch] text-sm text-[var(--color-text-tertiary)]">
-        The counts beside each filter come from the whole repository, so a combination can still
-        be empty.
+        The counts beside each filter already account for the other active filters. This
+        combination may come from a restored view state that no longer matches the index.
       </p>
       <button
         type="button"


### PR DESCRIPTION
## Summary

- Clarify that performance filter counts account for other active filters.
- Update single-value filter text to avoid implying repository-wide counts.
- Explain that empty combinations may come from restored view state.

## Related Issues

Fixes #2037 

## Test Plan

- [x] Tests pass (npm --workspace @repowise-dev/ui test)
- [x] Lint passes (ruff check .)
- [x] Web build passes (npm run build) (if frontend changes)

## Frontend screenshots before and after the fix:
- Before: 
<img width="1440" height="900" alt="Screenshot 2026-08-31 at 10 22 09 AM" src="https://github.com/user-attachments/assets/573d5d45-2d55-4938-a898-cb9650bb10dd" />

- After: 
<img width="1440" height="900" alt="Screenshot 2026-08-31 at 10 29 38 AM" src="https://github.com/user-attachments/assets/4db6e78b-7d4e-402b-b43c-f47303dd04be" />

The before/after screenshots were captured from different index snapshots (9c162335 and 361a7647), so the opportunity count changed from 413 to 411 after re-indexing. The PR only changes the displayed filter copy; it does not change analysis or counting logic.

## Checklist

- [x] My code follows the project's code style
- [x] I have added tests for new functionality
- [x] All existing tests still pass
- [x] I have updated documentation if needed