### PR TITLE
fix(server): support git logs in worktrees

### DIFF
--- a/packages/server/src/repowise/server/mcp_server/tool_why.py
+++ b/packages/server/src/repowise/server/mcp_server/tool_why.py
@@ -1869,7 +1869,7 @@ async def _git_archaeology_fallback(
     # --- Layer 3: Live git log (when local repo exists) ---
     git_log_results = []
     local_path = getattr(repository, "local_path", None)
-    if local_path and (Path(local_path) / ".git").is_dir():
+    if local_path and (Path(local_path) / ".git").exists():
         git_log_results = await _run_git_log(local_path, file_path, stem)
     result["git_log"] = git_log_results
 

--- a/tests/unit/server/mcp/test_recoverable_caps_wire_contracts.py
+++ b/tests/unit/server/mcp/test_recoverable_caps_wire_contracts.py
@@ -834,7 +834,12 @@ async def test_why_fallback_archaeology_and_rationale_wire_recover_annotated_tai
     from repowise.core.persistence.models import Repository
 
     repository = await session.get(Repository, setup_mcp)
-    repository.local_path = str(Path.cwd())
+    # A linked worktree stores `.git` as a gitdir pointer file. The live git
+    # log only needs a working tree, so this must still enable the fallback.
+    worktree_path = tmp_path / "worktree"
+    worktree_path.mkdir()
+    (worktree_path / ".git").write_text("gitdir: /tmp/repowise-test-worktree\n")
+    repository.local_path = str(worktree_path)
     await session.flush()
 
     async def sealed_git_log(*_args: Any, **_kwargs: Any) -> list[dict[str, Any]]:


### PR DESCRIPTION
## Summary

- Enable git archaeology fallback for repositories using linked worktrees.
- Treat .git pointer files as valid working trees for live git log execution.
- Add regression coverage for the worktree pointer-file case.

## Related Issues

Fixes #2024 

## Test Plan

- [x] Tests pass (pytest) — 1609 passed
- [x] Lint passes (ruff check .)
- [x] Web build passes (npm run build) (if frontend changes)

## Checklist

- [x] My code follows the project's code style
- [x] I have added tests for new functionality
- [x] All existing tests still pass
- [x] I have updated documentation if needed