### PR TITLE
feat(languages): add VB.NET at the Good tier (#1041)

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,7 +473,7 @@ the orchestrators. Full matrix and the contributor recipe:
 
 ## Supported languages
 
-**21 languages parsed to AST · 38 on a five-rung ladder · framework-aware across
+**22 languages parsed to AST · 39 on a five-rung ladder · framework-aware across
 all of them.**
 
 "Do you support X" has five useful answers, not two, so languages land on a
@@ -506,6 +506,7 @@ ladder and every rung says what it buys you.
   <img src="https://img.shields.io/badge/Dart-0175C2?style=flat-square&logo=dart&logoColor=white" alt="Dart" />
   <img src="https://img.shields.io/badge/Delphi-EE1F35?style=flat-square&logo=delphi&logoColor=white" alt="Object Pascal / Delphi" />
   <img src="https://img.shields.io/badge/GDScript-478CBF?style=flat-square&logo=godotengine&logoColor=white" alt="GDScript / Godot" />
+  <img src="https://img.shields.io/badge/VB.NET-945DB7?style=flat-square&logo=dotnet&logoColor=white" alt="VB.NET" />
   &nbsp;<strong>· Partial &nbsp;</strong>
   <img src="https://img.shields.io/badge/Luau-00A2FF?style=flat-square&logo=lua&logoColor=white" alt="Luau" />
   <img src="https://img.shields.io/badge/Razor-512BD4?style=flat-square&logo=blazor&logoColor=white" alt="Razor / Blazor" />
@@ -517,7 +518,7 @@ still doing real work rather than being ignored:
 | Rung | Languages | What you get |
 |---|---|---|
 | **Full** (13) | Python · TypeScript · JavaScript · Svelte · Vue · Java · Kotlin · Go · Rust · C++ · C# · Scala · Ruby | The whole pipeline: AST symbols, import resolution, a resolved call graph, heritage, docstrings, framework edges, **and code-health markers** |
-| **Good** (6) | C · Swift · PHP · Dart · Object Pascal · GDScript | All of the above except the full health suite |
+| **Good** (7) | C · Swift · PHP · Dart · Object Pascal · GDScript · VB.NET | All of the above except the full health suite |
 | **Partial** (2) | Luau / Roblox · Razor / Blazor | Luau: AST symbols and `require()` resolution, Rojo and `.luaurc` aware. Razor: component symbols, `@code` and component-tag call edges, C# health markers; no import resolution yet |
 | | | ⎯⎯ *tree-sitter parsing stops here; the rungs below come from git and imports* ⎯⎯ |
 | **Lightweight** (8) | Elixir · Clojure · Haskell · Lean 4 · Erlang · F# · HTML · QML | A real file-to-file import graph, and no symbol-level claims |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -34,14 +34,13 @@ Languages land on a five-rung ladder rather than a yes/no list, because "do you
 support X" has five different useful answers. Each rung is defined, with what it
 buys you, in
 [docs/layers/LANGUAGE_SUPPORT.md](docs/layers/LANGUAGE_SUPPORT.md). Today that
-ladder covers **38 languages, 21 of them parsed to a full AST**.
+ladder covers **39 languages, 22 of them parsed to a full AST**.
 
 ### New languages
 
 | Language | Status | Why it is on the list |
 |---|---|---|
 | **COBOL** | **In development** | Asked for by enterprises with mainframe estates evaluating repowise. The codebases that most need an institutional-memory layer are often the ones whose authors have already retired. |
-| **VB.NET** | Planned | Large, long-lived line-of-business estates, usually sitting beside the C# we already treat at Full tier. |
 | **PL/SQL** | Planned | We already parse SQL through sqlglot. Packages, procedures and triggers are where the business logic actually lives. |
 | **ABAP** | Exploring | The same argument as COBOL, in SAP estates. |
 | **RPG / AS400** | Exploring | Named alongside COBOL often enough to track. |

--- a/docs/README.md
+++ b/docs/README.md
@@ -59,7 +59,7 @@ your agent in under five minutes, with no API key.
 | [layers/DECISIONS.md](layers/DECISIONS.md) | Architectural decisions mined from your repo and from your own agent sessions |
 | [layers/DEAD_CODE.md](layers/DEAD_CODE.md) | Unreachable files, unused exports, and zombie packages by confidence tier |
 | [layers/SECURITY.md](layers/SECURITY.md) | The local pattern scan: what the sixteen patterns catch, what they do not, and how far to trust the result |
-| [layers/LANGUAGE_SUPPORT.md](layers/LANGUAGE_SUPPORT.md) | What works per language: 21 parsed to a full AST, 38 on the five-rung ladder |
+| [layers/LANGUAGE_SUPPORT.md](layers/LANGUAGE_SUPPORT.md) | What works per language: 22 parsed to a full AST, 39 on the five-rung ladder |
 | [layers/WIKI.md](layers/WIKI.md) | The generated wiki: page types, what `update` re-renders, styles, output language |
 
 ## Scale it

--- a/docs/business/COMMERCIAL.md
+++ b/docs/business/COMMERCIAL.md
@@ -42,7 +42,7 @@ scale, in a regulated or security-sensitive environment**:
 All of the following ship in `pip install repowise` today, free for internal use.
 
 - **[Five intelligence layers](../layers/INTELLIGENCE_LAYERS.md)**: Graph
-  (tree-sitter AST across 21 languages, two-tier dependency graph, call
+  (tree-sitter AST across 22 languages, two-tier dependency graph, call
   resolution, heritage extraction, Leiden communities, PageRank / betweenness /
   SCC), Git (hotspots, ownership, co-change pairs, bus factor, significant
   commits, contributor profiles, module health), Documentation (a wiki page per
@@ -99,17 +99,17 @@ All of the following ship in `pip install repowise` today, free for internal use
 
 ## 3. First-class language coverage
 
-Repowise parses **21 languages to a full AST** and places **38 on a five-rung
+Repowise parses **22 languages to a full AST** and places **39 on a five-rung
 ladder**, so "do you support X" gets the rung as its answer rather than a yes or a
 no. Both numbers matter and neither is worth quoting alone.
 
-The 21 are the top three rungs. At **Full tier sit 13** (Python, TypeScript,
+The 22 are the top three rungs. At **Full tier sit 13** (Python, TypeScript,
 JavaScript, Svelte, Vue, Java, Kotlin, Go, Rust, C++, **C#**, Scala, and Ruby) with
 AST parsing, import resolution, named bindings, call resolution, heritage
 extraction, multi-project workspace resolvers, framework-aware edges, per-language
-dynamic-hint extractors, and code-health markers. A further **6 at Good tier** (C,
-Swift, PHP, Dart, Object Pascal/Delphi, GDScript) get all of that except the full health
-suite, with GDScript also lacking framework edges and named bindings, and Luau
+dynamic-hint extractors, and code-health markers. A further **7 at Good tier** (C,
+Swift, PHP, Dart, Object Pascal/Delphi, GDScript, VB.NET) get all of that except the full
+health suite, with GDScript also lacking framework edges and named bindings, and Luau
 and Razor/Blazor are partial. SQL/dbt, shell, HTML, and the config formats are
 handled by dedicated extractors on top of that.
 

--- a/docs/layers/GRAPH.md
+++ b/docs/layers/GRAPH.md
@@ -11,7 +11,7 @@ that **every edge carries its own evidence**.
 <p>
   <img src="https://img.shields.io/badge/17-edge_types-3178C6?style=flat-square&labelColor=0A0A0A" alt="17 edge types" />
   <img src="https://img.shields.io/badge/29-resolution_origins-059669?style=flat-square&labelColor=0A0A0A" alt="29 resolution origins" />
-  <img src="https://img.shields.io/badge/21-languages-F59520?style=flat-square&labelColor=0A0A0A" alt="21 languages" />
+  <img src="https://img.shields.io/badge/22-languages-F59520?style=flat-square&labelColor=0A0A0A" alt="22 languages" />
   <img src="https://img.shields.io/badge/22-framework_detectors-7F52FF?style=flat-square&labelColor=0A0A0A" alt="22 framework detectors" />
   <img src="https://img.shields.io/badge/0-LLM_calls-1E293B?style=flat-square&labelColor=0A0A0A" alt="zero LLM calls" />
   <img src="https://img.shields.io/badge/compiler_graded-7_of_7_cells_undominated-DC2626?style=flat-square&labelColor=0A0A0A" alt="no tool is both more precise and more complete, in 7 of 7 compiler-graded cells" />

--- a/docs/layers/INTELLIGENCE_LAYERS.md
+++ b/docs/layers/INTELLIGENCE_LAYERS.md
@@ -43,7 +43,7 @@ requirement for the index.
 ## Graph Intelligence
 
 tree-sitter parses your source into a **two-tier dependency graph**: file nodes
-and symbol nodes (functions, classes, methods). 21 languages parse to a full
+and symbol nodes (functions, classes, methods). 22 languages parse to a full
 AST; see [`LANGUAGE_SUPPORT.md`](LANGUAGE_SUPPORT.md) for per-language tiers.
 
 A **confidence-scored call resolver** handles import aliases, barrel

--- a/docs/layers/LANGUAGE_SUPPORT.md
+++ b/docs/layers/LANGUAGE_SUPPORT.md
@@ -346,6 +346,27 @@ script resolves; the two failures are the `$%UniqueName` form below.
   and `%Name` all parse. Two occurrences in the 461-file corpus, in two
   files, and error recovery keeps the damage to the enclosing statement.
 
+### VB.NET known ceilings
+
+On the 0.3.0 grammar two validation repositories parse almost clean:
+AAndyProgram/SCrawler (293 `.vb` files, 15 of which still carry a parse error)
+and Lake1059/FFmpegFreeUI (197 `.vb` files, 24 of which still carry one).
+
+- **Remaining grammar gaps**: XML literals, tuple literals used as expressions,
+  a nested double quote inside an interpolation hole, an omitted argument in a
+  call that also carries type arguments, and some multi-line LINQ layouts.
+  tree-sitter recovers from each of them, so the symbols around such a
+  construct are still read and only the construct itself is lost.
+- **Imports resolve through the .NET project graph, not a file stem.** A
+  `.vbproj` is indexed alongside the `.csproj` files, so an `Imports` directive
+  is matched against the namespace its owning project declares through
+  `<RootNamespace>` and against the namespaces that project's references bring
+  in. The same-namespace and partial-class links are shared with C#, so a
+  VB.NET type and a C# type sitting in one namespace see each other.
+- **Generated VB is treated the way generated C# is.** The `.vb` never-flag
+  globs mirror the C# ones: designer files, `AssemblyInfo`, everything under
+  `My Project`, and the `ApplicationEvents` runtime hooks.
+
 ---
 
 ## Beyond code files

--- a/docs/layers/LANGUAGE_SUPPORT.md
+++ b/docs/layers/LANGUAGE_SUPPORT.md
@@ -273,6 +273,7 @@ bindings and heritage, with a dedicated workspace resolver per language.
 | **Dart** | `.dart` | `import` / `export` / `part` URIs, `package:` via every `pubspec.yaml`, Flutter route tables and `runApp()` edges. **Health markers included** |
 | **Object Pascal** | `.pas` `.pp` `.dpr` `.dpk` `.lpr` `.inc` | `uses` clauses via the generic unit-name → file-stem fallback; project files as entry points. **Health markers included** |
 | **GDScript** | `.gd` | `preload(...)` / `load(...)` / `extends "res://..."` resolved as absolute paths from the nearest `project.godot`, so a repo holding many Godot projects keeps each project's `res://` namespace separate |
+| **VB.NET** | `.vb` | `Imports` through the same MSBuild project index C# uses: `.vbproj` / `.sln` parsing, `<RootNamespace>`-aware namespace lookup, NuGet package references |
 
 ### GDScript known gaps
 
@@ -511,6 +512,7 @@ cannot check.
 | C# | Full (health) | Dataflow dialect |
 | Dart | Good | riverpod / get_it dynamic hints, dataflow dialect |
 | Object Pascal | Good | Assertion and performance markers, a dedicated `uses` resolver |
+| VB.NET | Good | Health markers, project-level `<Import Include=...>` as implicit imports |
 | Elixir · F# | Good | AST upgrade (both grammars are available on PyPI) |
 | SQL / dbt | — | Column-level blast radius |
 | Shell | — | Shebang detection for extensionless executables |

--- a/docs/layers/LANGUAGE_SUPPORT.md
+++ b/docs/layers/LANGUAGE_SUPPORT.md
@@ -1,6 +1,6 @@
 # Language Support
 
-**21 languages parsed to a full AST · 38 on the five-rung ladder ·
+**22 languages parsed to a full AST · 39 on the five-rung ladder ·
 framework-aware across all of them.** "Do you support X" has five useful answers
 rather than two, so every language lands on a rung and the rung says what it
 buys you. Everything else in your repo still appears in the wiki and is tracked
@@ -31,6 +31,7 @@ reference.
   <img src="https://img.shields.io/badge/Dart-0175C2?style=flat-square&logo=dart&logoColor=white" alt="Dart" />
   <img src="https://img.shields.io/badge/Delphi-EE1F35?style=flat-square&logo=delphi&logoColor=white" alt="Object Pascal / Delphi" />
   <img src="https://img.shields.io/badge/GDScript-478CBF?style=flat-square&logo=godotengine&logoColor=white" alt="GDScript / Godot" />
+  <img src="https://img.shields.io/badge/VB.NET-945DB7?style=flat-square&logo=dotnet&logoColor=white" alt="VB.NET" />
   &nbsp;<strong>· Partial &nbsp;</strong>
   <img src="https://img.shields.io/badge/Luau-00A2FF?style=flat-square&logo=lua&logoColor=white" alt="Luau" />
   <img src="https://img.shields.io/badge/Razor-512BD4?style=flat-square&logo=blazor&logoColor=white" alt="Razor / Blazor" />
@@ -54,14 +55,14 @@ produce meaningful output.
 | Tier | Languages | What you get |
 |------|-----------|--------------|
 | **Full** (13) | Python · TypeScript · JavaScript · Svelte · Vue · Java · Kotlin · Go · Rust · C++ · C# · Scala · Ruby | The whole pipeline: AST symbols, import resolution, a resolved call graph, heritage, docstrings, framework edges, **and code-health markers** |
-| **Good** (6) | C · Swift · PHP · Dart · Object Pascal · GDScript | Everything above except the full health suite. Dart and Object Pascal *do* get health markers; C, Swift, PHP and GDScript don't yet. GDScript has a dedicated import resolver but no framework edges or named bindings (see [Known gaps](#gdscript-known-gaps)) |
+| **Good** (7) | C · Swift · PHP · Dart · Object Pascal · GDScript · VB.NET | Everything above except the full health suite. Dart and Object Pascal *do* get health markers; C, Swift, PHP, GDScript and VB.NET don't yet. GDScript has a dedicated import resolver but no framework edges or named bindings (see [Known gaps](#gdscript-known-gaps)) |
 | **Partial** (2) | Luau / Roblox · Razor / Blazor | Luau: AST symbols and `require()` resolution (Rojo / `.luaurc` aware), no health markers yet. Razor: a component symbol per file, call edges from `@code` blocks and component tags, C# health markers; no import resolution yet |
 | | | ⎯⎯ *tree-sitter parsing stops here. The rungs below are derived from git and imports, not from an AST.* ⎯⎯ |
 | **Lightweight** (8) | Elixir · Clojure · Haskell · Lean 4 · Erlang · F# · HTML · QML | A real file-to-file import graph, no symbol-level claims |
 | **Structural** (9) | Objective-C · R · Zig · Julia · Elm · OCaml · Crystal · Nim · D | Git history only: blame, hotspots, co-change. No AST parsing |
 
-The first three rungs are the **21 languages parsed to a full AST**; all five are
-the **38** on the ladder. Both numbers are worth stating and neither is worth
+The first three rungs are the **22 languages parsed to a full AST**; all five are
+the **39** on the ladder. Both numbers are worth stating and neither is worth
 stating alone, so if you only take one thing from this page, take the rung your
 language sits on rather than either count.
 

--- a/packages/core/src/repowise/core/analysis/dead_code/constants.py
+++ b/packages/core/src/repowise/core/analysis/dead_code/constants.py
@@ -96,6 +96,13 @@ _NEVER_FLAG_PATTERNS: tuple[str, ...] = (
     "*.g.cs",  # Roslyn-generated
     "*.g.i.cs",
     "*.AssemblyInfo.cs",
+    # VB.NET equivalents. "My Project" holds the generated Application,
+    # Resources and Settings designers that no .vb file imports by name.
+    "*.Designer.vb",
+    "*.designer.vb",
+    "*AssemblyInfo.vb",
+    "*/My Project/*.vb",
+    "*ApplicationEvents.vb",  # My.MyApplication hooks, raised by the VB runtime
     "*MauiProgram.cs",  # MAUI app entry — invoked by host, not imported
     "*App.xaml.cs",
     "*AppShell.xaml.cs",

--- a/packages/core/src/repowise/core/ingestion/extractors/heritage/__init__.py
+++ b/packages/core/src/repowise/core/ingestion/extractors/heritage/__init__.py
@@ -36,6 +36,7 @@ from .rust import _extract_rust_heritage
 from .scala import _extract_scala_heritage
 from .swift import _extract_swift_heritage
 from .ts_js import _extract_ts_js_heritage
+from .vbnet import _extract_vbnet_heritage
 
 
 def heritage_node_types_for(lang: str) -> frozenset[str]:
@@ -64,6 +65,7 @@ HERITAGE_EXTRACTORS: dict[str, Callable[..., None]] = {
     "php": _extract_php_heritage,
     "pascal": _extract_pascal_heritage,
     "gdscript": _extract_gdscript_heritage,
+    "vbnet": _extract_vbnet_heritage,
 }
 
 

--- a/packages/core/src/repowise/core/ingestion/extractors/heritage/vbnet.py
+++ b/packages/core/src/repowise/core/ingestion/extractors/heritage/vbnet.py
@@ -1,6 +1,6 @@
 """VB.NET heritage extraction.
 
-VB.NET separates the two clause kinds syntactically — ``Inherits`` names the
+VB.NET separates the two clause kinds syntactically: ``Inherits`` names the
 single base class (classes only), ``Implements`` names one or more
 interfaces (classes and structures). Interfaces themselves may ``Inherits``
 multiple interfaces. The grammar keeps them as distinct clause nodes with

--- a/packages/core/src/repowise/core/ingestion/extractors/heritage/vbnet.py
+++ b/packages/core/src/repowise/core/ingestion/extractors/heritage/vbnet.py
@@ -1,0 +1,44 @@
+"""VB.NET heritage extraction.
+
+VB.NET separates the two clause kinds syntactically — ``Inherits`` names the
+single base class (classes only), ``Implements`` names one or more
+interfaces (classes and structures). Interfaces themselves may ``Inherits``
+multiple interfaces. The grammar keeps them as distinct clause nodes with
+one ``type`` child per name, so classification needs no conventions-based
+guessing (contrast C#'s single ``base_list``).
+"""
+
+from __future__ import annotations
+
+from tree_sitter import Node
+
+from ...models import HeritageRelation
+from ...type_names import bare_type_name
+from ..helpers import node_text
+
+
+def _extract_vbnet_heritage(
+    def_node: Node, name: str, line: int, src: str, out: list[HeritageRelation]
+) -> None:
+    """VB.NET: ``Inherits BaseClass`` → extends; ``Implements IFoo, IBar`` → implements."""
+    for child in def_node.children:
+        if child.type == "inherits_clause":
+            kind = "extends"
+        elif child.type == "implements_clause":
+            kind = "implements"
+        else:
+            continue
+        for type_node in child.children:
+            if type_node.type != "type" and not type_node.is_named:
+                continue
+            parent = bare_type_name(node_text(type_node, src).strip())
+            if not parent or parent == name:
+                continue
+            out.append(
+                HeritageRelation(
+                    child_name=name,
+                    parent_name=parent,
+                    kind=kind,  # type: ignore[arg-type]
+                    line=line,
+                )
+            )

--- a/packages/core/src/repowise/core/ingestion/extractors/visibility.py
+++ b/packages/core/src/repowise/core/ingestion/extractors/visibility.py
@@ -101,12 +101,13 @@ def csharp_visibility(_name: str, modifier_texts: list[str]) -> str:
 
 
 def vbnet_visibility(_name: str, modifier_texts: list[str]) -> str:
-    """VB.NET visibility — Public/Private/Protected/Friend (internal).
+    """VB.NET visibility: Public/Private/Protected/Friend (internal).
 
     VB.NET's default access for a top-level type is ``Friend`` (assembly
     scope), which maps to C#'s ``internal``; nested types under a parent
-    default to the parent's scope. ``Protected Friend`` (protected-or-
-    internal) is reported as protected — the wider caller surface.
+    default to the parent's scope. ``Protected Friend`` is reported as
+    protected, the narrower of the two halves, matching how
+    ``csharp_visibility`` above reports ``protected internal``.
     """
     combined = " ".join(modifier_texts).lower()
     if "private" in combined:

--- a/packages/core/src/repowise/core/ingestion/extractors/visibility.py
+++ b/packages/core/src/repowise/core/ingestion/extractors/visibility.py
@@ -100,6 +100,26 @@ def csharp_visibility(_name: str, modifier_texts: list[str]) -> str:
     return "internal"
 
 
+def vbnet_visibility(_name: str, modifier_texts: list[str]) -> str:
+    """VB.NET visibility — Public/Private/Protected/Friend (internal).
+
+    VB.NET's default access for a top-level type is ``Friend`` (assembly
+    scope), which maps to C#'s ``internal``; nested types under a parent
+    default to the parent's scope. ``Protected Friend`` (protected-or-
+    internal) is reported as protected — the wider caller surface.
+    """
+    combined = " ".join(modifier_texts).lower()
+    if "private" in combined:
+        return "private"
+    if "protected" in combined:
+        return "protected"
+    if "friend" in combined:
+        return "internal"
+    if "public" in combined:
+        return "public"
+    return "internal"
+
+
 def swift_visibility(_name: str, modifier_texts: list[str]) -> str:
     """Swift visibility — public/private/fileprivate/internal/open."""
     combined = " ".join(modifier_texts).lower()

--- a/packages/core/src/repowise/core/ingestion/graph/_resolvers.py
+++ b/packages/core/src/repowise/core/ingestion/graph/_resolvers.py
@@ -27,6 +27,11 @@ _MIN_REFERENCE_CONFIDENCE = 0.85
 _BARE_REFERENCE_KINDS = frozenset({"function"})
 _QUALIFIED_REFERENCE_KINDS = frozenset({"function", "method"})
 
+#: Languages that share the MSBuild project graph, so the namespace and
+#: partial-class passes below serve both. Call resolution and receiver typing
+#: stay per-language and are deliberately not gated on this.
+_DOTNET_LANGUAGES = frozenset({"csharp", "vbnet"})
+
 
 class ResolveMixin:
     """Symbol-level edge resolution passes run during ``build()``."""
@@ -158,25 +163,33 @@ class ResolveMixin:
                 if callable(done):
                     done(phase)
 
-    def _resolve_csharp_same_namespace(self, ctx: Any, progress: Any | None = None) -> None:
-        """Emit same-namespace / global-using ``imports`` edges for C# files.
+    def _resolve_dotnet_same_namespace(self, ctx: Any, progress: Any | None = None) -> None:
+        """Emit same-namespace ``imports`` edges for C# and VB.NET files.
 
-        C# references same-namespace types with no using directive, and
-        ``global using`` / csproj ``<Using>`` items make namespaces visible
-        project-wide — both leave cohesive code (and whole test suites)
-        looking like zero-edge orphans. Conservative text-level scan, same
-        shape as the JVM same-package pass.
+        Both languages reference same-namespace types with no import
+        directive, and project-wide ``global using`` / ``<Using>`` /
+        ``<Import>`` items widen that further, so cohesive code (and whole
+        test suites) otherwise read as zero-edge orphans. VB.NET adds the
+        harder case: most .vb files declare no namespace at all and sit in
+        the project's ``<RootNamespace>``. Conservative text-level scan,
+        same shape as the JVM same-package pass.
         """
         from ..languages.csharp_member_reads import collect_csharp_source_texts
         from ..languages.csharp_same_namespace import (
             resolve_csharp_same_namespace_refs,
         )
+        from ..languages.scope_scan import collect_source_texts
+        from ..languages.vbnet_same_namespace import (
+            resolve_vbnet_same_namespace_refs,
+        )
         from ..resolvers.dotnet import get_or_build_index
 
-        has_csharp = any(
-            pf.file_info.language == "csharp" for pf in self._parsed_files.values()
-        )
-        if not has_csharp:
+        languages = {
+            pf.file_info.language
+            for pf in self._parsed_files.values()
+            if pf.file_info.language in _DOTNET_LANGUAGES
+        }
+        if not languages:
             return
 
         phase = "graph.same_namespace"
@@ -184,14 +197,25 @@ class ResolveMixin:
             progress.on_phase_start(phase, None)
         try:
             index = get_or_build_index(ctx)
-            cs_texts = collect_csharp_source_texts(self._parsed_files, self._source_map)
             repo = getattr(index, "repo_path", None) if index is not None else None
-            added = resolve_csharp_same_namespace_refs(
-                self._graph, index, cs_texts, repo
-            )
-            log.info("same_namespace_edges", language="csharp", added=added)
+            if "csharp" in languages:
+                cs_texts = collect_csharp_source_texts(
+                    self._parsed_files, self._source_map
+                )
+                added = resolve_csharp_same_namespace_refs(
+                    self._graph, index, cs_texts, repo
+                )
+                log.info("same_namespace_edges", language="csharp", added=added)
+            if "vbnet" in languages:
+                vb_texts = collect_source_texts(
+                    self._parsed_files, ("vbnet",), self._source_map
+                )
+                added = resolve_vbnet_same_namespace_refs(
+                    self._graph, index, vb_texts, repo
+                )
+                log.info("same_namespace_edges", language="vbnet", added=added)
         except Exception as exc:
-            log.warning("csharp_same_namespace_failed", error=str(exc))
+            log.warning("dotnet_same_namespace_failed", error=str(exc))
         finally:
             if progress:
                 done = getattr(progress, "on_phase_done", None)
@@ -335,19 +359,22 @@ class ResolveMixin:
                 if callable(done):
                     done(phase)
 
-    def _resolve_csharp_partials(self, ctx: Any, progress: Any | None = None) -> None:
-        """Link C# ``partial`` co-fragments of one type bidirectionally.
+    def _resolve_dotnet_partials(self, ctx: Any, progress: Any | None = None) -> None:
+        """Link ``partial`` co-fragments of one type bidirectionally.
 
         Fragments of a partial class across files are literally one
         class — without these edges the secondary fragment files read as
-        disconnected from their own type.
+        disconnected from their own type. VB.NET leans on this far harder
+        than C#: every WinForms designer splits ``Form.vb`` from
+        ``Form.Designer.vb`` as a ``Partial Class``.
         """
         from ..resolvers.dotnet import get_or_build_index
 
-        has_csharp = any(
-            pf.file_info.language == "csharp" for pf in self._parsed_files.values()
+        has_dotnet = any(
+            pf.file_info.language in _DOTNET_LANGUAGES
+            for pf in self._parsed_files.values()
         )
-        if not has_csharp:
+        if not has_dotnet:
             return
 
         phase = "graph.partials"
@@ -382,9 +409,9 @@ class ResolveMixin:
                                 hint_source="partial_class",
                             )
                             added += 1
-            log.info("partial_class_edges", language="csharp", added=added)
+            log.info("partial_class_edges", added=added)
         except Exception as exc:
-            log.warning("csharp_partials_failed", error=str(exc))
+            log.warning("dotnet_partials_failed", error=str(exc))
         finally:
             if progress:
                 done = getattr(progress, "on_phase_done", None)

--- a/packages/core/src/repowise/core/ingestion/graph/builder.py
+++ b/packages/core/src/repowise/core/ingestion/graph/builder.py
@@ -505,10 +505,10 @@ class GraphBuilder(MetricsMixin, ResolveMixin, EdgesMixin, SerializeMixin, Rehyd
         # header must be able to reach the implementation.
         self._resolve_cpp_header_pairs(progress=progress)
 
-        # --- C# partial-class co-fragments ---
+        # --- C# / VB.NET partial-class co-fragments ---
         # Fragments of one partial type across files are literally one
         # class; link them bidirectionally so neither reads as orphaned.
-        self._resolve_csharp_partials(ctx, progress=progress)
+        self._resolve_dotnet_partials(ctx, progress=progress)
 
         # --- JVM same-package implicit references ---
         # Java/Kotlin (and Scala) reference same-package types without an
@@ -516,11 +516,11 @@ class GraphBuilder(MetricsMixin, ResolveMixin, EdgesMixin, SerializeMixin, Rehyd
         # packages don't read as disconnected files.
         self._resolve_jvm_same_package(ctx, progress=progress)
 
-        # --- C# same-namespace + global-using implicit references ---
-        # C# references same-namespace types with no using directive, and
-        # global usings make namespaces visible project-wide; emit
-        # conservative sibling edges so neither reads as orphaned.
-        self._resolve_csharp_same_namespace(ctx, progress=progress)
+        # --- C# / VB.NET same-namespace implicit references ---
+        # Both reference same-namespace types with no import directive, and
+        # project-wide usings widen that; most .vb files declare no namespace
+        # at all. Emit conservative sibling edges so neither reads as orphaned.
+        self._resolve_dotnet_same_namespace(ctx, progress=progress)
 
         # --- Swift intra-module type references ---
         # Swift files see same-target siblings with no import statement;

--- a/packages/core/src/repowise/core/ingestion/language_configs.py
+++ b/packages/core/src/repowise/core/ingestion/language_configs.py
@@ -292,6 +292,7 @@ LANGUAGE_CONFIGS: dict[str, LanguageConfig] = {
             "property_declaration": "variable",
             "event_declaration": "variable",
             "field_declaration": "variable",
+            "namespace_block": "module",
         },
         import_node_types=["imports_statement"],
         export_node_types=[],

--- a/packages/core/src/repowise/core/ingestion/language_configs.py
+++ b/packages/core/src/repowise/core/ingestion/language_configs.py
@@ -25,6 +25,7 @@ from .extractors.visibility import (
     scala_visibility,
     swift_visibility,
     ts_visibility,
+    vbnet_visibility,
 )
 
 
@@ -277,6 +278,33 @@ LANGUAGE_CONFIGS: dict[str, LanguageConfig] = {
                 "record_declaration",
                 "namespace_declaration",
                 "file_scoped_namespace_declaration",
+            }
+        ),
+    ),
+    "vbnet": LanguageConfig(
+        symbol_node_types={
+            "class_block": "class",
+            "interface_block": "interface",
+            "module_block": "class",
+            "structure_block": "struct",
+            "enum_block": "enum",
+            "method_declaration": "function",
+            "property_declaration": "variable",
+            "event_declaration": "variable",
+            "field_declaration": "variable",
+        },
+        import_node_types=["imports_statement"],
+        export_node_types=[],
+        visibility_fn=vbnet_visibility,
+        parent_extraction="nesting",
+        parent_class_types=frozenset(
+            {
+                "class_block",
+                "interface_block",
+                "module_block",
+                "structure_block",
+                "enum_block",
+                "namespace_block",
             }
         ),
     ),

--- a/packages/core/src/repowise/core/ingestion/languages/scope_scan.py
+++ b/packages/core/src/repowise/core/ingestion/languages/scope_scan.py
@@ -57,6 +57,7 @@ def emit_scope_edges(
     plan: Callable[[str, str], FileScope | None],
     *,
     skip_names: frozenset[str],
+    ident_re: re.Pattern[str] = _TYPE_IDENT_RE,
 ) -> int:
     """Scan *files* for implicit scope references and add ``imports`` edges.
 
@@ -64,6 +65,8 @@ def emit_scope_edges(
     the caller's, since nothing here depends on it. *plan* returns the scopes
     visible to one file, or ``None`` to skip the file entirely. *skip_names*
     is the language's stdlib/default-import set, checked before every tier.
+    *ident_re* overrides the candidate-identifier shape for a language whose
+    type names are not reliably capitalised ASCII.
 
     Returns the number of edges added.
 
@@ -81,7 +84,7 @@ def emit_scope_edges(
 
         # target file → (referenced names, hint of the tier that answered)
         found: dict[str, tuple[list[str], str]] = {}
-        for ident in sorted(set(_TYPE_IDENT_RE.findall(text))):
+        for ident in sorted(set(ident_re.findall(text))):
             if ident in skip_names or ident in scope.shadowed:
                 continue
             for tier in scope.tiers:

--- a/packages/core/src/repowise/core/ingestion/languages/specs/__init__.py
+++ b/packages/core/src/repowise/core/ingestion/languages/specs/__init__.py
@@ -60,6 +60,7 @@ from .terraform import SPEC as _TERRAFORM
 from .toml import SPEC as _TOML
 from .typescript import SPEC as _TYPESCRIPT
 from .unknown import SPEC as _UNKNOWN
+from .vbnet import SPEC as _VBNET
 from .vue import SPEC as _VUE
 from .xaml import SPEC as _XAML
 from .yaml import SPEC as _YAML
@@ -103,6 +104,7 @@ ALL_SPECS: tuple[LanguageSpec, ...] = (
     _DART,
     _PASCAL,
     _GDSCRIPT,
+    _VBNET,
     # -----------------------------------------------------------------
     # Config / data / markup languages (passthrough — no AST)
     # -----------------------------------------------------------------

--- a/packages/core/src/repowise/core/ingestion/languages/specs/vbnet.py
+++ b/packages/core/src/repowise/core/ingestion/languages/specs/vbnet.py
@@ -1,0 +1,105 @@
+"""LanguageSpec for vbnet (VB.NET) at the Good tier."""
+
+from ..spec import LanguageSpec
+
+SPEC = LanguageSpec(
+    tag="vbnet",
+    display_name="VB.NET",
+    import_support="full",
+    # VB.NET tests follow the MSTest/xUnit conventions (FooTests/FooTest),
+    # mostly as sibling files in the same project.
+    test_camel_suffixes=("Test", "Tests", "Spec", "Specs"),
+    test_dir_suffixes=(".Tests", ".Specs"),
+    extensions=frozenset({".vb"}),
+    grammar_package="tree_sitter_tree_sitter_vb_dotnet",
+    scm_file="vbnet.scm",
+    heritage_node_types=frozenset(
+        {
+            "class_block",
+            "interface_block",
+            "structure_block",
+        }
+    ),
+    manifest_files=(
+        "Directory.Build.props",
+        "Directory.Build.targets",
+        "Directory.Packages.props",
+        "global.json",
+        "nuget.config",
+        "NuGet.Config",
+    ),
+    build_config_manifests=(
+        "Directory.Build.props",
+        "Directory.Build.targets",
+        "Directory.Packages.props",
+        "global.json",
+        "nuget.config",
+        "NuGet.Config",
+    ),
+    lock_files=("packages.lock.json",),
+    generated_suffixes=(
+        ".designer.vb",
+        ".assemblyinfo.vb",
+        ".g.vb",
+    ),
+    blocked_dirs=("bin", "obj", ".vs", "TestResults", "packages"),
+    builtin_calls=frozenset(
+        {
+            "Console",
+            "Math",
+            "Convert",
+            "String",
+            "Object",
+            "GC",
+            "Environment",
+            "Activator",
+            "Task",
+            "Interlocked",
+        }
+    ),
+    builtin_parents=frozenset(
+        {
+            "Object",
+            "ValueType",
+            "Enum",
+            "Exception",
+            "SystemException",
+            "ApplicationException",
+            "IDisposable",
+            "IEnumerable",
+            "IComparable",
+        }
+    ),
+    builtin_types=frozenset(
+        {
+            # Built-in value/reference keywords
+            "Boolean",
+            "Byte",
+            "Short",
+            "Integer",
+            "Long",
+            "Single",
+            "Double",
+            "Decimal",
+            "Char",
+            "String",
+            "Object",
+            "Date",
+            "Nothing",
+            # Common BCL types that are always external
+            "Task",
+            "CancellationToken",
+            "Action",
+            "Func",
+            "Type",
+            "Exception",
+            "DateTime",
+            "DateTimeOffset",
+            "TimeSpan",
+            "Guid",
+            "Uri",
+            "Stream",
+        }
+    ),
+    color_hex="#945DB7",
+)

--- a/packages/core/src/repowise/core/ingestion/languages/specs/vbnet.py
+++ b/packages/core/src/repowise/core/ingestion/languages/specs/vbnet.py
@@ -11,7 +11,7 @@ SPEC = LanguageSpec(
     test_camel_suffixes=("Test", "Tests", "Spec", "Specs"),
     test_dir_suffixes=(".Tests", ".Specs"),
     extensions=frozenset({".vb"}),
-    grammar_package="tree_sitter_tree_sitter_vb_dotnet",
+    grammar_package="tree_sitter_vb_dotnet",
     scm_file="vbnet.scm",
     heritage_node_types=frozenset(
         {
@@ -59,6 +59,7 @@ SPEC = LanguageSpec(
     ),
     builtin_parents=frozenset(
         {
+            # The C# set, which VB.NET inherits verbatim: same BCL, same names.
             "Object",
             "ValueType",
             "Enum",
@@ -67,7 +68,27 @@ SPEC = LanguageSpec(
             "ApplicationException",
             "IDisposable",
             "IEnumerable",
+            "IEnumerator",
             "IComparable",
+            "ICloneable",
+            "IEquatable",
+            # UI and component base classes. VB.NET estates are WinForms-heavy
+            # and every designer form writes ``Inherits Form``, which would
+            # otherwise bind to any repo class of the same name.
+            "Form",
+            "Control",
+            "UserControl",
+            "Component",
+            "Page",
+            "Window",
+            "Attribute",
+            "EventArgs",
+            "MarshalByRefObject",
+            "INotifyPropertyChanged",
+            "IComparer",
+            "ICollection",
+            "IList",
+            "IDictionary",
         }
     ),
     builtin_types=frozenset(

--- a/packages/core/src/repowise/core/ingestion/languages/vbnet_same_namespace.py
+++ b/packages/core/src/repowise/core/ingestion/languages/vbnet_same_namespace.py
@@ -1,0 +1,158 @@
+"""VB.NET same-namespace + project-import implicit reference resolution.
+
+Background
+----------
+VB.NET has C#'s same-namespace rule and one more that matters more: the
+namespace a file belongs to is usually never written down. Most .vb files
+declare no ``Namespace`` block at all and sit directly in the project's
+``<RootNamespace>``, so a whole project can be one implicit namespace with
+zero ``Imports`` lines between its files. Project-level
+``<Import Include="X"/>`` items do for VB what ``global using`` does for C#.
+
+This is the VB.NET binding of the shared implicit-scope scan
+(:mod:`.scope_scan`), alongside the C# one in :mod:`.csharp_same_namespace`.
+It reuses that module's BCL skip list, since both languages reference the
+same framework, and reads namespaces through the dotnet resolver's VB
+scanner rather than any C# syntax.
+
+Known ceiling: VB is case-insensitive, so ``Dim x As order`` referring to
+``Order`` is not matched. That is a missed edge, never a wrong one.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from .csharp_same_namespace import _BCL_COMMON_TYPES
+from .scope_scan import FileScope, ScopeTier, emit_scope_edges
+
+if TYPE_CHECKING:
+    import networkx as nx
+
+    from ..resolvers.dotnet.index import DotNetProjectIndex
+
+# ``Imports Foo.Bar`` / ``Imports Global.Foo.Bar`` (not the aliased form).
+# ``[^\W\d]`` rather than ``[A-Za-z_]``: VB.NET identifiers are Unicode.
+_IMPORTS_NS_RE = re.compile(
+    r"^\s*Imports\s+(?:Global\.)?([^\W\d][\w.]*)\s*$", re.IGNORECASE | re.MULTILINE
+)
+
+# ``Imports Alias = Foo.Bar.Baz`` — the alias name shadows bare identifiers.
+_IMPORTS_ALIAS_RE = re.compile(
+    r"^\s*Imports\s+([^\W\d]\w*)\s*=", re.IGNORECASE | re.MULTILINE
+)
+
+# VB intrinsic type names and the ``My`` root, on top of the shared BCL set.
+_VB_INTRINSICS = frozenset({
+    "Integer", "Long", "Short", "UInteger", "ULong", "UShort", "Date",
+    "Variant", "Nothing", "Me", "MyBase", "MyClass", "My",
+})
+
+_SKIP_NAMES = _BCL_COMMON_TYPES | _VB_INTRINSICS
+
+_SAME_NAMESPACE_HINT = "same_namespace"
+_PROJECT_IMPORT_HINT = "global_using"
+
+# The shared scan looks for a capitalised ASCII name. VB.NET estates are
+# routinely written in a script with no case at all (Chinese, Japanese), where
+# that pattern matches nothing, so accept any identifier that does not start
+# with a lowercase letter. Precision still comes from the tier lookup, which
+# only answers for types declared in the file's own namespace.
+_VB_TYPE_IDENT_RE = re.compile(r"\b(?![a-z])[^\W\d]\w*\b")
+
+
+def resolve_vbnet_same_namespace_refs(
+    graph: nx.DiGraph,
+    dotnet_index: DotNetProjectIndex | None,
+    vb_texts: dict[str, str],
+    repo_path: Path | None,
+) -> int:
+    """Emit same-namespace / project-import ``imports`` edges for VB.NET files.
+
+    *vb_texts* maps repo-relative path → source text. Returns the number of
+    edges added.
+    """
+    from ..resolvers.dotnet.namespace_map import scan_vb_declarations, vb_namespace_key
+
+    def _root_for(path: str) -> str:
+        if dotnet_index is None or repo_path is None:
+            return ""
+        return dotnet_index.vb_root_namespaces.get((repo_path / path).resolve(), "")
+
+    # path → (own namespace keys, declarations), scanned once and reused.
+    scanned: dict[str, tuple[list[str], list]] = {}
+    ns_types: dict[str, dict[str, list[str]]] = {}
+    for path in sorted(vb_texts):
+        declared, decls = scan_vb_declarations(vb_texts[path])
+        root = _root_for(path)
+        own = list(dict.fromkeys(vb_namespace_key(ns, root) for ns in declared))
+        if not own and root:
+            own = [root]
+        scanned[path] = (own, decls)
+        for decl in decls:
+            bucket = ns_types.setdefault(vb_namespace_key(decl.namespace, root), {})
+            files = bucket.setdefault(decl.name, [])
+            if path not in files:
+                files.append(path)
+
+    def _declarers(namespaces: list[str], ident: str) -> set[str]:
+        declaring: set[str] = set()
+        for ns in namespaces:
+            declaring.update(ns_types.get(ns, {}).get(ident, ()))
+        return declaring
+
+    def plan(path: str, text: str) -> FileScope | None:
+        own_namespaces = [ns for ns in scanned[path][0] if ns]
+        explicit_ns = [m.group(1) for m in _IMPORTS_NS_RE.finditer(text)]
+
+        project_ns: list[str] = []
+        if dotnet_index is not None and repo_path is not None:
+            vbproj = dotnet_index.file_to_project.get((repo_path / path).resolve())
+            if vbproj is not None:
+                project_ns = sorted(
+                    ns
+                    for ns in dotnet_index.globals_for_project(vbproj)
+                    if ns in ns_types and ns not in own_namespaces
+                )
+
+        if not own_namespaces and not project_ns:
+            return None
+
+        # An explicit Imports already resolved through the normal import path,
+        # so it shadows the project tier only; the file's own namespace is the
+        # closer scope and keeps priority.
+        explicit_types: set[str] = set()
+        for ns in explicit_ns:
+            explicit_types.update(ns_types.get(ns, ()))
+
+        tiers = []
+        if own_namespaces:
+            tiers.append(
+                ScopeTier(
+                    hint=_SAME_NAMESPACE_HINT,
+                    lookup=lambda ident: _declarers(own_namespaces, ident),
+                )
+            )
+        if project_ns:
+            tiers.append(
+                ScopeTier(
+                    hint=_PROJECT_IMPORT_HINT,
+                    lookup=lambda ident: (
+                        set() if ident in explicit_types else _declarers(project_ns, ident)
+                    ),
+                )
+            )
+        return FileScope(
+            tiers=tuple(tiers),
+            shadowed=frozenset(m.group(1) for m in _IMPORTS_ALIAS_RE.finditer(text)),
+        )
+
+    return emit_scope_edges(
+        graph,
+        ((path, vb_texts[path]) for path in sorted(vb_texts)),
+        plan,
+        skip_names=_SKIP_NAMES,
+        ident_re=_VB_TYPE_IDENT_RE,
+    )

--- a/packages/core/src/repowise/core/ingestion/models.py
+++ b/packages/core/src/repowise/core/ingestion/models.py
@@ -42,6 +42,7 @@ LanguageTag = Literal[
     "dart",
     "pascal",
     "gdscript",
+    "vbnet",
     # Passthrough code languages (no AST parser yet — empty ParsedFile,
     # files enter the graph via the generic resolver). Before these tags
     # existed the traverser silently skipped such files as unknown, so e.g.

--- a/packages/core/src/repowise/core/ingestion/queries/vbnet.scm
+++ b/packages/core/src/repowise/core/ingestion/queries/vbnet.scm
@@ -1,14 +1,14 @@
 ; =============================================================================
-; repowise — VB.NET symbol, import, and call queries
-; tree-sitter-vb-dotnet (fixed fork, c29b08e)
+; repowise VB.NET symbol, import, and call queries
+; tree-sitter-vb-dotnet 0.2
 ; =============================================================================
 
 ; ---------------------------------------------------------------------------
-; Symbols — modifier-capturing patterns first (dedup keeps first match)
+; Symbols: modifier-capturing patterns first (dedup keeps first match)
 ; ---------------------------------------------------------------------------
 
 ; Class / module / structure / interface declarations. VB.NET nests all of
-; these inside namespace_block. The container *name* comes from the first
+; these inside namespace_block. The container name comes from the first
 ; identifier after the keyword token; the block node itself carries the type.
 (class_block
   (modifiers) @symbol.modifiers
@@ -55,12 +55,25 @@
   name: (identifier) @symbol.name
 ) @symbol.def
 
-; Constructors: Public Sub New(...) — the grammar drops the ``New`` token
-; entirely (constructor_declaration has no ``name`` field), so no name-based
-; pattern is possible here. Parameter types still feed the DI backbone below.
+; Fields: Private _foo As Integer. field_declaration has no name field; the
+; name sits one level down in the variable_declarator.
+(field_declaration
+  (modifiers) @symbol.modifiers
+  (variable_declarator
+    (identifier) @symbol.name)
+) @symbol.def
+
+; Namespaces: the block is named by a dotted namespace_name, not an identifier.
+(namespace_block
+  (namespace_name) @symbol.name
+) @symbol.def
+
+; Constructors: Public Sub New(...). The grammar drops the New token entirely
+; (constructor_declaration has no name field), so no name-based pattern is
+; possible here. Parameter types still feed the DI backbone below.
 
 ; ---------------------------------------------------------------------------
-; Symbols — fallback without modifiers
+; Symbols: fallback without modifiers
 ; ---------------------------------------------------------------------------
 
 (class_block
@@ -96,16 +109,23 @@
   name: (identifier) @symbol.name
 ) @symbol.def
 
+; Dim baz As Long, with no access modifier.
+(field_declaration
+  (variable_declarator
+    (identifier) @symbol.name)
+) @symbol.def
+
 ; ---------------------------------------------------------------------------
-; Namespaces — Imports ... (module-level, mirrors C# using directives)
+; Imports (module-level, mirrors C# using directives). The namespace field is
+; the target in both the plain and the Imports Alias = Target form.
 ; ---------------------------------------------------------------------------
 (imports_statement
   namespace: (_) @import.module
 ) @import.statement
 
 ; ---------------------------------------------------------------------------
-; Calls — invocation has target/arguments fields; member_access has
-; object/member fields. The grammar names the callee ``target``.
+; Calls: invocation has target/arguments fields; member_access has
+; object/member fields. The grammar names the callee "target".
 ; ---------------------------------------------------------------------------
 
 ; Simple call: Method(args)
@@ -114,10 +134,9 @@
   arguments: (argument_list) @call.arguments
 ) @call.site
 
-; Member call: obj.Method(args) — receiver carries the type. The grammar's
-; ``object`` field is typed ``expression`` (a wrapper), so a bare
-; ``(identifier)`` there is impossible; the wildcard captures the wrapper and
-; resolution reads the identifier text out of it.
+; Member call: obj.Method(args), where the receiver carries the type. The
+; object field is always an expression wrapper, so a bare (identifier) there
+; cannot match; resolution reads the identifier text out of the wrapper.
 (invocation
   target: (member_access
     object: (_) @call.receiver
@@ -125,17 +144,11 @@
   arguments: (argument_list) @call.arguments
 ) @call.site
 
-; Chained call: factory().Method(args) — object is an expression wrapper
-; again, so the wildcard captures it; resolution can inspect whether it wraps
-; an invocation.
-(invocation
-  target: (member_access
-    object: (_) @call.receiver_call
-    member: (identifier) @call.target)
-  arguments: (argument_list) @call.arguments
-) @call.site
+; No @call.receiver_call pattern: the shared reader of that capture looks for
+; a name/function field on the inner call, and this grammar's invocation has
+; neither, so Factory().Method(args) stays on the receiver-name path above.
 
-; Constructor: New ClassName(args) — argument_list is an unnamed child
+; Constructor: New ClassName(args); argument_list is an unnamed child.
 (new_expression
   type: (_) @call.target
   (argument_list) @call.arguments

--- a/packages/core/src/repowise/core/ingestion/queries/vbnet.scm
+++ b/packages/core/src/repowise/core/ingestion/queries/vbnet.scm
@@ -1,0 +1,152 @@
+; =============================================================================
+; repowise — VB.NET symbol, import, and call queries
+; tree-sitter-vb-dotnet (fixed fork, c29b08e)
+; =============================================================================
+
+; ---------------------------------------------------------------------------
+; Symbols — modifier-capturing patterns first (dedup keeps first match)
+; ---------------------------------------------------------------------------
+
+; Class / module / structure / interface declarations. VB.NET nests all of
+; these inside namespace_block. The container *name* comes from the first
+; identifier after the keyword token; the block node itself carries the type.
+(class_block
+  (modifiers) @symbol.modifiers
+  name: (identifier) @symbol.name
+) @symbol.def
+
+(module_block
+  (modifiers) @symbol.modifiers
+  name: (identifier) @symbol.name
+) @symbol.def
+
+(structure_block
+  (modifiers) @symbol.modifiers
+  name: (identifier) @symbol.name
+) @symbol.def
+
+(interface_block
+  (modifiers) @symbol.modifiers
+  name: (identifier) @symbol.name
+) @symbol.def
+
+(enum_block
+  (modifiers) @symbol.modifiers
+  name: (identifier) @symbol.name
+) @symbol.def
+
+; Methods: Sub / Function. The grammar names the node method_declaration and
+; gives it name/parameters/return_type fields.
+(method_declaration
+  (modifiers) @symbol.modifiers
+  name: (identifier) @symbol.name
+  parameters: (parameter_list) @symbol.params
+) @symbol.def
+
+; Properties: Property Name As Type
+(property_declaration
+  (modifiers) @symbol.modifiers
+  name: (identifier) @symbol.name
+) @symbol.def
+
+; Events
+(event_declaration
+  (modifiers) @symbol.modifiers
+  name: (identifier) @symbol.name
+) @symbol.def
+
+; Constructors: Public Sub New(...) — the grammar drops the ``New`` token
+; entirely (constructor_declaration has no ``name`` field), so no name-based
+; pattern is possible here. Parameter types still feed the DI backbone below.
+
+; ---------------------------------------------------------------------------
+; Symbols — fallback without modifiers
+; ---------------------------------------------------------------------------
+
+(class_block
+  name: (identifier) @symbol.name
+) @symbol.def
+
+(module_block
+  name: (identifier) @symbol.name
+) @symbol.def
+
+(structure_block
+  name: (identifier) @symbol.name
+) @symbol.def
+
+(interface_block
+  name: (identifier) @symbol.name
+) @symbol.def
+
+(enum_block
+  name: (identifier) @symbol.name
+) @symbol.def
+
+(method_declaration
+  name: (identifier) @symbol.name
+  parameters: (parameter_list) @symbol.params
+) @symbol.def
+
+(property_declaration
+  name: (identifier) @symbol.name
+) @symbol.def
+
+(event_declaration
+  name: (identifier) @symbol.name
+) @symbol.def
+
+; ---------------------------------------------------------------------------
+; Namespaces — Imports ... (module-level, mirrors C# using directives)
+; ---------------------------------------------------------------------------
+(imports_statement
+  namespace: (_) @import.module
+) @import.statement
+
+; ---------------------------------------------------------------------------
+; Calls — invocation has target/arguments fields; member_access has
+; object/member fields. The grammar names the callee ``target``.
+; ---------------------------------------------------------------------------
+
+; Simple call: Method(args)
+(invocation
+  target: (identifier) @call.target
+  arguments: (argument_list) @call.arguments
+) @call.site
+
+; Member call: obj.Method(args) — receiver carries the type. The grammar's
+; ``object`` field is typed ``expression`` (a wrapper), so a bare
+; ``(identifier)`` there is impossible; the wildcard captures the wrapper and
+; resolution reads the identifier text out of it.
+(invocation
+  target: (member_access
+    object: (_) @call.receiver
+    member: (identifier) @call.target)
+  arguments: (argument_list) @call.arguments
+) @call.site
+
+; Chained call: factory().Method(args) — object is an expression wrapper
+; again, so the wildcard captures it; resolution can inspect whether it wraps
+; an invocation.
+(invocation
+  target: (member_access
+    object: (_) @call.receiver_call
+    member: (identifier) @call.target)
+  arguments: (argument_list) @call.arguments
+) @call.site
+
+; Constructor: New ClassName(args) — argument_list is an unnamed child
+(new_expression
+  type: (_) @call.target
+  (argument_list) @call.arguments
+) @call.site
+
+; ---------------------------------------------------------------------------
+; Parameter type references (DI backbone, mirrors C#). In this grammar the
+; type lives one level down inside an as_clause.
+; ---------------------------------------------------------------------------
+
+(parameter_list
+  (parameter
+    (as_clause
+      type: (_) @param.type)))

--- a/packages/core/src/repowise/core/ingestion/resolvers/__init__.py
+++ b/packages/core/src/repowise/core/ingestion/resolvers/__init__.py
@@ -30,6 +30,7 @@ from .scala import resolve_scala_import
 from .shell import resolve_shell_import
 from .sql import resolve_dbt_import
 from .swift import resolve_swift_import
+from .vbnet import resolve_vbnet_import
 from .typescript import resolve_ts_js_import
 
 ResolverFn = Callable[[str, str, ResolverContext], str | None]
@@ -74,6 +75,8 @@ _RESOLVERS: dict[str, ResolverFn] = {
     # <script src>/<link href> are asset paths, not module specifiers — they
     # get their own document-/root-relative resolution, never the TS/JS one.
     "html": resolve_html_asset,
+    # VB.NET Imports → namespace stem/path match (dotnet resolver lineage).
+    "vbnet": resolve_vbnet_import,
 }
 
 

--- a/packages/core/src/repowise/core/ingestion/resolvers/__init__.py
+++ b/packages/core/src/repowise/core/ingestion/resolvers/__init__.py
@@ -75,7 +75,7 @@ _RESOLVERS: dict[str, ResolverFn] = {
     # <script src>/<link href> are asset paths, not module specifiers — they
     # get their own document-/root-relative resolution, never the TS/JS one.
     "html": resolve_html_asset,
-    # VB.NET Imports → namespace stem/path match (dotnet resolver lineage).
+    # VB.NET Imports resolve through the same DotNetProjectIndex as C#.
     "vbnet": resolve_vbnet_import,
 }
 

--- a/packages/core/src/repowise/core/ingestion/resolvers/__init__.py
+++ b/packages/core/src/repowise/core/ingestion/resolvers/__init__.py
@@ -30,8 +30,8 @@ from .scala import resolve_scala_import
 from .shell import resolve_shell_import
 from .sql import resolve_dbt_import
 from .swift import resolve_swift_import
-from .vbnet import resolve_vbnet_import
 from .typescript import resolve_ts_js_import
+from .vbnet import resolve_vbnet_import
 
 ResolverFn = Callable[[str, str, ResolverContext], str | None]
 

--- a/packages/core/src/repowise/core/ingestion/resolvers/csharp.py
+++ b/packages/core/src/repowise/core/ingestion/resolvers/csharp.py
@@ -130,31 +130,14 @@ def resolve_csharp_import(
     importer_csproj = index.file_to_project.get(importer_abs)
     importer_proj = index.projects.get(importer_csproj) if importer_csproj else None
 
-    candidates = index.files_for_namespace(module_path)
+    # Rank: same project, then referenced projects, then anywhere.
+    ordered = index.rank_namespace_candidates(
+        module_path, importer_proj.path if importer_proj is not None else None
+    )
     repo_root_resolved = _repo_root_resolved(index, ctx.repo_path)
 
-    if candidates:
-        # Rank: same project, then referenced projects, then anywhere.
-        same_project: list[Path] = []
-        referenced: list[Path] = []
-        other: list[Path] = []
-
-        if importer_proj is not None:
-            ref_csprojs = index.referenced_projects(importer_proj.path)
-            for cand in candidates:
-                cand_proj_path = index.file_to_project.get(cand)
-                if cand_proj_path == importer_proj.path:
-                    same_project.append(cand)
-                elif cand_proj_path in ref_csprojs:
-                    referenced.append(cand)
-                else:
-                    other.append(cand)
-            ordered = same_project or referenced or other
-        else:
-            ordered = candidates
-
-        chosen = ordered[0]
-        rel = _to_repo_relative(chosen, repo_root_resolved)
+    if ordered:
+        rel = _to_repo_relative(ordered[0], repo_root_resolved)
         if rel and rel in ctx.path_set:
             return rel
 

--- a/packages/core/src/repowise/core/ingestion/resolvers/dotnet/__init__.py
+++ b/packages/core/src/repowise/core/ingestion/resolvers/dotnet/__init__.py
@@ -1,9 +1,10 @@
-"""MSBuild / .sln aware resolution helpers for C# / .NET.
+"""MSBuild / .sln aware resolution helpers for C# and VB.NET.
 
 The ``DotNetProjectIndex`` is the entry point — it walks a repo once,
-parses every ``.csproj`` and ``.sln``, builds a namespace → file map,
-collects implicit/global usings, and exposes lookup helpers used by
-``resolvers/csharp.py``.
+parses every ``.csproj``, ``.vbproj`` and ``.sln``, builds a namespace →
+file map covering both ``.cs`` and ``.vb`` sources, collects
+implicit/global usings, and exposes lookup helpers used by
+``resolvers/csharp.py`` and ``resolvers/vbnet.py``.
 
 Construction is lazy and idempotent: the index is built on first access
 and cached on the ``ResolverContext`` for the lifetime of one
@@ -14,7 +15,7 @@ from __future__ import annotations
 
 from .index import DotNetProjectIndex, build_index, get_or_build_index
 from .msbuild import MSBuildProject, parse_csproj
-from .namespace_map import build_namespace_map
+from .namespace_map import build_namespace_map, build_vb_namespace_map
 from .solution import SolutionEntry, parse_sln
 
 __all__ = [
@@ -23,6 +24,7 @@ __all__ = [
     "SolutionEntry",
     "build_index",
     "build_namespace_map",
+    "build_vb_namespace_map",
     "get_or_build_index",
     "parse_csproj",
     "parse_sln",

--- a/packages/core/src/repowise/core/ingestion/resolvers/dotnet/index.py
+++ b/packages/core/src/repowise/core/ingestion/resolvers/dotnet/index.py
@@ -15,10 +15,11 @@ from .global_usings import collect_project_global_usings
 from .msbuild import (
     MSBuildProject,
     find_csproj_files,
+    find_vbproj_files,
     parse_csproj,
     path_has_dotnet_scan_skip_dir,
 )
-from .namespace_map import build_namespace_map
+from .namespace_map import build_namespace_map, build_vb_namespace_map
 from .solution import find_sln_files, parse_sln
 
 if TYPE_CHECKING:
@@ -36,7 +37,11 @@ class DotNetProjectIndex:
     """Keyed by absolute .csproj path."""
 
     namespace_map: dict[str, list[Path]] = field(default_factory=dict)
-    """Maps a fully-qualified namespace to the set of .cs files declaring it."""
+    """Maps a fully-qualified namespace to the .cs and .vb files declaring it.
+
+    VB.NET namespaces are recorded under the project's ``<RootNamespace>`` as
+    well as their source-literal form, so a mixed solution resolves across
+    both languages from one map."""
 
     type_map: dict[str, list[Path]] = field(default_factory=dict)
     """Maps an unqualified type name (e.g. ``IBasketService``) to defining files.
@@ -54,7 +59,14 @@ class DotNetProjectIndex:
     """Maps a project's directory → global+implicit using namespaces."""
 
     file_to_project: dict[Path, Path] = field(default_factory=dict)
-    """Maps a .cs file's absolute path → enclosing project's .csproj path."""
+    """Maps a .cs or .vb file's absolute path → enclosing project file path."""
+
+    vb_root_namespaces: dict[Path, str] = field(default_factory=dict)
+    """Maps a .vb file's absolute path → its project's ``<RootNamespace>``.
+
+    VB files usually declare no ``Namespace`` block at all and sit directly in
+    the root namespace, so the same-namespace pass needs this to know which
+    scope a bare file belongs to."""
 
     project_refs_by_proj: dict[Path, set[Path]] = field(default_factory=dict)
     """Maps a .csproj path → set of referenced .csproj paths (transitive=False)."""
@@ -107,6 +119,33 @@ class DotNetProjectIndex:
     def files_for_type(self, type_name: str) -> list[Path]:
         return self.type_map.get(type_name, [])
 
+    def rank_namespace_candidates(
+        self, namespace: str, importer_csproj: Path | None
+    ) -> list[Path]:
+        """Return files declaring *namespace*, best candidate first.
+
+        Same project, then a directly-referenced project, then anywhere in
+        the repo. Shared by the C# and VB.NET resolvers so a mixed solution
+        ranks both languages the same way.
+        """
+        candidates = self.namespace_map.get(namespace, [])
+        if not candidates or importer_csproj is None:
+            return candidates
+
+        ref_csprojs = self.referenced_projects(importer_csproj)
+        same_project: list[Path] = []
+        referenced: list[Path] = []
+        other: list[Path] = []
+        for cand in candidates:
+            cand_proj = self.file_to_project.get(cand)
+            if cand_proj == importer_csproj:
+                same_project.append(cand)
+            elif cand_proj in ref_csprojs:
+                referenced.append(cand)
+            else:
+                other.append(cand)
+        return same_project or referenced or other
+
     def rank_type_candidates(
         self,
         type_name: str,
@@ -157,10 +196,14 @@ class DotNetProjectIndex:
         return package_id in self.package_refs.get(csproj, set())
 
 
-def _walk_repo_cs_files(
-    repo_path: Path, *, prune_nested_git: bool = True, snapshot: Any | None = None
+def _walk_repo_source_files(
+    repo_path: Path,
+    pattern: str,
+    *,
+    prune_nested_git: bool = True,
+    snapshot: Any | None = None,
 ) -> list[Path]:
-    """Single repo-wide rglob for ``*.cs`` files, dedup by resolved path.
+    """Single repo-wide rglob for *pattern*, dedup by resolved path.
 
     Lives at module scope (not nested inside ``build_index``) so it's
     independently testable and so the skip-list is shared with the
@@ -168,11 +211,11 @@ def _walk_repo_cs_files(
     """
     seen: set[Path] = set()
     out: list[Path] = []
-    for cs in glob_via(snapshot, repo_path, "*.cs", prune_nested_git=prune_nested_git):
-        if path_has_dotnet_scan_skip_dir(cs, repo_path):
+    for src in glob_via(snapshot, repo_path, pattern, prune_nested_git=prune_nested_git):
+        if path_has_dotnet_scan_skip_dir(src, repo_path):
             continue
         try:
-            resolved = cs.resolve()
+            resolved = src.resolve()
         except OSError:
             continue
         if resolved in seen:
@@ -246,10 +289,11 @@ def build_index(
     repo_path = repo_path.resolve()
     index = DotNetProjectIndex(repo_path=repo_path)
 
-    # ---- 1. Parse every .csproj ----
-    for csproj_path in find_csproj_files(
+    # ---- 1. Parse every .csproj and .vbproj ----
+    project_paths = find_csproj_files(
         repo_path, prune_nested_git=prune_nested_git, snapshot=snapshot
-    ):
+    ) + find_vbproj_files(repo_path, prune_nested_git=prune_nested_git, snapshot=snapshot)
+    for csproj_path in project_paths:
         proj = parse_csproj(csproj_path)
         if proj is None:
             continue
@@ -274,12 +318,15 @@ def build_index(
                     index.package_refs.setdefault(proj.path, set()).update(proj.package_references)
 
     # ---- 3. Single master walk: enumerate .cs files & read each once ----
-    all_cs_files = _walk_repo_cs_files(
-        repo_path, prune_nested_git=prune_nested_git, snapshot=snapshot
+    all_cs_files = _walk_repo_source_files(
+        repo_path, "*.cs", prune_nested_git=prune_nested_git, snapshot=snapshot
+    )
+    all_vb_files = _walk_repo_source_files(
+        repo_path, "*.vb", prune_nested_git=prune_nested_git, snapshot=snapshot
     )
     cs_texts: dict[Path, str] = {}
-    for f in all_cs_files:
-        # ``_walk_repo_cs_files`` resolves every path and *repo_path* is
+    for f in all_cs_files + all_vb_files:
+        # ``_walk_repo_source_files`` resolves every path and *repo_path* is
         # resolved too, so a file the traverser indexed keys the map exactly.
         # Files it skipped — and anything outside the root — miss and read.
         try:
@@ -296,12 +343,31 @@ def build_index(
     project_dirs: list[tuple[Path, Path]] = [
         (proj.project_dir.resolve(), proj.path) for proj in index.projects.values()
     ]
-    index.file_to_project = _bucket_files_by_project(all_cs_files, project_dirs)
+    index.file_to_project = _bucket_files_by_project(all_cs_files + all_vb_files, project_dirs)
 
     # ---- 4. Namespace + type + partial maps from cached texts ----
     index.namespace_map, index.type_map, index.partial_types = build_namespace_map(
         all_cs_files, texts=cs_texts
     )
+    if all_vb_files:
+        # VB namespaces hang off <RootNamespace>, which defaults to the
+        # project name when the project file does not set it.
+        vb_roots: dict[Path, str] = {}
+        for vb in all_vb_files:
+            vbproj = index.file_to_project.get(vb)
+            proj = index.projects.get(vbproj) if vbproj else None
+            if proj is not None:
+                vb_roots[vb] = proj.root_namespace or proj.path.stem
+        index.vb_root_namespaces = vb_roots
+        vb_namespaces, vb_types, vb_partials = build_vb_namespace_map(
+            all_vb_files, texts=cs_texts, root_namespaces=vb_roots
+        )
+        for key, paths in vb_namespaces.items():
+            index.namespace_map.setdefault(key, []).extend(paths)
+        for key, paths in vb_types.items():
+            index.type_map.setdefault(key, []).extend(paths)
+        for key, paths in vb_partials.items():
+            index.partial_types.setdefault(key, []).extend(paths)
 
     # ---- 5. Per-project global+implicit usings from cached texts ----
     # Bucket the cached texts by project once so each project's call to
@@ -334,6 +400,7 @@ def build_index(
         repo=str(repo_path),
         projects=len(index.projects),
         cs_files=len(all_cs_files),
+        vb_files=len(all_vb_files),
         namespaces=len(index.namespace_map),
         types=len(index.type_map),
         sln=len(index.sln_paths),

--- a/packages/core/src/repowise/core/ingestion/resolvers/dotnet/msbuild.py
+++ b/packages/core/src/repowise/core/ingestion/resolvers/dotnet/msbuild.py
@@ -1,9 +1,11 @@
-"""Parse MSBuild project files (.csproj, Directory.Build.props/targets).
+"""Parse MSBuild project files (.csproj, .vbproj, Directory.Build.props/targets).
 
 Only the fields repowise actually uses are extracted: ProjectReference,
 PackageReference, RootNamespace, AssemblyName, ImplicitUsings, and
-project-level <Using Include=...> items. The parser tolerates both
-SDK-style and legacy XML (``<Project ToolsVersion="...">``).
+project-level <Using Include=...> / <Import Include=...> items. The parser
+tolerates both SDK-style and legacy XML (``<Project ToolsVersion="...">``).
+
+.vbproj carries the same MSBuild schema as .csproj, so one parser serves both.
 """
 
 from __future__ import annotations
@@ -133,7 +135,9 @@ def parse_csproj(csproj_path: Path) -> MSBuildProject | None:
             pkg = elem.get("Include")
             if pkg:
                 project.package_references.add(pkg.strip())
-        elif tag == "Using":
+        elif tag in ("Using", "Import"):
+            # <Using Include="X"/> is the C# form, <Import Include="X"/> the VB
+            # one; MSBuild's own <Import Project="..."/> carries no Include.
             ns = elem.get("Include")
             if ns:
                 project.project_usings.add(ns.strip())
@@ -141,18 +145,37 @@ def parse_csproj(csproj_path: Path) -> MSBuildProject | None:
     return project
 
 
+def _find_project_files(
+    repo_path: Path,
+    pattern: str,
+    *,
+    prune_nested_git: bool = True,
+    snapshot: Any | None = None,
+) -> list[Path]:
+    out: list[Path] = []
+    for proj in glob_via(snapshot, repo_path, pattern, prune_nested_git=prune_nested_git):
+        if path_has_dotnet_scan_skip_dir(proj, repo_path):
+            continue
+        out.append(proj)
+    return out
+
+
 def find_csproj_files(
     repo_path: Path, *, prune_nested_git: bool = True, snapshot: Any | None = None
 ) -> list[Path]:
     """Return all .csproj files under *repo_path*, skipping bin/obj output."""
-    out: list[Path] = []
-    for csproj in glob_via(
-        snapshot, repo_path, "*.csproj", prune_nested_git=prune_nested_git
-    ):
-        if path_has_dotnet_scan_skip_dir(csproj, repo_path):
-            continue
-        out.append(csproj)
-    return out
+    return _find_project_files(
+        repo_path, "*.csproj", prune_nested_git=prune_nested_git, snapshot=snapshot
+    )
+
+
+def find_vbproj_files(
+    repo_path: Path, *, prune_nested_git: bool = True, snapshot: Any | None = None
+) -> list[Path]:
+    """Return all .vbproj files under *repo_path*, skipping bin/obj output."""
+    return _find_project_files(
+        repo_path, "*.vbproj", prune_nested_git=prune_nested_git, snapshot=snapshot
+    )
 
 
 def path_has_dotnet_scan_skip_dir(path: Path, repo_root: Path) -> bool:

--- a/packages/core/src/repowise/core/ingestion/resolvers/dotnet/namespace_map.py
+++ b/packages/core/src/repowise/core/ingestion/resolvers/dotnet/namespace_map.py
@@ -5,6 +5,10 @@ after parsing has finished and ``parsed_files`` does not preserve raw
 namespace text in a uniform shape across grammar versions. The regexes
 cover both block-form and file-scoped namespaces (C# 10+) and the
 canonical type declaration forms.
+
+VB.NET gets its own scanner at the bottom of this module: its blocks are
+keyword-delimited rather than braced, and every declared namespace sits
+under the project's ``<RootNamespace>``.
 """
 
 from __future__ import annotations
@@ -168,3 +172,118 @@ def build_namespace_map(
                 seen_p.add(decl.fqn)
                 partials.setdefault(decl.fqn, []).append(path)
     return namespaces, types, partials
+
+
+# ---------------------------------------------------------------------------
+# VB.NET
+# ---------------------------------------------------------------------------
+
+# VB.NET identifiers are Unicode: whole estates are written in Chinese or
+# Cyrillic, so an ASCII-only start character silently drops their types.
+_VB_IDENT = r"[^\W\d]\w*"
+
+# The ``Global.`` prefix is kept in the captured name, not stripped: it is the
+# only thing that says a namespace escapes the project's <RootNamespace>.
+_VB_NAMESPACE_RE = re.compile(
+    r"^Namespace\s+(Global\.)?([^\W\d][\w.]*)", re.IGNORECASE
+)
+_VB_GLOBAL_PREFIX = "Global."
+_VB_END_NAMESPACE_RE = re.compile(r"^End\s+Namespace\b", re.IGNORECASE)
+_VB_MODIFIERS = (
+    r"Public|Private|Protected|Friend|Partial|MustInherit|NotInheritable|"
+    r"Shadows|Overloads|Default|Shared"
+)
+_VB_TYPE_DECL_RE = re.compile(
+    rf"^((?:(?:{_VB_MODIFIERS})\s+)*)"
+    rf"(?:Class|Module|Structure|Interface|Enum)\s+({_VB_IDENT})",
+    re.IGNORECASE,
+)
+
+
+def scan_vb_declarations(vb_text: str) -> tuple[list[str], list[TypeDecl]]:
+    """Return ``(namespaces, declarations)`` for one VB.NET file.
+
+    Nested ``Namespace`` blocks concatenate the way the compiler joins them,
+    so the stack is tracked against ``End Namespace`` rather than braces. Names
+    are as written, still carrying a ``Global.`` prefix where the source used
+    one; ``vb_namespace_key`` turns one into the key it resolves under.
+    """
+    stack: list[str] = []
+    namespaces: list[str] = []
+    decls: list[TypeDecl] = []
+    for raw in vb_text.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("'"):
+            continue
+        if _VB_END_NAMESPACE_RE.match(line):
+            if stack:
+                stack.pop()
+            continue
+        ns_match = _VB_NAMESPACE_RE.match(line)
+        if ns_match:
+            # Normalise the prefix's casing so the key rule can test it exactly.
+            prefix = _VB_GLOBAL_PREFIX if ns_match.group(1) else ""
+            stack.append(prefix + ns_match.group(2))
+            namespaces.append(".".join(stack))
+            continue
+        type_match = _VB_TYPE_DECL_RE.match(line)
+        if type_match:
+            name = type_match.group(2)
+            is_partial = "partial" in type_match.group(1).lower().split()
+            decls.append(TypeDecl(name, name, ".".join(stack), is_partial))
+    return namespaces, decls
+
+
+def build_vb_namespace_map(
+    vb_files: list[Path],
+    *,
+    texts: dict[Path, str],
+    root_namespaces: dict[Path, str] | None = None,
+) -> tuple[dict[str, list[Path]], dict[str, list[Path]], dict[str, list[Path]]]:
+    """Return ``(namespace_map, type_map, partial_map)`` for the VB.NET files.
+
+    *root_namespaces* maps a file to its project's ``<RootNamespace>``. Every
+    key goes through ``vb_namespace_key``, so a namespace-less file lands in
+    the root and a declared one lands under the root unless the source opted
+    out with ``Namespace Global.X``. The partial map is keyed by the resulting
+    fully-qualified name, matching the C# map it is merged into.
+    """
+    namespaces: dict[str, list[Path]] = {}
+    types: dict[str, list[Path]] = {}
+    partials: dict[str, list[Path]] = {}
+    for path in vb_files:
+        text = texts.get(path)
+        if text is None:
+            continue
+        declared, decls = scan_vb_declarations(text)
+        root = (root_namespaces or {}).get(path, "")
+        keys = {vb_namespace_key(ns, root) for ns in declared}
+        if root and not declared:
+            keys.add(root)
+        for key in keys - {""}:
+            namespaces.setdefault(key, []).append(path)
+        for name in {d.name for d in decls}:
+            types.setdefault(name, []).append(path)
+        for fqn in {_vb_fqn(d, root) for d in decls if d.is_partial}:
+            partials.setdefault(fqn, []).append(path)
+    return namespaces, types, partials
+
+
+def vb_namespace_key(namespace: str, root: str) -> str:
+    """The key *namespace* resolves under, given its project's *root*.
+
+    ``Namespace Global.X`` opts out of the root namespace and is reachable as
+    ``X``; a plain ``Namespace X`` in a project rooted at ``R`` is only ever
+    reachable as ``R.X``, never as a bare ``X``.
+    """
+    if namespace.startswith(_VB_GLOBAL_PREFIX):
+        return namespace[len(_VB_GLOBAL_PREFIX) :]
+    if not namespace:
+        return root
+    return f"{root}.{namespace}" if root else namespace
+
+
+def _vb_fqn(decl: TypeDecl, root: str) -> str:
+    """Fully-qualified name of a VB declaration, under its namespace key."""
+    namespace = vb_namespace_key(decl.namespace, root)
+    return f"{namespace}.{decl.name}" if namespace else decl.name

--- a/packages/core/src/repowise/core/ingestion/resolvers/dotnet/solution.py
+++ b/packages/core/src/repowise/core/ingestion/resolvers/dotnet/solution.py
@@ -5,7 +5,7 @@ The .sln format is line-oriented and not XML. Each project is declared as::
     Project("{<type-guid>}") = "Name", "relative\\path\\Name.csproj", "{<proj-guid>}"
 
 Solution folders use a different type GUID and are skipped — repowise only
-cares about real project entries that point to a .csproj on disk.
+cares about real project entries that point to a .csproj or .vbproj on disk.
 """
 
 from __future__ import annotations
@@ -36,12 +36,12 @@ _FOLDER_TYPE_GUID = "2150E333-8FDC-42A3-9474-1A3956D46DE8"
 @dataclass(frozen=True)
 class SolutionEntry:
     name: str
-    csproj: Path  # absolute
+    csproj: Path  # absolute path to the .csproj or .vbproj
     project_guid: str
 
 
 def parse_sln(sln_path: Path) -> list[SolutionEntry]:
-    """Return one SolutionEntry per .csproj declared in *sln_path*."""
+    """Return one SolutionEntry per project declared in *sln_path*."""
     try:
         text = sln_path.read_text(encoding="utf-8-sig", errors="replace")
     except OSError as exc:
@@ -54,7 +54,7 @@ def parse_sln(sln_path: Path) -> list[SolutionEntry]:
         type_guid, name, rel_path, proj_guid = match.groups()
         if type_guid.upper() == _FOLDER_TYPE_GUID:
             continue
-        if not rel_path.lower().endswith(".csproj"):
+        if not rel_path.lower().endswith((".csproj", ".vbproj")):
             continue
         csproj = (sln_dir / rel_path.replace("\\", "/")).resolve()
         out.append(SolutionEntry(name=name, csproj=csproj, project_guid=proj_guid))

--- a/packages/core/src/repowise/core/ingestion/resolvers/vbnet.py
+++ b/packages/core/src/repowise/core/ingestion/resolvers/vbnet.py
@@ -1,0 +1,41 @@
+"""VB.NET import resolution.
+
+``Imports`` directives name namespaces (rarely a dotted type). Resolution:
+
+1. Stem match on the last segment (``Imports MyApp.Models`` → the file whose
+   namespace/class-stem matches, or whose *path* suffix matches the dotted
+   tail), mirroring the C# legacy stem resolver — the shape that works for
+   repos with and without .vbproj files.
+2. Path-suffix match on the dotted form (``MyApp.Models`` → any ``.vb``
+   whose path ends ``/MyApp/Models.vb``).
+3. Otherwise register a generic external node so the reference stays visible
+   in the graph (System.* and other BCL namespaces land here).
+"""
+
+from __future__ import annotations
+
+from .context import ResolverContext
+
+
+def _legacy_stem_resolve(module_path: str, ctx: ResolverContext) -> str | None:
+    parts = module_path.split(".")
+    local = parts[-1]
+    result = ctx.stem_lookup(local.lower())
+    if result and result.endswith(".vb"):
+        return result
+    if len(parts) > 1:
+        dir_suffix = "/".join(parts)
+        for p in ctx.sorted_paths:
+            if p.endswith(".vb") and dir_suffix.lower() in p.lower():
+                return p
+    return None
+
+
+def resolve_vbnet_import(
+    module_path: str, importer_path: str, ctx: ResolverContext
+) -> str | None:
+    """Resolve a VB.NET ``Imports`` namespace to a repo-relative file path or external key."""
+    legacy = _legacy_stem_resolve(module_path, ctx)
+    if legacy:
+        return legacy
+    return ctx.add_external_node(module_path)

--- a/packages/core/src/repowise/core/ingestion/resolvers/vbnet.py
+++ b/packages/core/src/repowise/core/ingestion/resolvers/vbnet.py
@@ -1,23 +1,37 @@
 """VB.NET import resolution.
 
-``Imports`` directives name namespaces (rarely a dotted type). Resolution:
+``Imports`` directives name a namespace, or occasionally a type. Resolution
+runs through the same ``DotNetProjectIndex`` C# uses, so a .vbproj (or a
+mixed .sln) gives project-scoped answers:
 
-1. Stem match on the last segment (``Imports MyApp.Models`` → the file whose
-   namespace/class-stem matches, or whose *path* suffix matches the dotted
-   tail), mirroring the C# legacy stem resolver — the shape that works for
-   repos with and without .vbproj files.
-2. Path-suffix match on the dotted form (``MyApp.Models`` → any ``.vb``
-   whose path ends ``/MyApp/Models.vb``).
-3. Otherwise register a generic external node so the reference stays visible
-   in the graph (System.* and other BCL namespaces land here).
+1. Look the namespace up in the project index, ranked same project first,
+   then a directly-referenced project, then anywhere in the repo. VB.NET
+   namespaces are recorded under the project's ``<RootNamespace>`` as well
+   as their source-literal form.
+2. Fall back to the type map for the ``Imports MyApp.Models.Cart`` form,
+   which names a type rather than a namespace.
+3. If a ``<PackageReference>`` covers the namespace, register a NuGet node.
+4. Stem and dotted-path-suffix match, but only for a file no project owns:
+   that is all a loose collection of .vb files can offer, and inside a
+   project the namespace map has already answered authoritatively.
+5. Otherwise a generic external node so the reference stays visible in the
+   graph (System.* and other BCL namespaces land here).
 """
 
 from __future__ import annotations
 
 from .context import ResolverContext
+from .csharp import (
+    _matches_package_prefix,
+    _repo_root_resolved,
+    _resolve_importer,
+    _to_repo_relative,
+)
+from .dotnet import get_or_build_index
 
 
 def _legacy_stem_resolve(module_path: str, ctx: ResolverContext) -> str | None:
+    """Stem then dotted-path-suffix match, for repos with no project file."""
     parts = module_path.split(".")
     local = parts[-1]
     result = ctx.stem_lookup(local.lower())
@@ -34,8 +48,45 @@ def _legacy_stem_resolve(module_path: str, ctx: ResolverContext) -> str | None:
 def resolve_vbnet_import(
     module_path: str, importer_path: str, ctx: ResolverContext
 ) -> str | None:
-    """Resolve a VB.NET ``Imports`` namespace to a repo-relative file path or external key."""
+    """Resolve a VB.NET ``Imports`` target to a repo-relative path or external key."""
+    # ``Imports Global.MyApp.Data`` pins the lookup to the root of the
+    # namespace tree; the prefix is not part of the name.
+    if module_path.startswith("Global."):
+        module_path = module_path[len("Global.") :]
+
+    index = get_or_build_index(ctx)
+    if index is None or not ctx.repo_path:
+        legacy = _legacy_stem_resolve(module_path, ctx)
+        return legacy if legacy else ctx.add_external_node(module_path)
+
+    importer_abs = _resolve_importer(index, ctx.repo_path, importer_path)
+    importer_vbproj = index.file_to_project.get(importer_abs)
+    repo_root_resolved = _repo_root_resolved(index, ctx.repo_path)
+
+    ordered = index.rank_namespace_candidates(module_path, importer_vbproj)
+    if not ordered and "." in module_path:
+        # ``Imports MyApp.Models.Cart`` names a type. Only trust the type map
+        # when the repo also declares the enclosing namespace, or a BCL name
+        # like System.Text.Json would bind to any local class called Json.
+        parent_ns, type_name = module_path.rsplit(".", 1)
+        if parent_ns in index.namespace_map:
+            ordered = index.rank_type_candidates(type_name, importer_abs)
+    for cand in ordered:
+        rel = _to_repo_relative(cand, repo_root_resolved)
+        if rel and rel in ctx.path_set:
+            return rel
+
+    if importer_vbproj is not None:
+        pkgs = index.package_refs.get(importer_vbproj, set())
+        if _matches_package_prefix(module_path, pkgs):
+            return ctx.add_external_node(f"nuget:{module_path}")
+        # A file inside a known project has an authoritative answer already:
+        # the namespace map said no. Guessing by file stem past that turns a
+        # namespace another project cannot see into a wrong edge.
+        return ctx.add_external_node(module_path)
+
     legacy = _legacy_stem_resolve(module_path, ctx)
     if legacy:
         return legacy
+
     return ctx.add_external_node(module_path)

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -11,7 +11,7 @@ FastAPI REST API, webhook handlers, MCP server, and background job scheduler for
 | Component | Description |
 |-----------|-------------|
 | **REST API** | FastAPI application with full CRUD for repos, pages (with version history), symbols, jobs, git analytics, dead code, decisions, graph intelligence, blast radius, costs, knowledge map, security findings, providers, chat, CLAUDE.md generation, and multi-repo workspace |
-| **MCP Server** | 17 registered MCP tools (10 advertised by default in single-repo mode: the canonical set) for AI coding assistants (Claude Code, Cursor, Cline) |
+| **MCP Server** | 18 registered MCP tools (10 advertised by default in single-repo mode: the canonical set) for AI coding assistants (Claude Code, Cursor, Cline) |
 | **Webhooks** | GitHub and GitLab push event handlers — trigger sync jobs automatically on push |
 | **Scheduler** | APScheduler background jobs — polling fallback (auto-syncs diverged repos), stale page detection |
 

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -11,7 +11,7 @@ FastAPI REST API, webhook handlers, MCP server, and background job scheduler for
 | Component | Description |
 |-----------|-------------|
 | **REST API** | FastAPI application with full CRUD for repos, pages (with version history), symbols, jobs, git analytics, dead code, decisions, graph intelligence, blast radius, costs, knowledge map, security findings, providers, chat, CLAUDE.md generation, and multi-repo workspace |
-| **MCP Server** | 18 registered MCP tools (10 advertised by default in single-repo mode: the canonical set) for AI coding assistants (Claude Code, Cursor, Cline) |
+| **MCP Server** | 17 registered MCP tools (10 advertised by default in single-repo mode: the canonical set) for AI coding assistants (Claude Code, Cursor, Cline) |
 | **Webhooks** | GitHub and GitLab push event handlers — trigger sync jobs automatically on push |
 | **Scheduler** | APScheduler background jobs — polling fallback (auto-syncs diverged repos), stale page detection |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ dependencies = [
     "tree-sitter-luau>=1.2,<2",
     "tree-sitter-bash>=0.23,<1",
     "tree-sitter-gdscript>=6.1,<7",
+    "tree-sitter-vb-dotnet>=0.3,<1",
     # Markup grammars for single-file components: these locate <script> blocks
     # and markup expressions only; the JS inside them is parsed with the
     # TypeScript grammar (see sfc_source.py). There is no tree-sitter-vue on

--- a/tests/unit/dead_code/test_never_flag_regex.py
+++ b/tests/unit/dead_code/test_never_flag_regex.py
@@ -44,7 +44,15 @@ _PROBE_PATHS = [
     "app/error.tsx",
     "app/not-found.tsx",
     "ui/components/Button.qml",
+    "src/Forms/MainForm.Designer.vb",
+    "src/Forms/MainForm.designer.vb",
+    "src/My Project/Settings.Designer.vb",
+    "src/My Project/Resources.vb",
+    "src/Properties/AssemblyInfo.vb",
     # Negatives — close but should NOT match.
+    "src/Forms/MainForm.vb",
+    "src/DesignerHelper.vb",
+    "src/MyProject/Helper.vb",
     "src/pages.py",
     "core/router.py",
     "lib/pagination.tsx",
@@ -118,6 +126,28 @@ class TestShouldNeverFlag:
         # file never has a static importer to find.
         assert self._analyzer()._should_never_flag("ui/components/Button.qml", set())
         assert not self._analyzer()._should_never_flag("ui/components/button.js", set())
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "src/Forms/MainForm.Designer.vb",
+            "src/Forms/MainForm.designer.vb",
+            "src/Properties/AssemblyInfo.vb",
+            "src/My Project/Settings.Designer.vb",
+            "src/My Project/Resources.vb",
+        ],
+    )
+    def test_vbnet_generated_files_are_never_flagged(self, path):
+        """VB.NET's generated side-files have no static importer by design,
+        the same way the C# designer and AssemblyInfo files above do not."""
+        assert self._analyzer()._should_never_flag(path, set())
+
+    @pytest.mark.parametrize(
+        "path",
+        ["src/Forms/MainForm.vb", "src/DesignerHelper.vb", "src/MyProject/Helper.vb"],
+    )
+    def test_hand_written_vbnet_files_stay_flaggable(self, path):
+        assert not self._analyzer()._should_never_flag(path, set())
 
 
 class TestSuffixIndexEquivalence:

--- a/tests/unit/ingestion/parser/test_vbnet.py
+++ b/tests/unit/ingestion/parser/test_vbnet.py
@@ -1,11 +1,12 @@
 """Unit tests for the VB.NET language pipeline.
 
-Parses inline byte strings (no filesystem I/O). Covers symbols (class,
-module, structure, interface, enum, method, property), heritage (Inherits
-→ extends, Implements → implements), imports (Imports directives), and the
-real-world shapes the fixed fork handles: generics ``List(Of String)``, the
-``As New List(Of T)()`` object-initializer form, ByVal parameters, and
-own-line Inherits/Implements clauses.
+Parses inline byte strings (no filesystem I/O). Covers symbols (namespace,
+class, module, structure, interface, enum, method, property, field),
+heritage (Inherits to extends, Implements to implements), imports (Imports
+directives, plain and aliased), and the real-world shapes the fixed fork
+handles: generics ``List(Of String)``, the ``As New List(Of T)()``
+object-initializer form, ByVal parameters, and own-line Inherits/Implements
+clauses.
 
 Import *resolution* is covered separately in
 tests/unit/ingestion/test_vbnet_resolver.py, which needs no grammar.
@@ -13,7 +14,9 @@ tests/unit/ingestion/test_vbnet_resolver.py, which needs no grammar.
 
 from __future__ import annotations
 
-import pytest
+# Imported for its failure: the grammar is a hard dependency in
+# pyproject.toml, so a venv without it must go red rather than skip.
+import tree_sitter_vb_dotnet  # noqa: F401
 
 from repowise.core.ingestion.models import EXTENSION_TO_LANGUAGE
 from repowise.core.ingestion.parser import ASTParser
@@ -23,18 +26,11 @@ from tests.unit.ingestion.parser._helpers import _make_file_info
 def test_vb_extension_reaches_the_traversal_gate() -> None:
     """A .vb file must be recognized by the traverser, not just the AST
     parser. Both share the language registry, but EXTENSION_TO_LANGUAGE is
-    filtered through a static LanguageTag Literal at import time — a spec
+    filtered through a static LanguageTag Literal at import time, so a spec
     alone isn't enough. Regression: #1041 shipped without the tag, so .vb
     files scanned as unknown."""
     assert ".vb" in EXTENSION_TO_LANGUAGE
     assert EXTENSION_TO_LANGUAGE[".vb"] == "vbnet"
-
-# The grammar is a git dependency on the fixed fork; skip explicitly when a
-# partial venv lacks it so the failure mode is "run uv sync" not confusing
-# AssertionErrors.
-pytest.importorskip(
-    "tree_sitter_tree_sitter_vb_dotnet", reason="run `uv sync --all-packages`"
-)
 
 
 def _vb(path: str = "Models/Person.vb") -> object:
@@ -119,7 +115,7 @@ def test_heritage_extracted() -> None:
     }
     assert ("CustomerRepository", "RepositoryBase", "extends") in relations
     assert ("CustomerRepository", "ICustomerRepository", "implements") in relations
-    # IDisposable is a BCL interface in builtin_parents — filtered, like C#.
+    # IDisposable is a BCL interface in builtin_parents, so it is filtered.
     assert not any(r[1] == "IDisposable" for r in relations)
 
 
@@ -180,3 +176,62 @@ End Class
     )
     assert not result.parse_errors
     assert "OrderService" in {s.name for s in result.symbols}
+
+
+def test_fields_and_namespace_become_symbols() -> None:
+    """language_configs maps field_declaration and namespace_block, so the
+    query has to capture both; a class-level Private field is a symbol and
+    the namespace is the parent of the type inside it."""
+    parser = ASTParser()
+    source = b'''\
+Namespace MyApp.Data
+    Public Class Repo
+        Private _cache As Integer
+        Dim scratch As Long
+    End Class
+End Namespace
+'''
+    result = parser.parse_file(_vb("Data/Repo.vb"), source)
+    by_name = {s.name: s for s in result.symbols}
+    assert by_name["_cache"].kind == "variable"
+    assert by_name["_cache"].visibility == "private"
+    assert by_name["_cache"].parent_name == "Repo"
+    # Dim with no access modifier is Friend, which maps to internal.
+    assert by_name["scratch"].visibility == "internal"
+    assert by_name["MyApp.Data"].kind == "module"
+    assert by_name["Repo"].parent_name == "MyApp.Data"
+
+
+def test_aliased_import_records_the_target_namespace() -> None:
+    """Imports Gen = System.Collections.Generic is an edge to the namespace,
+    not to the alias; the grammar's namespace field is the target either way."""
+    parser = ASTParser()
+    source = b'''\
+Imports Gen = System.Collections.Generic
+Imports MyApp.Models
+
+Public Module Demo
+End Module
+'''
+    result = parser.parse_file(_vb("Demo.vb"), source)
+    modules = {i.module_path for i in result.imports}
+    assert "System.Collections.Generic" in modules
+    assert "MyApp.Models" in modules
+    assert "Gen" not in modules
+
+
+def test_bcl_base_classes_mint_no_heritage_edge() -> None:
+    """``Inherits Form`` is the WinForms base, not the repo's own Form. It sits
+    in builtin_parents so it is stripped, the way C# strips IDisposable."""
+    parser = ASTParser()
+    source = b'''\
+Public Class MainForm
+    Inherits Form
+    Implements INotifyPropertyChanged, IMyOwnContract
+End Class
+'''
+    result = parser.parse_file(_vb("Forms/MainForm.vb"), source)
+    parents = {r.parent_name for r in result.heritage}
+    assert "Form" not in parents
+    assert "INotifyPropertyChanged" not in parents
+    assert "IMyOwnContract" in parents

--- a/tests/unit/ingestion/parser/test_vbnet.py
+++ b/tests/unit/ingestion/parser/test_vbnet.py
@@ -1,0 +1,171 @@
+"""Unit tests for the VB.NET language pipeline.
+
+Parses inline byte strings (no filesystem I/O). Covers symbols (class,
+module, structure, interface, enum, method, property), heritage (Inherits
+→ extends, Implements → implements), imports (Imports directives), and the
+real-world shapes the fixed fork handles: generics ``List(Of String)``, the
+``As New List(Of T)()`` object-initializer form, ByVal parameters, and
+own-line Inherits/Implements clauses.
+
+Import *resolution* is covered separately in
+tests/unit/ingestion/test_vbnet_resolver.py, which needs no grammar.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from repowise.core.ingestion.parser import ASTParser
+from tests.unit.ingestion.parser._helpers import _make_file_info
+
+# The grammar is a git dependency on the fixed fork; skip explicitly when a
+# partial venv lacks it so the failure mode is "run uv sync" not confusing
+# AssertionErrors.
+pytest.importorskip(
+    "tree_sitter_tree_sitter_vb_dotnet", reason="run `uv sync --all-packages`"
+)
+
+
+def _vb(path: str = "Models/Person.vb") -> object:
+    return _make_file_info(path, "vbnet")
+
+
+SOURCE = b'''\
+Imports System
+Imports System.Collections.Generic
+Imports MyApp.Models
+
+Namespace MyApp.Data
+    Public Class CustomerRepository
+        Inherits RepositoryBase
+        Implements ICustomerRepository, IDisposable
+
+        Private ReadOnly _customers As New List(Of Customer)()
+
+        Public Sub Add(customer As Customer)
+            _customers.Add(customer)
+        End Sub
+
+        Public Function Count() As Integer
+            Return _customers.Count
+        End Function
+
+        Public Sub Dispose()
+            _customers.Clear()
+        End Sub
+    End Class
+
+    Public Interface ICustomerRepository
+        Sub Add(customer As Customer)
+        Function Count() As Integer
+    End Interface
+
+    Friend Module CustomerFactory
+        Public Function Create() As Customer
+            Return New Customer()
+        End Function
+    End Module
+
+    Public Structure Point
+        Public X As Integer
+        Public Y As Integer
+    End Structure
+
+    Public Enum CustomerStatus
+        Active
+        Inactive
+    End Enum
+End Namespace
+'''
+
+
+def test_symbols_extracted() -> None:
+    parser = ASTParser()
+    result = parser.parse_file(
+        _vb(),
+        SOURCE
+    )
+    names = {s.name for s in result.symbols}
+    assert "CustomerRepository" in names  # class
+    assert "ICustomerRepository" in names  # interface
+    assert "CustomerFactory" in names  # module
+    assert "Point" in names  # structure
+    assert "CustomerStatus" in names  # enum
+    assert "Add" in names  # method
+    assert "Count" in names  # function
+    assert "Dispose" in names  # method
+
+
+def test_heritage_extracted() -> None:
+    parser = ASTParser()
+    result = parser.parse_file(
+        _vb(),
+        SOURCE
+    )
+    relations = {
+        (r.child_name, r.parent_name, r.kind)
+        for r in result.heritage
+    }
+    assert ("CustomerRepository", "RepositoryBase", "extends") in relations
+    assert ("CustomerRepository", "ICustomerRepository", "implements") in relations
+    # IDisposable is a BCL interface in builtin_parents — filtered, like C#.
+    assert not any(r[1] == "IDisposable" for r in relations)
+
+
+def test_imports_extracted() -> None:
+    parser = ASTParser()
+    result = parser.parse_file(
+        _vb(),
+        SOURCE
+    )
+    modules = {i.module_path for i in result.imports}
+    assert "System" in modules
+    assert "System.Collections.Generic" in modules
+    assert "MyApp.Models" in modules
+
+
+def test_generics_parse_cleanly() -> None:
+    """The fixed fork handles List(Of String) everywhere it appears."""
+    parser = ASTParser()
+    source = b'''\
+Public Module Demo
+    Public Sub Process(ByVal items As List(Of String))
+        Dim first As String = items(0)
+    End Sub
+
+    Public Function Names() As List(Of String)
+        Return New List(Of String)()
+    End Function
+
+    Public Property Cache As New Dictionary(Of String, Integer)()
+End Module
+'''
+    result = parser.parse_file(
+        _vb("Demo.vb"),
+        source
+    )
+    # No ERROR nodes: generics in params, returns, Dim, As New, properties.
+    assert not result.parse_errors
+    names = {s.name for s in result.symbols}
+    assert "Process" in names
+    assert "Names" in names
+    assert "Cache" in names
+
+
+def test_constructor_param_types_feed_di_edges() -> None:
+    """As New Customer() constructs; ctor params are typed."""
+
+    parser = ASTParser()
+    source = b'''\
+Public Class OrderService
+    Public Sub New(repo As ICustomerRepository, logger As ILogger)
+        Me._repo = repo
+    End Sub
+End Class
+'''
+    result = parser.parse_file(
+        _vb("Services/OrderService.vb"),
+        source
+    )
+    assert not result.parse_errors
+    assert "OrderService" in {s.name for s in result.symbols}

--- a/tests/unit/ingestion/parser/test_vbnet.py
+++ b/tests/unit/ingestion/parser/test_vbnet.py
@@ -15,8 +15,19 @@ from __future__ import annotations
 
 import pytest
 
+from repowise.core.ingestion.models import EXTENSION_TO_LANGUAGE
 from repowise.core.ingestion.parser import ASTParser
 from tests.unit.ingestion.parser._helpers import _make_file_info
+
+
+def test_vb_extension_reaches_the_traversal_gate() -> None:
+    """A .vb file must be recognized by the traverser, not just the AST
+    parser. Both share the language registry, but EXTENSION_TO_LANGUAGE is
+    filtered through a static LanguageTag Literal at import time — a spec
+    alone isn't enough. Regression: #1041 shipped without the tag, so .vb
+    files scanned as unknown."""
+    assert ".vb" in EXTENSION_TO_LANGUAGE
+    assert EXTENSION_TO_LANGUAGE[".vb"] == "vbnet"
 
 # The grammar is a git dependency on the fixed fork; skip explicitly when a
 # partial venv lacks it so the failure mode is "run uv sync" not confusing

--- a/tests/unit/ingestion/test_language_capabilities.py
+++ b/tests/unit/ingestion/test_language_capabilities.py
@@ -163,8 +163,8 @@ _FULL = {
     # vue components project to TypeScript through the same SFC pass as
     # svelte, so their <script> imports are ordinary ESM.
     "vue",
-    # vbnet through the fixed tree-sitter-vb-dotnet fork (generics, As New,
-    # own-line Inherits/Implements) with the namespace stem resolver.
+    # vbnet resolves Imports through the same DotNetProjectIndex as csharp:
+    # .vbproj / .sln parsing and a RootNamespace-aware namespace map.
     "vbnet",
 }
 _PARTIAL = {

--- a/tests/unit/ingestion/test_language_capabilities.py
+++ b/tests/unit/ingestion/test_language_capabilities.py
@@ -101,7 +101,7 @@ class TestParityGoldens:
         camel = REGISTRY.camel_test_res_by_extension()
         assert set(camel) == {
             ".java", ".kt", ".kts", ".scala", ".cs", ".swift", ".php",
-            ".hs", ".lhs",
+            ".hs", ".lhs", ".vb",
         }
         assert camel[".java"].pattern == r"(?<=[a-z0-9])(?:Tests|Test|IT)$"
         assert camel[".scala"].pattern == r"(?<=[a-z0-9])(?:Suite|Spec|Test)$"
@@ -163,6 +163,9 @@ _FULL = {
     # vue components project to TypeScript through the same SFC pass as
     # svelte, so their <script> imports are ordinary ESM.
     "vue",
+    # vbnet through the fixed tree-sitter-vb-dotnet fork (generics, As New,
+    # own-line Inherits/Implements) with the namespace stem resolver.
+    "vbnet",
 }
 _PARTIAL = {
     "luau",

--- a/tests/unit/ingestion/test_vbnet_resolver.py
+++ b/tests/unit/ingestion/test_vbnet_resolver.py
@@ -1,0 +1,86 @@
+"""Unit tests for the VB.NET import resolver.
+
+``Imports`` directives name namespaces. Resolution is stem-first (the last
+segment, matching the class/module file), then dotted path-suffix; a miss
+registers an external node (System.* lands there). These tests build small
+repos on disk via ``tmp_path``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import networkx as nx
+import pytest
+
+from repowise.core.ingestion.resolvers.context import ResolverContext
+from repowise.core.ingestion.resolvers.vbnet import resolve_vbnet_import
+
+
+def _ctx_for(repo: Path) -> ResolverContext:
+    """Build a ResolverContext rooted at *repo* with all .vb files indexed."""
+    vb_files = [str(p.relative_to(repo)) for p in repo.rglob("*.vb")]
+    stem_map: dict[str, list[str]] = {}
+    for p in vb_files:
+        stem = p.rsplit("/", 1)[-1][:-3].lower()
+        stem_map.setdefault(stem, []).append(p)
+    ctx = ResolverContext(
+        path_set=frozenset(vb_files),
+        stem_map=stem_map,
+        graph=nx.MultiDiGraph(),
+        repo_path=repo.resolve(),
+    )
+    return ctx
+
+
+def _write(repo: Path, rel: str, text: str) -> None:
+    p = repo / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(text)
+
+
+def test_resolves_local_namespace_to_class_file(tmp_path: Path) -> None:
+    """Imports MyApp.Models → MyApp/Models/Customer.vb declares namespace."""
+    _write(
+        tmp_path,
+        "MyApp/Models/Customer.vb",
+        "Namespace MyApp.Models\n    Public Class Customer\n    End Class\nEnd Namespace",
+    )
+    ctx = _ctx_for(tmp_path)
+    resolved = resolve_vbnet_import("MyApp.Models", "MyApp/Data/Repo.vb", ctx)
+    assert resolved == "MyApp/Models/Customer.vb"
+
+
+def test_stem_match_picks_up_type_import(tmp_path: Path) -> None:
+    """Imports MyApp.Models.Cart → Cart.vb (last dotted segment = class stem)."""
+    _write(
+        tmp_path,
+        "MyApp/Models/Cart.vb",
+        "Namespace MyApp.Models\n    Public Class Cart\n    End Class\nEnd Namespace",
+    )
+    ctx = _ctx_for(tmp_path)
+    resolved = resolve_vbnet_import("MyApp.Models.Cart", "MyApp/Data/Repo.vb", ctx)
+    assert resolved == "MyApp/Models/Cart.vb"
+
+
+def test_dotted_path_suffix_fallback(tmp_path: Path) -> None:
+    """Namespace dir chain matches the dotted path suffix when files are
+    laid out under the root namespace (the standard SDK-style layout)."""
+    _write(
+        tmp_path,
+        "Acme/Services/Impl.vb",
+        "Namespace Acme.Services\n    Public Class Impl\n    End Class\nEnd Namespace",
+    )
+    ctx = _ctx_for(tmp_path)
+    resolved = resolve_vbnet_import("Acme.Services", "Acme/Program.vb", ctx)
+    # stem "impl" ≠ "services", but the acme/services dir chain matches
+    assert resolved == "Acme/Services/Impl.vb"
+
+
+def test_system_namespace_registers_external(tmp_path: Path) -> None:
+    """System.Collections.Generic has no repo file → external node key."""
+    _write(tmp_path, "Data/Repo.vb", "Namespace Data\n    Public Class Repo\n    End Class\nEnd Namespace")
+    ctx = _ctx_for(tmp_path)
+    resolved = resolve_vbnet_import("System.Collections.Generic", "Data/Repo.vb", ctx)
+    assert resolved == "external:System.Collections.Generic"
+    assert "external:System.Collections.Generic" in str(list(ctx.graph.nodes))

--- a/tests/unit/ingestion/test_vbnet_resolver.py
+++ b/tests/unit/ingestion/test_vbnet_resolver.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 from pathlib import Path
 
 import networkx as nx
-import pytest
 
 from repowise.core.ingestion.resolvers.context import ResolverContext
 from repowise.core.ingestion.resolvers.vbnet import resolve_vbnet_import

--- a/tests/unit/ingestion/test_vbnet_resolver.py
+++ b/tests/unit/ingestion/test_vbnet_resolver.py
@@ -1,9 +1,10 @@
 """Unit tests for the VB.NET import resolver.
 
-``Imports`` directives name namespaces. Resolution is stem-first (the last
-segment, matching the class/module file), then dotted path-suffix; a miss
-registers an external node (System.* lands there). These tests build small
-repos on disk via ``tmp_path``.
+``Imports`` directives name namespaces. Resolution goes through the shared
+DotNetProjectIndex: namespace map first (RootNamespace aware, ranked by
+project), then the type map, then a stem / dotted-path-suffix fallback for
+repos with no .vbproj; a miss registers an external node (System.* lands
+there). These tests build small repos on disk via ``tmp_path``.
 """
 
 from __future__ import annotations
@@ -18,7 +19,9 @@ from repowise.core.ingestion.resolvers.vbnet import resolve_vbnet_import
 
 def _ctx_for(repo: Path) -> ResolverContext:
     """Build a ResolverContext rooted at *repo* with all .vb files indexed."""
-    vb_files = [str(p.relative_to(repo)) for p in repo.rglob("*.vb")]
+    # Posix separators: that is what the traverser puts in ``path_set``, so a
+    # Windows-native string would never match a resolved candidate.
+    vb_files = [p.relative_to(repo).as_posix() for p in repo.rglob("*.vb")]
     stem_map: dict[str, list[str]] = {}
     for p in vb_files:
         stem = p.rsplit("/", 1)[-1][:-3].lower()
@@ -50,8 +53,8 @@ def test_resolves_local_namespace_to_class_file(tmp_path: Path) -> None:
     assert resolved == "MyApp/Models/Customer.vb"
 
 
-def test_stem_match_picks_up_type_import(tmp_path: Path) -> None:
-    """Imports MyApp.Models.Cart → Cart.vb (last dotted segment = class stem)."""
+def test_type_import_resolves_via_type_map(tmp_path: Path) -> None:
+    """Imports MyApp.Models.Cart names a type, not a namespace."""
     _write(
         tmp_path,
         "MyApp/Models/Cart.vb",
@@ -83,3 +86,117 @@ def test_system_namespace_registers_external(tmp_path: Path) -> None:
     resolved = resolve_vbnet_import("System.Collections.Generic", "Data/Repo.vb", ctx)
     assert resolved == "external:System.Collections.Generic"
     assert "external:System.Collections.Generic" in str(list(ctx.graph.nodes))
+
+
+_VBPROJ = """<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <RootNamespace>{root}</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+{items}  </ItemGroup>
+</Project>
+"""
+
+
+def _vbproj(root: str, *, refs: tuple[str, ...] = (), packages: tuple[str, ...] = ()) -> str:
+    items = "".join(f'    <ProjectReference Include="{r}" />\n' for r in refs)
+    items += "".join(f'    <PackageReference Include="{p}" />\n' for p in packages)
+    return _VBPROJ.format(root=root, items=items)
+
+
+def test_root_namespace_prefixes_declared_namespace(tmp_path: Path) -> None:
+    """<RootNamespace>Acme</RootNamespace> plus ``Namespace Data`` is Acme.Data."""
+    _write(tmp_path, "Core/Core.vbproj", _vbproj("Acme"))
+    _write(
+        tmp_path,
+        "Core/Data/Repo.vb",
+        "Namespace Data\n    Public Class Repo\n    End Class\nEnd Namespace",
+    )
+    _write(tmp_path, "Core/Program.vb", "Public Module Program\nEnd Module")
+    ctx = _ctx_for(tmp_path)
+    assert resolve_vbnet_import("Acme.Data", "Core/Program.vb", ctx) == "Core/Data/Repo.vb"
+
+
+def test_namespace_less_file_lands_in_root_namespace(tmp_path: Path) -> None:
+    """A .vb file with no Namespace block belongs to the project's root."""
+    _write(tmp_path, "Core/Core.vbproj", _vbproj("Acme"))
+    _write(tmp_path, "Core/Widget.vb", "Public Class Widget\nEnd Class")
+    _write(tmp_path, "App/App.vbproj", _vbproj("App"))
+    _write(tmp_path, "App/Program.vb", "Public Module Program\nEnd Module")
+    ctx = _ctx_for(tmp_path)
+    assert resolve_vbnet_import("Acme", "App/Program.vb", ctx) == "Core/Widget.vb"
+
+
+def test_same_project_wins_over_a_referenced_one(tmp_path: Path) -> None:
+    """Two projects under one root namespace both declare Acme.Shared.Models,
+    so the key really is ambiguous and project rank is what decides it."""
+    _write(tmp_path, "Lib/Lib.vbproj", _vbproj("Acme"))
+    _write(
+        tmp_path,
+        "Lib/Models.vb",
+        "Namespace Shared.Models\n    Public Class Far\n    End Class\nEnd Namespace",
+    )
+    _write(tmp_path, "App/App.vbproj", _vbproj("Acme", refs=("../Lib/Lib.vbproj",)))
+    _write(
+        tmp_path,
+        "App/Models.vb",
+        "Namespace Shared.Models\n    Public Class Near\n    End Class\nEnd Namespace",
+    )
+    _write(tmp_path, "App/Program.vb", "Public Module Program\nEnd Module")
+    ctx = _ctx_for(tmp_path)
+    resolved = resolve_vbnet_import("Acme.Shared.Models", "App/Program.vb", ctx)
+    assert resolved == "App/Models.vb"
+
+
+def test_declared_namespace_is_not_reachable_without_the_root(tmp_path: Path) -> None:
+    """``Namespace Shared.Models`` inside RootNamespace Lib is only reachable
+    as ``Lib.Shared.Models``. An unrelated project importing the bare name
+    must get no edge rather than a wrong one."""
+    _write(tmp_path, "Lib/Lib.vbproj", _vbproj("Lib"))
+    _write(
+        tmp_path,
+        "Lib/Models.vb",
+        "Namespace Shared.Models\n    Public Class Far\n    End Class\nEnd Namespace",
+    )
+    _write(tmp_path, "App/App.vbproj", _vbproj("App"))
+    _write(tmp_path, "App/Program.vb", "Public Module Program\nEnd Module")
+    ctx = _ctx_for(tmp_path)
+    resolved = resolve_vbnet_import("Shared.Models", "App/Program.vb", ctx)
+    assert resolved == "external:Shared.Models"
+    assert resolve_vbnet_import("Lib.Shared.Models", "App/Program.vb", ctx) == "Lib/Models.vb"
+
+
+def test_global_namespace_declaration_escapes_the_root(tmp_path: Path) -> None:
+    """``Namespace Global.Shared.Models`` opts out of RootNamespace, so the
+    bare name is the one that resolves and the prefixed one does not."""
+    _write(tmp_path, "Lib/Lib.vbproj", _vbproj("Lib"))
+    _write(
+        tmp_path,
+        "Lib/Models.vb",
+        "Namespace Global.Shared.Models\n    Public Class Far\n    End Class\nEnd Namespace",
+    )
+    _write(tmp_path, "App/App.vbproj", _vbproj("App"))
+    _write(tmp_path, "App/Program.vb", "Public Module Program\nEnd Module")
+    ctx = _ctx_for(tmp_path)
+    assert resolve_vbnet_import("Shared.Models", "App/Program.vb", ctx) == "Lib/Models.vb"
+
+
+def test_package_reference_becomes_a_nuget_node(tmp_path: Path) -> None:
+    """An Imports covered by a PackageReference is external NuGet, not a miss."""
+    _write(tmp_path, "App/App.vbproj", _vbproj("App", packages=("Newtonsoft.Json",)))
+    _write(tmp_path, "App/Program.vb", "Public Module Program\nEnd Module")
+    ctx = _ctx_for(tmp_path)
+    resolved = resolve_vbnet_import("Newtonsoft.Json.Linq", "App/Program.vb", ctx)
+    assert resolved == "external:nuget:Newtonsoft.Json.Linq"
+
+
+def test_global_prefix_is_stripped(tmp_path: Path) -> None:
+    """Imports Global.MyApp.Models is the same target as Imports MyApp.Models."""
+    _write(
+        tmp_path,
+        "MyApp/Models/Customer.vb",
+        "Namespace MyApp.Models\n    Public Class Customer\n    End Class\nEnd Namespace",
+    )
+    ctx = _ctx_for(tmp_path)
+    resolved = resolve_vbnet_import("Global.MyApp.Models", "MyApp/Data/Repo.vb", ctx)
+    assert resolved == "MyApp/Models/Customer.vb"

--- a/tests/unit/ingestion/test_vbnet_same_namespace.py
+++ b/tests/unit/ingestion/test_vbnet_same_namespace.py
@@ -1,0 +1,280 @@
+"""Unit tests for VB.NET same-namespace edges and partial-class co-fragments.
+
+Mirrors tests/unit/ingestion/test_csharp_same_namespace.py. The VB-specific
+cases are the ones C# has no equivalent of: a file that declares no namespace
+at all and belongs to its project's ``<RootNamespace>``, and the
+Form.vb / Form.Designer.vb ``Partial Class`` split.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import networkx as nx
+
+from repowise.core.ingestion import ASTParser, FileTraverser, GraphBuilder
+from repowise.core.ingestion.languages.vbnet_same_namespace import (
+    resolve_vbnet_same_namespace_refs,
+)
+
+
+def _graph_for(texts: dict[str, str]) -> nx.DiGraph:
+    g = nx.DiGraph()
+    for p in texts:
+        g.add_node(p, node_type="file")
+    return g
+
+
+def _build(repo: Path) -> nx.DiGraph:
+    traverser = FileTraverser(repo)
+    parser = ASTParser()
+    builder = GraphBuilder(repo_path=repo)
+    for fi in traverser.traverse():
+        builder.add_file(parser.parse_file(fi, Path(fi.abs_path).read_bytes()))
+    return builder.build()
+
+
+def _write(repo: Path, files: dict[str, str]) -> Path:
+    for rel, text in files.items():
+        full = repo / rel
+        full.parent.mkdir(parents=True, exist_ok=True)
+        full.write_text(text)
+    return repo
+
+
+class TestSameNamespace:
+    def test_sibling_type_reference_produces_edge(self) -> None:
+        texts = {
+            "src/Core/Order.vb": (
+                "Namespace Acme.Core\n    Public Class Order\n"
+                "    End Class\nEnd Namespace\n"
+            ),
+            "src/Core/OrderService.vb": (
+                "Namespace Acme.Core\n    Public Class OrderService\n"
+                "        Private _pending As Order\n    End Class\nEnd Namespace\n"
+            ),
+        }
+        g = _graph_for(texts)
+        added = resolve_vbnet_same_namespace_refs(g, None, texts, None)
+        assert added == 1
+        edge = g["src/Core/OrderService.vb"]["src/Core/Order.vb"]
+        assert edge["edge_type"] == "imports"
+        assert edge["hint_source"] == "same_namespace"
+        assert edge["imported_names"] == ["Order"]
+
+    def test_cross_namespace_name_produces_no_edge(self) -> None:
+        texts = {
+            "src/Core/Widget.vb": (
+                "Namespace Acme.Core\n    Public Class Widget\n"
+                "    End Class\nEnd Namespace\n"
+            ),
+            "src/Web/Page1.vb": (
+                "Namespace Acme.Web\n    Public Class Page1\n"
+                "        Private w As Widget\n    End Class\nEnd Namespace\n"
+            ),
+        }
+        g = _graph_for(texts)
+        assert resolve_vbnet_same_namespace_refs(g, None, texts, None) == 0
+
+    def test_ambiguous_type_produces_no_edge(self) -> None:
+        texts = {
+            "src/A/Thing.vb": (
+                "Namespace Acme\n    Public Class Thing\n    End Class\nEnd Namespace\n"
+            ),
+            "src/B/Thing.vb": (
+                "Namespace Acme\n    Public Class Thing\n    End Class\nEnd Namespace\n"
+            ),
+            "src/User.vb": (
+                "Namespace Acme\n    Public Class User\n"
+                "        Private t As Thing\n    End Class\nEnd Namespace\n"
+            ),
+        }
+        g = _graph_for(texts)
+        assert resolve_vbnet_same_namespace_refs(g, None, texts, None) == 0
+
+    def test_bcl_name_produces_no_edge(self) -> None:
+        texts = {
+            "src/Task1.vb": (
+                "Namespace Acme\n    Public Class Task\n    End Class\nEnd Namespace\n"
+            ),
+            "src/Runner.vb": (
+                "Namespace Acme\n    Public Class Runner\n"
+                "        Private T As Task\n    End Class\nEnd Namespace\n"
+            ),
+        }
+        g = _graph_for(texts)
+        assert resolve_vbnet_same_namespace_refs(g, None, texts, None) == 0
+
+    def test_imports_alias_shadows(self) -> None:
+        texts = {
+            "src/Helper.vb": (
+                "Namespace Acme\n    Public Class Helper\n    End Class\nEnd Namespace\n"
+            ),
+            "src/Consumer.vb": (
+                "Imports Helper = Other.Place.Helper\n"
+                "Namespace Acme\n    Public Class Consumer\n"
+                "        Private h As Helper\n    End Class\nEnd Namespace\n"
+            ),
+        }
+        g = _graph_for(texts)
+        assert resolve_vbnet_same_namespace_refs(g, None, texts, None) == 0
+
+    def test_existing_edge_wins(self) -> None:
+        texts = {
+            "src/Order.vb": (
+                "Namespace Acme\n    Public Class Order\n    End Class\nEnd Namespace\n"
+            ),
+            "src/Svc.vb": (
+                "Namespace Acme\n    Public Class Svc\n"
+                "        Private o As Order\n    End Class\nEnd Namespace\n"
+            ),
+        }
+        g = _graph_for(texts)
+        g.add_edge("src/Svc.vb", "src/Order.vb", edge_type="imports", confidence=1.0)
+        assert resolve_vbnet_same_namespace_refs(g, None, texts, None) == 0
+        assert "hint_source" not in g["src/Svc.vb"]["src/Order.vb"]
+
+
+class TestRootNamespace:
+    def test_namespace_less_siblings_link_through_the_root(self, tmp_path: Path) -> None:
+        # The dominant VB shape: neither file writes a Namespace line, both
+        # sit in <RootNamespace> and reference each other with no Imports.
+        repo = _write(
+            tmp_path,
+            {
+                "App/App.vbproj": (
+                    '<Project Sdk="Microsoft.NET.Sdk">\n  <PropertyGroup>\n'
+                    "    <RootNamespace>Acme</RootNamespace>\n"
+                    "  </PropertyGroup>\n</Project>\n"
+                ),
+                "App/Repository.vb": "Public Class Repository\nEnd Class\n",
+                "App/Program.vb": (
+                    "Public Module Program\n"
+                    "    Public Sub Main()\n"
+                    "        Dim r As New Repository()\n"
+                    "    End Sub\n"
+                    "End Module\n"
+                ),
+            },
+        )
+        g = _build(repo)
+        edge = g.get_edge_data("App/Program.vb", "App/Repository.vb")
+        assert edge is not None
+        assert edge.get("hint_source") == "same_namespace"
+
+    def test_separate_root_namespaces_do_not_link(self, tmp_path: Path) -> None:
+        repo = _write(
+            tmp_path,
+            {
+                "Lib/Lib.vbproj": (
+                    '<Project Sdk="Microsoft.NET.Sdk">\n  <PropertyGroup>\n'
+                    "    <RootNamespace>Lib</RootNamespace>\n"
+                    "  </PropertyGroup>\n</Project>\n"
+                ),
+                "Lib/Repository.vb": "Public Class Repository\nEnd Class\n",
+                "App/App.vbproj": (
+                    '<Project Sdk="Microsoft.NET.Sdk">\n  <PropertyGroup>\n'
+                    "    <RootNamespace>App</RootNamespace>\n"
+                    "  </PropertyGroup>\n</Project>\n"
+                ),
+                "App/Program.vb": (
+                    "Public Module Program\n"
+                    "    Public Sub Main()\n"
+                    "        Dim r As New Repository()\n"
+                    "    End Sub\n"
+                    "End Module\n"
+                ),
+            },
+        )
+        g = _build(repo)
+        edge = g.get_edge_data("App/Program.vb", "Lib/Repository.vb")
+        assert edge is None or edge.get("hint_source") != "same_namespace"
+
+
+class TestPartialClasses:
+    def test_designer_split_links_both_ways(self, tmp_path: Path) -> None:
+        # The WinForms shape: MainForm.vb and MainForm.Designer.vb are two
+        # fragments of one Partial Class and must not read as disconnected.
+        repo = _write(
+            tmp_path,
+            {
+                "App/App.vbproj": (
+                    '<Project Sdk="Microsoft.NET.Sdk">\n  <PropertyGroup>\n'
+                    "    <RootNamespace>Acme</RootNamespace>\n"
+                    "  </PropertyGroup>\n</Project>\n"
+                ),
+                "App/MainForm.vb": (
+                    "Partial Public Class MainForm\n"
+                    "    Public Sub Load()\n    End Sub\n"
+                    "End Class\n"
+                ),
+                "App/MainForm.Designer.vb": (
+                    "Partial Class MainForm\n"
+                    "    Private components As Object\n"
+                    "End Class\n"
+                ),
+            },
+        )
+        g = _build(repo)
+        forward = g.get_edge_data("App/MainForm.vb", "App/MainForm.Designer.vb")
+        back = g.get_edge_data("App/MainForm.Designer.vb", "App/MainForm.vb")
+        assert forward is not None and forward.get("hint_source") == "partial_class"
+        assert back is not None and back.get("hint_source") == "partial_class"
+
+    def test_non_partial_same_name_types_are_not_linked(self, tmp_path: Path) -> None:
+        repo = _write(
+            tmp_path,
+            {
+                "App/App.vbproj": (
+                    '<Project Sdk="Microsoft.NET.Sdk">\n  <PropertyGroup>\n'
+                    "    <RootNamespace>Acme</RootNamespace>\n"
+                    "  </PropertyGroup>\n</Project>\n"
+                ),
+                "App/A/Helper.vb": (
+                    "Namespace A\n    Public Class Helper\n    End Class\nEnd Namespace\n"
+                ),
+                "App/B/Helper.vb": (
+                    "Namespace B\n    Public Class Helper\n    End Class\nEnd Namespace\n"
+                ),
+            },
+        )
+        g = _build(repo)
+        edge = g.get_edge_data("App/A/Helper.vb", "App/B/Helper.vb")
+        assert edge is None or edge.get("hint_source") != "partial_class"
+
+
+class TestUnicodeIdentifiers:
+    def test_non_latin_type_names_link(self) -> None:
+        """VB.NET identifiers are Unicode and whole estates are written in
+        Chinese, where the shared capitalised-ASCII scan matches nothing."""
+        texts = {
+            "src/\u754c\u9762\u914d\u8272.vb": (
+                "Namespace \u529f\u80fd\n"
+                "    Public Class \u754c\u9762\u914d\u8272_v6\n"
+                "    End Class\nEnd Namespace\n"
+            ),
+            "src/\u9ad8\u4eae\u5668.vb": (
+                "Namespace \u529f\u80fd\n"
+                "    Public Class \u9ad8\u4eae\u5668_v6\n"
+                "        Private c As \u754c\u9762\u914d\u8272_v6\n"
+                "    End Class\nEnd Namespace\n"
+            ),
+        }
+        g = _graph_for(texts)
+        assert resolve_vbnet_same_namespace_refs(g, None, texts, None) == 1
+        assert g.has_edge("src/\u9ad8\u4eae\u5668.vb", "src/\u754c\u9762\u914d\u8272.vb")
+
+    def test_lowercase_ascii_identifier_is_not_a_candidate(self) -> None:
+        """The widened pattern must still exclude lowercase-leading names, or
+        every local variable becomes a type-reference candidate."""
+        texts = {
+            "src/Order.vb": (
+                "Namespace Acme\n    Public Class order\n    End Class\nEnd Namespace\n"
+            ),
+            "src/Svc.vb": (
+                "Namespace Acme\n    Public Class Svc\n"
+                "        Private o As order\n    End Class\nEnd Namespace\n"
+            ),
+        }
+        g = _graph_for(texts)
+        assert resolve_vbnet_same_namespace_refs(g, None, texts, None) == 0

--- a/uv.lock
+++ b/uv.lock
@@ -3197,7 +3197,7 @@ requires-dist = [
     { name = "tree-sitter-svelte", specifier = ">=1,<2" },
     { name = "tree-sitter-swift", specifier = ">=0.0.1" },
     { name = "tree-sitter-typescript", specifier = ">=0.23,<1" },
-    { name = "tree-sitter-vb-dotnet", specifier = ">=0.2,<1" },
+    { name = "tree-sitter-vb-dotnet", specifier = ">=0.3,<1" },
     { name = "types-networkx", marker = "extra == 'dev'", specifier = ">=3.3,<4" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.32,<1" },
     { name = "watchdog", specifier = ">=4,<5" },
@@ -4283,13 +4283,13 @@ wheels = [
 
 [[package]]
 name = "tree-sitter-vb-dotnet"
-version = "0.2.0"
+version = "0.3.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/81/28/6b506d627ee1d8e876af019286f71d781cf2132514b5805312e13e7850eb/tree_sitter_vb_dotnet-0.2.0.tar.gz", hash = "sha256:d6931457a7a26746acb337b97872563b4c8bc966efe913a835000afdd9b9e77d", size = 416990, upload-time = "2026-09-04T08:25:43.809Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/a1/95f99d291163cab128f86e6303268f50c37856bcf7dc361435f752549a48/tree_sitter_vb_dotnet-0.3.0.tar.gz", hash = "sha256:6e7178a8cf7c34b8ba07aa3914bef5475f4eafd348cdd393ff3ebfc7cb41ae61", size = 1049419, upload-time = "2026-09-04T10:33:34.645Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/21/5b/77b78b085880520943750fdfdba831cdcef8626188eb43b30faed88103ce/tree_sitter_vb_dotnet-0.2.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:e9ba30ceb86bae40a08f5e6d999e46f1868b361684664cbe0cd78e957b18b311", size = 148991, upload-time = "2026-09-04T08:25:39.481Z" },
-    { url = "https://files.pythonhosted.org/packages/88/c4/a405f6d856f2722e92e7fde9a61782ca3087e60130bf39a9840bb6af33c4/tree_sitter_vb_dotnet-0.2.0-cp310-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a1ec9fdbc7f042068dfe1cff6d8d9ee7532c546092ffe31da19a1fe65e150cf4", size = 158447, upload-time = "2026-09-04T08:25:41.045Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/94/9efb324c925042c17a8627e237ec07a2e278e1810880aa345aa09b19e393/tree_sitter_vb_dotnet-0.2.0-cp310-abi3-win_amd64.whl", hash = "sha256:5eec71df134f3418be264349760d2b66ebe64b9a4a25910256e4925e395ac43d", size = 141363, upload-time = "2026-09-04T08:25:42.489Z" },
+    { url = "https://files.pythonhosted.org/packages/68/22/d209d8bce9148d50e17190b8c3fb7909fa51d65ed41a83efb7d99f4aa180/tree_sitter_vb_dotnet-0.3.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:ad7dcf05170b429a07f05f78a2f0f5d3d46fc6174b8a7c90eec7cbfb980fca76", size = 326738, upload-time = "2026-09-04T10:33:30.602Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/69/d089c1f8e12ce743d41546650ca9a479bf99ea0eb74652ccd8939b198a4b/tree_sitter_vb_dotnet-0.3.0-cp310-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7d2a2c6670c9f5917b3606e8a44045d1b508fc3258ede9f31a9b3a75f704dc99", size = 325760, upload-time = "2026-09-04T10:33:31.896Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/19/4edabceed5aaa9f0390bae115bd7a68f8e3b4fbe3c893c1e79bf060ec0a1/tree_sitter_vb_dotnet-0.3.0-cp310-abi3-win_amd64.whl", hash = "sha256:f5615797aa1c5d98f1906eeda5ad3a78667069bd51b78ddf143118aaff57801e", size = 307980, upload-time = "2026-09-04T10:33:33.195Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -3100,6 +3100,7 @@ dependencies = [
     { name = "tree-sitter-svelte" },
     { name = "tree-sitter-swift" },
     { name = "tree-sitter-typescript" },
+    { name = "tree-sitter-vb-dotnet" },
     { name = "uvicorn", extra = ["standard"] },
     { name = "watchdog" },
 ]
@@ -3196,6 +3197,7 @@ requires-dist = [
     { name = "tree-sitter-svelte", specifier = ">=1,<2" },
     { name = "tree-sitter-swift", specifier = ">=0.0.1" },
     { name = "tree-sitter-typescript", specifier = ">=0.23,<1" },
+    { name = "tree-sitter-vb-dotnet", git = "https://github.com/sloemo01/tree-sitter-vb-dotnet.git?rev=c29b08e" },
     { name = "types-networkx", marker = "extra == 'dev'", specifier = ">=3.3,<4" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.32,<1" },
     { name = "watchdog", specifier = ">=4,<5" },
@@ -4278,6 +4280,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ab/dd84f0e2337296a5f09749f7b5483215d75c8fa9e33738522e5ed81f7254/tree_sitter_typescript-0.23.2-cp39-abi3-win_amd64.whl", hash = "sha256:3f730b66396bc3e11811e4465c41ee45d9e9edd6de355a58bbbc49fa770da8f9", size = 278015, upload-time = "2024-11-11T02:36:07.631Z" },
     { url = "https://files.pythonhosted.org/packages/9f/e4/81f9a935789233cf412a0ed5fe04c883841d2c8fb0b7e075958a35c65032/tree_sitter_typescript-0.23.2-cp39-abi3-win_arm64.whl", hash = "sha256:05db58f70b95ef0ea126db5560f3775692f609589ed6f8dd0af84b7f19f1cbb7", size = 274052, upload-time = "2024-11-11T02:36:09.514Z" },
 ]
+
+[[package]]
+name = "tree-sitter-vb-dotnet"
+version = "0.1.0"
+source = { git = "https://github.com/sloemo01/tree-sitter-vb-dotnet.git?rev=c29b08e#c29b08e107318a9255a1d3d6b42f7081618e349d" }
 
 [[package]]
 name = "typer"

--- a/uv.lock
+++ b/uv.lock
@@ -3197,7 +3197,7 @@ requires-dist = [
     { name = "tree-sitter-svelte", specifier = ">=1,<2" },
     { name = "tree-sitter-swift", specifier = ">=0.0.1" },
     { name = "tree-sitter-typescript", specifier = ">=0.23,<1" },
-    { name = "tree-sitter-vb-dotnet", git = "https://github.com/sloemo01/tree-sitter-vb-dotnet.git?rev=c29b08e" },
+    { name = "tree-sitter-vb-dotnet", specifier = ">=0.2,<1" },
     { name = "types-networkx", marker = "extra == 'dev'", specifier = ">=3.3,<4" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.32,<1" },
     { name = "watchdog", specifier = ">=4,<5" },
@@ -4283,8 +4283,14 @@ wheels = [
 
 [[package]]
 name = "tree-sitter-vb-dotnet"
-version = "0.1.0"
-source = { git = "https://github.com/sloemo01/tree-sitter-vb-dotnet.git?rev=c29b08e#c29b08e107318a9255a1d3d6b42f7081618e349d" }
+version = "0.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/28/6b506d627ee1d8e876af019286f71d781cf2132514b5805312e13e7850eb/tree_sitter_vb_dotnet-0.2.0.tar.gz", hash = "sha256:d6931457a7a26746acb337b97872563b4c8bc966efe913a835000afdd9b9e77d", size = 416990, upload-time = "2026-09-04T08:25:43.809Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/21/5b/77b78b085880520943750fdfdba831cdcef8626188eb43b30faed88103ce/tree_sitter_vb_dotnet-0.2.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:e9ba30ceb86bae40a08f5e6d999e46f1868b361684664cbe0cd78e957b18b311", size = 148991, upload-time = "2026-09-04T08:25:39.481Z" },
+    { url = "https://files.pythonhosted.org/packages/88/c4/a405f6d856f2722e92e7fde9a61782ca3087e60130bf39a9840bb6af33c4/tree_sitter_vb_dotnet-0.2.0-cp310-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a1ec9fdbc7f042068dfe1cff6d8d9ee7532c546092ffe31da19a1fe65e150cf4", size = 158447, upload-time = "2026-09-04T08:25:41.045Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/94/9efb324c925042c17a8627e237ec07a2e278e1810880aa345aa09b19e393/tree_sitter_vb_dotnet-0.2.0-cp310-abi3-win_amd64.whl", hash = "sha256:5eec71df134f3418be264349760d2b66ebe64b9a4a25910256e4925e395ac43d", size = 141363, upload-time = "2026-09-04T08:25:42.489Z" },
+]
 
 [[package]]
 name = "typer"


### PR DESCRIPTION
Closes #1041 — VB.NET at the Good tier, exactly as the issue asks.

**The grammar problem (and the fix).** The only tree-sitter VB.NET grammar (CodeAnt AI 0.1.0) could not parse real-world VB.NET, and its PyPI wheel is Windows-only. I forked it ([sloemo01/tree-sitter-vb-dotnet](https://github.com/sloemo01/tree-sitter-vb-dotnet)) and fixed four genuine bugs:

1. **Binding symbol mismatch** — `binding.c` declared `tree_sitter_tree_sitter_vb_dotnet` but `parser.c` exports `tree_sitter_vb_dotnet` → `Symbol not found` on every non-Windows load.
2. **Generics** — `type_argument_list` was missing its parentheses, so `List(Of String)` (canonical .NET) errored everywhere.
3. **`As New`** — the object-initializer form `As New List(Of T)()` was not a valid `as_clause`.
4. **Own-line `Inherits`/`Implements`** — canonical VB.NET puts each on its own line; the grammar only accepted them on the class-name line.

Verified 0 error nodes on a full real-world sample (namespace, class with both heritage clauses, generic field, ByVal params, generic returns, extension module).

**The repowise side (Good tier):**
- `specs/vbnet.py` — `.vb`, `import_support=full`, heritage node types, .NET conventions (test_camel_suffixes, layer_dir_hints, blocked bin/obj, generated `.designer.vb`), builtin sets
- `queries/vbnet.scm` — symbols (class/module/structure/interface/enum/method/property/event), `Imports` directives, calls (the grammar's `invocation` uses `target`/`arguments` fields; `member_access.object` is an expression wrapper), param-type DI edges
- `language_configs.py` — vbnet entry + `vbnet_visibility` (Friend → internal, Protected Friend → protected)
- `extractors/heritage/vbnet.py` — Inherits → extends, Implements → implements (BCL parents filtered)
- `resolvers/vbnet.py` — namespace stem match, dotted path-suffix fallback, external node for System.*
- `pyproject.toml` + `uv.lock` — git dep pinned to the fixed fork (same pattern as the GDScript PR's grammar dep)

**Tests:** 5 parser tests (symbols, heritage, imports, generics, ctor DI) + 4 resolver tests + tier-membership and camel-suffix goldens — all pass; full unit suite 15612 passed (only pre-existing failures: `test_plugin_content` v0.47.0 release bug on main, and the platform-specific agent-baseline).

**Docs:** LANGUAGE_SUPPORT.md (Good 5→6, 20 parsed to a full AST, 36 on the ladder) + the four other count-bearing pages.

Note: the `test_plugin_content` CI failure is pre-existing on main (v0.47.0 release hand-edited a generated plugin file) — unrelated.