### PR TITLE
feat(ingestion): emit Flutter widget-tree edges from build() bodies (#142)

### DIFF
--- a/packages/core/src/repowise/core/ingestion/framework_edges/flutter.py
+++ b/packages/core/src/repowise/core/ingestion/framework_edges/flutter.py
@@ -1,4 +1,4 @@
-"""Flutter navigation edges.
+"""Flutter framework edges: navigation + widget tree.
 
 Flutter wires screens together through route tables and builder callbacks
 rather than direct imports of a call site — a widget referenced only from
@@ -13,6 +13,14 @@ are deliberately out of scope here — they need dynamic hints, not regex):
   route-owning file to the page widget's defining file.
 - ``runApp(MyApp())`` — edge to the root widget's file, which is also
   stamped ``is_entry_point``.
+
+Plus the widget tree itself (the Phase 2 ask in #142): a ``build()``
+method returns a widget tree, so every constructor name in the returned
+expression is a *child widget* of the file's widget class. Framework
+widgets (Scaffold, Column, Text, …) resolve to nothing in the repo's
+class map and are skipped; repo widgets emit a parent→child edge from the
+building file to the child's file — the composition structure an LLM
+needs to reuse components.
 """
 
 from __future__ import annotations
@@ -52,6 +60,12 @@ _BUILDER_BLOCK_RE = re.compile(
 _RUNAPP_RE = re.compile(r"""runApp\s*\(""")
 _CTOR_NAME_RE = re.compile(r"""([A-Z]\w*)\s*\(""")
 _RUNAPP_WINDOW = 400
+
+# Widget build(BuildContext context) { return ...; } — the widget tree. The
+# window after the opening brace/arrow holds the returned expression; every
+# constructor name in it is a child widget of this file's widget class.
+_BUILD_METHOD_RE = re.compile(r"""\bWidget\s+build\s*\(\s*[^)]*\)\s*(?:=>|\{)""")
+_BUILD_WINDOW = 600
 
 
 def _uses_flutter(parsed_files: dict[str, Any]) -> bool:
@@ -96,9 +110,25 @@ def _add_flutter_edges(
             if _add_edge_if_new(graph, path, target):
                 count += 1
             if widget in entry_widgets:
-                node = graph.nodes.get(target)
-                if node is not None:
-                    node["is_entry_point"] = True
+                # The runApp target is usually the same file (MyApp lives in
+                # main.dart), so no edge is added and the node may not exist
+                # yet — create it before stamping.
+                if target not in graph:
+                    graph.add_node(target)
+                graph.nodes[target]["is_entry_point"] = True
+
+        # Widget tree: every constructor name inside a build() body is a
+        # child widget of this file's widget class. Framework widgets
+        # (Scaffold, Column, Text, ...) are absent from the repo class map
+        # and skipped; repo widgets get a parent→child edge.
+        for m in _BUILD_METHOD_RE.finditer(text):
+            window = text[m.end() : m.end() + _BUILD_WINDOW]
+            for child in _CTOR_NAME_RE.findall(window):
+                target = class_to_file.get(child)
+                if target is None or target not in path_set:
+                    continue
+                if _add_edge_if_new(graph, path, target):
+                    count += 1
 
     return count
 

--- a/packages/core/src/repowise/core/ingestion/framework_edges/flutter.py
+++ b/packages/core/src/repowise/core/ingestion/framework_edges/flutter.py
@@ -14,13 +14,14 @@ are deliberately out of scope here — they need dynamic hints, not regex):
 - ``runApp(MyApp())`` — edge to the root widget's file, which is also
   stamped ``is_entry_point``.
 
-Plus the widget tree itself (the Phase 2 ask in #142): a ``build()``
-method returns a widget tree, so every constructor name in the returned
-expression is a *child widget* of the file's widget class. Framework
-widgets (Scaffold, Column, Text, …) resolve to nothing in the repo's
-class map and are skipped; repo widgets emit a parent→child edge from the
-building file to the child's file — the composition structure an LLM
-needs to reuse components.
+Plus the widget tree itself (issue #142): a ``build()`` method returns a
+widget tree, so every constructor call in the body names a *child widget*
+of the building class. The body is read by matching braces from the
+signature rather than through a fixed window, so a long ``build()`` keeps
+its tail. Only classes whose heritage makes them widgets become targets,
+without which any repo class spelled like a constructor call
+(``Repository(...)``) would mint an edge, and a name resolves only to a
+file this one imports, which is also what settles a name two files declare.
 """
 
 from __future__ import annotations
@@ -28,7 +29,7 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING, Any
 
-from ..resolvers import ResolverContext
+from ..resolvers import ResolverContext, resolve_import
 from .base import (
     DetectionContext,
     FrameworkHandler,
@@ -58,14 +59,34 @@ _BUILDER_BLOCK_RE = re.compile(
 # collect every constructor-looking name in the argument window and let the
 # local class map decide which are this repo's widgets.
 _RUNAPP_RE = re.compile(r"""runApp\s*\(""")
-_CTOR_NAME_RE = re.compile(r"""([A-Z]\w*)\s*\(""")
+# A constructor call: the class name, an optional type-argument list
+# (``Foo<int>(``, one level of nesting) and an optional named constructor
+# (``Foo.named(``). Group 1 is the class either suffix hangs off, and must
+# start the identifier: private ``_AppSearchBar(`` otherwise reads as a call
+# to the unrelated public ``AppSearchBar``.
+_CTOR_NAME_RE = re.compile(
+    r"""(?<![\w$])([A-Z]\w*)(?:<[^<>]*(?:<[^<>]*>[^<>]*)*>)?(?:\.[A-Za-z_]\w*)?\s*\("""
+)
 _RUNAPP_WINDOW = 400
 
-# Widget build(BuildContext context) { return ...; } — the widget tree. The
-# window after the opening brace/arrow holds the returned expression; every
-# constructor name in it is a child widget of this file's widget class.
+# The widget tree: Widget build(BuildContext context) { ... } or => ... ;
 _BUILD_METHOD_RE = re.compile(r"""\bWidget\s+build\s*\(\s*[^)]*\)\s*(?:=>|\{)""")
-_BUILD_WINDOW = 600
+
+# Flutter's own widget supertypes. A repo class extending, mixing in or
+# implementing one of these is a widget, and so is one whose parent is such
+# a class. Two hops cover ``PageBase extends StatelessWidget``; a longer
+# chain stays unresolved and emits no edge.
+_WIDGET_BASES = frozenset({
+    "StatelessWidget",
+    "StatefulWidget",
+    "State",
+    "InheritedWidget",
+    "RenderObjectWidget",
+    "PreferredSizeWidget",
+    "Widget",
+})
+
+_CLASS_KINDS = ("class", "interface", "struct", "record", "enum", "trait")
 
 
 def _uses_flutter(parsed_files: dict[str, Any]) -> bool:
@@ -78,6 +99,137 @@ def _uses_flutter(parsed_files: dict[str, Any]) -> bool:
     return False
 
 
+def _widget_class_names(parsed_files: dict[str, Any]) -> set[str]:
+    """Repo class names whose heritage makes them Flutter widgets."""
+    parents: dict[str, set[str]] = {}
+    for parsed in parsed_files.values():
+        if parsed.file_info.language != "dart":
+            continue
+        for rel in parsed.heritage:
+            parents.setdefault(rel.child_name, set()).add(rel.parent_name)
+    direct = {name for name, bases in parents.items() if bases & _WIDGET_BASES}
+    return direct | {name for name, bases in parents.items() if bases & direct}
+
+
+def _class_owners(parsed_files: dict[str, Any]) -> dict[str, set[str]]:
+    """Map a declared Dart class name to every file declaring it."""
+    owners: dict[str, set[str]] = {}
+    for path, parsed in parsed_files.items():
+        if parsed.file_info.language != "dart":
+            continue
+        for sym in parsed.symbols:
+            if sym.kind in _CLASS_KINDS:
+                owners.setdefault(sym.name, set()).add(path)
+    return owners
+
+
+def _skip_string(text: str, start: int) -> int:
+    """Index just past the string literal opening at *start*."""
+    quote = text[start]
+    delim = quote * 3 if text.startswith(quote * 3, start) else quote
+    raw = start > 0 and text[start - 1] == "r"
+    i = start + len(delim)
+    while i < len(text):
+        if not raw and text[i] == "\\":
+            i += 2
+            continue
+        if not raw and text.startswith("${", i):
+            i = _skip_interpolation(text, i + 2)
+            continue
+        if text.startswith(delim, i):
+            return i + len(delim)
+        i += 1
+    return i
+
+
+def _skip_interpolation(text: str, start: int) -> int:
+    """Index just past the ``}`` closing a ``${...}`` interpolation."""
+    depth = 1
+    i = start
+    while i < len(text):
+        char = text[i]
+        if char in "'\"":
+            i = _skip_string(text, i)
+            continue
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return i + 1
+        i += 1
+    return i
+
+
+def _build_body(text: str, start: int, arrow: bool) -> str:
+    """The build() body from *start*, with strings and comments blanked out.
+
+    Block form ends at the ``}`` matching the signature's ``{``, arrow form
+    at the ``;`` closing the expression. Blanking literals keeps a class
+    name quoted inside a message from reading as a constructor call.
+    """
+    out: list[str] = []
+    depth = 0
+    i = start
+    end = len(text)
+    while i < end:
+        char = text[i]
+        if char == "/" and text.startswith("//", i):
+            newline = text.find("\n", i)
+            i = end if newline < 0 else newline
+            continue
+        if char == "/" and text.startswith("/*", i):
+            close = text.find("*/", i + 2)
+            i = end if close < 0 else close + 2
+            out.append(" ")
+            continue
+        if char in "'\"":
+            i = _skip_string(text, i)
+            out.append(" ")
+            continue
+        if char in "([{":
+            depth += 1
+        elif char in ")]}":
+            depth -= 1
+            if depth < 0:
+                break
+        elif arrow and char == ";" and depth == 0:
+            break
+        out.append(char)
+        i += 1
+    return "".join(out)
+
+
+def _imported_paths(parsed: Any, path: str, ctx: ResolverContext) -> set[str] | None:
+    """Repo files this file imports, or ``None`` when that cannot be known.
+
+    A ``part of`` file sees its library's imports, which are not written on
+    the file itself, so its own import list cannot settle an ambiguous name.
+    """
+    resolved: set[str] = set()
+    for imp in parsed.imports:
+        if imp.module_path.startswith("library:"):
+            return None
+        target = resolve_import(imp.module_path, path, "dart", ctx)
+        if target:
+            resolved.add(target)
+    return resolved
+
+
+def _child_target(owners: set[str], imports: set[str] | None) -> str | None:
+    """The one imported file declaring a child widget, else ``None``.
+
+    Dart makes nothing visible across files without an import, so requiring
+    one both settles a name two files declare and refuses a repo class that
+    merely shadows a framework widget. A class reached through an ``export``
+    barrel is missed, which costs an edge rather than inventing one.
+    """
+    if imports is None:
+        return None
+    named = owners & imports
+    return next(iter(named)) if len(named) == 1 else None
+
+
 def _add_flutter_edges(
     graph: nx.DiGraph,
     parsed_files: dict[str, Any],
@@ -86,6 +238,8 @@ def _add_flutter_edges(
 ) -> int:
     count = 0
     class_to_file = _build_class_to_file(parsed_files, ("dart",))
+    widget_classes = _widget_class_names(parsed_files)
+    owners_by_name = _class_owners(parsed_files)
 
     for path, parsed in parsed_files.items():
         if parsed.file_info.language != "dart":
@@ -112,19 +266,29 @@ def _add_flutter_edges(
             if widget in entry_widgets:
                 # The runApp target is usually the same file (MyApp lives in
                 # main.dart), so no edge is added and the node may not exist
-                # yet — create it before stamping.
+                # yet, so create it before stamping.
                 if target not in graph:
                     graph.add_node(target)
                 graph.nodes[target]["is_entry_point"] = True
 
-        # Widget tree: every constructor name inside a build() body is a
+        # Widget tree: every constructor call inside a build() body names a
         # child widget of this file's widget class. Framework widgets
-        # (Scaffold, Column, Text, ...) are absent from the repo class map
-        # and skipped; repo widgets get a parent→child edge.
+        # (Scaffold, Column, Text, ...) declare nothing in the repo and are
+        # skipped; repo widgets get a parent→child edge.
+        imports: set[str] | None = None
+        imports_read = False
         for m in _BUILD_METHOD_RE.finditer(text):
-            window = text[m.end() : m.end() + _BUILD_WINDOW]
-            for child in _CTOR_NAME_RE.findall(window):
-                target = class_to_file.get(child)
+            body = _build_body(text, m.end(), arrow=m.group(0).endswith("=>"))
+            for child in _CTOR_NAME_RE.findall(body):
+                if child not in widget_classes:
+                    continue
+                owners = owners_by_name.get(child)
+                if not owners:
+                    continue
+                if not imports_read:
+                    imports = _imported_paths(parsed, path, ctx)
+                    imports_read = True
+                target = _child_target(owners, imports)
                 if target is None or target not in path_set:
                     continue
                 if _add_edge_if_new(graph, path, target):

--- a/tests/unit/ingestion/test_flutter_framework_edges.py
+++ b/tests/unit/ingestion/test_flutter_framework_edges.py
@@ -1,0 +1,249 @@
+"""Unit tests for Flutter framework edges (navigation + widget tree).
+
+Covers the two shapes the handler emits: route-table/builder edges and
+runApp entry-point edges (pre-existing), plus the widget-tree pass added
+for #142 — build() bodies emitting parent→child edges between repo widget
+classes, with framework widgets (Scaffold, Column, Text) skipped.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+
+import networkx as nx
+
+from repowise.core.ingestion.framework_edges import add_framework_edges
+from repowise.core.ingestion.models import FileInfo, ParsedFile
+from repowise.core.ingestion.parser import ASTParser
+from repowise.core.ingestion.resolvers.context import ResolverContext
+
+
+def _file_info(rel: str, abs_path: str) -> FileInfo:
+    return FileInfo(
+        path=rel,
+        abs_path=abs_path,
+        language="dart",
+        size_bytes=100,
+        git_hash="",
+        last_modified=datetime.now(),
+        is_test=False,
+        is_config=False,
+        is_api_contract=False,
+        is_entry_point=False,
+    )
+
+
+def _build_parsed(repo: Path) -> dict[str, ParsedFile]:
+    parser = ASTParser()
+    out: dict[str, ParsedFile] = {}
+    for src in repo.rglob("*.dart"):
+        rel = src.resolve().relative_to(repo.resolve()).as_posix()
+        fi = _file_info(rel, str(src.resolve()))
+        out[rel] = parser.parse_file(fi, src.read_bytes())
+    return out
+
+
+def _ctx(repo: Path, parsed: dict[str, ParsedFile]) -> ResolverContext:
+    path_set = set(parsed.keys())
+    stem_map: dict[str, list[str]] = {}
+    for p in path_set:
+        stem = Path(p).stem.lower()
+        stem_map.setdefault(stem, []).append(p)
+    return ResolverContext(
+        path_set=path_set, stem_map=stem_map, graph=nx.DiGraph(), repo_path=repo
+    )
+
+
+def _write(repo: Path, rel: str, text: str) -> None:
+    p = repo / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(text)
+
+
+class TestWidgetTreeEdges:
+    def test_build_method_emits_parent_child_edges(self, tmp_path: Path) -> None:
+        """A build() returning a repo widget emits a parent→child edge."""
+        _write(
+            tmp_path,
+            "lib/main.dart",
+            """import 'package:flutter/material.dart';
+import 'cart_page.dart';
+
+void main() => runApp(MyApp());
+
+class MyApp extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: CartPage(),
+    );
+  }
+}
+""",
+        )
+        _write(
+            tmp_path,
+            "lib/cart_page.dart",
+            """import 'package:flutter/material.dart';
+
+class CartPage extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Column(
+        children: [Text('Cart')],
+      ),
+    );
+  }
+}
+""",
+        )
+        parsed = _build_parsed(tmp_path)
+        ctx = _ctx(tmp_path, parsed)
+        graph = nx.DiGraph()
+        add_framework_edges(graph, parsed, ctx)
+
+        # main.dart builds CartPage → edge
+        assert graph.has_edge("lib/main.dart", "lib/cart_page.dart")
+        # CartPage's build returns only framework widgets → no self/other edges
+        assert not graph.has_edge("lib/cart_page.dart", "lib/main.dart")
+        # runApp stamps MyApp's file as entry point
+        assert graph.nodes["lib/main.dart"].get("is_entry_point") is True
+
+    def test_framework_widgets_are_skipped(self, tmp_path: Path) -> None:
+        """Scaffold/Column/Text resolve to nothing in the repo class map."""
+        _write(
+            tmp_path,
+            "lib/app.dart",
+            """import 'package:flutter/material.dart';
+
+class App extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Column(children: [Text('hi')]),
+    );
+  }
+}
+""",
+        )
+        parsed = _build_parsed(tmp_path)
+        ctx = _ctx(tmp_path, parsed)
+        graph = nx.DiGraph()
+        add_framework_edges(graph, parsed, ctx)
+        # No edges at all — every constructor is a framework widget.
+        assert graph.number_of_edges() == 0
+
+    def test_widget_tree_edge_from_non_entry_file(self, tmp_path: Path) -> None:
+        """A widget file (no runApp) building a repo widget emits the edge —
+        this is the pass the runApp window heuristic cannot produce."""
+        _write(
+            tmp_path,
+            "lib/main.dart",
+            """import 'package:flutter/material.dart';
+import 'app.dart';
+
+void main() => runApp(App());
+""",
+        )
+        _write(
+            tmp_path,
+            "lib/app.dart",
+            """import 'package:flutter/material.dart';
+import 'product_card.dart';
+
+class App extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: ProductCard(product: 'x'),
+    );
+  }
+}
+""",
+        )
+        _write(
+            tmp_path,
+            "lib/product_card.dart",
+            """import 'package:flutter/material.dart';
+
+class ProductCard extends StatelessWidget {
+  final String product;
+  const ProductCard({super.key, required this.product});
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(child: Text(product));
+  }
+}
+""",
+        )
+        parsed = _build_parsed(tmp_path)
+        ctx = _ctx(tmp_path, parsed)
+        graph = nx.DiGraph()
+        add_framework_edges(graph, parsed, ctx)
+
+        # app.dart builds ProductCard → edge (widget-tree pass)
+        assert graph.has_edge("lib/app.dart", "lib/product_card.dart")
+        # main.dart's runApp window is tiny — no accidental edge to ProductCard
+        assert not graph.has_edge("lib/main.dart", "lib/product_card.dart")
+
+    def test_route_table_edges_still_work(self, tmp_path: Path) -> None:
+        """Route tables and builders still emit edges alongside the tree."""
+        _write(
+            tmp_path,
+            "lib/main.dart",
+            """import 'package:flutter/material.dart';
+import 'home_page.dart';
+import 'details_page.dart';
+
+void main() => runApp(MyApp());
+
+class MyApp extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      routes: {
+        '/': (context) => HomePage(),
+        '/details': (context) => DetailsPage(),
+      },
+    );
+  }
+}
+""",
+        )
+        _write(
+            tmp_path,
+            "lib/home_page.dart",
+            """import 'package:flutter/material.dart';
+
+class HomePage extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(body: Text('Home'));
+  }
+}
+""",
+        )
+        _write(
+            tmp_path,
+            "lib/details_page.dart",
+            """import 'package:flutter/material.dart';
+
+class DetailsPage extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(body: Text('Details'));
+  }
+}
+""",
+        )
+        parsed = _build_parsed(tmp_path)
+        ctx = _ctx(tmp_path, parsed)
+        graph = nx.DiGraph()
+        add_framework_edges(graph, parsed, ctx)
+
+        assert graph.has_edge("lib/main.dart", "lib/home_page.dart")
+        assert graph.has_edge("lib/main.dart", "lib/details_page.dart")
+        assert graph.nodes["lib/main.dart"].get("is_entry_point") is True

--- a/tests/unit/ingestion/test_flutter_framework_edges.py
+++ b/tests/unit/ingestion/test_flutter_framework_edges.py
@@ -2,7 +2,7 @@
 
 Covers the two shapes the handler emits: route-table/builder edges and
 runApp entry-point edges (pre-existing), plus the widget-tree pass added
-for #142 — build() bodies emitting parent→child edges between repo widget
+for #142: build() bodies emitting parent-to-child edges between repo widget
 classes, with framework widgets (Scaffold, Column, Text) skipped.
 """
 
@@ -132,12 +132,12 @@ class App extends StatelessWidget {
         ctx = _ctx(tmp_path, parsed)
         graph = nx.DiGraph()
         add_framework_edges(graph, parsed, ctx)
-        # No edges at all — every constructor is a framework widget.
+        # No edges at all, since every constructor is a framework widget.
         assert graph.number_of_edges() == 0
 
     def test_widget_tree_edge_from_non_entry_file(self, tmp_path: Path) -> None:
-        """A widget file (no runApp) building a repo widget emits the edge —
-        this is the pass the runApp window heuristic cannot produce."""
+        """A widget file (no runApp) building a repo widget emits the edge,
+        which is what the runApp window heuristic cannot produce."""
         _write(
             tmp_path,
             "lib/main.dart",
@@ -186,7 +186,7 @@ class ProductCard extends StatelessWidget {
 
         # app.dart builds ProductCard → edge (widget-tree pass)
         assert graph.has_edge("lib/app.dart", "lib/product_card.dart")
-        # main.dart's runApp window is tiny — no accidental edge to ProductCard
+        # main.dart's runApp window is tiny, so no accidental edge to ProductCard
         assert not graph.has_edge("lib/main.dart", "lib/product_card.dart")
 
     def test_route_table_edges_still_work(self, tmp_path: Path) -> None:
@@ -247,3 +247,459 @@ class DetailsPage extends StatelessWidget {
         assert graph.has_edge("lib/main.dart", "lib/home_page.dart")
         assert graph.has_edge("lib/main.dart", "lib/details_page.dart")
         assert graph.nodes["lib/main.dart"].get("is_entry_point") is True
+
+
+_HEADER_BAR = """import 'package:flutter/material.dart';
+
+class HeaderBar extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Text('header');
+  }
+}
+"""
+
+
+class TestConstructorForms:
+    """Named-constructor, generic and arrow spellings of a widget call."""
+
+    def _run(self, tmp_path: Path, body: str, child: str) -> nx.DiGraph:
+        _write(
+            tmp_path,
+            "lib/app.dart",
+            f"""import 'package:flutter/material.dart';
+import 'child.dart';
+
+class App extends StatelessWidget {{
+  @override
+  {body}
+}}
+""",
+        )
+        _write(tmp_path, "lib/child.dart", child)
+        parsed = _build_parsed(tmp_path)
+        ctx = _ctx(tmp_path, parsed)
+        graph = nx.DiGraph()
+        add_framework_edges(graph, parsed, ctx)
+        return graph
+
+    def test_named_constructor(self, tmp_path: Path) -> None:
+        """Badge.small() is a call to Badge."""
+        graph = self._run(
+            tmp_path,
+            "Widget build(BuildContext context) {\n"
+            "    return Column(children: [Badge.small()]);\n"
+            "  }",
+            """import 'package:flutter/material.dart';
+
+class Badge extends StatelessWidget {
+  const Badge.small();
+
+  @override
+  Widget build(BuildContext context) {
+    return Text('badge');
+  }
+}
+""",
+        )
+        assert graph.has_edge("lib/app.dart", "lib/child.dart")
+
+    def test_generic_type_arguments(self, tmp_path: Path) -> None:
+        """TypedList<int>() is a call to TypedList."""
+        graph = self._run(
+            tmp_path,
+            "Widget build(BuildContext context) {\n"
+            "    return TypedList<int>(items: const []);\n"
+            "  }",
+            """import 'package:flutter/material.dart';
+
+class TypedList<T> extends StatelessWidget {
+  final List<T> items;
+  const TypedList({required this.items});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(children: const []);
+  }
+}
+""",
+        )
+        assert graph.has_edge("lib/app.dart", "lib/child.dart")
+
+    def test_dot_builder_constructor(self, tmp_path: Path) -> None:
+        """Grid.builder() is a call to Grid, not a route builder callback."""
+        graph = self._run(
+            tmp_path,
+            "Widget build(BuildContext context) {\n"
+            "    return Grid.builder(count: 3);\n"
+            "  }",
+            """import 'package:flutter/material.dart';
+
+class Grid extends StatelessWidget {
+  final int count;
+  const Grid.builder({required this.count});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(children: const []);
+  }
+}
+""",
+        )
+        assert graph.has_edge("lib/app.dart", "lib/child.dart")
+
+    def test_arrow_form_build(self, tmp_path: Path) -> None:
+        """An expression-bodied build() is read up to its semicolon."""
+        graph = self._run(
+            tmp_path,
+            "Widget build(BuildContext context) => Column(children: [HeaderBar()]);",
+            _HEADER_BAR,
+        )
+        assert graph.has_edge("lib/app.dart", "lib/child.dart")
+
+
+class TestBodyExtraction:
+    def test_long_body_keeps_its_tail(self, tmp_path: Path) -> None:
+        """A build() past the old 600-char window still finds its last child."""
+        filler = "\n".join(
+            f"      const Text('row {i} padding padding padding padding'),"
+            for i in range(20)
+        )
+        _write(
+            tmp_path,
+            "lib/app.dart",
+            f"""import 'package:flutter/material.dart';
+import 'header_bar.dart';
+
+class App extends StatelessWidget {{
+  @override
+  Widget build(BuildContext context) {{
+    return Column(
+      children: [
+{filler}
+        HeaderBar(),
+      ],
+    );
+  }}
+}}
+""",
+        )
+        _write(tmp_path, "lib/header_bar.dart", _HEADER_BAR)
+        parsed = _build_parsed(tmp_path)
+        ctx = _ctx(tmp_path, parsed)
+        graph = nx.DiGraph()
+        add_framework_edges(graph, parsed, ctx)
+
+        body_len = len((tmp_path / "lib/app.dart").read_text())
+        assert body_len > 600
+        assert graph.has_edge("lib/app.dart", "lib/header_bar.dart")
+
+    def test_helper_method_subtree_is_not_followed(self, tmp_path: Path) -> None:
+        """The ceiling: a child built by a helper method is invisible.
+
+        Only build() bodies are read, so HeaderBar reached through
+        _buildHeader() yields no edge.
+        """
+        _write(
+            tmp_path,
+            "lib/app.dart",
+            """import 'package:flutter/material.dart';
+import 'header_bar.dart';
+
+class App extends StatelessWidget {
+  Widget _buildHeader() => HeaderBar();
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(children: [_buildHeader()]);
+  }
+}
+""",
+        )
+        _write(tmp_path, "lib/header_bar.dart", _HEADER_BAR)
+        parsed = _build_parsed(tmp_path)
+        ctx = _ctx(tmp_path, parsed)
+        graph = nx.DiGraph()
+        add_framework_edges(graph, parsed, ctx)
+
+        assert not graph.has_edge("lib/app.dart", "lib/header_bar.dart")
+
+
+class TestWidgetCheck:
+    def test_non_widget_repo_class_yields_no_edge(self, tmp_path: Path) -> None:
+        """A repo class that is not a widget is not a child, however it reads."""
+        _write(
+            tmp_path,
+            "lib/app.dart",
+            """import 'package:flutter/material.dart';
+import 'repository.dart';
+
+class App extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final repo = Repository();
+    return Text(repo.title);
+  }
+}
+""",
+        )
+        _write(
+            tmp_path,
+            "lib/repository.dart",
+            """class Repository {
+  final String title = 'x';
+}
+""",
+        )
+        parsed = _build_parsed(tmp_path)
+        ctx = _ctx(tmp_path, parsed)
+        graph = nx.DiGraph()
+        add_framework_edges(graph, parsed, ctx)
+
+        assert not graph.has_edge("lib/app.dart", "lib/repository.dart")
+
+    def test_private_widget_is_not_read_as_its_public_namesake(
+        self, tmp_path: Path
+    ) -> None:
+        """_AppSearchBar() is its own class, not a call to AppSearchBar."""
+        _write(
+            tmp_path,
+            "lib/app.dart",
+            """import 'package:flutter/material.dart';
+import 'search_bar.dart';
+
+class App extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return _AppSearchBar();
+  }
+}
+
+class _AppSearchBar extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Text('private');
+  }
+}
+""",
+        )
+        _write(
+            tmp_path,
+            "lib/search_bar.dart",
+            """import 'package:flutter/material.dart';
+
+class AppSearchBar extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Text('public');
+  }
+}
+""",
+        )
+        parsed = _build_parsed(tmp_path)
+        ctx = _ctx(tmp_path, parsed)
+        graph = nx.DiGraph()
+        add_framework_edges(graph, parsed, ctx)
+
+        assert not graph.has_edge("lib/app.dart", "lib/search_bar.dart")
+
+    def test_unimported_widget_yields_no_edge(self, tmp_path: Path) -> None:
+        """A repo widget shadowing a framework one is not silently adopted.
+
+        app.dart never imports card.dart, so its Card() is Flutter's.
+        """
+        _write(
+            tmp_path,
+            "lib/app.dart",
+            """import 'package:flutter/material.dart';
+
+class App extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Card(child: Text('hi'));
+  }
+}
+""",
+        )
+        _write(
+            tmp_path,
+            "lib/card.dart",
+            """import 'package:flutter/material.dart';
+
+class Card extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Text('card');
+  }
+}
+""",
+        )
+        parsed = _build_parsed(tmp_path)
+        ctx = _ctx(tmp_path, parsed)
+        graph = nx.DiGraph()
+        add_framework_edges(graph, parsed, ctx)
+
+        assert not graph.has_edge("lib/app.dart", "lib/card.dart")
+
+    def test_stateful_widget_edge_belongs_to_the_state_class(
+        self, tmp_path: Path
+    ) -> None:
+        """A StatefulWidget builds nothing; its State's build() owns the edge."""
+        _write(
+            tmp_path,
+            "lib/counter.dart",
+            """import 'package:flutter/material.dart';
+import 'counter_state.dart';
+
+class Counter extends StatefulWidget {
+  @override
+  State<Counter> createState() => CounterState();
+}
+""",
+        )
+        _write(
+            tmp_path,
+            "lib/counter_state.dart",
+            """import 'package:flutter/material.dart';
+import 'counter.dart';
+import 'header_bar.dart';
+
+class CounterState extends State<Counter> {
+  @override
+  Widget build(BuildContext context) {
+    return Column(children: [HeaderBar()]);
+  }
+}
+""",
+        )
+        _write(tmp_path, "lib/header_bar.dart", _HEADER_BAR)
+        parsed = _build_parsed(tmp_path)
+        ctx = _ctx(tmp_path, parsed)
+        graph = nx.DiGraph()
+        add_framework_edges(graph, parsed, ctx)
+
+        assert graph.has_edge("lib/counter_state.dart", "lib/header_bar.dart")
+        assert not graph.has_edge("lib/counter.dart", "lib/header_bar.dart")
+
+
+class TestSameNameCollision:
+    def _write_two_badges(self, tmp_path: Path) -> None:
+        badge = """import 'package:flutter/material.dart';
+
+class Badge extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Text('badge');
+  }
+}
+"""
+        _write(tmp_path, "lib/cart/badge.dart", badge)
+        _write(tmp_path, "lib/chat/badge.dart", badge)
+
+    def test_collision_refuses_the_edge(self, tmp_path: Path) -> None:
+        """Two files declare Badge and nothing says which one, so no edge."""
+        self._write_two_badges(tmp_path)
+        _write(
+            tmp_path,
+            "lib/app.dart",
+            """import 'package:flutter/material.dart';
+
+class App extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Badge();
+  }
+}
+""",
+        )
+        parsed = _build_parsed(tmp_path)
+        ctx = _ctx(tmp_path, parsed)
+        graph = nx.DiGraph()
+        add_framework_edges(graph, parsed, ctx)
+
+        assert not graph.has_edge("lib/app.dart", "lib/cart/badge.dart")
+        assert not graph.has_edge("lib/app.dart", "lib/chat/badge.dart")
+
+    def test_import_settles_the_collision(self, tmp_path: Path) -> None:
+        """The importing file names one of the two declarers, so it wins."""
+        self._write_two_badges(tmp_path)
+        _write(
+            tmp_path,
+            "lib/app.dart",
+            """import 'package:flutter/material.dart';
+import 'chat/badge.dart';
+
+class App extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Badge();
+  }
+}
+""",
+        )
+        parsed = _build_parsed(tmp_path)
+        ctx = _ctx(tmp_path, parsed)
+        graph = nx.DiGraph()
+        add_framework_edges(graph, parsed, ctx)
+
+        assert graph.has_edge("lib/app.dart", "lib/chat/badge.dart")
+        assert not graph.has_edge("lib/app.dart", "lib/cart/badge.dart")
+
+    def test_part_of_file_cannot_settle_the_collision(self, tmp_path: Path) -> None:
+        """A part file's imports live on the library, so the name stays open.
+
+        Its only import is the ``part of`` pointing at the library, and the
+        library declares one of the two Badges, so resolving to it would be a
+        guess about which Badge the part meant.
+        """
+        _write(
+            tmp_path,
+            "lib/cart/badge.dart",
+            """import 'package:flutter/material.dart';
+
+class Badge extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Text('cart');
+  }
+}
+""",
+        )
+        _write(
+            tmp_path,
+            "lib/app.dart",
+            """part of shell;
+
+class App extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Badge();
+  }
+}
+""",
+        )
+        _write(
+            tmp_path,
+            "lib/shell.dart",
+            """library shell;
+
+import 'package:flutter/material.dart';
+import 'cart/badge.dart';
+
+part 'app.dart';
+
+class Badge extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Text('shell');
+  }
+}
+""",
+        )
+        parsed = _build_parsed(tmp_path)
+        ctx = _ctx(tmp_path, parsed)
+        graph = nx.DiGraph()
+        add_framework_edges(graph, parsed, ctx)
+
+        assert not graph.has_edge("lib/app.dart", "lib/shell.dart")
+        assert not graph.has_edge("lib/app.dart", "lib/cart/badge.dart")


### PR DESCRIPTION
## What

Fixes #142 — Phase 2 of the Flutter ask, exactly as scoped in the thread.

## Root cause

Phase 1 (Dart at Good tier) is already shipped — spec, queries, resolver, heritage all exist. The Flutter handler in `framework_edges/flutter.py` already covered **navigation** (route tables, GoRoute/MaterialPageRoute builders, `runApp` → entry point). What was missing is the **widget tree itself**: a `build()` method returning a widget tree is the composition structure an LLM needs to reuse components, and it had no edges.

## Changes

- New pass in the Flutter handler: every constructor name inside a `build()` body is a child widget of the file's widget class. Framework widgets (Scaffold, Column, Text, …) resolve to nothing in the repo class map and are skipped; repo widgets get a parent→child edge.
- **Latent bug fixed:** `runApp`'s target is usually the same file (MyApp lives in main.dart), so no edge is added and the `is_entry_point` stamp silently no-oped on a nonexistent node. The node is now created before stamping.

## Tests

4 framework-edge tests — widget-tree edges, framework-widget skip, non-entry-file composition (proves the new pass, not the runApp window), route tables still working. Sabotage-verified: the widget-tree test fails without the new pass. 106 framework-edge + Dart tests pass.

Note: `test_plugin_content` is red on main itself (v0.47.0 release bug, unrelated to this PR).
