### PR TITLE
fix(answer): grade degraded get_answer confidence from retrieval instead of pinning it low

### DIFF
--- a/packages/server/src/repowise/server/mcp_server/tool_answer/confidence.py
+++ b/packages/server/src/repowise/server/mcp_server/tool_answer/confidence.py
@@ -586,10 +586,11 @@ def _retrieval_quality(hits: list[dict], agreement_dominant: bool) -> str:
     """Rate the retrieval, independently of the text it fed.
 
     Kept as one function because the degraded path needs the same rating and must
-    not invent a second one. That path has no synthesised text to rate (its
-    ``confidence`` stays low, correctly), but it ran exactly the same retrieval,
-    and "high" has to mean the same thing to a keyless caller as to a keyed one
-    or the field is worth less than nothing.
+    not invent a second one. That path has no synthesised text to rate, but it ran
+    exactly the same retrieval, and "high" has to mean the same thing to a keyless
+    caller as to a keyed one or the field is worth less than nothing. It is also
+    what :func:`_degraded_confidence` grades from, so the two fields on a
+    synthesis-less payload can never disagree about the same retrieval.
 
     Reads :func:`is_dominant` rather than re-deriving the ratio, so "weak" means
     exactly "not dominant" — the same fact the confidence ceiling and the
@@ -601,6 +602,36 @@ def _retrieval_quality(hits: list[dict], agreement_dominant: bool) -> str:
     if dominant_grade and top_score >= _HIGH_CONFIDENCE_SCORE_FLOOR:
         return "high"
     return "partial" if dominant_grade else "weak"
+
+
+def _degraded_confidence(reason: str, retrieval_quality: str) -> str:
+    """Grade a synthesis-less payload on what a caller can act on, not on prose.
+
+    ``confidence`` used to be pinned to "low" here on the grounds that it rates
+    the synthesised text and there is none. That referent is the problem, not the
+    answer to it: the field is what an agent reads to decide whether it still has
+    work to do, and pinning it told 69 percent of field calls to distrust evidence
+    that was often excellent — 84 percent of those "low" verdicts were unearned,
+    and the keyless install that never configures a provider got one on every call
+    forever. So the field is graded from the retrieval it actually served.
+
+    Two ceilings, both load bearing:
+
+    "high" is unreachable. ``answer`` on this path is assembled boilerplate, and
+    our own agent instructions license citing a high-confidence answer directly,
+    so a "high" here would be an invitation to cite the boilerplate. That was the
+    real objection behind the old pin and it is preserved as a cap rather than
+    discarded.
+
+    ``synthesis-failed`` stays "low" whatever retrieval did. The evidence is
+    identical to the no-provider case, but the *situation* is not: a provider is
+    configured, so a retry can still produce a real answer and this payload is not
+    the end of the line. "no-llm-provider" is the end of the line — no better reply
+    is coming for that install — so there the evidence is all there is to grade.
+    """
+    if reason != "no-llm-provider":
+        return "low"
+    return "low" if retrieval_quality == "weak" else "medium"
 
 
 def _is_question_named_body_cut_by_us(entry: dict, question_ids: set[str]) -> bool:

--- a/packages/server/src/repowise/server/mcp_server/tool_answer/degraded.py
+++ b/packages/server/src/repowise/server/mcp_server/tool_answer/degraded.py
@@ -19,7 +19,10 @@ from repowise.server.mcp_server.tool_answer.bodies import (
     _build_symbol_bodies,
     _gather_body_candidates,
 )
-from repowise.server.mcp_server.tool_answer.confidence import _retrieval_quality
+from repowise.server.mcp_server.tool_answer.confidence import (
+    _degraded_confidence,
+    _retrieval_quality,
+)
 from repowise.server.mcp_server.tool_answer.evidence import (
     _drop_already_surfaced,
     _first_resolvable_id,
@@ -96,14 +99,15 @@ async def _degraded_payload(
     health signals from there; the failure path used to set only the top-level
     key, so a caller watching ``_meta`` saw a normal empty answer.
 
-    ``confidence`` stays "low" and is not up for debate: it rates the synthesised
-    text, and here that text is assembled boilerplate that an agent told to cite
-    it would cite. What ``retrieval_quality`` rates instead is the retrieval,
-    which ran identically to the keyed path, so the same rule grades it here —
-    and it stays honest in the other direction, since a genuinely weak retrieval
-    still grades "weak".
+    ``confidence`` is graded by :func:`_degraded_confidence` from the retrieval
+    this payload actually served, not pinned. It rates what the caller can act on
+    without further work, which is the same thing it rates on the keyed path; the
+    boilerplate ``answer`` is why "high" is unreachable here rather than why the
+    field says nothing. ``retrieval_quality`` rates the retrieval on its own and
+    is what the grade is derived from, so the two can never disagree.
     """
     retrieval_quality = _retrieval_quality(hits, agreement_dominant)
+    confidence = _degraded_confidence(reason, retrieval_quality)
     repo_root = _repo_root(ctx)
     symbol_bodies, _served_named_body = _build_symbol_bodies(
         _gather_body_candidates(hits, "", anchor_names=question_ids or set()),
@@ -131,7 +135,7 @@ async def _degraded_payload(
     payload: dict = {
         "answer": summary,
         "citations": citations,
-        "confidence": "low",
+        "confidence": confidence,
         "retrieval_quality": retrieval_quality,
         "degraded": reason,
         "fallback_targets": fallback_targets,
@@ -170,7 +174,7 @@ async def _degraded_payload(
         **_build_meta(
             timing_ms=(time.perf_counter() - t0) * 1000,
             hint=_answer_hint(
-                "low",
+                confidence,
                 degraded=reason,
                 retrieval_quality=retrieval_quality,
                 has_bodies=bool(symbol_bodies),

--- a/packages/server/src/repowise/server/mcp_server/tool_answer/projection.py
+++ b/packages/server/src/repowise/server/mcp_server/tool_answer/projection.py
@@ -211,7 +211,13 @@ def _keep(payload: dict[str, Any], key: str, limit: int | None) -> None:
 
 
 def _default_shape(payload: dict[str, Any], question: str) -> None:
-    confidence = payload.get("confidence", "low")
+    # A degraded payload keeps the fullest evidence shape whatever it graded.
+    # The trimming above is keyed on prose REPLACING evidence: a high-confidence
+    # answer makes the ranked list redundant, so it goes. There is no answer on
+    # this path - the evidence IS the product - and its ``confidence`` now rates
+    # that evidence rather than prose, so reading the two on one scale would cut
+    # a body and a hit from exactly the caller who has nothing else to read.
+    confidence = "low" if payload.get("degraded") else payload.get("confidence", "low")
     why = question.lstrip().lower().startswith("why")
     if confidence == "high":
         for key in ("retrieval", "best_guesses", "candidates", "fallback_targets"):

--- a/tests/unit/server/mcp/test_answer_degraded_evidence.py
+++ b/tests/unit/server/mcp/test_answer_degraded_evidence.py
@@ -574,3 +574,63 @@ async def test_first_resolvable_id_keeps_an_id_whose_file_cannot_be_read(tmp_pat
     ctx = SimpleNamespace(path=str(tmp_path), session_factory=None)
 
     assert await _first_resolvable_id(["gone.py::Thing"], ctx, None, None) == "gone.py::Thing"
+
+
+# --- projection of a degraded payload --------------------------------------
+#
+# The projection trims evidence by `confidence`, on the rule that prose replaces
+# it: a high-confidence answer makes the ranked list redundant. A degraded
+# payload has no prose, so nothing replaces anything, and grading its evidence
+# must not be read as licence to serve less of it.
+
+
+def _degraded_raw(confidence: str) -> dict:
+    return {
+        "answer": "No synthesized prose (no-llm-provider), but the evidence is here",
+        "citations": ["pkg/m0.py"],
+        "confidence": confidence,
+        "retrieval_quality": "high",
+        "degraded": "no-llm-provider",
+        "fallback_targets": ["pkg/m0.py"],
+        "retrieval": [
+            {"path": f"pkg/m{i}.py", "title": f"m{i}", "summary": "s"} for i in range(4)
+        ],
+        "symbol_bodies": [
+            {"name": f"S{i}", "path": f"pkg/m{i}.py", "lines": [1, 4], "source": "x"}
+            for i in range(3)
+        ],
+        "_meta": {},
+    }
+
+
+def test_a_graded_degraded_payload_serves_the_same_evidence_as_before():
+    """The regression guard on grading confidence at all.
+
+    `medium` trims symbol_bodies to 1 and the ranked list to 2. Applying that to
+    a payload whose whole value is the evidence would take a body and a hit away
+    from the keyless caller this change exists to help.
+    """
+    projected = project_answer_payload(_degraded_raw("medium"), question="how does this work")
+
+    assert len(projected["symbol_bodies"]) == 2
+    assert len(projected["retrieval"]) == 3
+
+
+def test_the_degraded_shape_does_not_move_with_the_grade():
+    """Whatever it graded, the caller is served the same evidence."""
+    low = project_answer_payload(_degraded_raw("low"), question="how does this work")
+    medium = project_answer_payload(_degraded_raw("medium"), question="how does this work")
+
+    assert len(low["symbol_bodies"]) == len(medium["symbol_bodies"])
+    assert len(low["retrieval"]) == len(medium["retrieval"])
+    assert medium["confidence"] == "medium"
+
+
+def test_a_synthesised_payload_still_trims_on_its_grade():
+    """The control: the trimming rule is untouched where prose really does exist."""
+    raw = _degraded_raw("medium")
+    del raw["degraded"]
+
+    projected = project_answer_payload(raw, question="how does this work")
+
+    assert len(projected["symbol_bodies"]) == 1

--- a/tests/unit/server/mcp/test_answer_degraded_evidence.py
+++ b/tests/unit/server/mcp/test_answer_degraded_evidence.py
@@ -19,11 +19,14 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+import pytest
+
 from repowise.server.mcp_server.tool_answer import symbols as symbols_mod
 from repowise.server.mcp_server.tool_answer.answer import (
     _degraded_payload,
     _drop_duplicated_guess_excerpts,
 )
+from repowise.server.mcp_server.tool_answer.confidence import _degraded_confidence
 from repowise.server.mcp_server.tool_answer.projection import project_answer_payload
 
 
@@ -345,7 +348,39 @@ async def test_degraded_never_reaches_high():
         t0=0.0,
     )
     assert payload["retrieval_quality"] == "high"
-    assert payload["confidence"] != "high"
+    assert payload["confidence"] == "medium"
+
+
+@pytest.mark.parametrize("reason", ["no-llm-provider", "synthesis-failed"])
+@pytest.mark.parametrize("quality", ["high", "partial", "weak"])
+def test_the_ceiling_holds_over_every_input(reason: str, quality: str):
+    """The ceiling as a property, not a coincidence of one fixture.
+
+    An assertion on a single payload cannot say "never high" - it says "not high
+    here". This walks the whole input space the grader can be called with.
+    """
+    assert _degraded_confidence(reason, quality) in {"low", "medium"}
+
+
+def test_only_a_no_provider_payload_over_real_retrieval_earns_medium():
+    """The exact shape of the grade, pinned as a table.
+
+    Reading it as one block is what makes the two rules visible: retrieval
+    decides the grade, and only for the install that has no better reply coming.
+    """
+    grades = {
+        (reason, quality): _degraded_confidence(reason, quality)
+        for reason in ("no-llm-provider", "synthesis-failed")
+        for quality in ("high", "partial", "weak")
+    }
+    assert grades == {
+        ("no-llm-provider", "high"): "medium",
+        ("no-llm-provider", "partial"): "medium",
+        ("no-llm-provider", "weak"): "low",
+        ("synthesis-failed", "high"): "low",
+        ("synthesis-failed", "partial"): "low",
+        ("synthesis-failed", "weak"): "low",
+    }
 
 
 async def test_synthesis_failed_stays_low_however_good_the_retrieval_was():
@@ -634,3 +669,23 @@ def test_a_synthesised_payload_still_trims_on_its_grade():
     projected = project_answer_payload(raw, question="how does this work")
 
     assert len(projected["symbol_bodies"]) == 1
+
+
+def test_the_hint_is_the_same_whatever_the_payload_graded():
+    """The grade moved; the hint deliberately does not read it.
+
+    `answer_hint` keys on `degraded` before it looks at confidence, because on
+    this path what is missing is the prose and not the evidence - the push to go
+    verify would be the wrong one. The payload passes its real grade in rather
+    than a hardcoded "low" so the two never drift apart, and this pins that the
+    hint ignoring it is the intended behaviour rather than an oversight.
+    """
+    from repowise.server.mcp_server._meta import answer_hint
+
+    hints = {
+        answer_hint(grade, degraded="no-llm-provider", retrieval_quality="high")
+        for grade in ("low", "medium", "high")
+    }
+
+    assert len(hints) == 1
+    assert "Synthesis is what is missing here" in hints.pop()

--- a/tests/unit/server/mcp/test_answer_degraded_evidence.py
+++ b/tests/unit/server/mcp/test_answer_degraded_evidence.py
@@ -187,19 +187,20 @@ async def test_degraded_hint_never_advertises_an_unresolvable_id(tmp_path, monke
     assert "src/flask/app.py:122-200" in hint
 
 
-async def test_degraded_with_no_anchor_match_keeps_its_verdict(tmp_path):
-    """The no-body degraded payload keeps every judgement it was making.
+async def test_degraded_with_no_anchor_match_still_describes_a_ranking(tmp_path):
+    """The no-body degraded payload keeps the shape it reports about itself.
 
     This path is still reached (a question that names nothing indexed). It has
     since gained the choosing evidence (best_guesses, and code_rationale where
-    the source carries any), but the verdict it reports about itself — low
-    confidence, the degradation reason, an `answer` that describes a ranking and
-    not a body — must be exactly what it was.
+    the source carries any), and the degradation reason and the `answer` that
+    describes a ranking rather than a body are unchanged. Confidence is no
+    longer part of that fixed verdict: this hit is a sole hit over the score
+    floor, so the retrieval is good and the grade follows it.
     """
     ctx = _tree(tmp_path)
     payload = await _degraded(ctx, _hits(end_line=6), set())
 
-    assert payload["confidence"] == "low"
+    assert payload["confidence"] == "medium"
     assert payload["degraded"] == "no-llm-provider"
     assert "ranked" in payload["answer"]
     assert "symbol_bodies" not in payload
@@ -208,11 +209,11 @@ async def test_degraded_with_no_anchor_match_keeps_its_verdict(tmp_path):
 # --- retrieval_quality on the degraded payload (D10) -----------------------
 #
 # 26 of 26 measured keyless payloads carried no `retrieval_quality` key at all,
-# so the only trust signal a caller had was `confidence: "low"`, which rates
+# so the only trust signal a caller had was `confidence: "low"`, which rated
 # synthesised prose that a degraded payload does not have. 11 of those 26 said
-# "low" while rank 1 was a file the keyed arm went on to cite. `confidence`
-# stays low on purpose; the retrieval gets rated separately, by the same rule
-# the synthesised path uses.
+# "low" while rank 1 was a file the keyed arm went on to cite. The retrieval is
+# rated separately here, by the same rule the synthesised path uses; the grade
+# derived from it is pinned in the confidence block further down.
 
 
 def _scored(*scores: float) -> list[dict]:
@@ -278,12 +279,61 @@ async def test_degraded_agreement_can_lift_but_the_floor_still_binds():
     assert await _quality(_scored(0.9, 0.8), agreement_dominant=True) == "partial"
 
 
-async def test_degraded_keeps_confidence_low():
-    """The label the reporter asked to raise stays where it is.
+# --- confidence on the degraded payload ------------------------------------
+#
+# `confidence` was pinned to "low" here on the grounds that it rates synthesised
+# text and there is none. In the field that told 69 percent of get_answer calls
+# to distrust evidence that was frequently excellent, and 84 percent of those
+# verdicts were unearned: a keyless install never configures a provider, so it
+# got "low" on every call forever, decoupled from what retrieval actually did.
+# The field is now graded from the retrieval, under a ceiling that preserves the
+# original objection rather than discarding it.
 
-    Confidence rates the synthesised text, and a degraded `answer` is assembled
-    boilerplate, byte-identical on 24 of the 26 measured questions. Telling an
-    agent to cite that is worse than the extra call it saves.
+
+async def _confidence(hits, *, reason: str = "no-llm-provider") -> str:
+    payload = await _degraded_payload(
+        reason=reason,
+        note="DEGRADED",
+        question="how does the module work",
+        hits=hits,
+        fallback_targets=["pkg/m0.py"],
+        repository=None,
+        t0=0.0,
+    )
+    return payload["confidence"]
+
+
+async def test_degraded_grades_a_good_retrieval_medium():
+    """The unearned "low" this whole block exists to remove."""
+    assert await _confidence(_scored(6.0, 1.0)) == "medium"
+
+
+async def test_degraded_grades_a_partial_retrieval_medium_too():
+    """Dominant but under the score floor is still a payload worth acting on.
+
+    Only "weak" — no dominant page at all — leaves the caller with a real choice
+    to make, and that is the one the grade should push back on.
+    """
+    assert await _confidence(_scored(1.0, 0.1)) == "medium"
+
+
+async def test_degraded_keeps_a_weak_retrieval_low():
+    """The control. An ambiguous retrieval was always an earned "low".
+
+    This agrees with the `_meta` hint on the same payload, which tells a caller
+    on weak retrieval to refine the query rather than read the hits in order.
+    Two signals that disagreed about the same retrieval would be worse than one.
+    """
+    assert await _confidence(_scored(6.0, 5.9)) == "low"
+
+
+async def test_degraded_never_reaches_high():
+    """The original objection, kept as a ceiling.
+
+    A degraded `answer` is assembled boilerplate, byte-identical on 24 of the 26
+    measured questions, and our own agent instructions license citing a
+    high-confidence answer directly. So "high" has to stay unreachable here even
+    though the retrieval under it graded high.
     """
     payload = await _degraded_payload(
         reason="no-llm-provider",
@@ -294,8 +344,19 @@ async def test_degraded_keeps_confidence_low():
         repository=None,
         t0=0.0,
     )
-    assert payload["confidence"] == "low"
     assert payload["retrieval_quality"] == "high"
+    assert payload["confidence"] != "high"
+
+
+async def test_synthesis_failed_stays_low_however_good_the_retrieval_was():
+    """A configured provider that failed is not the end of the line.
+
+    The evidence is identical to the no-provider case, but a retry can still
+    produce a real answer here, so the payload is not everything the caller is
+    going to get. "no-llm-provider" is the end of the line for that install,
+    which is what makes grading its evidence the honest thing to do.
+    """
+    assert await _confidence(_scored(6.0, 1.0), reason="synthesis-failed") == "low"
 
 
 async def test_degraded_hint_says_what_is_missing_not_what_to_doubt():

--- a/tests/unit/server/mcp/test_answer_projection.py
+++ b/tests/unit/server/mcp/test_answer_projection.py
@@ -322,6 +322,15 @@ async def test_no_llm_and_failed_legs_remain_compact_and_actionable(
     )
 
     assert result["degraded"] == expected_degraded
+    # The grade, through the real tool rather than the payload builder: derived
+    # from the retrieval on the no-provider path, and pinned low when a
+    # configured provider failed and a retry could still answer properly.
+    if expected_degraded == "synthesis-failed":
+        assert result["confidence"] == "low"
+    else:
+        expected = "low" if result["retrieval_quality"] == "weak" else "medium"
+        assert result["confidence"] == expected
+    assert result["confidence"] != "high"
     assert result["answer"]
     assert result["next_action_hint"]
     assert result.get("best_guesses") or result.get("symbol_bodies") or result.get("retrieval")


### PR DESCRIPTION
## Summary

- `get_answer` returned `confidence: "low"` on ~69% of field calls, and the great majority of those were unearned. An install with no LLM provider — the keyless path we advertise as "start in minutes, no API key" — got `low` on every call forever, regardless of how good retrieval was.
- The value was hardcoded in the synthesis-less payload. It is now graded from the retrieval that payload actually served: a weak retrieval still grades `low`, anything better grades `medium`, and `high` stays unreachable.
- Evidence served to the caller is unchanged. The projection layer trims by `confidence`, so grading alone would have *cut* a symbol body and a retrieval hit from exactly the callers this helps; degraded payloads now keep the fullest shape regardless of grade.

### Why the field moved

`confidence` was pinned on the grounds that it rates synthesized text and there is none on this path. That is a problem with the field's referent rather than an argument for saying nothing: `confidence` is what an agent reads to decide whether it still has work to do, which is the same question on both paths. So it rates what the caller can act on.

The original objection survives as a ceiling rather than being discarded. `answer` on this path is assembled boilerplate, and our own agent instructions tell agents a high-confidence answer can be cited directly, so `high` must stay unreachable here.

`synthesis-failed` stays `low` whatever retrieval did. The evidence is identical to the no-provider case, but a provider is configured there, so a retry can still produce a real answer and the payload is not the end of the line the way it is for a keyless install.

No answer-cache version bump: the cache write is gated on `answer_text` and sits below both degraded returns, so no cached row can carry the old shape.

## Related Issues

## Test Plan

- [x] Tests pass — full `tests/unit/server/mcp` suite, 1,634 passed
- [x] Lint passes (`ruff check .`)
- [ ] Web build passes — n/a, no frontend changes

New coverage: the grade as a table over every (degrade reason × retrieval quality) pair, the ceiling as a property rather than one fixture, the value asserted through the real tool and not only the payload builder, and three regression tests on the projection shape that fail if the guard is reverted.

## Checklist

- [x] My code follows the project's code style
- [x] I have added tests for new functionality
- [x] All existing tests still pass
- [x] I have updated documentation if needed
