### PR TITLE
docs(benchmarks): say what file coverage does and does not grade

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -344,6 +344,13 @@ including the prediction that it would come last.
 **This is retrieval, not task success.** It says we find the right files, not that
 an agent using us writes better code.
 
+**The grader never reads `confidence`.** File coverage compares the paths a tool
+returns against ContextBench's gold spans, and nothing else in the response is
+scored. A `get_answer` call can cover every gold file and still report
+`confidence: low`, or the reverse, without either affecting this number. So the
+0.876 is not a claim about how well-calibrated that field is; those are separate
+axes, measured separately, and neither is evidence about the other.
+
 Measured on repowise `081a59fa` (between v0.37.0 and v0.38.0). Raw cells:
 **[rung8](https://github.com/repowise-dev/repowise-bench/tree/master/results/bakeoff_2026_08/rung8)**.
 


### PR DESCRIPTION
## Summary

- States in `docs/BENCHMARKS.md` that the 0.876 file-coverage figure is a deterministic comparison of returned paths against ContextBench's gold spans, and that nothing else in the response is graded — `confidence` included.
- A `get_answer` call can cover every gold file while reporting low confidence, or the reverse, without either affecting the number. The two are separate axes measured separately, and neither is evidence about the other.

Worth stating once, so the pair does not later look like a contradiction.

## Related Issues

## Test Plan

- [x] Tests pass — documentation only, no code changed
- [x] Lint passes (`ruff check .`)
- [ ] Web build passes — n/a, no frontend changes

## Checklist

- [x] My code follows the project's code style
- [ ] I have added tests for new functionality — n/a, documentation only
- [x] All existing tests still pass
- [x] I have updated documentation if needed
