### PR TITLE
fix(cli): keep init dry runs from writing a wiki

### DIFF
--- a/docs/reference/CLI_REFERENCE.md
+++ b/docs/reference/CLI_REFERENCE.md
@@ -176,7 +176,7 @@ All three reach the indexing knobs; the LLM-only knobs appear only when model-wr
 | `--seed-from` | Seed the index from an explicit base checkout instead of the auto-detected one. Rarely needed: inside a linked git worktree the base is detected and seeded automatically. See [WORKTREES.md](../scale/WORKTREES.md). |
 | `--no-seed` | Disable worktree auto-seeding and run a full init even inside a linked worktree. |
 | `--yes` / `-y` | Skip confirmation prompts |
-| `--dry-run` | Show generation plan and cost estimate without running |
+| `--dry-run` | Show the generation plan and cost estimate. Writes no wiki |
 | `--test-run` | Generate docs for only the top 10 files (by PageRank) |
 | `--all` | In multi-repo mode, index every detected repo without prompting |
 | `--no-workspace` | Force single-repo mode even when invoked from a workspace root (indexes only the target PATH instead of fanning out across workspace repos) |

--- a/packages/cli/src/repowise/cli/commands/init_cmd/command.py
+++ b/packages/cli/src/repowise/cli/commands/init_cmd/command.py
@@ -156,6 +156,60 @@ def _record_init_outcome(
         return
 
 
+def _print_structural_plan(
+    *,
+    result: Any,
+    repo_path: Path,
+    concurrency: int,
+    language: str,
+    onboarding: bool,
+    wiki_style: str,
+    max_file_pages: int | None,
+    skip_tests: bool,
+    skip_infra: bool,
+) -> None:
+    """The plan a dry run owes the deterministic branch.
+
+    ``build_generation_plan`` is provider-free, so the same selector that
+    generation would run gives the real per-type counts. A raw file count
+    would not: ``select_pages`` caps file pages, and module, onboarding and
+    infra pages are not in it at all.
+    """
+    from repowise.core.cost_estimator import build_generation_plan
+    from repowise.core.generation import GenerationConfig
+
+    gen_config = GenerationConfig.from_repo_config(
+        load_config(repo_path),
+        deterministic=True,
+        max_concurrency=concurrency,
+        language=language,
+        enable_onboarding=onboarding,
+        wiki_style=wiki_style,
+        max_file_pages=max_file_pages,
+    )
+    kg_modules = getattr(getattr(result, "knowledge_graph_result", None), "modules", None) or None
+    plans = build_generation_plan(
+        result.parsed_files,
+        result.graph_builder,
+        gen_config,
+        skip_tests,
+        skip_infra,
+        kg_modules=kg_modules,
+    )
+
+    table = Table(title="Generation Plan (dry run)", border_style=BRAND)
+    table.add_column("Pages", style="cyan")
+    table.add_column("Count", justify="right")
+    total = 0
+    for plan in plans:
+        total += plan.count
+        table.add_row(page_type_label(plan.page_type), f"{plan.count:,}")
+    table.add_section()
+    table.add_row("[bold]Total[/bold]", f"[bold]{total:,}[/bold]")
+    console.print(table)
+    console.print("  Dry run: every page above is rendered from structure. No wiki written.")
+
+
 def _run_deterministic_generation_phase(
     *,
     repo_path: Path,
@@ -437,7 +491,12 @@ def _run_generation_phase(
 @click.option("--skip-tests", is_flag=True, default=False, help="Skip test files.")
 @click.option("--skip-infra", is_flag=True, default=False, help="Skip infrastructure files.")
 @click.option(
-    "--dry-run", is_flag=True, default=False, help="Show generation plan without running."
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    # "No wiki", not "writes nothing": the pipeline still warms its parse and
+    # duplication caches, which are derived data.
+    help="Show the generation plan and cost estimate. Writes no wiki.",
 )
 @click.option("--yes", "-y", is_flag=True, default=False, help="Skip cost confirmation prompt.")
 @click.option(
@@ -1290,7 +1349,9 @@ def init_command(
     # the run isn't wasted, and propagate the choice to the persisted docs
     # mode so subsequent updates default to index-only.
     cost_declined = False
-    llm_client = provider if not index_only else decision_provider
+    # None on a dry run: decision extraction and KG enrichment both call this
+    # client before the generation phase's dry-run return is reached.
+    llm_client = None if dry_run else (provider if not index_only else decision_provider)
 
     from repowise.core.pipeline import PhaseTimingRecorder, run_pipeline
     from repowise.core.pipeline.modes import OrchestratorMode
@@ -1394,9 +1455,32 @@ def init_command(
     show_analysis_summary(result)
 
     # ---- Phase 3: Generation ----
+    # The priced branch below has its own dry-run return; these two rendered
+    # the template wiki and fell through to persistence, overwriting a
+    # model-written one. Same shape as #2005 (update) and #1526 (workspace).
+    if dry_run and (index_only or no_provider):
+        if run_mode == "fast":
+            # Fast skips generation outright, so promising a wiki here would
+            # preview the opposite of what the real run does.
+            console.print("\n  Dry run: fast mode indexes graph and git only. No wiki written.")
+        else:
+            _print_structural_plan(
+                result=result,
+                repo_path=repo_path,
+                concurrency=concurrency,
+                language=language,
+                onboarding=onboarding,
+                wiki_style=wiki_style,
+                max_file_pages=max_file_pages,
+                skip_tests=skip_tests,
+                skip_infra=skip_infra,
+            )
+        return
+
     # The embedder the template wiki was actually built with, persisted below
     # so `repowise update` reuses it. None means no template wiki was rendered.
     _index_only_embedder: str | None = None
+
     # Both modes generate. Index-only renders from templates; full mode picks
     # a coverage level, estimates the spend and prompts a model.
     #

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -155,6 +155,103 @@ class TestInitDryRun:
         # No DB should be created
         assert not (work_repo / ".repowise" / "wiki.db").exists()
 
+    def test_no_prose_dry_run_writes_no_wiki(self, runner, work_repo):
+        """The branch above prices a model and returns; this one never did.
+
+        ``--no-prose`` and a keyless run both reach the deterministic
+        generation phase, which takes no ``dry_run`` argument at all.
+        """
+        result = runner.invoke(
+            cli,
+            ["init", str(work_repo), "--no-prose", "--dry-run", "--yes"],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, result.output
+        assert "Dry run" in result.output
+        assert not (work_repo / ".repowise" / "wiki.db").exists()
+        assert not (work_repo / ".repowise" / "state.json").exists()
+
+    def test_no_provider_dry_run_writes_no_wiki(self, runner, work_repo, monkeypatch):
+        """The other half of the predicate, and the worse one.
+
+        A keyless run sets ``no_provider`` rather than ``index_only``, so it
+        walked past the downgrade guard at the top of the command even
+        interactively.
+        """
+        for key in (
+            "OPENAI_API_KEY",
+            "ANTHROPIC_API_KEY",
+            "GEMINI_API_KEY",
+            "GOOGLE_API_KEY",
+            "OPENROUTER_API_KEY",
+            "DEEPSEEK_API_KEY",
+            "REPOWISE_PROVIDER",
+        ):
+            monkeypatch.delenv(key, raising=False)
+
+        result = runner.invoke(
+            cli,
+            ["init", str(work_repo), "--prose", "--dry-run", "--yes"],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, result.output
+        assert "Dry run" in result.output
+        assert not (work_repo / ".repowise" / "wiki.db").exists()
+        assert not (work_repo / ".repowise" / "state.json").exists()
+
+    def test_fast_dry_run_promises_no_wiki(self, runner, work_repo):
+        """Fast skips generation, so the preview must not promise a wiki."""
+        result = runner.invoke(
+            cli,
+            ["init", str(work_repo), "--mode", "fast", "--dry-run", "--yes"],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, result.output
+        assert "No wiki written" in result.output
+        assert "Generation Plan" not in result.output
+        assert not (work_repo / ".repowise" / "wiki.db").exists()
+
+    def test_dry_run_does_not_replace_a_model_written_wiki(self, runner, work_repo):
+        """Rendering templates over an existing wiki rewrote every page and
+        downgraded ``docs_mode``, on the one command that promises not to act.
+        Recoverable through page history, but every reader served templates
+        afterwards and the spend behind the originals was wasted.
+        """
+        import json
+        import sqlite3
+        from contextlib import closing
+
+        seed = runner.invoke(
+            cli,
+            ["init", str(work_repo), "--provider", "mock", "--yes"],
+            catch_exceptions=False,
+        )
+        assert seed.exit_code == 0, seed.output
+
+        db_path = work_repo / ".repowise" / "wiki.db"
+        state_path = work_repo / ".repowise" / "state.json"
+        with closing(sqlite3.connect(db_path)) as db:
+            db.execute("UPDATE wiki_pages SET provider_name='gemini', content='WRITTEN'")
+            db.commit()
+        state = json.loads(state_path.read_text(encoding="utf-8"))
+        state["docs_mode"] = "llm"
+        state_path.write_text(json.dumps(state), encoding="utf-8")
+
+        result = runner.invoke(
+            cli,
+            ["init", str(work_repo), "--no-prose", "--dry-run", "--yes"],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, result.output
+
+        written = _db_scalar(db_path, "SELECT COUNT(*) FROM wiki_pages WHERE content='WRITTEN'")
+        templated = _db_scalar(
+            db_path, "SELECT COUNT(*) FROM wiki_pages WHERE provider_name='template'"
+        )
+        assert templated == 0
+        assert written > 0
+        assert json.loads(state_path.read_text(encoding="utf-8"))["docs_mode"] == "llm"
+
 
 class TestInitFullMock:
     def test_creates_db_and_state(self, runner, work_repo):


### PR DESCRIPTION
`init --dry-run` has three generation branches and only one honoured the flag.
The branch that prices a model returns before persistence. The fast and
deterministic branches did not: `_run_deterministic_generation_phase` takes no
`dry_run` argument, so both rendered the full template wiki and fell through
to persist.

The consequence is worse than a stray index. Against a repo that already has a
model-written wiki, `--dry-run` rewrote all of it from templates and downgraded
`docs_mode` to deterministic, on the one command whose promise is that it does
not act. The prior text survives as page-version snapshots, so it is a
recoverable downgrade rather than data loss, but `status`, the dashboard and
the MCP tools all serve the templates afterwards and the spend behind the
originals is wasted. The downgrade guard at the top of the command tests
`index_only and _prior_docs_mode == "llm" and not (force or yes)`, covering
neither `dry_run` nor `no_provider`, so a keyless `--prose --dry-run` walked
past it even interactively.

## What changed

- Return before the dispatch on the two branches that do not price a model.
  `index_only or no_provider` is exhaustive over them: fast mode forces
  `index_only`, and the cost-declined fallback sits behind the priced branch's
  own earlier dry-run return. The priced branch is untouched, since showing a
  plan and a cost estimate is what the flag was written for.
- Those branches now print a plan rather than a sentence.
  `build_generation_plan` is provider-free, so the same selector generation
  would run gives real per-type counts; a raw file count would be neither the
  page count (file pages are capped) nor the count already on screen. Fast mode
  states that it writes no wiki, because that is what fast does.
- No LLM client on a dry run. Decision extraction receives it inside the
  pipeline ahead of the generation phase's return, so `--prose --dry-run` with
  a working key was billable.
- The help text and CLI reference said "without running" and now say "Writes no
  wiki". The pipeline still warms its parse and duplication caches, which are
  derived data and cost only time.

Same shape as #2005 for `update --full` and #1526 for the workspace path. Both
cited single-repo init as the correct reference; it was not.

## Verification

`tests/integration/test_cli.py::TestInitDryRun` covers both halves of the
predicate (`--no-prose` for `index_only`, a key-stripped `--prose` for
`no_provider`), the fast-mode message, and a regression test that seeds a
model-written wiki and asserts a dry run leaves every page and `docs_mode`
intact.

Measured on a 172-file repo: before, `--dry-run` left an 8 MB `wiki.db`, 188
pages, `state.json`, `mcp.json` and `lancedb/`; after, none of them, and a
seeded model-written wiki survives at 188/188 pages with `docs_mode` still
`llm`.