### PR TITLE
release: v0.48.0, a review queue for decisions and a rewritten repo overview

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "name": "repowise",
       "source": "./plugins/claude-code",
       "description": "Codebase intelligence for Claude Code. Indexes your repo into five layers (Graph, Git, Docs, Decisions, Code Health) and gives Claude deep understanding of architecture, ownership, hotspots, decisions, and defect risk — fewer greps, fewer file reads, lower cost per query.",
-      "version": "0.47.0",
+      "version": "0.48.0",
       "category": "productivity",
       "keywords": [
         "codebase",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.48.0] — 2026-09-02
+
+Architectural decisions stop being a passive record and become a review queue. A decision is captured under one policy, keyed by the identity it dedupes on, and acceptance is the only thing that grants it authority — recorded as an event, on a tracked manifest, so every read can say who vouched for what. On top of that sits a queue that leads with the work you can actually finish. The other change you will see first is the repo overview: the front page described a file tree because a file tree was all it was given, and it now reads like a description of a product. Elsewhere: `doctor` stops trusting config files and launches the MCP server for real, the keyless and degraded paths report why they degraded, and a cycle of persistence and generation performance work.
+
+### Added
+
+- **Decisions are a review queue, not a log.** Capture runs under one policy with acceptance as the only authority (#2067), acceptance is a recorded event against a tracked manifest (#2069), and discovery is one broad grounded call per update instead of many narrow ones (#2068). Reads carry review lanes and a single vocabulary, with authority stated on every read (#2070). A decision's id is derived from the identity it dedupes on, so the same decision found twice is the same row (#2071). `decision` reports what capture actually did and reviews a backlog in one command (#2072), and the queue leads with work that can be finished now (#2073).
+- **The repo overview reads like a product, not a directory.** The front page every reader opens described a file tree: `assemble_repo_overview` handed the model pagerank, communities, package file counts and entry-point paths with no natural-language input at all, so a page of paths was the specified output. The context gains one bounded prose keyhole — a README digest capped at 2,500 characters — and the page has a fixed shape: what this is, how the parts fit, then five to seven named concepts. Prose supplies vocabulary and framing; structure stays the sole authority on paths, counts and package names (#2078).
+- **`doctor` launches the MCP server** rather than reading its config and assuming (#2065). A config that looks right and a server that will not start are different problems, and only one of them was previously detectable.
+- **Failure and degradation are reportable.** `init` failures carry a reason code (#2057), and telemetry reports the degrade reason, the keyless case and every crash leaf (#2056).
+- **Five more JS/TS security patterns** in the registry (#2047).
+- **`augment` takes `--verbose`**, wired through `configure_cli_logging` (#2033).
+- The TypeScript HTTP contract is generated from the FastAPI schema rather than hand-maintained (#2035).
+- `tech_stack` detects bun as the script runner (#1940).
+
+### Changed
+
+- **`HEALTH_ANALYZER_VERSION` is 8.** Paired-test detection had `test_<stem>.py` hardcoded, so the prefix layout only ever matched Python; it now follows the file's own suffix, and `<stem>_spec` joins the suffix forms (#1841). Files wrongly counted untested become tested, which moves untested-hotspot findings and the scores carrying them. An existing index re-scores on its next update; it does not force a re-index. `STORE_FORMAT_VERSION` and `PARSER_SCHEMA_VERSION` are unchanged.
+- **Indexing and persistence are faster.** Betweenness is reused inside a churn budget instead of rescored (#2066), the full-text index is written in one transaction (#2052), job checkpoints are buffered behind a bounded atomic flush (#2053), and the generation and persistence tail is timed (#2050).
+- **Repository-scale native memory is bounded** during indexing (#1778).
+- Every MCP tool shares one response-budget contract (#2051).
+- `get_answer` grades a degraded answer's confidence from retrieval quality instead of pinning it low (#2055).
+- `init --resume` is documented, with expanded help text (#113, #2030).
+
+### Fixed
+
+- **Dry runs are read-only.** `update --full --dry-run` could create locks and mutate the index; it now reports the persisted upgrade plan instead (#2005). `init --dry-run` had the same shape and was worse: only the branch that prices a model honoured the flag, so a keyless or `--no-prose` dry run rendered the whole template wiki and persisted it. Against a repo that already had a model-written wiki that rewrote every page from templates and downgraded `docs_mode`, on the one command whose promise is that it does not act (#2075). It also no longer passes an LLM client, so a dry run cannot bill.
+- **The configured embedder is the one `init` uses.** `resolve_embedder` auto-detected from environment variables and fell through to `mock`, never reading the `embedder` field in `~/.repowise/config.yaml` — the field `repowise serve`'s prompt writes. A machine configured only there indexed with keyless vectors, pinned `mock`, and got no semantic search, with nothing to say so (#2074).
+- **Persistence**: symbol names are stored as `Text` rather than `VARCHAR(255)` (#1705), the WAL switch no longer kills a read against a live writer (#2064), page snapshots are swept when a repository is deleted (#1945), and stale pages take one `UPDATE` rather than two copies (#1199).
+- **Embedder**: `--embedder auto` resolves through the repo pin rather than the environment, so a pinned backend is the one that queries the table it wrote (#2032).
+- **Health and risk**: `analyzed_commit` is stamped by every remaining metric writer (#1864, #2034), and `get_risk` normalizes the `git_metadata` target path (#1849).
+- **Ingestion**: a package language tie resolves by name rather than walk order (#2028).
+- **CLI and server**: the page listing is no longer capped at 10,000 (#2061), git logs work in worktrees (#2045), `doctor` explains stale pages and why `--repair` cannot clear them (#1710, #1956), and workspace contract links in `CLAUDE.md` are ranked by confidence before the cap (#1588, #1957).
+- **The provenance footer on structural pages is a horizontal rule again.** It rendered as `---*Built from the code's structure...`, with the rule and the text joined, which is a paragraph beginning with three dashes rather than a rule (#2080).
+- **UI**: performance filter counts are clarified (#2044) and the context "all" badge is scoped (#2042).
+- Plugin: the `change-review` skill renders from its shared source (#2023).
+
+---
+
 ## [0.47.0] — 2026-08-30
 
 The headline this cycle is that Code Health stops handing you observations and starts handing you work. Performance findings compose into per-file opportunities with a real lifecycle, served from a materialized read model so the web page, the CLI and the agent surface cannot disagree about what one opportunity is. Alongside it, a contextual chat dock that can read the indexed repository and keep its artifacts, coupling that says whether two files *should* change together rather than just that they did, and an architecture view that finally does something useful with external dependencies.

--- a/packages/cli/src/repowise/cli/__init__.py
+++ b/packages/cli/src/repowise/cli/__init__.py
@@ -16,4 +16,4 @@ from repowise.cli._stdio import _ensure_utf8_stdio
 # is already UTF-8.
 _ensure_utf8_stdio()
 
-__version__ = "0.47.0"
+__version__ = "0.48.0"

--- a/packages/core/src/repowise/core/__init__.py
+++ b/packages/core/src/repowise/core/__init__.py
@@ -6,4 +6,4 @@ generation engine. This is the heart of repowise — all other packages depend o
 Namespace package: repowise.core is part of the repowise namespace.
 """
 
-__version__ = "0.47.0"
+__version__ = "0.48.0"

--- a/packages/core/src/repowise/core/analysis/health/engine.py
+++ b/packages/core/src/repowise/core/analysis/health/engine.py
@@ -91,13 +91,13 @@ log = structlog.get_logger(__name__)
 # Not a licence to move a calibrated scoring weight — those are frozen
 # independently of this stamp.
 #
-# Current stamp: the performance identity kernel moved to model version 2. A
-# cross-function cause is now named by the caller that repeats the work as well
-# as the sink that pays for it, so a shared infrastructure helper no longer
-# merges unrelated workflows, and execution context gained ``unknown`` instead of
-# defaulting an unclassifiable file to production. Stored opportunity ids and
-# plan links are restamped by the rescore this forces.
-HEALTH_ANALYZER_VERSION = 7
+# Current stamp: paired-test detection changed. ``_has_paired_test_file`` had
+# ``test_<stem>.py`` hardcoded, so the prefix layout only ever matched Python;
+# it now follows the file's own suffix, and ``<stem>_spec`` joins the suffix
+# forms. Files that were counted untested and are not become tested, which
+# moves untested-hotspot findings and the scores that carry them, on every
+# language with a prefix or spec convention rather than Ruby alone.
+HEALTH_ANALYZER_VERSION = 8
 
 # Method-level smells that make the dataflow / Extract Method pass worthwhile.
 # Only files carrying one of these get a CFG + def/use + reaching pass built.

--- a/packages/core/src/repowise/core/upgrade/_data/CHANGELOG.md
+++ b/packages/core/src/repowise/core/upgrade/_data/CHANGELOG.md
@@ -9,6 +9,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.48.0] — 2026-09-02
+
+Architectural decisions stop being a passive record and become a review queue. A decision is captured under one policy, keyed by the identity it dedupes on, and acceptance is the only thing that grants it authority — recorded as an event, on a tracked manifest, so every read can say who vouched for what. On top of that sits a queue that leads with the work you can actually finish. The other change you will see first is the repo overview: the front page described a file tree because a file tree was all it was given, and it now reads like a description of a product. Elsewhere: `doctor` stops trusting config files and launches the MCP server for real, the keyless and degraded paths report why they degraded, and a cycle of persistence and generation performance work.
+
+### Added
+
+- **Decisions are a review queue, not a log.** Capture runs under one policy with acceptance as the only authority (#2067), acceptance is a recorded event against a tracked manifest (#2069), and discovery is one broad grounded call per update instead of many narrow ones (#2068). Reads carry review lanes and a single vocabulary, with authority stated on every read (#2070). A decision's id is derived from the identity it dedupes on, so the same decision found twice is the same row (#2071). `decision` reports what capture actually did and reviews a backlog in one command (#2072), and the queue leads with work that can be finished now (#2073).
+- **The repo overview reads like a product, not a directory.** The front page every reader opens described a file tree: `assemble_repo_overview` handed the model pagerank, communities, package file counts and entry-point paths with no natural-language input at all, so a page of paths was the specified output. The context gains one bounded prose keyhole — a README digest capped at 2,500 characters — and the page has a fixed shape: what this is, how the parts fit, then five to seven named concepts. Prose supplies vocabulary and framing; structure stays the sole authority on paths, counts and package names (#2078).
+- **`doctor` launches the MCP server** rather than reading its config and assuming (#2065). A config that looks right and a server that will not start are different problems, and only one of them was previously detectable.
+- **Failure and degradation are reportable.** `init` failures carry a reason code (#2057), and telemetry reports the degrade reason, the keyless case and every crash leaf (#2056).
+- **Five more JS/TS security patterns** in the registry (#2047).
+- **`augment` takes `--verbose`**, wired through `configure_cli_logging` (#2033).
+- The TypeScript HTTP contract is generated from the FastAPI schema rather than hand-maintained (#2035).
+- `tech_stack` detects bun as the script runner (#1940).
+
+### Changed
+
+- **`HEALTH_ANALYZER_VERSION` is 8.** Paired-test detection had `test_<stem>.py` hardcoded, so the prefix layout only ever matched Python; it now follows the file's own suffix, and `<stem>_spec` joins the suffix forms (#1841). Files wrongly counted untested become tested, which moves untested-hotspot findings and the scores carrying them. An existing index re-scores on its next update; it does not force a re-index. `STORE_FORMAT_VERSION` and `PARSER_SCHEMA_VERSION` are unchanged.
+- **Indexing and persistence are faster.** Betweenness is reused inside a churn budget instead of rescored (#2066), the full-text index is written in one transaction (#2052), job checkpoints are buffered behind a bounded atomic flush (#2053), and the generation and persistence tail is timed (#2050).
+- **Repository-scale native memory is bounded** during indexing (#1778).
+- Every MCP tool shares one response-budget contract (#2051).
+- `get_answer` grades a degraded answer's confidence from retrieval quality instead of pinning it low (#2055).
+- `init --resume` is documented, with expanded help text (#113, #2030).
+
+### Fixed
+
+- **Dry runs are read-only.** `update --full --dry-run` could create locks and mutate the index; it now reports the persisted upgrade plan instead (#2005). `init --dry-run` had the same shape and was worse: only the branch that prices a model honoured the flag, so a keyless or `--no-prose` dry run rendered the whole template wiki and persisted it. Against a repo that already had a model-written wiki that rewrote every page from templates and downgraded `docs_mode`, on the one command whose promise is that it does not act (#2075). It also no longer passes an LLM client, so a dry run cannot bill.
+- **The configured embedder is the one `init` uses.** `resolve_embedder` auto-detected from environment variables and fell through to `mock`, never reading the `embedder` field in `~/.repowise/config.yaml` — the field `repowise serve`'s prompt writes. A machine configured only there indexed with keyless vectors, pinned `mock`, and got no semantic search, with nothing to say so (#2074).
+- **Persistence**: symbol names are stored as `Text` rather than `VARCHAR(255)` (#1705), the WAL switch no longer kills a read against a live writer (#2064), page snapshots are swept when a repository is deleted (#1945), and stale pages take one `UPDATE` rather than two copies (#1199).
+- **Embedder**: `--embedder auto` resolves through the repo pin rather than the environment, so a pinned backend is the one that queries the table it wrote (#2032).
+- **Health and risk**: `analyzed_commit` is stamped by every remaining metric writer (#1864, #2034), and `get_risk` normalizes the `git_metadata` target path (#1849).
+- **Ingestion**: a package language tie resolves by name rather than walk order (#2028).
+- **CLI and server**: the page listing is no longer capped at 10,000 (#2061), git logs work in worktrees (#2045), `doctor` explains stale pages and why `--repair` cannot clear them (#1710, #1956), and workspace contract links in `CLAUDE.md` are ranked by confidence before the cap (#1588, #1957).
+- **The provenance footer on structural pages is a horizontal rule again.** It rendered as `---*Built from the code's structure...`, with the rule and the text joined, which is a paragraph beginning with three dashes rather than a rule (#2080).
+- **UI**: performance filter counts are clarified (#2044) and the context "all" badge is scoped (#2042).
+- Plugin: the `change-review` skill renders from its shared source (#2023).
+
+---
+
 ## [0.47.0] — 2026-08-30
 
 The headline this cycle is that Code Health stops handing you observations and starts handing you work. Performance findings compose into per-file opportunities with a real lifecycle, served from a materialized read model so the web page, the CLI and the agent surface cannot disagree about what one opportunity is. Alongside it, a contextual chat dock that can read the indexed repository and keep its artifacts, coupling that says whether two files *should* change together rather than just that they did, and an architecture view that finally does something useful with external dependencies.

--- a/packages/server/src/repowise/server/__init__.py
+++ b/packages/server/src/repowise/server/__init__.py
@@ -7,4 +7,4 @@ Provides:
     - Background job scheduler (APScheduler)
 """
 
-__version__ = "0.47.0"
+__version__ = "0.48.0"

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "repowise",
   "description": "Codebase intelligence for Claude Code. Indexes your codebase into five layers (Graph, Git, Docs, Decisions, Code Health) and exposes them through ten task-shaped MCP tools — so Claude understands architecture, ownership, hotspots, why code is built the way it is, and where the defect risk lives.",
-  "version": "0.47.0",
+  "version": "0.48.0",
   "author": {
     "name": "Repowise",
     "email": "hello@repowise.dev",

--- a/plugins/claude-code/CHANGELOG.md
+++ b/plugins/claude-code/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the Repowise Claude Code plugin are documented here.
 
+## 0.48.0
+
+### Changed
+- Version bump only. No command, skill or doc change this cycle: the CLI flags
+  each command names are unchanged, `hooks.json` still mirrors
+  `claude_config.py`, and every tool named in a command or skill is one the
+  server lists. `generate_refactoring_code` is live and deliberately unreferenced.
+
 ## 0.47.0
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "repowise"
-version = "0.47.0"
+version = "0.48.0"
 description = "The codebase intelligence layer for your AI coding agent — dependency graph, git history, dead code, decisions, and code health, exposed over MCP"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/server.json
+++ b/server.json
@@ -8,12 +8,12 @@
     "source": "github"
   },
   "websiteUrl": "https://www.repowise.dev",
-  "version": "0.47.0",
+  "version": "0.48.0",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "repowise",
-      "version": "0.47.0",
+      "version": "0.48.0",
       "transport": {
         "type": "stdio"
       },

--- a/tests/unit/health/test_model_version_coupling.py
+++ b/tests/unit/health/test_model_version_coupling.py
@@ -22,7 +22,7 @@ from repowise.core.analysis.health.refactoring.identity import (
 
 # The three stamps as they stand together. Moving either identity model means
 # moving the analyzer with it, and updating this tuple in the same commit.
-_STAMPS = (7, 2, 2)
+_STAMPS = (8, 2, 2)
 
 
 def test_the_identity_models_and_the_analyzer_stamp_are_pinned_together() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -3051,7 +3051,7 @@ wheels = [
 
 [[package]]
 name = "repowise"
-version = "0.47.0"
+version = "0.48.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Version bump to 0.48.0 plus the changelog. Cut from `main` at e4992d33c.

## What's in it

Repowise has recorded architectural decisions for a while, but recording was
most of what it did. You could capture a decision and read it back, and that was
about the end of it. This release turns that store into something you work
through. Capture runs under one policy instead of several, discovery makes one
broad grounded call per update rather than many narrow ones, and acceptance
becomes the only thing that grants a decision authority. Acceptance is now a
recorded event against a tracked manifest, so a read can tell you who vouched for
a decision and when, rather than presenting every row with equal confidence. A
decision's id is derived from the identity it dedupes on, which means the same
decision found twice is the same row instead of two. On top of that sits a review
queue that leads with the decisions you can actually resolve now, and
`repowise decision` reports what a capture run did rather than leaving you to
infer it.

The other change you will notice immediately is the repo overview. It is the
first page most readers open, and it described a file tree, because a file tree
was essentially all it was given: pagerank, communities, package file counts,
entry point paths, and no natural language at all. It now gets one bounded prose
keyhole, a README digest capped at 2,500 characters, and writes to a fixed shape:
what this is, how the parts fit, then five to seven named concepts. The cap is
the guardrail rather than an arbitrary limit. Nine thousand characters of README
into the outline planner was measured to collapse page coverage from 23 pages at
87.5% to 3 pages at 5.4%, so the prose supplies vocabulary and framing while
structure stays the sole authority on paths, counts and package names.

`repowise doctor` now launches the MCP server instead of reading its config and
assuming. A config that looks correct and a server that will not start are
different problems, and only one of them was previously visible. In the same
spirit, `init` failures carry a reason code and telemetry reports the degrade
reason, the keyless case, and every crash leaf, so a run that quietly did less
than you expected can say so.

Two fixes are worth calling out because both were silent. `init --dry-run` was
not a dry run on two of its three paths: it rendered the full template wiki and
persisted it, and against a repo that already had a model written wiki it
rewrote every page from templates and downgraded `docs_mode`. The prior text
survives in page history, so it was a recoverable downgrade rather than data
loss, but nothing told you it had happened. Separately, `init` auto-detected its
embedder from environment variables only and never read the `embedder` field in
`~/.repowise/config.yaml`, which is the field `repowise serve` writes when you
configure one. If that was your only configuration, every fresh index was built
with keyless vectors and had no semantic search, and the single line
`Embedder: mock` was the only sign.

Indexing and persistence got faster in a few places that showed up in profiles:
betweenness is reused inside a churn budget rather than rescored, the full text
index is written in one transaction, job checkpoints are buffered behind a
bounded atomic flush, and repository-scale native memory is now bounded during
indexing.

## What this branch changes

- Version bumped in `pyproject.toml`, the three package `__init__` constants,
  `uv.lock`, `server.json` (twice) and both Claude Code plugin manifests.
- `docs/CHANGELOG.md` gains the 0.48.0 section, resynced to the bundled copy
  under `packages/core/.../upgrade/_data/`.
- Plugin parity: version bump only. No command, skill or hook change this cycle,
  and every tool named in a command or skill is one the server lists.

`HEALTH_ANALYZER_VERSION` moves 7 to 8. `_has_paired_test_file` had
`test_<stem>.py` hardcoded, so the prefix layout only ever matched Python. It now
follows the file's own suffix, and `<stem>_spec` joins the suffix forms (#1841).
Files that were counted untested and are not become tested, which moves
untested hotspot findings and the scores that carry them, on every language with
a prefix or spec convention rather than Ruby alone. An existing index re-scores
on its next update instead of waiting out the decay timer. `_STAMPS` in
`tests/unit/health/test_model_version_coupling.py` moves with it to (8, 2, 2);
that tripwire exists to stop an identity model bump landing without an analyzer
bump, and here only the analyzer moves.

`STORE_FORMAT_VERSION` and `PARSER_SCHEMA_VERSION` stay at 2. Nothing this cycle
needs an older store to react to, so no re-index is forced.

The Codex plugin stays at 0.6.1. It tracks its own version line, and #2023 was a
rendering change to a shared source rather than a change to its surface.

## Test plan

- [x] `tests/unit/test_release_manifests.py` and
      `tests/unit/upgrade/test_bundled_changelog_sync.py` pass (9 passed)
- [x] `tests/unit/health/test_model_version_coupling.py` passes against the new
      analyzer stamp
- [x] No stale `0.47.0` string in any versioned manifest
- [x] `uv build --wheel` produces `repowise-0.48.0-py3-none-any.whl` with 43 CLI
      command modules, 19 tree-sitter `.scm` queries, 36 Jinja templates and the
      bundled changelog
- [x] `npm ci && npm run build --workspace packages/web` succeeds, standalone
      `server.js` emitted, workspace package code present in the compiled route
      chunks
- [x] Cold `init` of a real repo against this tree, keyless `--no-prose`
      (174 files, 1,217 symbols, 188 pages, 23s, 0 tokens) and with prose
      (27,832 tokens, $0.02, 9 artifact checks, 0 rejected)
- [x] Every MCP tool answers over stdio against that index, in both single repo
      and workspace mode
- [x] Every PR number cited in the changelog is present in `v0.47.0..main`
- [ ] Tag `v0.48.0` on `main` after merge and watch `publish.yml`
- [ ] Publish `server.json` to the MCP registry once PyPI has the wheel
- [ ] Install from PyPI into a throwaway venv and index a real repo cold
