### PR TITLE
fix(generation): give the provenance footer a real horizontal rule

### DIFF
--- a/packages/core/src/repowise/core/generation/templates/stub/_footer.j2
+++ b/packages/core/src/repowise/core/generation/templates/stub/_footer.j2
@@ -1,6 +1,6 @@
 ---
 
-{#- No CLI command here: this page is read on the web as often as in a terminal,
+{# No CLI command here: this page is read on the web as often as in a terminal,
     and the CLI offers the prose upgrade in its own surfaces. The opening
     sentence is matched by tests/integration/test_deterministic_generation.py. -#}
 *Built from the code's structure. It states what is there, not why it is that

--- a/tests/unit/generation/test_overview_package_table.py
+++ b/tests/unit/generation/test_overview_package_table.py
@@ -207,6 +207,34 @@ def test_embed_replaces_the_models_own_packages_section():
     assert "text" in out
 
 
+def test_embed_stops_at_the_provenance_footer():
+    """The footer is last on the page and carries no heading, so the
+    horizontal rule is the only terminator between it and a trailing section.
+
+    It rendered as ``---*Built from...`` for as long as the rule and the text
+    were joined, which is not a rule at all, so the section ran to the end of
+    the document and took the footer with it.
+    """
+    page = (
+        "# Page\n\n## Packages\n\n- **core** (`packages/core`, python)\n\n"
+        "---\n\n*Built from the code's structure.*\n"
+    )
+    out = embed_package_table(page, "| Package |\n|---|\n| a |")
+    assert "Built from the code's structure" in out
+    assert "- **core**" not in out
+
+
+def test_the_stub_footer_renders_a_standalone_rule():
+    """Guards the shape the terminator above depends on, at the source."""
+    from jinja2 import Environment, PackageLoader
+
+    env = Environment(loader=PackageLoader("repowise.core.generation", "templates"))
+    rendered = env.get_template("stub/_footer.j2").render()
+
+    assert rendered.startswith("---\n\n")
+    assert "---*" not in rendered
+
+
 def test_embed_without_a_table_leaves_the_page_alone():
     page = "# Page\n\nprose\n"
     assert embed_package_table(page, None) == page


### PR DESCRIPTION
`tests/integration/test_deterministic_generation.py::test_every_page_carries_the_provenance_footer` is red on `main`. The deterministic repo overview loses its footer entirely.

## Cause

#2078 stopped the overview rendering a path table below its packages, which left `## Packages` as the last section on the page. `embed_package_table` replaces a heading and everything up to the next terminator, so that section now ran to the end of the document and took the footer with it.

#2078 saw this and added `^---$` as a terminator, on the reasonable assumption that the footer opens with a horizontal rule. It does not, and never did. `stub/_footer.j2` opens with `---`, a blank line, then a Jinja comment whose `{#-` strips the whitespace before it, so the rule and the text render joined:

```
---*Built from the code's structure. It states what is there, not why it is that
way. The explanatory prose is a separate, model-written layer.*
```

There is no `---` line for the terminator to match. Instrumenting the real render confirms it: the content reaching `embed_package_table` contains the footer text and no `---`, and the content leaving it contains neither.

That shape is also not a horizontal rule in any Markdown renderer, so every page carrying this footer has been showing a paragraph that starts with three dashes.

## Fix

Drop the whitespace-control dash on the comment. The footer renders `---\n\n*Built from...*`, which is the rule the terminator was written against and the Markdown the page was always meant to have.

The template bug predates #2078 and was invisible while a path table sat between the packages section and the footer, so nothing in that PR was wrong except the assumption.

## Test plan

- [x] `tests/integration/test_deterministic_generation.py` — 15 passed (was 1 failed)
- [x] `tests/unit/generation` + `tests/unit/persistence/test_information_floor.py` — 1528 passed
- [x] `tests/unit/generation/test_overview_package_table.py` — 24 passed
- [x] New footer test fails on `main` and passes here, verified by reverting the template alone
- [x] `ruff check` clean

Two tests: one pins the terminator against a page shaped like the real one, one pins the rendered footer at the source, which is the half that was actually wrong.