### PR TITLE
fix(cli): stop doctor reporting excluded files as missing

### DIFF
--- a/packages/cli/src/repowise/cli/commands/doctor_cmd/repo_checks.py
+++ b/packages/cli/src/repowise/cli/commands/doctor_cmd/repo_checks.py
@@ -449,8 +449,13 @@ def _run_repo_checks(
             # Held-back stubs are not drift, but they are also not nothing: the
             # wiki has a page there that no model wrote. Say so on the same row
             # rather than letting "in sync" imply the wiki is complete.
+            # Name the command, not just the flag. `--resume` exists only on
+            # `init`, so a reader who takes this advice tries `generate
+            # --resume` first — 0.48.0 answers "No such option '--resume'. Did
+            # you mean '--yes'?" — and has to guess which command was meant. A
+            # health report is the worst place to make someone guess.
             if stub_count:
-                vec_detail += f" · {stub_count} stub(s) awaiting --resume"
+                vec_detail += f" · {stub_count} stub(s) awaiting `repowise init --resume`"
             checks.append(_check("SQL ↔ Vector Store", vec_ok, vec_detail))
 
             fts_ok = not missing_from_fts and not orphaned_fts

--- a/packages/cli/src/repowise/cli/commands/doctor_cmd/repo_checks.py
+++ b/packages/cli/src/repowise/cli/commands/doctor_cmd/repo_checks.py
@@ -17,6 +17,7 @@ from repowise.cli.helpers import (
     reconcile_schema_best_effort,
     run_async,
 )
+from repowise.core.exclusion import build_exclude_spec, is_excluded
 
 from ._types import DoctorCheck, _check, _status_markup
 from .advisories import _advise_claude_md_stamp
@@ -92,9 +93,9 @@ async def _all_pages_for_reconciliation(session: object, repo_id: str) -> list:
     8900 of them. ``--repair`` deletes what this reports, so what it removed
     was the live index.
 
-    Three columns rather than whole rows: the id to match against the stores,
-    the content for the information floor, and metadata_json for the stub
-    predicate. Nothing downstream reads any other field, and hydrating full
+    Four columns rather than whole rows: the id to match against the stores,
+    the content for the information floor, metadata_json for the stub
+    predicate, and target_path to tell whether the file is excluded. Nothing downstream reads any other field, and hydrating full
     ORM objects for every page only to discard them is what made a cap look
     necessary in the first place.
     """
@@ -103,7 +104,7 @@ async def _all_pages_for_reconciliation(session: object, repo_id: str) -> list:
     from repowise.core.persistence.models import Page
 
     result = await session.execute(  # type: ignore[attr-defined]
-        select(Page.id, Page.content, Page.metadata_json).where(
+        select(Page.id, Page.content, Page.metadata_json, Page.target_path).where(
             Page.repository_id == repo_id
         )
     )
@@ -360,8 +361,35 @@ def _run_repo_checks(
                     # excluded for, one line above. It stays on the ORPHAN
                     # side: a stored vector for a page now below the floor is
                     # real drift, and deleting it is a repair that works.
+                    # A page whose FILE the user excluded is absent from both
+                    # indexes because they asked for that, so reporting it as
+                    # missing is drift no action can clear: `--repair`'s only
+                    # remedy is to index content they excluded. Every other read
+                    # path already filters here — `filter_graph_nodes`,
+                    # `_node_id_is_excluded`, `_prose_symbols` — and
+                    # `core/exclusion.py` documents why: rows outlive an
+                    # `exclude_patterns` edit by design, so readers filter rather
+                    # than force a reindex. This check was the one reader that did
+                    # not, and on a repo excluding its generated sources that was
+                    # 5015 of 5049 reported-missing rows.
+                    #
+                    # Matched on the FILE: a symbol page's target_path is
+                    # `path::Name`, which no file pattern matches. Same split
+                    # `_node_id_is_excluded` does, for the same reason.
+                    #
+                    # MISSING side only, like the floor and stub exclusions
+                    # above. Whether a store entry for a newly-excluded file is
+                    # itself drift worth deleting is a separate question, and
+                    # answering it here would make `--repair` delete on a rules
+                    # edit — too sharp an edge to add in passing.
+                    exclude_spec = build_exclude_spec(repo_path)
                     indexable_ids = {
-                        p.id for p in pages if meets_information_floor(p.content or "")
+                        p.id
+                        for p in pages
+                        if meets_information_floor(p.content or "")
+                        and not is_excluded(
+                            (p.target_path or "").split("::", 1)[0], exclude_spec
+                        )
                     }
                     # A stub standing in for a failed model page is held out of
                     # the vector store on purpose: ``_seed_resume`` reads the

--- a/tests/unit/cli/test_doctor_honours_exclusions.py
+++ b/tests/unit/cli/test_doctor_honours_exclusions.py
@@ -1,0 +1,108 @@
+"""``doctor`` does not report excluded files as missing from the indexes.
+
+A page whose file the user excluded is absent from FTS and the vector store
+because they asked for that. The reconciliation counted it as drift anyway, so
+the row FAILed on every run and no action could clear it — ``--repair``'s only
+remedy is to index the content they excluded.
+
+``core/exclusion.py`` documents the contract this violated: rows outlive an
+``exclude_patterns`` edit by design, so read paths filter at query time rather
+than forcing a reindex. Every other reader does — ``filter_graph_nodes``,
+``_node_id_is_excluded``, ``_prose_symbols`` — and this check did not.
+
+The symbol case is the one that hides: a symbol page's ``target_path`` is
+``path::Name``, which no file pattern matches, so filtering without splitting on
+``::`` silently keeps every symbol of every excluded file.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from repowise.cli.commands.doctor_cmd import repo_checks
+
+KEPT = "file_page:kept.py"
+EXCLUDED_FILE = "file_page:lib/model.g.dart"
+EXCLUDED_SYMBOL = "symbol_spotlight:lib/model.g.dart::GeneratedThing"
+
+_BODY = "Body with enough words in it to clear the information floor."
+
+
+async def _build_repo(tmp_path: Path) -> Path:
+    """A repo excluding ``*.g.dart``, with pages for it left in the database.
+
+    The pattern is extension-anchored on purpose. A directory prefix like
+    ``build/**`` matches ``build/x.py::Name`` too, so it would let a fix that
+    forgot to split on ``::`` pass; ``*.g.dart`` does not match
+    ``model.g.dart::GeneratedThing`` and pins the symbol case.
+
+    Only the kept page is indexed, which is the correct state: the excluded
+    ones were skipped at ingest, and their rows predate the exclusion.
+    """
+    import git as gitpython
+
+    from repowise.core.persistence import (
+        FullTextSearch,
+        create_engine,
+        create_session_factory,
+        get_session,
+    )
+    from repowise.core.persistence.crud import upsert_page, upsert_repository
+    from repowise.core.persistence.database import init_db
+
+    repo_path = (tmp_path / "repo").resolve()
+    repo_path.mkdir()
+    gitpython.Repo.init(repo_path)
+    repowise_dir = repo_path / ".repowise"
+    repowise_dir.mkdir()
+    (repowise_dir / "config.yaml").write_text(
+        "exclude_patterns:\n  - '**/*.g.dart'\n", encoding="utf-8"
+    )
+
+    engine = create_engine(f"sqlite+aiosqlite:///{repowise_dir / 'wiki.db'}")
+    await init_db(engine)
+    sf = create_session_factory(engine)
+    async with get_session(sf) as session:
+        repo = await upsert_repository(
+            session, name="repo", local_path=str(repo_path), url="https://example.test/repo"
+        )
+        for page_id, page_type, target in (
+            (KEPT, "file_page", "kept.py"),
+            (EXCLUDED_FILE, "file_page", "lib/model.g.dart"),
+            (EXCLUDED_SYMBOL, "symbol_spotlight", "lib/model.g.dart::GeneratedThing"),
+        ):
+            await upsert_page(
+                session,
+                page_id=page_id,
+                repository_id=repo.id,
+                page_type=page_type,
+                title=f"Page: {target}",
+                content=_BODY,
+                summary="",
+                target_path=target,
+                source_hash="",
+                model_name="mock",
+                provider_name="mock",
+            )
+        await session.commit()
+
+    fts = FullTextSearch(engine)
+    await fts.ensure_index()
+    await fts.index(KEPT, "Page: kept.py", _BODY, summary="", target_path="kept.py")
+    await engine.dispose()
+    return repo_path
+
+
+def _rows(repo_path: Path) -> dict[str, tuple[bool, str]]:
+    _all_ok, checks = repo_checks._run_repo_checks(repo_path, repair=False)
+    return {c.name: (c.ok, c.detail) for c in checks}
+
+
+def test_an_excluded_file_is_not_missing_from_the_index(tmp_path: Path) -> None:
+    """Both excluded pages are absent on purpose, so neither is drift."""
+    rows = _rows(asyncio.run(_build_repo(tmp_path)))
+
+    ok, detail = rows["SQL ↔ FTS Index"]
+    assert detail == "in sync"
+    assert ok is True

--- a/tests/unit/cli/test_doctor_resume_stub.py
+++ b/tests/unit/cli/test_doctor_resume_stub.py
@@ -107,7 +107,10 @@ def test_an_unembedded_stub_is_not_vector_drift(tmp_path: Path) -> None:
     assert "missing" not in detail
     # Not drift, but not nothing either: the wiki has a page there that no
     # model wrote, and "in sync" alone would imply the wiki is complete.
-    assert "1 stub(s) awaiting --resume" in detail
+    #
+    # The command is named, not just the flag: `--resume` exists only on `init`,
+    # so a bare "--resume" sends the reader to try it on `generate` first.
+    assert "1 stub(s) awaiting `repowise init --resume`" in detail
 
 
 def test_the_stub_is_still_indexed_for_full_text(tmp_path: Path) -> None:


### PR DESCRIPTION
Fixes #2084.

## What

`doctor` reports pages for **excluded** files as missing from the indexes. They are absent because the user excluded them, so the row FAILs permanently and nothing clears it — `--repair`'s only remedy is to index the content they asked to exclude.

On an 18949-page repository with `**/*.mocks.dart` and generated localizations in `exclude_patterns`:

```
SQL ↔ FTS Index    FAIL   5049 missing, 0 orphaned
```

5015 of those 5049 are pages whose file is excluded. 34 are genuine drift.

## Root cause

`repo_checks.py` never built an exclusion spec — `grep -c "is_excluded\|build_exclude_spec"` over the file returned 0.

`core/exclusion.py`'s module docstring states the contract it missed:

> Excluded files are skipped at ingest time, but DB rows may predate an `exclude_patterns` / gitignore change, so read paths (MCP tools, editor-file generation) filter again at query time.

Every other reader honours it, including for the `path::Name` shape symbol pages carry:

- `_helpers.py:692` `filter_graph_nodes` — *"file nodes match on `node_id`, symbol nodes on `file_path`"*
- `_graph_utils.py:29` `_node_id_is_excluded` — `path = node_id.split("::", 1)[0]`
- `_prose_symbols.py:209` — matches on `row.file_path`

The reconciliation was the one reader that did not.

## Changes

- `_all_pages_for_reconciliation` also selects `target_path`.
- `indexable_ids` drops pages whose file is excluded, matched on the file: `target_path.split("::", 1)[0]`. A symbol page's `target_path` is `path::Name`, which no file pattern matches, so filtering without the split silently keeps every symbol of every excluded file.
- MISSING side only, matching the information-floor and stub exclusions beside it. Whether a store entry for a newly-excluded file is itself drift worth deleting is a separate question, and answering it here would make `--repair` delete on a rules edit.

## Tests

`tests/unit/cli/test_doctor_honours_exclusions.py` — a repo excluding `**/*.g.dart` with a file page and a symbol page left in the database for an excluded file, and only the kept page indexed.

Two negative controls, both checked:

| Reverted to | Result |
|---|---|
| no exclusion filter (main) | `2 missing, 0 orphaned` — fails |
| filter present, `::` split removed | `1 missing, 0 orphaned` — fails on the symbol page |
| the fix | `in sync` — passes |

The pattern is extension-anchored deliberately. A directory prefix like `build/**` matches `build/x.py::Name` too, so it would let a fix that forgot the split pass — my first draft of this test used one and the second control did not bite.

Doctor suite: 81 passed. CLI suite: 2383 passed, 1 skipped, 2 xfailed. `ruff check packages/ tests/` clean. `test_agent_target_baseline.py::test_integration_writes_match_baseline` fails with and without this branch — it compares against a Windows baseline and fails on macOS.

Against the live 18949-page index, the FTS row goes from `5049 missing` to `34 missing`.

## Relationship to #2060 / #2061

This was masked until now. Before #2061 the SQL side was read with `list_pages(limit=10000)`, so the reconciliation saw only the first 10000 pages and under-reported missing entries along with everything else. Uncapping it made the check see the whole database, which surfaced that it had never filtered excluded pages.

The defect predates #2061; that PR made it visible. Flagging it so the number does not read as a regression from it.


## Second commit: naming the command in the resume hint

Same file, same failure shape — doctor's output sending a reader somewhere unhelpful.

The SQL ↔ Vector row printed `N stub(s) awaiting --resume` without saying which command takes the flag. `--resume` exists only on `init`, so a reader following the advice reaches for the command they were just told about, `generate`, and 0.48.0 answers `No such option '--resume'. Did you mean '--yes'?`. From there they are guessing, prompted by a health report.

The row now names `repowise init --resume`. `test_doctor_resume_stub.py` asserted the bare flag and now pins the new string.

Separable if you would rather take only the exclusion fix — it is its own commit.
