### PR TITLE
fix(doctor): report actual LLM provider availability

### DIFF
--- a/packages/cli/src/repowise/cli/commands/doctor_cmd/repo_checks.py
+++ b/packages/cli/src/repowise/cli/commands/doctor_cmd/repo_checks.py
@@ -111,6 +111,49 @@ async def _all_pages_for_reconciliation(session: object, repo_id: str) -> list:
     return list(result.all())
 
 
+def _provider_checks(repo_path: _DoctorPath) -> list[DoctorCheck]:
+    """Report provider implementations, configuration errors, and usability.
+
+    These are three distinct claims.  In particular, an empty validation
+    warning list means no configured key is malformed; it does not prove that
+    an LLM provider will resolve for this repository.
+    """
+    checks: list[DoctorCheck] = []
+
+    try:
+        from repowise.core.providers import list_providers
+
+        providers = list_providers()
+        checks.append(
+            _check(
+                "Providers",
+                bool(providers),
+                f"Implementations loaded: {', '.join(providers)}",
+            )
+        )
+    except Exception as exc:
+        checks.append(_check("Providers", False, str(exc)))
+
+    from repowise.cli.helpers import validate_provider_config
+
+    config_warnings = validate_provider_config()
+    config_ok = not config_warnings
+    config_detail = "No misconfigured provider keys" if config_ok else "; ".join(config_warnings)
+    checks.append(_check("Provider config", config_ok, config_detail))
+
+    from repowise.core.providers.llm.registry import provider_available_for_repo
+
+    llm_available = provider_available_for_repo(repo_path)
+    llm_detail = (
+        "Resolves for this repository"
+        if llm_available
+        else "None configured — prose degrades to a structural wiki; set a key or pass --provider"
+    )
+    # Keyless operation is supported, so this is informational rather than a
+    # failing health check.  The detail tells users what init will actually do.
+    checks.append(_check("LLM provider", True, llm_detail))
+    return checks
+
 
 def _run_repo_checks(
     repo_path: _DoctorPath, repair: bool, *, fmt: str = "table"
@@ -212,24 +255,8 @@ def _run_repo_checks(
         except Exception as e:
             checks.append(_check("Store format", True, f"Could not check: {e}"))
 
-    # 5. Provider importable?
-    provider_ok = False
-    try:
-        from repowise.core.providers import list_providers
-
-        providers = list_providers()
-        provider_ok = len(providers) > 0
-        checks.append(_check("Providers", provider_ok, ", ".join(providers)))
-    except Exception as e:
-        checks.append(_check("Providers", False, str(e)))
-
-    # 6. Provider configuration?
-    from repowise.cli.helpers import validate_provider_config
-
-    config_warnings = validate_provider_config()
-    config_ok = len(config_warnings) == 0
-    config_detail = "All required API keys configured" if config_ok else "; ".join(config_warnings)
-    checks.append(_check("Provider config", config_ok, config_detail))
+    # 5-6. Provider implementations, configuration, and repo-level usability.
+    checks.extend(_provider_checks(repo_path))
 
     # 6b. Hosted account (informational: signed out is not a failure).
     try:

--- a/tests/unit/cli/test_doctor_provider_status.py
+++ b/tests/unit/cli/test_doctor_provider_status.py
@@ -1,0 +1,76 @@
+"""Provider diagnostics distinguish availability from valid configuration."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from repowise.cli.commands.doctor_cmd import repo_checks
+
+
+def _rows(repo_path: Path) -> dict[str, tuple[bool, str]]:
+    return {
+        check.name: (check.ok, check.detail) for check in repo_checks._provider_checks(repo_path)
+    }
+
+
+def _patch_provider_state(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    available: bool,
+    warnings: list[str] | None = None,
+) -> None:
+    monkeypatch.setattr(
+        "repowise.core.providers.list_providers",
+        lambda: ["gemini", "openai"],
+    )
+    monkeypatch.setattr(
+        "repowise.core.providers.llm.registry.provider_available_for_repo",
+        lambda _repo_path: available,
+    )
+    monkeypatch.setattr(
+        "repowise.cli.helpers.validate_provider_config",
+        lambda: warnings or [],
+    )
+
+
+def test_keyless_repo_reports_structural_fallback_without_failing_doctor(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_provider_state(monkeypatch, available=False)
+
+    rows = _rows(tmp_path)
+
+    assert rows["Providers"] == (True, "Implementations loaded: gemini, openai")
+    assert rows["Provider config"] == (True, "No misconfigured provider keys")
+    assert rows["LLM provider"] == (
+        True,
+        "None configured — prose degrades to a structural wiki; set a key or pass --provider",
+    )
+
+
+def test_resolvable_provider_is_reported_for_this_repository(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_provider_state(monkeypatch, available=True)
+
+    assert _rows(tmp_path)["LLM provider"] == (True, "Resolves for this repository")
+
+
+def test_misconfigured_provider_key_still_fails_its_own_check(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_provider_state(
+        monkeypatch,
+        available=False,
+        warnings=["openai requires environment variables: OPENAI_API_KEY"],
+    )
+
+    assert _rows(tmp_path)["Provider config"] == (
+        False,
+        "openai requires environment variables: OPENAI_API_KEY",
+    )


### PR DESCRIPTION
## Summary

- split doctor provider diagnostics into implementation loading, configuration validity, and repository-level LLM availability
- replace the misleading “All required API keys configured” message with the narrower “No misconfigured provider keys” claim
- keep keyless mode healthy while explaining that prose generation will fall back to a structural wiki
- add focused coverage for keyless, resolvable, and misconfigured provider states

## Related Issues

Fixes #2076

## Test Plan

- [x] `uv run pytest -q tests/unit/cli/test_doctor*.py` (62 passed)
- [x] `uv run ruff check packages/cli/src/repowise/cli/commands/doctor_cmd/repo_checks.py tests/unit/cli/test_doctor_provider_status.py`
- [x] `git diff --check`

## Risk

Repowise change risk: 43rd percentile (Typical / moderate review priority). The production change is isolated to doctor reporting and does not alter provider resolution or generation behavior.