### PR TITLE
fix MCP workspace detection and add no-workspace flag

### DIFF
--- a/packages/cli/src/repowise/cli/commands/mcp_cmd.py
+++ b/packages/cli/src/repowise/cli/commands/mcp_cmd.py
@@ -12,7 +12,9 @@ from repowise.cli.ui import load_dotenv
 from repowise.core.workspace.config import WorkspaceConfig, find_workspace_root
 
 
-def _workspace_summary(path: Path) -> dict[str, object] | None:
+def _workspace_summary(path: Path, *, no_workspace: bool = False) -> dict[str, object] | None:
+    if no_workspace:
+        return None
     workspace_root = find_workspace_root(path)
     if workspace_root is None:
         return None
@@ -121,6 +123,16 @@ def _print_network_startup(
     default=False,
     help="Expose every tool eligible in the current repository/workspace mode.",
 )
+@click.option(
+    "--no-workspace",
+    is_flag=True,
+    default=False,
+    help=(
+        "Force single-repo mode even when the path is inside a workspace. "
+        "Useful for nested indexed repos that should not inherit the "
+        "enclosing workspace's default repo."
+    ),
+)
 def mcp_command(
     path: str | None,
     transport: str,
@@ -128,6 +140,7 @@ def mcp_command(
     host: str | None,
     tools: str | None,
     all_tools: bool,
+    no_workspace: bool,
 ) -> None:
     """Start the MCP server for editor integration.
 
@@ -149,6 +162,7 @@ def mcp_command(
         repowise mcp --tools +get_execution_flows  # default set plus one
         repowise mcp --tools lean        # six-tool agent-lean profile
         repowise mcp --all               # every available tool
+        repowise mcp --no-workspace      # force single-repo mode
         repowise mcp --transport streamable-http  # HTTP on port 7338
     """
     if path is None:
@@ -157,7 +171,7 @@ def mcp_command(
         repo_path = resolve_repo_path(path)
     load_dotenv(repo_path)
 
-    workspace = _workspace_summary(repo_path)
+    workspace = _workspace_summary(repo_path, no_workspace=no_workspace)
     repowise_dir = repo_path / ".repowise"
     if workspace is None and not repowise_dir.exists():
         console.print(
@@ -183,4 +197,5 @@ def mcp_command(
         host=resolved_host,
         port=port,
         tools=tools_override,
+        workspace_mode=not no_workspace,
     )

--- a/packages/server/src/repowise/server/mcp_server/_server.py
+++ b/packages/server/src/repowise/server/mcp_server/_server.py
@@ -349,6 +349,7 @@ def _detect_workspace(repo_path: str | None):
         resolved = _Path(repo_path).resolve()
         repo_alias = None
         best_match_depth = -1
+        best_match_abs = None
         for entry in ws_config.repos:
             entry_abs = (ws_root / entry.path).resolve()
             try:
@@ -360,11 +361,19 @@ def _detect_workspace(repo_path: str | None):
             if match_depth > best_match_depth:
                 repo_alias = entry.alias
                 best_match_depth = match_depth
+                best_match_abs = entry_abs
 
         if repo_alias is None:
             # Path is inside workspace but doesn't match a repo — use default
             primary = ws_config.get_primary()
             repo_alias = primary.alias if primary else ws_config.repos[0].alias
+        elif resolved != best_match_abs and (resolved / ".repowise" / "state.json").exists():
+            # resolved is its own indexed repo, nested inside a matched
+            # member/primary's directory but not itself a registered member.
+            # Containment made it match the enclosing entry above; that's
+            # wrong for an indexed, non-member repo — drop to single-repo
+            # mode instead of silently serving the enclosing repo.
+            return None, None, None
 
         return ws_root, ws_config, repo_alias
     except Exception:
@@ -388,7 +397,10 @@ async def _lifespan(server: FastMCP):
     _warm_task = asyncio.create_task(_warm_lancedb(), name="lancedb-warmup")
 
     # --- Workspace detection ------------------------------------------------
-    ws_root, ws_config, ws_repo_alias = _detect_workspace(_state._repo_path)
+    if _state._force_single_repo:
+        ws_root, ws_config, ws_repo_alias = None, None, None
+    else:
+        ws_root, ws_config, ws_repo_alias = _detect_workspace(_state._repo_path)
 
     if ws_root is not None and ws_config is not None:
         # Workspace mode — use RepoRegistry for multi-repo serving
@@ -561,6 +573,7 @@ mcp = FastMCP(
 def create_mcp_server(
     repo_path: str | None = None,
     tools: str | list[str] | None = None,
+    workspace_mode: bool = True,
 ) -> FastMCP:
     """Create and return the MCP server instance, optionally scoped to a repo.
 
@@ -568,6 +581,7 @@ def create_mcp_server(
     deltas, or ``"all"``); when omitted the ``mcp.tools`` config block is used.
     """
     _state._repo_path = repo_path
+    _state._force_single_repo = not workspace_mode
     from repowise.server.mcp_server import ensure_full_surface
     from repowise.server.mcp_server._tool_selection import apply_tool_selection
 
@@ -683,6 +697,7 @@ def run_mcp(
     host: str = "127.0.0.1",
     port: int = 7338,
     tools: str | list[str] | None = None,
+    workspace_mode: bool = True,
 ) -> None:
     """Run the MCP server with the specified transport.
 
@@ -700,6 +715,7 @@ def run_mcp(
     """
     try:
         _state._repo_path = repo_path
+        _state._force_single_repo = not workspace_mode
         from repowise.server.mcp_server import ensure_full_surface
         from repowise.server.mcp_server._tool_selection import apply_tool_selection
 
@@ -761,4 +777,3 @@ def run_mcp(
                 tuple(sorted({type(leaf).__name__ for leaf in leaves})),
             )
         raise first from group
-

--- a/packages/server/src/repowise/server/mcp_server/_state.py
+++ b/packages/server/src/repowise/server/mcp_server/_state.py
@@ -18,6 +18,9 @@ _vector_store: Any = None
 _decision_store: Any = None
 _fts: Any = None
 _repo_path: str | None = None
+# When set, the server skips workspace auto-detection even if the path is
+# inside a workspace root. This backs the CLI's `--no-workspace` escape hatch.
+_force_single_repo: bool = False
 # Set to an asyncio.Event by _lifespan; signals that vector stores are loaded.
 # tool_search awaits this before searching to avoid racing a background load.
 _vector_store_ready: asyncio.Event | None = None

--- a/tests/unit/cli/test_mcp_transport.py
+++ b/tests/unit/cli/test_mcp_transport.py
@@ -32,6 +32,7 @@ def test_mcp_cli_passes_tools_override(monkeypatch, tmp_path: Path) -> None:
     assert result.exit_code == 0
     assert captured["tools"] == "+get_execution_flows,-get_dead_code"
     assert captured["host"] == "127.0.0.1"
+    assert captured["workspace_mode"] is True
 
 
 def test_mcp_cli_all_flag_overrides_tools(monkeypatch, tmp_path: Path) -> None:
@@ -46,6 +47,51 @@ def test_mcp_cli_all_flag_overrides_tools(monkeypatch, tmp_path: Path) -> None:
     assert result.exit_code == 0
     assert captured["tools"] == "all"
     assert captured["host"] == "127.0.0.1"
+    assert captured["workspace_mode"] is True
+
+
+def test_mcp_cli_no_workspace_flag_forces_single_repo(
+    monkeypatch, tmp_path: Path
+) -> None:
+    (tmp_path / ".repowise").mkdir()
+    captured: dict[str, object] = {}
+    monkeypatch.setattr(
+        "repowise.server.mcp_server.run_mcp", lambda **kw: captured.update(kw)
+    )
+
+    result = CliRunner().invoke(cli, ["mcp", str(tmp_path), "--no-workspace"])
+
+    assert result.exit_code == 0
+    assert captured["workspace_mode"] is False
+
+
+def test_mcp_cli_no_workspace_ignores_enclosing_workspace(
+    monkeypatch, tmp_path: Path
+) -> None:
+    workspace = tmp_path / "workspace"
+    nested = workspace / "vendor" / "microdot"
+    nested.mkdir(parents=True)
+    (workspace / ".repowise-workspace.yaml").write_text(
+        "version: 1\n"
+        "default_repo: repowise\n"
+        "repos:\n"
+        "- path: .\n"
+        "  alias: repowise\n"
+        "  is_primary: true\n",
+        encoding="utf-8",
+    )
+    (nested / ".repowise").mkdir()
+    (nested / ".repowise" / "state.json").write_text("{}", encoding="utf-8")
+
+    captured: dict[str, object] = {}
+    monkeypatch.setattr(
+        "repowise.server.mcp_server.run_mcp", lambda **kw: captured.update(kw)
+    )
+
+    result = CliRunner().invoke(cli, ["mcp", str(nested), "--no-workspace"])
+
+    assert result.exit_code == 0
+    assert captured["workspace_mode"] is False
 
 
 def test_mcp_cli_accepts_streamable_http_transport(
@@ -80,6 +126,7 @@ def test_mcp_cli_accepts_streamable_http_transport(
         "host": "127.0.0.1",
         "port": 7339,
         "tools": None,
+        "workspace_mode": True,
     }
 
 
@@ -132,6 +179,7 @@ def test_mcp_cli_streamable_http_prints_workspace_summary(
         "host": "127.0.0.1",
         "port": 7341,
         "tools": None,
+        "workspace_mode": True,
     }
 
 
@@ -435,4 +483,3 @@ def test_an_interrupt_is_not_reported_as_a_crash(monkeypatch, tmp_path: Path) ->
     CliRunner().invoke(cli, ["mcp", str(tmp_path)])
 
     assert "error_leaves" not in recorded
-

--- a/tests/unit/server/test_mcp_workspace_detection.py
+++ b/tests/unit/server/test_mcp_workspace_detection.py
@@ -55,7 +55,25 @@ def test_detect_workspace_root_uses_primary(workspace: Path) -> None:
     assert repo_alias == "repowise"
 
 
-def test_detect_workspace_non_member_uses_primary(workspace: Path) -> None:
+def test_detect_workspace_non_member_bare_dir_uses_primary(workspace: Path) -> None:
+    """A plain subdirectory (no .repowise/ of its own) is not a repo at all,
+    so containment correctly falls through to the primary."""
     _, _, repo_alias = _detect_workspace(str(workspace / "test-repos" / "microdot"))
-
     assert repo_alias == "repowise"
+
+
+def test_detect_workspace_non_member_indexed_repo_drops_to_single_repo(
+    workspace: Path,
+) -> None:
+    """A path that is itself an indexed repo (has .repowise/state.json) but
+    isn't a registered workspace member must not silently serve the
+    enclosing primary, it should drop to single-repo mode instead."""
+    nested = workspace / "test-repos" / "microdot"
+    (nested / ".repowise").mkdir(parents=True, exist_ok=True)
+    (nested / ".repowise" / "state.json").write_text("{}", encoding="utf-8")
+
+    ws_root, ws_config, repo_alias = _detect_workspace(str(nested))
+
+    assert ws_root is None
+    assert ws_config is None
+    assert repo_alias is None


### PR DESCRIPTION
## Summary

  - Fix MCP workspace detection so a nested indexed repo inside a workspace no longer silently serves the workspace primary.
  - Add a --no-workspace escape hatch for repowise mcp to force single-repo mode when needed.
  - Expand CLI and server regression coverage for both the nested-repo case and the new flag.

  ## Related Issues

  - Fixes #2077 

  ## Test Plan

  - [x] Tests pass (pytest)
  - [x] Lint passes (ruff check .)
  - [x] Web build passes (npm run build) (if frontend changes)

  ## Checklist

  - [x] My code follows the project's code style
  - [x] I have added tests for new functionality
  - [x] All existing tests still pass
  - [x] I have updated documentation if needed