### PR TITLE
fix(wiki): let the file page and the code reach each other

### DIFF
--- a/packages/core/src/repowise/core/generation/context/assembler.py
+++ b/packages/core/src/repowise/core/generation/context/assembler.py
@@ -22,6 +22,7 @@ from repowise.core.ingestion.package_roots import (
     package_roots_from_paths,
     scan_package_roots,
 )
+from repowise.core.test_paths import is_test_related_path
 
 from ...co_change import STRUCTURAL_UNEXPLAINED, parse_partners
 from ..categories import file_category
@@ -757,8 +758,16 @@ class ContextAssembler:
         scc_set = set(scc_files)
         member_symbols = []
         for fc in file_contexts:
-            pub = [s for s in fc.symbols if s.get("visibility") == "public"][:5]
-            member_symbols.append({"file_path": fc.file_path, "symbols": pub})
+            # Both guards are what the section renders: an unnamed symbol
+            # printed a bare "- " bullet, and a file with nothing public got a
+            # heading with no list under it.
+            pub = [
+                s
+                for s in fc.symbols
+                if s.get("visibility") == "public" and (s.get("name") or "").strip()
+            ][:5]
+            if pub:
+                member_symbols.append({"file_path": fc.file_path, "symbols": pub})
 
         cross_imports = [
             {"from": fc.file_path, "to": dep}
@@ -774,6 +783,8 @@ class ContextAssembler:
             total_symbols=total_symbols,
             member_symbols=member_symbols,
             cross_imports=cross_imports,
+            test_only=bool(scc_files)
+            and all(is_test_related_path(f) for f in scc_files),
         )
 
     # ------------------------------------------------------------------

--- a/packages/core/src/repowise/core/generation/context/contexts.py
+++ b/packages/core/src/repowise/core/generation/context/contexts.py
@@ -164,6 +164,9 @@ class SccPageContext:
     # [{"file_path": str, "symbols": [{"name": str, "signature": str, "docstring": str}]}]
     cross_imports: list[dict] = field(default_factory=list)
     # [{"from": str, "to": str}]
+    # Every member is a test file, which reads as a fixture module its siblings
+    # share rather than as a dependency knot.
+    test_only: bool = False
 
 
 @dataclass

--- a/packages/core/src/repowise/core/generation/structural_labels.py
+++ b/packages/core/src/repowise/core/generation/structural_labels.py
@@ -164,14 +164,24 @@ ENGLISH_LABELS: dict[str, str] = {
         "this group can be loaded, tested or extracted without the rest of it."
     ),
     "cycle_id": "Cycle id",
-    "files_in_cycle": "Files in the cycle",
+    "test_cycle_overview": (
+        "{count} test files import each other in a loop, through the fixtures and helpers "
+        "they share. A test tree is built this way on purpose, so this is a cycle in the "
+        "import graph rather than debt to pay down."
+    ),
     "and_more_edges": "and {count} more edges.",
     "the_loop": "The loop",
     "where_to_break": "Where to break it",
+    "what_holds_it_together": "What holds it together",
     "decouple_ranking_description": (
         "Ranked by how many of the cycle's edges each file carries. The file at the top is "
         "the most entangled, so it is usually where an extracted interface or a moved "
         "import buys the most."
+    ),
+    "test_cycle_ranking_description": (
+        "Ranked by how many of the cycle's edges each file carries. The file at the top is "
+        "the shared fixture the rest import, so it is the one to read first to understand "
+        "how this suite is set up."
     ),
     "imports_in_cycle": "Imports in cycle",
     "imported_by": "Imported by",
@@ -313,14 +323,24 @@ LOCALIZED_LABELS: dict[str, dict[str, str]] = {
             "werden."
         ),
         "cycle_id": "Zyklus-ID",
-        "files_in_cycle": "Dateien im Zyklus",
+        "test_cycle_overview": (
+            "{count} Testdateien importieren einander in einer Schleife, über die Fixtures "
+            "und Helfer, die sie teilen. Ein Testbaum wird absichtlich so gebaut; das ist "
+            "also ein Zyklus im Importgraphen und keine abzutragende Schuld."
+        ),
         "and_more_edges": "und {count} weitere Kanten.",
         "the_loop": "Die Schleife",
         "where_to_break": "Wo sie aufgebrochen werden kann",
+        "what_holds_it_together": "Was sie zusammenhält",
         "decouple_ranking_description": (
             "Sortiert danach, wie viele Kanten des Zyklus jede Datei trägt. Die oberste "
             "Datei ist am stärksten verflochten; dort bringt eine extrahierte Schnittstelle "
             "oder ein verschobener Import gewöhnlich am meisten."
+        ),
+        "test_cycle_ranking_description": (
+            "Sortiert danach, wie viele Kanten des Zyklus jede Datei trägt. Die oberste "
+            "Datei ist das geteilte Fixture, das die übrigen importieren, und daher die, "
+            "die man zuerst liest, um den Aufbau dieser Testsuite zu verstehen."
         ),
         "imports_in_cycle": "Importe im Zyklus",
         "imported_by": "Importiert von",

--- a/packages/core/src/repowise/core/generation/templates/scc_page.j2
+++ b/packages/core/src/repowise/core/generation/templates/scc_page.j2
@@ -7,63 +7,60 @@
 -#}
 {#- ``default(..., true)`` so an absent *or* empty title both fall back: the
     caller names the whole set at once and a caller that does not is still
-    entitled to a page. #}
+    entitled to a page. -#}
 # {{ page_title | default(labels.circular_dependency ~ ": " ~ ctx.scc_id, true) }}
+{#- A cycle whose every member is a test file is a fixture module its siblings
+    all import, which is how a test tree is built rather than debt it carries.
+    The generic sentence tells that reader to go untangle something correct. #}
 
-{{ labels.cycle_overview.format(count=ctx.files | length) }}
+{% if ctx.test_only %}{{ labels.test_cycle_overview.format(count=ctx.files | length) }}{% else %}{{ labels.cycle_overview.format(count=ctx.files | length) }}{% endif %}
 
 {#- The id is no longer in the heading, and it is what logs, links and the
     dependency tooling call this cycle, so it is stated once rather than being
     findable only in the URL. #}
 
 **{{ labels.cycle_id }}:** `{{ ctx.scc_id }}`
+{%- if ctx.cross_imports %}
 
-## {{ labels.files_in_cycle }}
-{# Capped, here and in the two listings below: a test-suite cycle routed
-   through a shared conftest can run to 80+ files and 200+ edges, and a page
-   that dumps all of them is 50KB of noise. The decouple ranking is the part
-   worth acting on. #}
-{% for f in ctx.files[:30] %}
-- `{{ f }}`
-{% endfor %}
-{%- if ctx.files | length > 30 %}
-- ...{{ labels.and_more.format(count=ctx.files | length - 30) }}
-{% endif %}
-
-{% if ctx.cross_imports %}
 ## {{ labels.the_loop }}
 {% for edge in ctx.cross_imports[:40] %}
 - `{{ edge.from }}` → `{{ edge.to }}`
-{% endfor %}
+{%- endfor %}
 {%- if ctx.cross_imports | length > 40 %}
 - ...{{ labels.and_more_edges.format(count=ctx.cross_imports | length - 40) }}
-{% endif %}
-{% endif %}
+{%- endif %}
+{%- endif %}
+{#- The members used to be listed as bullets above and then again as rows
+    here, uncapped, so a 20-file cycle printed 20 paths twice. The table is the
+    superset: it names every member and says how entangled each one is. #}
+{%- if decouple_ranking %}
 
-{% if decouple_ranking %}
-## {{ labels.where_to_break }}
+## {{ labels.what_holds_it_together if ctx.test_only else labels.where_to_break }}
 
-{{ labels.decouple_ranking_description }}
+{{ labels.test_cycle_ranking_description if ctx.test_only else labels.decouple_ranking_description }}
 
 | {{ labels.file }} | {{ labels.imports_in_cycle }} | {{ labels.imported_by }} | {{ labels.total }} |
 | --- | --- | --- | --- |
-{% for r in decouple_ranking -%}
+{%- for r in decouple_ranking %}
 | `{{ r.path }}` | {{ r.out }} | {{ r["in"] }} | {{ r.total }} |
-{% endfor %}
-{% endif %}
+{%- endfor %}
+{%- endif %}
+{%- if ctx.member_symbols %}
 
-{% if ctx.member_symbols %}
 ## {{ labels.symbols_defined_in_cycle }}
-{% for m in ctx.member_symbols[:20] %}
+{%- for m in ctx.member_symbols[:20] %}
+
 ### `{{ m.file_path }}`
 {% for s in m.symbols[:15] %}
 - `{{ s.name }}`{% if s.signature %}: `{{ s.signature | signature(120) }}`{% endif %}
-{% endfor %}
-{% endfor %}
-{% if ctx.member_symbols | length > 20 %}
+{%- endfor %}
+{%- endfor %}
+{%- if ctx.member_symbols | length > 20 %}
+
 *{{ labels.remaining_symbols.format(count=ctx.member_symbols | length - 20) }}*
-{% endif %}
-{% endif %}
+{%- endif %}
+{%- endif %}
 
 **{{ labels.total_symbols_in_cycle }}:** {{ ctx.total_symbols }}
+
 {% include "_footer.j2" %}

--- a/packages/web/src/app/repos/[id]/files/[...path]/page.tsx
+++ b/packages/web/src/app/repos/[id]/files/[...path]/page.tsx
@@ -3,7 +3,6 @@ import { notFound } from "next/navigation";
 import Link from "next/link";
 import { bundledLanguages, getSingletonHighlighter, type BundledLanguage } from "shiki";
 import { getFileContent, getFileDetail } from "@/lib/api/files";
-import { WikiMarkdown } from "@repowise-dev/ui/wiki/wiki-markdown";
 import {
   docsPagePath,
   fileEntityPath,
@@ -18,6 +17,7 @@ import {
   type FilePageTab,
 } from "@repowise-dev/ui/files";
 import { FilePageHost } from "@/components/files/file-page-host";
+import { FileDocBody } from "@/components/files/file-doc-body";
 import { FileTestsPanel } from "@/components/files/file-tests-panel";
 import { FileHealthPanel } from "@/components/files/file-health-panel";
 import type { FileDetailResponse } from "@repowise-dev/types/files";
@@ -178,7 +178,7 @@ export default async function FileEntityPage({ params, searchParams }: Props) {
     fileHref: (p) => fileEntityPath(prefix, p),
     symbolHref: (s) => symbolEntityPath(prefix, s),
     ...(detail.wiki_page?.content
-      ? { docSlot: <WikiMarkdown content={detail.wiki_page.content} /> }
+      ? { docSlot: <FileDocBody repoId={id} content={detail.wiki_page.content} /> }
       : {}),
     coverageCodeHtml,
     healthPanel: (

--- a/packages/web/src/components/files/file-doc-body.test.tsx
+++ b/packages/web/src/components/files/file-doc-body.test.tsx
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { FileDocBody } from "./file-doc-body";
+
+const mocks = vi.hoisted(() => ({
+  pages: [] as { id: string; target_path: string }[],
+}));
+
+vi.mock("@/lib/hooks/use-pages", () => ({
+  usePages: () => ({ pages: mocks.pages, error: undefined, isLoading: false, mutate: vi.fn() }),
+}));
+vi.mock("next/link", () => ({
+  default: ({ href, children, ...rest }: { href: string; children: React.ReactNode }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+describe("FileDocBody", () => {
+  // No `globals`, so nothing unmounts the previous render for us.
+  afterEach(cleanup);
+
+  it("links a backticked path in the embedded body to that file's route", () => {
+    mocks.pages = [
+      { id: "file_page:packages/core/src/parser.py", target_path: "packages/core/src/parser.py" },
+    ];
+
+    render(
+      <FileDocBody
+        repoId="r1"
+        content="The walker calls `packages/core/src/parser.py` once per file."
+      />,
+    );
+
+    const link = screen.getByRole("link", { name: /parser\.py/ });
+    expect(link.getAttribute("href")).toBe("/repos/r1/files/packages/core/src/parser.py");
+  });
+
+  it("leaves a path with no page behind it as plain text", () => {
+    mocks.pages = [];
+
+    render(<FileDocBody repoId="r1" content="See `packages/core/src/parser.py`." />);
+
+    expect(screen.queryByRole("link")).toBeNull();
+  });
+
+  it("sends a directory ref to the docs reader, since the file route 404s on one", () => {
+    // The path index resolves a directory to its module page, and a module
+    // page is not a file: linking it to the file route is a dead link.
+    mocks.pages = [{ id: "module_page:packages/ui", target_path: "packages/ui" }];
+
+    render(<FileDocBody repoId="r1" content="Lives under `packages/ui` today." />);
+
+    const link = screen.getByRole("link", { name: /packages\/ui/ });
+    expect(link.getAttribute("href")).toBe("/repos/r1/docs?page=module_page%3Apackages%2Fui");
+  });
+});

--- a/packages/web/src/components/files/file-doc-body.tsx
+++ b/packages/web/src/components/files/file-doc-body.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useCallback } from "react";
+import Link from "next/link";
+import { WikiMarkdown } from "@repowise-dev/ui/wiki/wiki-markdown";
+import { usePages } from "@/lib/hooks/use-pages";
+import { pageHref } from "@/lib/utils/page-href";
+
+/**
+ * The wiki body on the file route's Documentation tab.
+ *
+ * It rendered with no page list, so every backticked path in it was dead text
+ * on the one surface where the reader is already looking at a file. Resolving
+ * them needs `buildHref`, and a function cannot cross into a client component
+ * from a server one, which is what this wrapper is for.
+ *
+ * The list is fetched here rather than in the route because it is repo-wide:
+ * server-side it would ride the flight payload of every file page, where the
+ * shared SWR key is one fetch per session and is already warm for anyone who
+ * opened the wiki. The tab mounts only when it is selected, and until the list
+ * lands the paths render as plain code, exactly as they did before.
+ */
+export function FileDocBody({ repoId, content }: { repoId: string; content: string }) {
+  const { pages } = usePages(repoId);
+
+  // `pageHref`, not `fileEntityPath`: the path index also resolves a directory
+  // ref to its module page, and the file route 404s on a directory. Routing by
+  // id prefix sends those to the docs reader instead of to a dead link.
+  const buildHref = useCallback((pageId: string) => pageHref(repoId, pageId), [repoId]);
+
+  return (
+    <WikiMarkdown
+      content={content}
+      pages={pages}
+      buildHref={buildHref}
+      LinkComponent={Link}
+    />
+  );
+}

--- a/packages/web/vitest.config.ts
+++ b/packages/web/vitest.config.ts
@@ -2,6 +2,10 @@ import { defineConfig } from "vitest/config";
 import path from "node:path";
 
 export default defineConfig({
+  // The app's own `tsconfig` says `jsx: preserve`, which Next compiles and
+  // esbuild cannot, so it falls back to the classic transform and any
+  // component rendered from a test throws `React is not defined`.
+  esbuild: { jsx: "automatic" },
   test: {
     include: ["src/**/*.{test,spec}.{ts,tsx}"],
   },

--- a/tests/unit/generation/test_context_assembler.py
+++ b/tests/unit/generation/test_context_assembler.py
@@ -365,6 +365,83 @@ def test_assemble_scc_page_cycle_description_contains_files(
         assert f in ctx.cycle_description
 
 
+def test_assemble_scc_page_drops_a_symbol_with_no_name(
+    sample_config, sample_parsed_file, sample_graph, graph_metrics, sample_source_bytes
+):
+    # An unnamed symbol rendered a bare "- " bullet on the page.
+    assembler = ContextAssembler(sample_config)
+    fc = assembler.assemble_file_page(
+        sample_parsed_file,
+        sample_graph,
+        graph_metrics["pagerank"],
+        graph_metrics["betweenness"],
+        graph_metrics["community"],
+        sample_source_bytes,
+    )
+    named = dataclasses.replace(
+        fc,
+        file_path="pkg/a.py",
+        symbols=[
+            {"name": "A", "visibility": "public"},
+            {"name": "   ", "visibility": "public"},
+        ],
+    )
+    ctx = assembler.assemble_scc_page("scc-0", ["pkg/a.py"], [named])
+    assert [s["name"] for s in ctx.member_symbols[0]["symbols"]] == ["A"]
+
+
+def test_assemble_scc_page_omits_a_file_with_nothing_public(
+    sample_config, sample_parsed_file, sample_graph, graph_metrics, sample_source_bytes
+):
+    # Kept, it rendered a heading with no list under it.
+    assembler = ContextAssembler(sample_config)
+    fc = assembler.assemble_file_page(
+        sample_parsed_file,
+        sample_graph,
+        graph_metrics["pagerank"],
+        graph_metrics["betweenness"],
+        graph_metrics["community"],
+        sample_source_bytes,
+    )
+    public = dataclasses.replace(
+        fc, file_path="pkg/a.py", symbols=[{"name": "A", "visibility": "public"}]
+    )
+    private = dataclasses.replace(
+        fc, file_path="pkg/b.py", symbols=[{"name": "_x", "visibility": "private"}]
+    )
+    ctx = assembler.assemble_scc_page("scc-0", ["pkg/a.py", "pkg/b.py"], [public, private])
+    assert [m["file_path"] for m in ctx.member_symbols] == ["pkg/a.py"]
+
+
+def test_assemble_scc_page_flags_a_cycle_that_is_only_test_files(
+    sample_config, sample_parsed_file, sample_graph, graph_metrics, sample_source_bytes
+):
+    # A conftest its siblings all import is a cycle in the import graph and
+    # nothing to go and fix, so the page has to be able to say so.
+    assembler = ContextAssembler(sample_config)
+    fc = assembler.assemble_file_page(
+        sample_parsed_file,
+        sample_graph,
+        graph_metrics["pagerank"],
+        graph_metrics["betweenness"],
+        graph_metrics["community"],
+        sample_source_bytes,
+    )
+    member = dataclasses.replace(fc, file_path="tests/unit/parser/conftest.py", symbols=[])
+
+    all_tests = assembler.assemble_scc_page(
+        "scc-0",
+        ["tests/unit/parser/conftest.py", "tests/unit/parser/test_go.py"],
+        [member],
+    )
+    assert all_tests.test_only
+
+    mixed = assembler.assemble_scc_page(
+        "scc-1", ["tests/unit/parser/conftest.py", "pkg/a.py"], [member]
+    )
+    assert not mixed.test_only
+
+
 # ---------------------------------------------------------------------------
 # assemble_repo_overview
 # ---------------------------------------------------------------------------

--- a/tests/unit/generation/test_deterministic_templates.py
+++ b/tests/unit/generation/test_deterministic_templates.py
@@ -594,7 +594,7 @@ def test_scc_page_renders_german(german_generator):
 
     assert page.title == "Zyklische Abhängigkeit: scc-001"
     assert "**Zyklus-ID:** `scc-001`" in page.content
-    assert "## Dateien im Zyklus" in page.content
+    assert "## Wo sie aufgebrochen werden kann" in page.content
     assert "## Die Schleife" in page.content
     assert "**Symbole insgesamt im Zyklus:** 2" in page.content
 

--- a/tests/unit/generation/test_templates.py
+++ b/tests/unit/generation/test_templates.py
@@ -19,7 +19,10 @@ from repowise.core.generation.context_assembler import (
     SymbolSpotlightContext,
     _TopFile,
 )
-from repowise.core.generation.page_generator.structural import register_filters
+from repowise.core.generation.page_generator.structural import (
+    _rank_cycle_participants,
+    register_filters,
+)
 from repowise.core.generation.structural_labels import resolve_structural_labels
 from repowise.core.ingestion.models import PackageInfo
 
@@ -632,22 +635,100 @@ def scc_page_ctx() -> SccPageContext:
         files=["pkg/a.py", "pkg/b.py"],
         cycle_description="Circular dependency cycle: pkg/a.py → pkg/b.py",
         total_symbols=10,
+        member_symbols=[
+            {"file_path": "pkg/a.py", "symbols": [{"name": "A", "signature": "class A"}]}
+        ],
+        cross_imports=[{"from": "pkg/a.py", "to": "pkg/b.py"}],
     )
 
 
+@pytest.fixture(scope="module")
+def bare_scc_page_ctx() -> SccPageContext:
+    """A cycle the graph knows about and nothing else: no edges, no symbols."""
+    return SccPageContext(
+        scc_id="scc-1",
+        files=["pkg/a.py", "pkg/b.py"],
+        cycle_description="",
+        total_symbols=0,
+    )
+
+
+@pytest.fixture(scope="module")
+def test_scc_page_ctx() -> SccPageContext:
+    return SccPageContext(
+        scc_id="scc-2",
+        files=["tests/unit/parser/conftest.py", "tests/unit/parser/test_go.py"],
+        cycle_description="",
+        total_symbols=1,
+        cross_imports=[
+            {"from": "tests/unit/parser/test_go.py", "to": "tests/unit/parser/conftest.py"}
+        ],
+        test_only=True,
+    )
+
+
+def render_scc(env: jinja2.Environment, ctx: SccPageContext) -> str:
+    """Render with the ranking the generator actually passes.
+
+    The suite used to hand this template ``decouple_ranking=[]``, a shape
+    production never produces - the ranking is derived from the same member
+    list the page exists for - and it hid every defect in the one section
+    that names them.
+    """
+    return render(env, "scc_page.j2", ctx, decouple_ranking=_rank_cycle_participants(ctx))
+
+
 def test_scc_page_renders_without_error(jinja_env, scc_page_ctx):
-    result = render(jinja_env, "scc_page.j2", scc_page_ctx, decouple_ranking=[])
-    assert result
+    assert render_scc(jinja_env, scc_page_ctx)
 
 
 def test_scc_page_has_heading(jinja_env, scc_page_ctx):
-    result = render(jinja_env, "scc_page.j2", scc_page_ctx, decouple_ranking=[])
-    assert "##" in result
+    assert "##" in render_scc(jinja_env, scc_page_ctx)
 
 
-def test_scc_page_contains_cycle_description(jinja_env, scc_page_ctx):
-    result = render(jinja_env, "scc_page.j2", scc_page_ctx, decouple_ranking=[])
-    # The structural page writes its own sentence about the cycle rather than
-    # echoing the assembled description, so assert on the members it names.
+def test_scc_page_names_every_member_exactly_once(jinja_env, scc_page_ctx):
+    # The members were bulleted under a heading of their own and then listed
+    # again as ranking rows. Once, with its edge counts beside it, is the same
+    # information for the index and less of a wall for the reader.
+    result = render_scc(jinja_env, scc_page_ctx)
     for member in scc_page_ctx.files:
-        assert member in result
+        assert result.count(f"| `{member}` |") == 1
+    assert "## Files in the cycle" not in result
+
+
+def test_scc_page_leaves_no_gap_where_a_section_was_dropped(
+    jinja_env, scc_page_ctx, bare_scc_page_ctx, test_scc_page_ctx
+):
+    for ctx in (scc_page_ctx, bare_scc_page_ctx, test_scc_page_ctx):
+        result = render_scc(jinja_env, ctx)
+        assert "\n\n\n" not in result
+        assert not result.startswith("\n")
+
+
+def test_scc_page_keeps_its_table_intact(jinja_env, scc_page_ctx):
+    # A blank line between the delimiter row and the first row is not a table.
+    result = render_scc(jinja_env, scc_page_ctx)
+    assert "| --- | --- | --- | --- |\n| `pkg/a.py` |" in result
+
+
+def test_scc_page_renders_no_bullet_without_a_name(jinja_env, scc_page_ctx):
+    result = render_scc(jinja_env, scc_page_ctx)
+    assert "- ``" not in result
+    assert not any(line.rstrip() == "-" for line in result.splitlines())
+
+
+def test_an_all_test_cycle_is_not_called_a_knot_to_untangle(jinja_env, test_scc_page_ctx):
+    # Every member is a test file reaching a shared fixture, so the generic
+    # sentence ("nothing here can be loaded, tested or extracted without the
+    # rest") tells the reader to go break something that works as intended.
+    result = render_scc(jinja_env, test_scc_page_ctx)
+    assert "Nothing in this group can be loaded" not in result
+    assert "test files import each other" in result
+    assert "## What holds it together" in result
+    assert "## Where to break it" not in result
+
+
+def test_a_production_cycle_keeps_the_sentence_that_names_the_problem(jinja_env, scc_page_ctx):
+    result = render_scc(jinja_env, scc_page_ctx)
+    assert "Nothing in this group can be loaded" in result
+    assert "## Where to break it" in result


### PR DESCRIPTION
## The wiki and the file route documented the same file and could not reach each other

Two crossings, one of them missing and one of them dead.

**The file route rendered a wiki body with no page list.** `files/[...path]/page.tsx`
passed `content` and nothing else to `WikiMarkdown`, so every backticked path in the
embedded documentation was plain text. The docs reader has resolved those since the
path index shipped; the file page, where the reader is already looking at a file, did
not.

**The cycle page said something untrue about test code.** `scc-620e46d9a910` on this
repo's own index is twenty files under `tests/unit/ingestion/parser/`, all reaching a
shared `conftest.py`. The page told the reader that "nothing in this group can be
loaded, tested or extracted without the rest of it", which describes a working pytest
tree as debt to pay down, and then offered to help break it.

### The crossing

`WikiMarkdown` needs `buildHref` as well as `pages`, and a function cannot cross from
a server component into a client one, so this is a small client wrapper rather than
the one prop it looked like. It fetches the page list through the existing shared SWR
key instead of server-side: the list is repo-wide, and server-side it would ride the
flight payload of every file page. The tab mounts only when it is selected, and until
the list lands the paths render as plain code, exactly as before.

Refs route through the existing `pageHref` helper, not `fileEntityPath`. The path
index resolves a directory ref to its module page, and the file route calls
`notFound()` on a directory, so keying the href off "has a target_path" would have
turned seven dead text spans in this index into seven links to a 404. A wrong link is
worse than no link.

### The cycle page

Before, on `scc-620e46d9a910`:

```
20 files import each other in a loop, directly or transitively. Nothing in this
group can be loaded, tested or extracted without the rest of it.

## Files in the cycle

                                        <- blank line between every bullet
- `tests/unit/ingestion/parser/_helpers.py`

- `tests/unit/ingestion/parser/conftest.py`
...                                     <- all 20, then all 20 again in the table

## Symbols defined in the cycle

### `tests/unit/ingestion/parser/_helpers.py`
                                        <- heading, nothing under it

**Total symbols in cycle:** 270
---                                     <- markdown reads this as a heading
```

After:

```
20 test files import each other in a loop, through the fixtures and helpers they
share. A test tree is built this way on purpose, so this is a cycle in the import
graph rather than debt to pay down.

**Cycle id:** `scc-620e46d9a910`

## The loop

- `tests/unit/ingestion/parser/_helpers.py` -> `tests/unit/ingestion/parser/conftest.py`
- `tests/unit/ingestion/parser/conftest.py` -> `tests/unit/ingestion/parser/test_cpp.py`

## What holds it together

Ranked by how many of the cycle's edges each file carries. The file at the top is the
shared fixture the rest import, so it is the one to read first to understand how this
suite is set up.

| File | Imports in cycle | Imported by | Total |
| --- | --- | --- | --- |
| `tests/unit/ingestion/parser/conftest.py` | 18 | 19 | 37 |
| `tests/unit/ingestion/parser/_helpers.py` | 1 | 18 | 19 |

**Total symbols in cycle:** 270

---
```

The member list is now printed once. It moved from the bullets to the ranking table,
which is the superset: the bullets were capped at 30 and the table never was, and the
table says how entangled each member is. The empty-bullet and empty-heading fixes are
in the assembler rather than the template, because that is where a blank name and a
file with nothing public are produced.

### Nothing leaves the index

`Page.content` is one string that FTS5 indexes, the vector store embeds, `get_context`
returns verbatim and a reader reads, so a prettier page that drops tokens is a
regression. Measured on all 15 SCC pages in this repo's live index by rendering the
same reconstructed context through both templates and diffing the backticked tokens:
**nothing is lost on any page**. Member counts run 2 / 3 / 20 (min / median / max), so
the 30-bullet cap was never reached and the deleted list was pure duplication. The one
live case of the new empty-heading guard is `_helpers.py`, whose path still appears in
the table and on both sides of its loop edges.

Three of the fifteen summaries change, the three all-test cycles, because
`_extract_summary` reads the opening paragraph. It trades boilerplate that was
byte-identical across all fifteen summaries for `test files`, `fixtures`, `helpers`,
`test tree`, and stops asserting something false to `get_answer`.

### What I did not do

**I did not bump `STRUCTURAL_GENERATION_VERSION`.** I started to, and then checked
what it reaches. `_structural_scc_page` passes no `subject_hash`, so
`structural_content_hash` returns `""` and `_structural_page` stores no render key;
`structural.py:600` says so directly ("an empty hash keeps them out of the
fingerprint-staleness sweep"). The bump therefore refreshes none of the pages this
change touches, while marking every stored `file_page` and `symbol_spotlight` stale
through `structural_fingerprint` and re-rendering 4,438 of them, in this repo alone,
to byte-identical output. All cost, no effect. Say the word if you want it anyway.

**The "Open file page" link is unchanged.** It shipped in #2082 and it works: the
door on a wiki file page reaches the file route, and this change completes the loop
back out of it. The dead-ref treatment was proposed for it (tertiary ink, accent on
hover only) and it currently renders in full accent. I left it alone. The comment
above it records deliberate decisions about its size and its position in the
provenance row, and the case for restyling is that it is the page's only action, not
that it is wrong. Worth a separate look, not a drive-by.

### Gate

Clicked through on this repo's own index, against a local `next dev` build:

- wiki file page, `Open file page ->`, lands on
  `/repos/{id}/files/packages/cli/src/repowise/cli/helpers.py`
- that page's Documentation tab carries 39 resolved path links; clicking one lands on
  `/repos/{id}/files/packages/cli/src/repowise/cli/output.py`
- no directory-shaped link in the body; the only ones on the page are the breadcrumb

The links read as ink: live refs take a 6% ground and primary ink with accent on hover
only, dead refs stay plain tertiary mono. In the "Depends on" section of that page,
`.../cli/output.py` is decorated and `.../cli/errors.py` and the `__init__.py` entries
are not, because there is no page behind them.

### Tests

Each behaviour change has a test that fails on the baseline source, verified by
restoring the pre-change file and re-running, not by assumption:

- a path in an embedded body becomes a link to that file's route
- a directory ref goes to the docs reader, not to a 404
- a path with no page behind it stays plain text
- the members are named exactly once
- no blank-line run and no leading newline, on a full, a bare and an all-test cycle
- the delimiter row is followed by the first row, not by a blank line
- an all-test cycle drops the untangle-this sentence and the "Where to break it" heading
- a production cycle keeps both
- the assembler drops an unnamed symbol, drops a file with nothing public, and flags a
  cycle whose members are all test files

`packages/web/vitest.config.ts` needed `esbuild: { jsx: "automatic" }`: the app's
tsconfig says `jsx: preserve`, which Vite cannot compile, so it fell back to the
classic transform and any component rendered from a test threw `React is not defined`.

```
tests/unit/generation      1546 passed
packages/ui                1575 passed (186 files)
packages/web                 87 passed (17 files)
ruff check                 All checks passed
tsc --noEmit (web)         clean
```
