### PR TITLE
fix(augment): BM25 floor for the rescue's FTS fallback (#2092)

### DIFF
--- a/packages/cli/src/repowise/cli/commands/augment_cmd/search.py
+++ b/packages/cli/src/repowise/cli/commands/augment_cmd/search.py
@@ -50,6 +50,11 @@ _RESCUE_TOP_N = 2
 # answer depend on row order; this is small enough to stay one indexed lookup
 # and large enough that the ranking, not the LIMIT, picks the winner.
 _RESCUE_EXACT_FETCH = 8
+# BM25 floor for the rescue's FTS fallback. A multi-token query where only
+# one common token matches ("fallback") still returns rows at score ~3;
+# genuinely related pages score 2-3x higher (observed: weak 3.45 vs real
+# 8.70). Below the floor, silence beats a confident wrong suggestion.
+_RESCUE_FTS_MIN_SCORE = 6.0
 # Files the triage ranker considers. Ranking is over the grep's own matches,
 # so this only bites on floods wider than 200 files, where the tail is taken
 # by match count, the one signal available before any index lookup.
@@ -793,6 +798,10 @@ async def _rescue(
     except Exception:
         fts_rows = []
     for r in fts_rows:
+        if r.score < _RESCUE_FTS_MIN_SCORE:
+            # A weak FTS hit is a single-token ride, not a real match —
+            # silence beats a confident wrong suggestion.
+            continue
         target = getattr(r, "target_path", None) or ""
         page_type = getattr(r, "page_type", "") or ""
         if "::" in target:

--- a/tests/unit/cli/test_augment_search.py
+++ b/tests/unit/cli/test_augment_search.py
@@ -13,7 +13,8 @@ and are exercised end-to-end in integration tests instead.
 
 from __future__ import annotations
 
-from unittest.mock import patch
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -748,3 +749,64 @@ class TestWidenedRescueGate:
         session = _FakeSession([])
         out = await _rescue(session, None, 1, "parse_yaml", "parse_yaml", {"src/a.py": 3})
         assert out is None
+
+    async def test_fts_fallback_silent_below_the_score_floor(self) -> None:
+        """A single-token ride (score ~3) must not produce a suggestion.
+
+        The repro from #2092: `bluetooth codec negotiation fallback` rides
+        on the one common token "fallback" at BM25 3.45 and names an
+        unrelated file. Below the floor, silence beats a confident wrong
+        suggestion.
+        """
+        session = _FakeSession([])
+        fake_fts = SimpleNamespace(
+            search=AsyncMock(
+                return_value=[
+                    SimpleNamespace(
+                        score=3.45,
+                        target_path="config/shared/claude/hooks/prefer-web-tools.py",
+                        page_type="file_page",
+                    )
+                ]
+            )
+        )
+        with patch(
+            "repowise.core.persistence.FullTextSearch",
+            return_value=fake_fts,
+        ):
+            out = await _rescue(
+                session,
+                object(),
+                1,
+                "bluetooth codec negotiation fallback",
+                "bluetooth codec negotiation fallback",
+            )
+        assert out is None
+
+    async def test_fts_fallback_fires_above_the_score_floor(self) -> None:
+        """A genuinely related page (score 2-3x the weak cluster) still fires."""
+        session = _FakeSession([])
+        fake_fts = SimpleNamespace(
+            search=AsyncMock(
+                return_value=[
+                    SimpleNamespace(
+                        score=16.47,
+                        target_path="config/btrfs/monitor.py",
+                        page_type="file_page",
+                    )
+                ]
+            )
+        )
+        with patch(
+            "repowise.core.persistence.FullTextSearch",
+            return_value=fake_fts,
+        ):
+            out = await _rescue(
+                session,
+                object(),
+                1,
+                "btrfs space monitoring",
+                "btrfs space monitoring",
+            )
+        assert out is not None
+        assert "btrfs/monitor.py" in out


### PR DESCRIPTION
## What

Fixes #2092. The zero-result grep rescue's FTS fallback returned the first row without checking its relevance score, so a multi-token pattern where only one common token matched produced a confident "Wiki suggests ..." line for an unrelated file (repro: `bluetooth codec negotiation fallback` riding on "fallback" at BM25 3.45).

## Root cause

`_rescue` in `augment_cmd/search.py` returned the first FTS row pointing at a code page with no score check. Weak matches cluster ~3; genuine ones score 2-3x higher (observed 3.45 vs 8.70), so the fallback leg had no quality gate while the symbol path held an exact-match bar.

## Changes

- Added `_RESCUE_FTS_MIN_SCORE = 6.0` — below the floor, silence beats a confident wrong suggestion.

## Tests

- Below-floor silent, above-floor fires — sabotage-verified (below-floor test fails without the fix).

Note: `test_plugin_content` is red on main itself (v0.47.0 release bug, unrelated to this PR).
