### PR TITLE
fix(init): --resume skips the interactive questionnaire (#2098)

### DIFF
--- a/packages/cli/src/repowise/cli/commands/init_cmd/command.py
+++ b/packages/cli/src/repowise/cli/commands/init_cmd/command.py
@@ -409,6 +409,25 @@ def _run_generation_phase(
 # ---------------------------------------------------------------------------
 
 
+def _interactive_gate(
+    *,
+    isatty: bool,
+    provider_name: str | None,
+    index_only: bool,
+    yes: bool,
+    resume: bool,
+) -> bool:
+    """Whether the interactive questionnaire runs.
+
+    Interactive requires a TTY, no explicit provider, docs on, and neither
+    --yes nor --resume. --resume skips the gate because the prior run
+    already answered every question and those answers are on disk
+    (config.yaml); re-asking would let a resumed run diverge from the pages
+    already written with them (issue #2098).
+    """
+    return isatty and provider_name is None and not index_only and not yes and not resume
+
+
 @click.command("init")
 @click.argument("path", required=False, default=None)
 @click.option(
@@ -948,7 +967,23 @@ def init_command(
     # ---- Interactive mode (TTY, no explicit flags) ----
     # --yes forces non-interactive even on a TTY (mirrors the workspace path),
     # so a scripted `init -y` never blocks on the mode-selection menu.
-    is_interactive = sys.stdin.isatty() and provider_name is None and not index_only and not yes
+    # --resume skips the gate too: the prior run already answered every
+    # question, and those answers are on disk (config.yaml), so re-asking
+    # would let a resumed run diverge from the pages already written with
+    # them (issue #2098).
+    is_interactive = _interactive_gate(
+        isatty=sys.stdin.isatty(),
+        provider_name=provider_name,
+        index_only=index_only,
+        yes=yes,
+        resume=resume,
+    )
+
+    if resume:
+        console.print(
+            f"[bold]Resuming[/] the previous run in {repo_path} — "
+            "reusing its answers; pass --yes to skip this notice."
+        )
 
     # Output language picked in the advanced-mode generation section; None
     # until chosen. Resolved below: flag > this > config.yaml > English.

--- a/packages/cli/src/repowise/cli/commands/init_cmd/command.py
+++ b/packages/cli/src/repowise/cli/commands/init_cmd/command.py
@@ -981,8 +981,8 @@ def init_command(
 
     if resume:
         console.print(
-            f"[bold]Resuming[/] the previous run in {repo_path} — "
-            "reusing its answers; pass --yes to skip this notice."
+            f"[bold]Resuming[/] the previous run in {repo_path}, "
+            "reusing the answers it already saved to config.yaml."
         )
 
     # Output language picked in the advanced-mode generation section; None

--- a/tests/unit/cli/test_init_noninteractive.py
+++ b/tests/unit/cli/test_init_noninteractive.py
@@ -17,8 +17,44 @@ from click.testing import CliRunner
 
 from repowise.cli import cost_gate
 from repowise.cli.commands.init_cmd._interactive import offer_hook_install
+from repowise.cli.commands.init_cmd.command import _interactive_gate
 from repowise.cli.helpers import NO_SAVE_KEY_ENV, save_config
 from repowise.cli.main import cli
+
+
+class TestInteractiveGate:
+    """The questionnaire gate: --resume must skip it (issue #2098)."""
+
+    def test_tty_with_no_flags_is_interactive(self) -> None:
+        assert _interactive_gate(
+            isatty=True, provider_name=None, index_only=False, yes=False, resume=False
+        )
+
+    def test_resume_skips_the_gate_on_a_tty(self) -> None:
+        """A resume must not re-ask questions the prior run already answered."""
+        assert not _interactive_gate(
+            isatty=True, provider_name=None, index_only=False, yes=False, resume=True
+        )
+
+    def test_yes_skips_the_gate(self) -> None:
+        assert not _interactive_gate(
+            isatty=True, provider_name=None, index_only=False, yes=True, resume=False
+        )
+
+    def test_explicit_provider_skips_the_gate(self) -> None:
+        assert not _interactive_gate(
+            isatty=True, provider_name="anthropic", index_only=False, yes=False, resume=False
+        )
+
+    def test_index_only_skips_the_gate(self) -> None:
+        assert not _interactive_gate(
+            isatty=True, provider_name=None, index_only=True, yes=False, resume=False
+        )
+
+    def test_non_tty_skips_the_gate(self) -> None:
+        assert not _interactive_gate(
+            isatty=False, provider_name=None, index_only=False, yes=False, resume=False
+        )
 
 
 def _est(usd: float) -> SimpleNamespace:


### PR DESCRIPTION
## What

Fixes #2098. `repowise init --resume` on a TTY re-ran the entire interactive questionnaire — banner, scan, mode menu, provider, embedder, style — indistinguishable from a fresh run, and a user who answered differently resumed under a different provider/style than the pages on disk were written with.

## Root cause

`is_interactive` at `init_cmd/command.py:951` never excluded `--resume`, so the flag had no effect on whether the prompts ran. The prior run's answers were already on disk (config.yaml), which the non-interactive path reads.

## Changes

- Extracted the gate into `_interactive_gate()` (pure, testable) and added `and not resume`.
- A one-line "Resuming ... reusing its answers" notice replaces the menu so the user can see the run was picked up, not restarted.

## Tests

- 6 gate cases (resume/yes/provider/index-only/non-tty all skip; plain TTY prompts).

Note: `test_plugin_content` is red on main itself (v0.47.0 release bug, unrelated to this PR).
