### PR TITLE
fix(update): surface the two silent embedder degradations (#1370)

### DIFF
--- a/packages/cli/src/repowise/cli/commands/update_cmd/command.py
+++ b/packages/cli/src/repowise/cli/commands/update_cmd/command.py
@@ -1623,7 +1623,7 @@ def run_update(
 
     # Build the shared vector store once: reused by the supersession detector
     # below and by the decision upsert in _persist (semantic dedup + search).
-    decision_vector_store = _build_update_vector_store(repo_path, cfg)
+    decision_vector_store = _build_update_vector_store(repo_path, cfg, degraded)
 
     # --- Two-pass decision evolution (Phase 3C), BEFORE page regeneration ----
     # Cross-reference the diff + new commit bodies against existing decisions

--- a/packages/cli/src/repowise/cli/commands/update_cmd/incremental.py
+++ b/packages/cli/src/repowise/cli/commands/update_cmd/incremental.py
@@ -12,7 +12,9 @@ from typing import Any
 from repowise.cli.helpers import console, run_async
 
 
-def _build_update_vector_store(repo_path: Any, cfg: dict) -> Any | None:
+def _build_update_vector_store(
+    repo_path: Any, cfg: dict, degraded: list[str] | None = None
+) -> Any | None:
     """Build the shared page/decision vector store for the update path.
 
     Phase-2 follow-up + Phase-3 requirement: ``repowise update`` historically
@@ -21,14 +23,19 @@ def _build_update_vector_store(repo_path: Any, cfg: dict) -> Any | None:
     runs. We mirror ``init``'s store construction (LanceDB at
     ``.repowise/lancedb`` so previously-embedded decisions are matchable; the
     in-memory store is a degraded fallback that only sees this run's vectors).
-    Returns ``None`` on any failure — the decision upsert still works without it.
+    Returns ``None`` on any failure — the decision upsert still works without
+    it. A failure is recorded in *degraded* (when given) so the run's degraded
+    panel says why semantic dedup is off instead of silently skipping it
+    (issue #1370).
     """
     try:
         from repowise.cli.providers import build_embedder, build_vector_store, resolve_embedder
 
         embedder = build_embedder(resolve_embedder(cfg.get("embedder")), repo_path)
         return build_vector_store(repo_path, embedder)
-    except Exception:
+    except Exception as exc:
+        if degraded is not None:
+            degraded.append(f"Decision vector store: {type(exc).__name__}: {exc}")
         return None
 
 

--- a/packages/cli/src/repowise/cli/commands/update_cmd/persistence.py
+++ b/packages/cli/src/repowise/cli/commands/update_cmd/persistence.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import contextlib
 import os
+import sys
 import time
 from pathlib import Path
 from typing import Any
@@ -1264,7 +1265,15 @@ def _full_rescore_interval_days() -> float:
         try:
             return max(0.0, float(raw))
         except ValueError:
-            pass
+            # Say it where the user will actually see it: a silently-ignored
+            # value makes the rescore cadence look deliberate when it is
+            # actually the default (issue #1370). stderr matches how
+            # build_embedder reports the same class of misconfiguration.
+            print(
+                f"REPOWISE_FULL_RESCORE_INTERVAL_DAYS={raw!r} is not a number; "
+                f"using the default {_FULL_RESCORE_INTERVAL_DAYS} days.",
+                file=sys.stderr,
+            )
     return _FULL_RESCORE_INTERVAL_DAYS
 
 

--- a/tests/unit/cli/test_health_rescore_gate.py
+++ b/tests/unit/cli/test_health_rescore_gate.py
@@ -10,10 +10,33 @@ from __future__ import annotations
 import pytest
 
 from repowise.cli.commands.update_cmd.persistence import (
+    _full_rescore_interval_days,
     full_rescore_due,
     health_analyzer_changed,
 )
 from repowise.core.analysis.health import HEALTH_ANALYZER_VERSION
+
+
+class TestRescoreIntervalEnv:
+    """REPOWISE_FULL_RESCORE_INTERVAL_DAYS parsing (issue #1370)."""
+
+    def test_valid_value_parses(self, monkeypatch, capsys) -> None:
+        monkeypatch.setenv("REPOWISE_FULL_RESCORE_INTERVAL_DAYS", "3.5")
+        assert _full_rescore_interval_days() == 3.5
+        assert capsys.readouterr().err == ""
+
+    def test_invalid_value_warns_on_stderr(self, monkeypatch, capsys) -> None:
+        """A malformed value must not silently default — say it out loud."""
+        monkeypatch.setenv("REPOWISE_FULL_RESCORE_INTERVAL_DAYS", "soon")
+        assert _full_rescore_interval_days() == 7.0
+        err = capsys.readouterr().err
+        assert "REPOWISE_FULL_RESCORE_INTERVAL_DAYS" in err
+        assert "soon" in err
+
+    def test_unset_uses_default_silently(self, monkeypatch, capsys) -> None:
+        monkeypatch.delenv("REPOWISE_FULL_RESCORE_INTERVAL_DAYS", raising=False)
+        assert _full_rescore_interval_days() == 7.0
+        assert capsys.readouterr().err == ""
 
 
 class TestHealthAnalyzerChanged:

--- a/tests/unit/cli/test_update_vector_store_degraded.py
+++ b/tests/unit/cli/test_update_vector_store_degraded.py
@@ -1,0 +1,50 @@
+"""Tests for the update path's decision vector store (issue #1370).
+
+``_build_update_vector_store`` swallows failures and returns None so the
+decision upsert still works without a store — but the failure must land in
+the run's ``degraded`` list, or the panel says nothing while semantic dedup
+is silently off.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from repowise.cli.commands.update_cmd.incremental import _build_update_vector_store
+
+
+def test_failure_is_recorded_in_degraded() -> None:
+    """A store build failure must surface in the degraded list."""
+    degraded: list[str] = []
+    with patch(
+        "repowise.cli.providers.build_embedder",
+        side_effect=RuntimeError("boom"),
+    ):
+        assert _build_update_vector_store("/tmp/repo", {"embedder": "ollama"}, degraded) is None
+    assert any("Decision vector store" in d and "boom" in d for d in degraded)
+
+
+def test_failure_without_degraded_stays_silent() -> None:
+    """Callers without a degraded list keep the old silent contract."""
+    with patch(
+        "repowise.cli.providers.build_embedder",
+        side_effect=RuntimeError("boom"),
+    ):
+        assert _build_update_vector_store("/tmp/repo", {"embedder": "ollama"}) is None
+
+
+def test_success_returns_the_store() -> None:
+    """A healthy build returns the store and records nothing."""
+    degraded: list[str] = []
+    store = object()
+    with patch(
+        "repowise.cli.providers.build_embedder",
+        return_value=object(),
+    ), patch(
+        "repowise.cli.providers.build_vector_store",
+        return_value=store,
+    ):
+        assert _build_update_vector_store("/tmp/repo", {"embedder": "ollama"}, degraded) is store
+    assert degraded == []

--- a/tests/unit/cli/test_update_vector_store_degraded.py
+++ b/tests/unit/cli/test_update_vector_store_degraded.py
@@ -10,8 +10,6 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
-import pytest
-
 from repowise.cli.commands.update_cmd.incremental import _build_update_vector_store
 
 


### PR DESCRIPTION
## What

Fixes #1370 — the two survivors Raghav enumerated in his close comment on #1373.

## Root cause

1. `_full_rescore_interval_days` still did `except ValueError: pass`, so a malformed `REPOWISE_FULL_RESCORE_INTERVAL_DAYS` silently defaulted to 7.0.
2. `_build_update_vector_store` swallowed failures with a bare `except` and never touched the run's `degraded` list, so semantic dedup could be off with the panel saying nothing.

## Changes

- Rescore interval now warns on stderr naming the var and the offending value (same pattern as `build_embedder`'s misconfiguration report).
- Vector store now records `Decision vector store: <exc>` in `degraded` when one is passed; no-degraded callers keep the old silent contract.

## Tests

- 3 rescore-interval cases + 3 vector-store cases, sabotage-verified.

Note: `test_plugin_content` is red on main itself (v0.47.0 release bug, unrelated to this PR).
