### PR TITLE
fix(init): surface generation-phase embed failures in the run's degraded list (#1369)

### DIFF
--- a/packages/cli/src/repowise/cli/commands/init_cmd/command.py
+++ b/packages/cli/src/repowise/cli/commands/init_cmd/command.py
@@ -270,6 +270,7 @@ def _run_generation_phase(
     resume: bool,
     test_run: bool,
     timings: Any | None = None,
+    warnings: list[str] | None = None,
 ) -> tuple[bool, bool]:
     """Run the LLM generation phase for a single-repo init.
 
@@ -400,6 +401,7 @@ def _run_generation_phase(
         verbose=True,
         test_run=test_run,
         timings=timings,
+        warnings=warnings,
     )
     return False, False
 
@@ -1452,6 +1454,7 @@ def init_command(
             # file. Resuming against it would skip the entire model run and
             # say nothing, so a template wiki is never a run to continue.
             resume=resume and _prior_docs_mode != "deterministic",
+            warnings=run_warnings,
             test_run=test_run,
             timings=callback.table,
         )

--- a/packages/cli/src/repowise/cli/commands/init_cmd/generation.py
+++ b/packages/cli/src/repowise/cli/commands/init_cmd/generation.py
@@ -260,6 +260,7 @@ def run_repo_generation(
     verbose: bool,
     test_run: bool = False,
     timings: Any | None = None,
+    warnings: list[str] | None = None,
 ) -> list[Any]:
     """Generate wiki pages for one repo and enrich its knowledge graph.
 
@@ -369,6 +370,8 @@ def run_repo_generation(
                 test_run=test_run,
             )
         )
+        if warnings is not None:
+            warnings.extend(gen_callback.warnings)
 
     jobs_dir = Path(repo_path) / ".repowise" / "jobs"
     failed_page_ids: list[str] = []

--- a/packages/core/src/repowise/core/generation/page_generator/core.py
+++ b/packages/core/src/repowise/core/generation/page_generator/core.py
@@ -249,6 +249,7 @@ class PageGenerator(PerTypeGenerationMixin, StructuralRenderMixin):
         only_page_ids: set[str] | None = None,
         preserved_page_ids: set[str] | None = None,
         timings: Any | None = None,
+        on_warning: Callable[[str], None] | None = None,
     ) -> list[GeneratedPage]:
         """Generate all wiki pages for a repository.
 
@@ -308,6 +309,7 @@ class PageGenerator(PerTypeGenerationMixin, StructuralRenderMixin):
             only_page_ids=only_page_ids,
             preserved_page_ids=preserved_page_ids,
             timings=timings,
+            on_warning=on_warning,
         )
 
     # ------------------------------------------------------------------

--- a/packages/core/src/repowise/core/generation/page_generator/orchestrate.py
+++ b/packages/core/src/repowise/core/generation/page_generator/orchestrate.py
@@ -110,6 +110,7 @@ class _GenerationRun:
         only_page_ids: set[str] | None = None,
         preserved_page_ids: set[str] | None = None,
         timings: Any | None = None,
+        on_warning: Callable[[str], None] | None = None,
     ) -> None:
         self.gen = gen
         self.config = gen._config
@@ -142,6 +143,7 @@ class _GenerationRun:
         self.on_page_ready = on_page_ready
         self.on_total_known = on_total_known
         self.on_subphase = on_subphase
+        self.on_warning = on_warning
         self.git_meta_map = git_meta_map
         self.resume = resume
         self.repo_path = repo_path
@@ -734,6 +736,12 @@ class _GenerationRun:
                                 error=str(e),
                                 hint="semantic search will miss these pages; run `repowise reindex` to repair",
                             )
+                            if self.on_warning is not None:
+                                self.on_warning(
+                                    f"Embedding failed for {len(embed_items)} page(s) "
+                                    f"({type(e).__name__}: {e}) — semantic search will "
+                                    "miss them; run `repowise reindex` to repair."
+                                )
                 pages = [r for r in results if isinstance(r, GeneratedPage)]
                 with timed(self.timings, "generation.checkpoint"):
                     if self.job_system is not None and self.job_id is not None:

--- a/packages/core/src/repowise/core/pipeline/phases/generation.py
+++ b/packages/core/src/repowise/core/pipeline/phases/generation.py
@@ -169,6 +169,14 @@ async def run_generation(
         if progress:
             progress.on_phase_start(name, total)
 
+    def on_warning(text: str) -> None:
+        """Surface a generation-time degradation through the progress callback
+        so it lands in the run's warnings (persisted as ``degraded``), not
+        only in structlog — the CLI pins structlog to ERROR unless -v, so a
+        log-only warning is invisible on the path that matters (issue #1369)."""
+        if progress:
+            progress.on_message("warning", text)
+
     generator = PageGenerator(
         llm_client,
         assembler,
@@ -204,6 +212,7 @@ async def run_generation(
         only_page_ids=only_page_ids,
         preserved_page_ids=preserved_page_ids,
         timings=getattr(progress, "table", None),
+        on_warning=on_warning,
     )
 
     # Onboarding summary — count generated slots and surface which ones

--- a/tests/unit/pipeline/test_generation_warning_wiring.py
+++ b/tests/unit/pipeline/test_generation_warning_wiring.py
@@ -1,0 +1,107 @@
+"""A generation-time embed failure must reach the progress callback.
+
+Regression anchor for #1369: the orchestrator warned only through structlog,
+and the CLI pins structlog to ERROR unless -v, so a dead Ollama mid-run
+produced no visible degradation — the run's ``degraded`` list (persisted to
+state.json) stayed empty. ``run_generation`` now threads an ``on_warning``
+callback down to the embed-batch failure handler, routing it through
+``progress.on_message("warning", ...)`` so the Rich callback records it in
+its ``warnings`` list (which init persists as ``degraded``).
+
+This test pins the seam: a stub generator captures the ``on_warning`` it is
+handed, and invoking that callback must surface the text through the
+progress callback's ``on_message``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from types import SimpleNamespace
+
+import pytest
+
+from repowise.core.pipeline.phases.generation import run_generation
+
+
+class _WarningRecorder:
+    """A progress callback that captures on_message(warning) the way
+    RichProgressCallback does."""
+
+    def __init__(self) -> None:
+        self.warnings: list[str] = []
+
+    def on_phase_start(self, phase: str, total: int | None) -> None:
+        pass
+
+    def on_item_done(self, phase: str) -> None:
+        pass
+
+    def on_phase_done(self, phase: str) -> None:
+        pass
+
+    def on_stage(self, stage: str) -> None:
+        pass
+
+    def on_message(self, level: str, text: str) -> None:
+        if level == "warning":
+            self.warnings.append(text)
+
+
+class _StubGenerator:
+    """Records the on_warning callback it was handed, then returns pages."""
+
+    def __init__(self) -> None:
+        self.on_warning: Callable[[str], None] | None = None
+
+    async def generate_all(
+        self,
+        parsed_files: list,
+        *args: object,
+        **kwargs: object,
+    ) -> list:
+        callback = kwargs.get("on_warning")
+        assert callback is not None, "run_generation must thread on_warning through"
+        self.on_warning = callback  # type: ignore[assignment]
+        return []
+
+
+@pytest.fixture(autouse=True)
+def _stub_generator(monkeypatch: pytest.MonkeyPatch) -> _StubGenerator:
+    stub = _StubGenerator()
+    monkeypatch.setattr(
+        "repowise.core.generation.PageGenerator",
+        lambda *a, **k: stub,
+    )
+    return stub
+
+
+def _parsed_files(n: int) -> list:
+    return [SimpleNamespace(file_info=SimpleNamespace(path=f"pkg/mod_{i}.py")) for i in range(n)]
+
+
+async def test_embed_failure_handled_through_progress_warnings(
+    _stub_generator: _StubGenerator, tmp_path: pytest.TempPathFactory
+) -> None:
+    progress = _WarningRecorder()
+    await run_generation(
+        repo_path=tmp_path,
+        parsed_files=_parsed_files(1),
+        source_map={},
+        graph_builder=SimpleNamespace(),
+        repo_structure=SimpleNamespace(),
+        git_meta_map={},
+        llm_client=SimpleNamespace(),
+        embedder=None,
+        vector_store=None,
+        concurrency=1,
+        progress=progress,
+    )
+    # The orchestrator's embed-batch handler calls on_warning on failure;
+    # wherever it fires, the text must land in the progress warnings.
+    assert _stub_generator.on_warning is not None
+    _stub_generator.on_warning(
+        "Embedding failed for 3 page(s) (RuntimeError: boom) — semantic search "
+        "will miss them; run `repowise reindex` to repair."
+    )
+    assert len(progress.warnings) == 1
+    assert "Embedding failed for 3 page(s)" in progress.warnings[0]


### PR DESCRIPTION
## What

Fixes #1369 — residual from the #852 config-warning fix.

## Root cause

The init header probes `build_embedder` and warns on degradation, but the generation phase rebuilds the embedder and a mid-run embed failure (e.g. a local Ollama that goes down) only wrote a structlog warning — and the CLI pins structlog to ERROR unless `-v`, so the run finished looking clean with semantic search silently off, and state.json carried no `degraded` entry.

## Changes

- Threads an `on_warning` callback from `run_generation` down through `PageGenerator.generate_all` into the orchestrator's embed-batch failure handler, routing the text through `progress.on_message('warning', ...)` so the Rich callback records it.
- `run_repo_generation` merges the generation callback's warnings into the caller's list, so init's persisted `degraded` (state.json) and the completion panel see it.

## Tests

- Stub generator + progress recorder pin the seam — sabotage-verified.

Note: `test_plugin_content` is red on main itself (v0.47.0 release bug, unrelated to this PR).
