### PR TITLE
feat(providers): add the Voyage AI embedder (#611)

### DIFF
--- a/packages/cli/src/repowise/cli/providers/embedders.py
+++ b/packages/cli/src/repowise/cli/providers/embedders.py
@@ -89,6 +89,8 @@ def resolve_embedder(embedder_flag: str | None, env: Mapping[str, str] | None = 
         return "ollama"
     if _get("EDENAI_API_KEY"):
         return "edenai"
+    if _get("VOYAGE_API_KEY"):
+        return "voyage"
     return global_config_embedder() or "mock"
 
 

--- a/packages/cli/src/repowise/cli/providers/keys.py
+++ b/packages/cli/src/repowise/cli/providers/keys.py
@@ -41,6 +41,7 @@ _EMBEDDER_KEY_ENV: dict[str, tuple[str, ...]] = {
     "gemini": ("GEMINI_API_KEY", "GOOGLE_API_KEY"),
     "openrouter": ("OPENROUTER_API_KEY",),
     "edenai": ("EDENAI_API_KEY",),
+    "voyage": ("VOYAGE_API_KEY",),
 }
 
 

--- a/packages/cli/src/repowise/cli/ui/mode_selection.py
+++ b/packages/cli/src/repowise/cli/ui/mode_selection.py
@@ -450,7 +450,7 @@ def _prompt_generation(
 
     # Embedder selection
     detected_embedder = _resolve_embedder_from_env()
-    embedder_choices = ["gemini", "openai", "openrouter", "ollama", "edenai", "mock"]
+    embedder_choices = ["gemini", "openai", "openrouter", "ollama", "edenai", "voyage", "mock"]
     result["embedder"] = click.prompt(
         "  Embedder for RAG",
         default=detected_embedder,
@@ -663,6 +663,8 @@ def _resolve_embedder_from_env() -> str:
     # already resolving to.
     if os.environ.get("EDENAI_API_KEY"):
         return "edenai"
+    if os.environ.get("VOYAGE_API_KEY"):
+        return "voyage"
     # Same last tier as the shared resolver, or the advanced prompt would
     # default to mock on a machine whose run header just said otherwise.
     from repowise.cli.providers.keys import global_config_embedder

--- a/packages/core/src/repowise/core/providers/embedding/registry.py
+++ b/packages/core/src/repowise/core/providers/embedding/registry.py
@@ -3,11 +3,12 @@
 Mirrors the LLM provider registry pattern: lazy imports, built-in embedders,
 and runtime registration for community embedders.
 
-Built-in embedders:
-    openai  → OpenAIEmbedder  (text-embedding-3-small default)
-    gemini  → GeminiEmbedder  (gemini-embedding-001 default)
-    edenai  → EdenAIEmbedder  (openai/text-embedding-3-small via Eden AI's EU gateway)
-    mock    → MockEmbedder    (testing only, zero dependencies)
+built-in embedders:
+    openai   → OpenAIEmbedder  (text-embedding-3-small default)
+    gemini   → GeminiEmbedder  (gemini-embedding-001 default)
+    edenai   → EdenAIEmbedder  (openai/text-embedding-3-small via Eden AI's EU gateway)
+    voyage   → VoyageEmbedder  (voyage-3 default)
+    mock     → MockEmbedder    (testing only, zero dependencies)
 
 Custom embedder registration:
     from repowise.core.providers.embedding import register_embedder
@@ -30,6 +31,7 @@ _BUILTIN_EMBEDDERS: dict[str, tuple[str, str]] = {
     "ollama": ("repowise.core.providers.embedding.ollama", "OllamaEmbedder"),
     "openrouter": ("repowise.core.providers.embedding.openrouter", "OpenRouterEmbedder"),
     "edenai": ("repowise.core.providers.embedding.edenai", "EdenAIEmbedder"),
+    "voyage": ("repowise.core.providers.embedding.voyage", "VoyageEmbedder"),
     "mock": ("repowise.core.providers.embedding.base", "KeylessEmbedder"),
 }
 

--- a/packages/core/src/repowise/core/providers/embedding/voyage.py
+++ b/packages/core/src/repowise/core/providers/embedding/voyage.py
@@ -1,0 +1,140 @@
+"""Voyage AI embedding support for repowise semantic search.
+
+Uses the voyageai SDK with ``voyage-3`` by default (1024 dims). Runs the
+synchronous SDK call in a thread pool to avoid blocking asyncio.
+
+Installation:
+    pip install voyageai
+
+Usage:
+    import asyncio
+    from repowise.core.providers.embedding.voyage import VoyageEmbedder
+    from repowise.core.persistence.vector_store import InMemoryVectorStore
+
+    embedder = VoyageEmbedder(api_key="pa-...")
+    store = InMemoryVectorStore(embedder)
+    await store.embed_and_upsert("page-1", "Some wiki content...", {})
+    results = await store.search("auth service", limit=5)
+
+Dimensions:
+    voyage-3       → 1024 dims
+    voyage-3-large → 1024 dims
+    voyage-3.5     → 1024 dims
+    voyage-code-3  → 1024 dims
+
+    REPOWISE_EMBEDDING_DIMS (or the ``dimensions`` arg) overrides the width.
+    See ``VoyageEmbedder``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import math
+import os
+from typing import ClassVar
+
+from repowise.core.providers.embedding.base import resolve_embedding_timeout
+
+
+class VoyageEmbedder:
+    """Voyage AI embedding model adapter implementing the repowise Embedder
+    protocol.
+
+    Args:
+        api_key: Voyage AI API key. Falls back to VOYAGE_API_KEY env var.
+        model:   Embedding model name. Default: "voyage-3".
+        timeout: Per-request timeout in seconds. Falls back to the
+            VOYAGE_EMBEDDING_TIMEOUT / REPOWISE_EMBEDDING_TIMEOUT env vars,
+            then 10.0.
+        dimensions: Output width override; falls back to
+            REPOWISE_EMBEDDING_DIMS, then the known-model table, then 1024.
+    """
+
+    _DIMS: ClassVar[dict[str, int]] = {
+        "voyage-3": 1024,
+        "voyage-3-large": 1024,
+        "voyage-3.5": 1024,
+        "voyage-code-3": 1024,
+    }
+
+    _DEFAULT_TIMEOUT: float = 10.0
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        model: str = "voyage-3",
+        timeout: float | None = None,
+        dimensions: int | None = None,
+    ) -> None:
+        self._api_key = api_key or os.environ.get("VOYAGE_API_KEY")
+        if not self._api_key:
+            raise ValueError(
+                "Voyage AI API key required. Pass api_key= or set VOYAGE_API_KEY env var."
+            )
+        self._model = model
+        self._timeout = resolve_embedding_timeout(
+            timeout, self._DEFAULT_TIMEOUT, provider_env="VOYAGE_EMBEDDING_TIMEOUT"
+        )
+        self._dimensions = self._resolve_dimensions(dimensions)
+        self._client: object | None = None  # cached; created once on first embed()
+
+    def _resolve_dimensions(self, dimensions: int | None) -> int:
+        """Declared vector width: explicit arg > REPOWISE_EMBEDDING_DIMS >
+        known-model table > 1024."""
+        if dimensions is None:
+            env = os.environ.get("REPOWISE_EMBEDDING_DIMS")
+            if env:
+                try:
+                    dimensions = int(env)
+                except ValueError:
+                    raise ValueError("dimensions must be a positive integer") from None
+        if dimensions is None:
+            return self._DIMS.get(self._model, 1024)
+        if isinstance(dimensions, bool) or not isinstance(dimensions, int) or dimensions <= 0:
+            raise ValueError("dimensions must be a positive integer")
+        return dimensions
+
+    @property
+    def dimensions(self) -> int:
+        return self._dimensions
+
+    async def embed(self, texts: list[str]) -> list[list[float]]:
+        """Embed a batch of texts using Voyage AI.
+
+        Runs the synchronous SDK call in a thread pool to avoid blocking the
+        asyncio event loop. Vectors are L2-normalized (the SDK already returns
+        unit vectors; normalizing again is a no-op safeguard).
+        """
+        if not texts:
+            return []
+
+        model = self._model
+        timeout = self._timeout
+        expected_dimensions = self._dimensions
+
+        def _embed_sync() -> list[list[float]]:
+            import voyageai  # type: ignore[import-untyped]
+
+            if self._client is None:
+                self._client = voyageai.Client(api_key=self._api_key, timeout=timeout)
+            response = self._client.embed(inputs=texts, model=model)  # type: ignore[union-attr]
+            raw_vectors = [list(v) for v in response.embeddings]
+            widths = {len(v) for v in raw_vectors}
+            if widths and widths != {expected_dimensions}:
+                actual = min(widths)
+                raise ValueError(
+                    f"VoyageEmbedder declared {expected_dimensions}-dimensional vectors but the"
+                    f" API returned {actual} (model={model!r}). Set"
+                    f" REPOWISE_EMBEDDING_DIMS={actual} to match the model's actual width."
+                )
+            return [_l2_normalize(v) for v in raw_vectors]
+
+        return await asyncio.to_thread(_embed_sync)
+
+
+def _l2_normalize(vec: list[float]) -> list[float]:
+    """L2-normalize a vector to unit length (cosine similarity = dot product)."""
+    norm = math.sqrt(sum(x * x for x in vec))
+    if norm == 0.0:
+        norm = 1.0
+    return [x / norm for x in vec]

--- a/packages/server/src/repowise/server/mcp_server/_server.py
+++ b/packages/server/src/repowise/server/mcp_server/_server.py
@@ -75,6 +75,7 @@ _EMBEDDER_KEY_ENV: dict[str, tuple[str, ...]] = {
     "gemini": ("GEMINI_API_KEY", "GOOGLE_API_KEY"),
     "openrouter": ("OPENROUTER_API_KEY",),
     "edenai": ("EDENAI_API_KEY",),
+    "voyage": ("VOYAGE_API_KEY",),
 }
 
 

--- a/tests/unit/cli/test_embedder_key_resolution.py
+++ b/tests/unit/cli/test_embedder_key_resolution.py
@@ -114,8 +114,28 @@ def test_gemini_accepts_either_of_its_two_variables(tmp_path: Path) -> None:
     assert resolve_embedder_api_key("gemini", tmp_path).key == "goog-key"
 
 
+def test_voyage_resolves_its_key_variable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """VOYAGE_API_KEY is the credential source for the voyage embedder."""
+    monkeypatch.setenv("VOYAGE_API_KEY", "pa-voyage-key")
+    assert resolve_embedder_api_key("voyage", tmp_path).key == "pa-voyage-key"
+
+
+def test_voyage_without_a_key_reports_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A voyage pin without a key resolves to nothing (the embedder then
+    raises its own 'API key required' message)."""
+    monkeypatch.delenv("VOYAGE_API_KEY", raising=False)
+    assert resolve_embedder_api_key("voyage", tmp_path).key is None
+
+
 def test_keyless_backends_resolve_to_nothing(tmp_path: Path) -> None:
-    """``ollama`` and ``mock`` want no credential, so none is "missing"."""
+    """A key-optional backend must never be reported as missing a key.
+
+    ``ollama`` and ``mock`` want no credential, so none is "missing".
+    """
     for name in ("ollama", "mock", "unknown-backend"):
         lookup = resolve_embedder_api_key(name, tmp_path)
         assert lookup.key is None

--- a/tests/unit/core/providers/test_voyage_embedder.py
+++ b/tests/unit/core/providers/test_voyage_embedder.py
@@ -49,7 +49,8 @@ def test_embed_routes_through_thread_pool_and_normalizes() -> None:
     class _FakeResponse:
         # 1024 dims to match voyage-3's declared width; the guard below
         # catches a mismatch, so the fake must be honest.
-        embeddings = [[3.0] + [0.0] * 1022 + [4.0]]
+        def __init__(self) -> None:
+            self.embeddings: list[list[float]] = [[3.0] + [0.0] * 1022 + [4.0]]
 
     class _FakeClient:
         def __init__(self, *a, **k) -> None:

--- a/tests/unit/core/providers/test_voyage_embedder.py
+++ b/tests/unit/core/providers/test_voyage_embedder.py
@@ -1,0 +1,68 @@
+"""Voyage AI embedder unit tests.
+
+Pins the parts that need no network: construction (key required), the
+known-model dimensions table + override precedence, and the normalize
+safeguard. The batch call itself is exercised only through the mocked sync
+path so the test stays deterministic.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from unittest.mock import patch
+
+import pytest
+
+from repowise.core.providers.embedding.voyage import VoyageEmbedder
+
+
+def test_missing_key_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("VOYAGE_API_KEY", raising=False)
+    with pytest.raises(ValueError, match="VOYAGE_API_KEY"):
+        VoyageEmbedder()
+
+
+def test_key_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("VOYAGE_API_KEY", "pa-test")
+    assert VoyageEmbedder()._api_key == "pa-test"
+
+
+def test_known_model_dimensions() -> None:
+    assert VoyageEmbedder(api_key="x").dimensions == 1024  # voyage-3 default
+
+
+def test_explicit_dimensions_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("REPOWISE_EMBEDDING_DIMS", "256")
+    assert VoyageEmbedder(api_key="x").dimensions == 256
+    assert VoyageEmbedder(api_key="x", dimensions=512).dimensions == 512
+
+
+def test_invalid_dimensions_raise() -> None:
+    with pytest.raises(ValueError, match="positive integer"):
+        VoyageEmbedder(api_key="x", dimensions=0)
+
+
+def test_embed_routes_through_thread_pool_and_normalizes() -> None:
+    """The sync SDK path runs in a thread and the vector is unit length."""
+
+    class _FakeResponse:
+        # 1024 dims to match voyage-3's declared width; the guard below
+        # catches a mismatch, so the fake must be honest.
+        embeddings = [[3.0] + [0.0] * 1022 + [4.0]]
+
+    class _FakeClient:
+        def __init__(self, *a, **k) -> None:
+            pass
+
+        def embed(self, inputs, model):
+            return _FakeResponse()
+
+    fake_sdk = type(sys)("voyageai")
+    fake_sdk.Client = _FakeClient
+    with patch.dict(sys.modules, {"voyageai": fake_sdk}):
+        embedder = VoyageEmbedder(api_key="pa-test")
+        vectors = asyncio.run(embedder.embed(["hello world"]))
+    assert len(vectors) == 1
+    _l2 = (sum(x * x for x in vectors[0])) ** 0.5
+    assert _l2 == pytest.approx(1.0)


### PR DESCRIPTION
## What

Fixes #611 — the Voyage half of "language + VOYAGE settings in the custom init generation options" (output language was already prompted in the advanced generation section, both via `--language` and interactively; what was missing was Voyage).

## Root cause

Voyage was named in the embedder registry docstring as a custom-registration example but had no module, no CLI choice, and no key resolution.

## Changes

- `embedding/voyage.py`: `VoyageEmbedder` (voyage-3 default 1024 dims, known-model dims table, `REPOWISE_EMBEDDING_DIMS` override, width-mismatch guard, L2 normalization, thread-pooled SDK calls)
- registry: `voyage` built-in
- CLI + server key maps: `VOYAGE_API_KEY` resolution (both copies of `_EMBEDDER_KEY_ENV`)
- auto-detect `VOYAGE_API_KEY` and offer voyage in the advanced-config embedder prompt

## Tests

- 6 embedder unit tests + 2 key-resolution tests; 86 embedder/init/server tests pass.

Note: `test_plugin_content` is red on main itself (v0.47.0 release bug, unrelated to this PR).
