### PR TITLE
fix(graph): declare every graph hook above the loading early-return

### DIFF
--- a/packages/ui/__tests__/graph/graph-flow.test.tsx
+++ b/packages/ui/__tests__/graph/graph-flow.test.tsx
@@ -592,3 +592,44 @@ describe("GraphFlow drill-down honesty", () => {
     expect(screen.queryByText(/dead files/)).toBeNull();
   });
 });
+
+describe("GraphFlow hook order", () => {
+  it("keeps the same hooks on the loading pass and the loaded one", () => {
+    // The loading branch returns a skeleton before the render body, so a hook
+    // declared below it does not run on that pass. React then sees the hook
+    // count change on the next render and takes the whole canvas down with
+    // "change in the order of Hooks called by GraphFlow" — recoverable only by
+    // a page refresh.
+    const errors: unknown[][] = [];
+    const spy = vi
+      .spyOn(console, "error")
+      .mockImplementation((...args: unknown[]) => {
+        errors.push(args);
+      });
+    try {
+      const { rerender } = render(
+        <GraphFlow {...baseProps} viewMode="full" isLoadingFullGraph={true} />,
+      );
+      rerender(
+        <GraphFlow
+          {...baseProps}
+          viewMode="full"
+          isLoadingFullGraph={false}
+          fullGraph={
+            {
+              nodes: [fileNode("src/a.ts", "typescript")],
+              links: [],
+            } as never
+          }
+        />,
+      );
+      const hookComplaint = errors.find((e) =>
+        String(e[0] ?? "").includes("order of Hooks"),
+      );
+      expect(hookComplaint).toBeUndefined();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});
+

--- a/packages/ui/src/graph/graph-flow.tsx
+++ b/packages/ui/src/graph/graph-flow.tsx
@@ -1132,6 +1132,34 @@ export function GraphFlow(props: GraphFlowProps) {
     setCtxMenu(null);
   }, [ctxMenu, setCtxMenu]);
 
+  // Both of these are read far below, next to the key they feed. They are
+  // declared here because the skeleton branch that follows returns early, and a
+  // hook after it does not run on the loading pass — which changes the hook
+  // count between renders and takes the whole canvas down.
+
+  // What the key reports. `displayGraph.size` counts every edge in the graph
+  // including the kinds the edge filter is hiding, which is how a slice showing
+  // only its exits could still claim 553 edges. Reconciles the edge filter
+  // only: the ego filter hides nodes at the canvas rather than in the graph,
+  // and reports its own count in the status row beside this.
+  const visibleEdgeCount = useMemo(() => {
+    if (!displayGraph) return 0;
+    let n = 0;
+    displayGraph.forEachEdge((_, attrs) => {
+      if (visibleEdgeTypes.has(attrs.edgeKind)) n++;
+    });
+    return n;
+  }, [displayGraph, visibleEdgeTypes]);
+
+  // Members vs the one-hop stubs around them, from the same payload the banner
+  // counts, so the two figures on screen cannot disagree.
+  const sliceCounts = useMemo(() => {
+    if (!communitySlice) return undefined;
+    const members = communitySlice.nodes.filter((n) => !n.is_boundary).length;
+    return { members, boundary: communitySlice.nodes.length - members };
+  }, [communitySlice]);
+
+  // No hooks below this line.
   if (
     (isLoading || isAwaitingAsyncBuild || isBuildingGraph) &&
     !displayGraph
@@ -1256,28 +1284,6 @@ export function GraphFlow(props: GraphFlowProps) {
     }
     return `${parts.join(", ")}.`;
   })();
-
-  // What the key reports. `displayGraph.size` counts every edge in the graph
-  // including the kinds the edge filter is hiding, which is how a slice showing
-  // only its exits could still claim 553 edges. Reconciles the edge filter
-  // only: the ego filter hides nodes at the canvas rather than in the graph,
-  // and reports its own count in the status row beside this.
-  const visibleEdgeCount = useMemo(() => {
-    if (!displayGraph) return 0;
-    let n = 0;
-    displayGraph.forEachEdge((_, attrs) => {
-      if (visibleEdgeTypes.has(attrs.edgeKind)) n++;
-    });
-    return n;
-  }, [displayGraph, visibleEdgeTypes]);
-
-  // Members vs the one-hop stubs around them, from the same payload the banner
-  // counts, so the two figures on screen cannot disagree.
-  const sliceCounts = useMemo(() => {
-    if (!communitySlice) return undefined;
-    const members = communitySlice.nodes.filter((n) => !n.is_boundary).length;
-    return { members, boundary: communitySlice.nodes.length - members };
-  }, [communitySlice]);
 
   const activeCommunityLabel =
     activeCommunity !== null


### PR DESCRIPTION
Opening the Architecture Map could take the canvas down with React's
"change in the order of Hooks called by GraphFlow", leaving the page stuck
until a refresh.

`GraphFlow` returns a skeleton early while the graph is loading. Two memos
that feed the footer key were declared below that branch, next to the key
they feed, so they did not run on the loading pass. The hook count then
changed on the next render, which is the one thing React cannot recover from.

They are lifted above the early return, with a marker saying nothing else may
be declared below it. The test renders through the loading pass into the
loaded one and fails on the hook-order complaint, so the same mistake cannot
land again unnoticed.
