### PR TITLE
perf(update): record a phase timing row per update stage

### DIFF
--- a/packages/cli/src/repowise/cli/commands/update_cmd/command.py
+++ b/packages/cli/src/repowise/cli/commands/update_cmd/command.py
@@ -40,6 +40,7 @@ from repowise.cli.helpers import (
     write_update_pending,
 )
 from repowise.core.docs_mode import docs_mode_state_fields, resolve_docs_mode
+from repowise.core.pipeline import PhaseTimings, timed
 from repowise.core.reasoning import REASONING_MODES
 
 from .incremental import (
@@ -585,6 +586,14 @@ def run_update(
     a no-op until you committed.
     """
     start = time.monotonic()
+    # Per-stage wall clock for this run, written to ``state.json`` as
+    # ``phase_timings`` by the paths that rebuild the index. ``run`` is the
+    # denominator; stages nest and overlap, so compare each against it and
+    # never against their sum. The fast paths (already up to date, no changed
+    # files, config-only re-score) do not record: they do no stage work and
+    # would overwrite the last real run's numbers with nothing.
+    timings = PhaseTimings()
+    timings.start("run")
 
     # --- Machine-readable progress (--progress json) --------------------
     # Silence structlog/stdlib logging and redirect the shared Rich console
@@ -1081,10 +1090,11 @@ def run_update(
 
     from repowise.core.ingestion.change_detector import merge_file_diffs
 
-    file_diffs = merge_file_diffs(
-        detector.get_changed_files(base_ref, head or "HEAD"),
-        working_tree_diffs,
-    )
+    with timed(timings, "detect_changes"):
+        file_diffs = merge_file_diffs(
+            detector.get_changed_files(base_ref, head or "HEAD"),
+            working_tree_diffs,
+        )
 
     if not file_diffs and not config_changed and not renderer_changed:
         console.print("[green]No changed files detected.[/green]")
@@ -1216,12 +1226,14 @@ def run_update(
             include_submodules=bool(state.get("include_submodules", False)),
             include_nested_repos=bool(state.get("include_nested_repos", False)),
             idle_decay_sink=git_decay_map,
+            timings=timings,
         )
     )
 
     if emitter is not None:
         emitter.stage("plan_pages")
 
+    timings.start("plan_pages")
     # Determine affected pages (auto-scale budget if not explicitly set)
     if cascade_budget is None:
         from repowise.core.ingestion.change_detector import compute_adaptive_budget
@@ -1244,6 +1256,7 @@ def run_update(
     # and no model will come along later to fix it. Appended rather than merged
     # so the cascade's own ordering is preserved.
     stale_renderer_paths = _stale_renderer_paths(repo_path, parsed_files)
+    timings.stop("plan_pages")
     if stale_renderer_paths:
         affected.regenerate = list(dict.fromkeys([*affected.regenerate, *stale_renderer_paths]))
         console.print(f"Pages from an older renderer: [cyan]{len(stale_renderer_paths)}[/cyan]")
@@ -1269,6 +1282,10 @@ def run_update(
     # as "no commits" without the stored rows. The stored function-mod p80
     # keeps the hotspot gate repo-wide instead of derived from the changed
     # subset (issue #1484).
+    with timed(timings, "analysis.stored_reads"):
+        stored_git_meta = _load_stored_git_meta(repo_path)
+        stored_performance_callers = _load_stored_performance_callers(repo_path, file_diffs)
+        repo_function_mod_p80 = _load_stored_function_mod_p80(repo_path)
     partial_health_report, dead_code_report = _run_partial_analysis(
         repo_path,
         graph_builder,
@@ -1276,9 +1293,10 @@ def run_update(
         parsed_files,
         file_diffs,
         source_map,
-        stored_git_meta=_load_stored_git_meta(repo_path),
-        stored_performance_callers=_load_stored_performance_callers(repo_path, file_diffs),
-        repo_function_mod_p80=_load_stored_function_mod_p80(repo_path),
+        stored_git_meta=stored_git_meta,
+        stored_performance_callers=stored_performance_callers,
+        repo_function_mod_p80=repo_function_mod_p80,
+        timings=timings,
     )
 
     # Partial health has consumed the per-file ``BlameIndex``; drop it before
@@ -1292,15 +1310,16 @@ def run_update(
     # shape changed — previously init-only, so update served a stale
     # orientation snapshot to CLAUDE.md/get_overview forever (#669). None
     # means fingerprint-unchanged: the persisted artifact is still current.
-    knowledge_graph_result = _refresh_knowledge_graph(
-        repo_path,
-        parsed_files,
-        graph_builder,
-        repo_structure,
-        git_meta_map,
-        dead_code_report,
-        (state.get("knowledge_graph") or {}).get("fingerprint"),
-    )
+    with timed(timings, "knowledge_graph"):
+        knowledge_graph_result = _refresh_knowledge_graph(
+            repo_path,
+            parsed_files,
+            graph_builder,
+            repo_structure,
+            git_meta_map,
+            dead_code_report,
+            (state.get("knowledge_graph") or {}).get("fingerprint"),
+        )
 
     if index_only:
         # A repo whose wiki was rendered from templates keeps it current here.
@@ -1327,31 +1346,35 @@ def run_update(
             # keep separate: a file page can no longer be model-written, so a
             # page that predates the single-renderer change re-renders to its
             # structural form here, which is the shape it now has.
-            det_pages = regenerate_deterministic_pages(
-                repo_path=repo_path,
-                parsed_files=parsed_files,
-                source_map=source_map,
-                graph_builder=graph_builder,
-                repo_structure=repo_structure,
-                git_meta_map=git_meta_map,
-                regenerate_paths=affected.regenerate,
-                cfg=cfg,
-                concurrency=concurrency,
-                degraded=degraded,
-                dead_code_report=dead_code_report,
-                prior_page_ids=prior_ids,
-            )
+            with timed(timings, "render"):
+                det_pages = regenerate_deterministic_pages(
+                    repo_path=repo_path,
+                    parsed_files=parsed_files,
+                    source_map=source_map,
+                    graph_builder=graph_builder,
+                    repo_structure=repo_structure,
+                    git_meta_map=git_meta_map,
+                    regenerate_paths=affected.regenerate,
+                    cfg=cfg,
+                    concurrency=concurrency,
+                    degraded=degraded,
+                    dead_code_report=dead_code_report,
+                    prior_page_ids=prior_ids,
+                )
 
             if det_pages:
-                state["total_pages"] = persist_deterministic_pages(
-                    repo_path=repo_path,
-                    generated_pages=det_pages,
-                    # decay_only are cascade-reached templates the render did not
-                    # touch: marked stale so the view stays honest about which
-                    # pages predate this commit.
-                    decay_paths=affected.decay_only,
-                    degraded=degraded,
-                )
+                # Its own session, apart from the index persist below, so it
+                # is its own row rather than a ``persist.*`` one.
+                with timed(timings, "render.persist"):
+                    state["total_pages"] = persist_deterministic_pages(
+                        repo_path=repo_path,
+                        generated_pages=det_pages,
+                        # decay_only are cascade-reached templates the render
+                        # did not touch: marked stale so the view stays honest
+                        # about which pages predate this commit.
+                        decay_paths=affected.decay_only,
+                        degraded=degraded,
+                    )
                 state["last_docs_commit"] = head
                 console.print(
                     f"  [green]✓[/green] Re-rendered [bold]{len(det_pages)}[/bold] "
@@ -1383,6 +1406,7 @@ def run_update(
                 exclude_patterns=exclude_patterns,
                 head_ts=head_ts,
                 force_full_rescore=config_changed,
+                timings=timings,
             )
         except Exception as exc:
             if emitter is not None:
@@ -1466,6 +1490,11 @@ def run_update(
     provider._cost_tracker = cost_tracker
 
     # (dead_code_report computed above, before the index-only branch)
+
+    # One row for the decision passes below: the marker re-scan, session
+    # mining, discovery, injection feedback, hook efficacy and evolution. Each
+    # is best-effort and most are model calls, so they are read as a group.
+    timings.start("decisions")
 
     # Re-scan changed files for inline decision markers
     from repowise.core.analysis.decisions.policy import resolve_policy
@@ -1707,6 +1736,7 @@ def run_update(
         degraded.append(f"Decision evolution: {exc}")
         if verbose:
             console.print(f"[yellow]Decision evolution skipped: {exc}[/yellow]")
+    timings.stop("decisions")
 
     # Filter to only affected files
     regen_set = set(affected.regenerate)
@@ -1829,7 +1859,8 @@ def run_update(
         )
 
         try:
-            generated_pages = run_async(_generate_with_checkpoint())
+            with timed(timings, "generate"):
+                generated_pages = run_async(_generate_with_checkpoint())
         except Exception as exc:
             if emitter is not None:
                 emitter.error(str(exc))
@@ -1866,17 +1897,18 @@ def run_update(
         try:
             from repowise.core.generation.knowledge_graph import enrich_knowledge_graph
 
-            knowledge_graph_result = run_async(
-                enrich_knowledge_graph(
-                    kg_skeleton=knowledge_graph_result,
-                    llm_client=provider,
-                    graph_builder=graph_builder,
-                    repo_structure=repo_structure,
-                    tech_stack=knowledge_graph_result.project.get("tech_stack", []),
-                    generated_pages=generated_pages,
-                    reasoning=config.reasoning,
+            with timed(timings, "knowledge_graph.enrich"):
+                knowledge_graph_result = run_async(
+                    enrich_knowledge_graph(
+                        kg_skeleton=knowledge_graph_result,
+                        llm_client=provider,
+                        graph_builder=graph_builder,
+                        repo_structure=repo_structure,
+                        tech_stack=knowledge_graph_result.project.get("tech_stack", []),
+                        generated_pages=generated_pages,
+                        reasoning=config.reasoning,
+                    )
                 )
-            )
         except Exception as exc:
             console.print(f"[yellow]Knowledge-graph enrichment skipped: {exc}[/yellow]")
             degraded.append(f"Knowledge-graph enrichment: {exc}")
@@ -1888,24 +1920,26 @@ def run_update(
     if emitter is not None:
         emitter.stage("persist")
     try:
-        db_total_pages = _persist_full_update(
-            repo_path=repo_path,
-            repo_name=repo_name,
-            generated_pages=generated_pages,
-            file_diffs=file_diffs,
-            git_meta_map=git_meta_map,
-            new_decision_markers=[*new_decision_markers, *session_decisions],
-            decision_vector_store=decision_vector_store,
-            provider=provider,
-            partial_health_report=partial_health_report,
-            dead_code_report=dead_code_report,
-            graph_builder=graph_builder,
-            knowledge_graph_result=knowledge_graph_result,
-            degraded=degraded,
-            decay_paths=affected.decay_only,
-            parsed_files=parsed_files,
-            git_decay_map=git_decay_map,
-        )
+        with timed(timings, "persist"):
+            db_total_pages = _persist_full_update(
+                repo_path=repo_path,
+                repo_name=repo_name,
+                generated_pages=generated_pages,
+                file_diffs=file_diffs,
+                git_meta_map=git_meta_map,
+                new_decision_markers=[*new_decision_markers, *session_decisions],
+                decision_vector_store=decision_vector_store,
+                provider=provider,
+                partial_health_report=partial_health_report,
+                dead_code_report=dead_code_report,
+                graph_builder=graph_builder,
+                knowledge_graph_result=knowledge_graph_result,
+                degraded=degraded,
+                decay_paths=affected.decay_only,
+                parsed_files=parsed_files,
+                git_decay_map=git_decay_map,
+                timings=timings,
+            )
     except Exception as exc:
         if emitter is not None:
             emitter.error(str(exc))
@@ -1924,9 +1958,13 @@ def run_update(
     # config edit invalidates every persisted score, and the partial health
     # update only reaches the changed files. Reusing this hook is what makes
     # falling through cost nothing extra — the graph is already built.
-    if (config_changed or full_rescore_due(state, head_ts)) and run_decay_health_rescore(
-        repo_path, graph_builder, parsed_files, exclude_patterns
-    ):
+    rescored = False
+    if config_changed or full_rescore_due(state, head_ts):
+        with timed(timings, "rescore"):
+            rescored = run_decay_health_rescore(
+                repo_path, graph_builder, parsed_files, exclude_patterns
+            )
+    if rescored:
         # Only the time gate reads this stamp, and it treats a non-numeric
         # value as "never re-scored". A forced re-score with git unavailable
         # has no timestamp to record, so leave a real stamp alone rather than
@@ -1936,7 +1974,8 @@ def run_update(
         state["health_analyzer_version"] = HEALTH_ANALYZER_VERSION
 
     # ---- Editor project files (best-effort) ----
-    _refresh_editor_stamp(repo_path, agents_md, degraded)
+    with timed(timings, "editor_files"):
+        _refresh_editor_stamp(repo_path, agents_md, degraded)
 
     # Update state
     from repowise.cli.helpers import config_fingerprint
@@ -1958,6 +1997,10 @@ def run_update(
     state["total_pages"] = db_total_pages
     state["config_fingerprint"] = config_fingerprint(repo_path)
     state["renderer_fingerprint"] = _current_renderer_fingerprint(repo_path)
+    # Closed at the state write, as the index-only path does, so the two
+    # paths' ``run`` rows measure the same span.
+    timings.stop("run")
+    state["phase_timings"] = timings.totals
     save_state(repo_path, state)
 
     # --- Pending-marker cleanup --------------------------------------------

--- a/packages/cli/src/repowise/cli/commands/update_cmd/incremental.py
+++ b/packages/cli/src/repowise/cli/commands/update_cmd/incremental.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from typing import Any
 
 from repowise.cli.helpers import console, run_async
+from repowise.core.pipeline import PhaseTimings, timed
 
 
 def _build_update_vector_store(repo_path: Any, cfg: dict) -> Any | None:
@@ -75,6 +76,7 @@ def _rebuild_graph_and_git(
     include_submodules: bool = False,
     include_nested_repos: bool = False,
     idle_decay_sink: dict[str, dict] | None = None,
+    timings: PhaseTimings | None = None,
 ) -> tuple[list, dict[str, bytes], Any, Any, int, dict[str, dict]]:
     """Re-traverse + parse the repo, rebuild the graph (+ framework edges), and
     re-index git metadata for the changed files.
@@ -112,6 +114,7 @@ def _rebuild_graph_and_git(
             include_nested_repos=include_nested_repos,
             idle_decay_sink=idle_decay_sink,
             log=console.print,
+            timings=timings,
         )
     )
 
@@ -191,6 +194,7 @@ def _run_partial_analysis(
     stored_git_meta: dict[str, dict] | None = None,
     stored_performance_callers: set[str] | None = None,
     repo_function_mod_p80: int | None = None,
+    timings: PhaseTimings | None = None,
 ) -> tuple[Any, Any]:
     """Run partial code-health + repo-wide dead-code analysis.
 
@@ -205,6 +209,9 @@ def _run_partial_analysis(
         run_partial_analysis,
     )
 
+    # Same row as the caller's stored reads: the table accumulates repeats.
+    with timed(timings, "analysis.stored_reads"):
+        coverage_map = run_async(load_stored_coverage_map(repo_path, log=console.print))
     return run_partial_analysis(
         repo_path,
         graph_builder,
@@ -215,6 +222,7 @@ def _run_partial_analysis(
         stored_git_meta=stored_git_meta,
         stored_performance_callers=stored_performance_callers,
         repo_function_mod_p80=repo_function_mod_p80,
-        coverage_map=run_async(load_stored_coverage_map(repo_path, log=console.print)),
+        coverage_map=coverage_map,
         log=console.print,
+        timings=timings,
     )

--- a/packages/cli/src/repowise/cli/commands/update_cmd/persistence.py
+++ b/packages/cli/src/repowise/cli/commands/update_cmd/persistence.py
@@ -18,6 +18,7 @@ import structlog
 
 from repowise.cli.helpers import console, head_commit_ts, run_async, save_state
 from repowise.core.analysis.health import HEALTH_ANALYZER_VERSION
+from repowise.core.pipeline import PhaseTimings, timed
 
 from .incremental import _build_repo_graph
 
@@ -363,6 +364,7 @@ def _persist_index_only_update(
     exclude_patterns: list[str] | None = None,
     head_ts: float | None = None,
     force_full_rescore: bool = False,
+    timings: PhaseTimings | None = None,
 ) -> None:
     """Persist the index-only update (graph + symbols + git + dead-code + health + KG),
     save state, and print the completion line. No LLM regeneration.
@@ -371,6 +373,10 @@ def _persist_index_only_update(
     periodic gate. Set by the config-changed caller, which relies on this path
     rather than re-scoring separately and returning — doing that advanced
     ``last_sync_commit`` past commits it never indexed.
+
+    ``timings`` is the run's phase table. Its ``run`` row is closed here, at
+    the state write, and the whole table lands in ``state.json`` as
+    ``phase_timings`` the way ``init`` records its own run.
 
     DB persistence delegates to :mod:`repowise.core.pipeline.incremental`;
     state-file updates and console reporting stay here. Best-effort steps
@@ -398,6 +404,7 @@ def _persist_index_only_update(
             log=console.print,
             degraded=degraded,
             failed_steps=failed_steps,
+            timings=timings,
         )
     )
     from repowise.cli.helpers import config_fingerprint
@@ -412,9 +419,13 @@ def _persist_index_only_update(
     # only reached the changed files.
     last_full_rescore_at = state.get("last_full_rescore_at")
     health_analyzer_version = state.get("health_analyzer_version")
-    if (force_full_rescore or full_rescore_due(state, head_ts)) and run_decay_health_rescore(
-        repo_path, graph_builder, parsed_files or [], exclude_patterns or []
-    ):
+    rescored = False
+    if force_full_rescore or full_rescore_due(state, head_ts):
+        with timed(timings, "rescore"):
+            rescored = run_decay_health_rescore(
+                repo_path, graph_builder, parsed_files or [], exclude_patterns or []
+            )
+    if rescored:
         # Only the time gate reads this, and it treats a non-numeric value as
         # "never re-scored", so leave a real stamp alone rather than writing
         # None over it when git gave us no timestamp.
@@ -456,6 +467,9 @@ def _persist_index_only_update(
         except Exception as exc:
             console.print(f"[yellow]Knowledge-graph export skipped: {exc}[/yellow]")
             degraded.append(f"Knowledge-graph export: {exc}")
+    if timings is not None:
+        timings.stop("run")
+        new_state["phase_timings"] = timings.totals
     save_state(repo_path, new_state)
     elapsed = time.monotonic() - start
     from .reporting import show_index_only_completion
@@ -572,6 +586,7 @@ def _persist_full_update(
     decay_paths: list[str] | None = None,
     parsed_files: list | None = None,
     git_decay_map: dict | None = None,
+    timings: PhaseTimings | None = None,
 ) -> int:
     """Persist a full (LLM-regenerating) update in one transaction.
 
@@ -606,6 +621,7 @@ def _persist_full_update(
             decay_paths=decay_paths,
             parsed_files=parsed_files,
             git_decay_map=git_decay_map,
+            timings=timings,
         )
     )
 
@@ -628,6 +644,7 @@ async def _persist_full_update_async(
     decay_paths: list[str] | None = None,
     parsed_files: list | None = None,
     git_decay_map: dict | None = None,
+    timings: PhaseTimings | None = None,
 ) -> int:
     from repowise.cli.helpers import get_db_url_for_repo
     from repowise.core.persistence import (
@@ -652,18 +669,21 @@ async def _persist_full_update_async(
     # Same contract, for rows of a page that has been retired outright.
     swept_page_ids: list[str] = []
     try:
-        await init_db(engine)
-        sf = create_session_factory(engine)
+        with timed(timings, "persist.open"):
+            await init_db(engine)
+            sf = create_session_factory(engine)
 
         async with get_session(sf) as session:
-            repo = await upsert_repository(session, name=repo_name, local_path=str(repo_path))
+            with timed(timings, "persist.open"):
+                repo = await upsert_repository(session, name=repo_name, local_path=str(repo_path))
             repo_id = repo.id
 
             # Pages first and without a net: everything else is derived
             # metadata, but a docs-mode update that can't write pages failed.
             # Batched (one SELECT + one flush); the checkpointer sink already
             # streamed each page per-commit for durability.
-            await upsert_pages_from_generated(session, generated_pages, repo_id)
+            with timed(timings, "persist.pages"):
+                await upsert_pages_from_generated(session, generated_pages, repo_id)
 
             # Delete rows of pages that have been retired since this index was
             # built. Nothing else on the update path can reach them: an update
@@ -678,13 +698,15 @@ async def _persist_full_update_async(
                     sweep_retired_pages,
                 )
 
-                swept_page_ids = await sweep_retired_pages(session, repo_id)
-                # Cycle pages are never regenerated on this path (the ladder
-                # stops at file pages), so a cycle that no longer exists can
-                # only be retired by asking the rebuilt graph directly.
-                swept_page_ids += await sweep_absent_cycle_pages(
-                    session, repo_id, graph_builder
-                )
+                with timed(timings, "persist.sweeps"):
+                    swept_page_ids = await sweep_retired_pages(session, repo_id)
+                    # Cycle pages are never regenerated on this path (the
+                    # ladder stops at file pages), so a cycle that no longer
+                    # exists can only be retired by asking the rebuilt graph
+                    # directly.
+                    swept_page_ids += await sweep_absent_cycle_pages(
+                        session, repo_id, graph_builder
+                    )
 
                 # Drop the embeddings before the SQL session commits, the same
                 # ordering ``init`` uses: the vector store is a separate engine,
@@ -705,9 +727,10 @@ async def _persist_full_update_async(
                     tombstone_candidates,
                 )
 
-                tombstoned_page_ids = await mark_tombstone_pages(
-                    session, repo_id, tombstone_candidates(file_diffs)
-                )
+                with timed(timings, "persist.tombstones"):
+                    tombstoned_page_ids = await mark_tombstone_pages(
+                        session, repo_id, tombstone_candidates(file_diffs)
+                    )
             except Exception as exc:
                 _skip("Tombstone marking", exc)
 
@@ -719,16 +742,17 @@ async def _persist_full_update_async(
                 from repowise.core.generation.related_pages import file_import_edges
                 from repowise.core.persistence.crud import backfill_related_pages
 
-                await backfill_related_pages(
-                    session,
-                    repo_id,
-                    import_edges=file_import_edges(graph_builder),
-                    git_meta_map=git_meta_map,
-                    pagerank=graph_builder.pagerank(),
-                    # This run's pages carry fresher metadata (including
-                    # module siblings) than the recompute could produce.
-                    skip_page_ids={p.page_id for p in generated_pages},
-                )
+                with timed(timings, "persist.related_pages"):
+                    await backfill_related_pages(
+                        session,
+                        repo_id,
+                        import_edges=file_import_edges(graph_builder),
+                        git_meta_map=git_meta_map,
+                        pagerank=graph_builder.pagerank(),
+                        # This run's pages carry fresher metadata (including
+                        # module siblings) than the recompute could produce.
+                        skip_page_ids={p.page_id for p in generated_pages},
+                    )
             except Exception as exc:
                 _skip("Related-pages backfill", exc)
 
@@ -740,7 +764,8 @@ async def _persist_full_update_async(
             try:
                 from repowise.core.pipeline.persist import mark_stale_pages
 
-                await mark_stale_pages(session, repo_id, decay_paths or [])
+                with timed(timings, "persist.stale_pages"):
+                    await mark_stale_pages(session, repo_id, decay_paths or [])
             except Exception as exc:
                 _skip("Stale-page decay", exc)
 
@@ -749,7 +774,8 @@ async def _persist_full_update_async(
             try:
                 from repowise.core.pipeline.page_tree_sync import rebuild_page_tree
 
-                await rebuild_page_tree(session, repo_id)
+                with timed(timings, "persist.page_tree"):
+                    await rebuild_page_tree(session, repo_id)
             except Exception as exc:
                 _skip("Page tree rebuild", exc)
 
@@ -759,7 +785,8 @@ async def _persist_full_update_async(
                 try:
                     from repowise.core.pipeline.persist import persist_kg
 
-                    await persist_kg(knowledge_graph_result, session, repo_id)
+                    with timed(timings, "persist.kg"):
+                        await persist_kg(knowledge_graph_result, session, repo_id)
                 except Exception as exc:
                     _skip("Knowledge-graph persist", exc)
 
@@ -774,21 +801,25 @@ async def _persist_full_update_async(
                     # Changed files' full rows + idle files' decay-only rows
                     # (#728), then a repo-wide percentile re-rank over the fresh
                     # scores.
-                    await upsert_git_metadata_bulk(
-                        session,
-                        repo_id,
-                        [*git_meta_map.values(), *(git_decay_map or {}).values()],
-                    )
-                    await recompute_git_percentiles(session, repo_id)
+                    with timed(timings, "persist.git"):
+                        await upsert_git_metadata_bulk(
+                            session,
+                            repo_id,
+                            [*git_meta_map.values(), *(git_decay_map or {}).values()],
+                        )
+                        await recompute_git_percentiles(session, repo_id)
                 except Exception as exc:
                     _skip("Git persist", exc)
                 try:
-                    await _persist_incremental_commits(session, repo_id, repo_path)
+                    with timed(timings, "persist.commits"):
+                        await _persist_incremental_commits(session, repo_id, repo_path)
                 except Exception as exc:
                     _skip("Commit capture", exc)
 
             # Decision records: new markers + harvested decisions, supersession
             # detection, staleness recompute.
+            if timings is not None:
+                timings.start("persist.decisions")
             try:
                 # The same three store repairs the full-index path runs, in the
                 # same order (see ``pipeline/persist.py``). They live here too
@@ -865,8 +896,13 @@ async def _persist_full_update_async(
                     await recompute_decision_staleness(session, repo_id, git_meta_map)
             except Exception as exc:
                 _skip("Decision persist", exc)
+            finally:
+                if timings is not None:
+                    timings.stop("persist.decisions")
 
             # Governance findings pass: runs after decisions + staleness.
+            if timings is not None:
+                timings.start("persist.governance")
             try:
                 from sqlalchemy import select as _sel_dec
 
@@ -889,11 +925,15 @@ async def _persist_full_update_async(
                 await replace_governance_findings(session, repo_id, _gov)
             except Exception as exc:
                 _skip("Governance findings", exc)
+            finally:
+                if timings is not None:
+                    timings.stop("persist.governance")
 
             # Code-health findings + metrics (partial — upsert only).
             if partial_health_report is not None:
                 try:
-                    await _persist_partial_health(session, repo_id, partial_health_report)
+                    with timed(timings, "persist.health"):
+                        await _persist_partial_health(session, repo_id, partial_health_report)
                 except Exception as exc:
                     _skip("Health persist", exc)
 
@@ -908,12 +948,13 @@ async def _persist_full_update_async(
 
                     from repowise.core.persistence.crud import replace_dead_code_findings
 
-                    await replace_dead_code_findings(
-                        session,
-                        repo_id,
-                        [_dc_dead.asdict(f) for f in dead_code_report.findings],
-                        scope=dead_code_report.authoritative_paths,
-                    )
+                    with timed(timings, "persist.dead_code"):
+                        await replace_dead_code_findings(
+                            session,
+                            repo_id,
+                            [_dc_dead.asdict(f) for f in dead_code_report.findings],
+                            scope=dead_code_report.authoritative_paths,
+                        )
                 except Exception as exc:
                     _skip("Dead-code persist", exc)
 
@@ -922,7 +963,8 @@ async def _persist_full_update_async(
             try:
                 from repowise.core.pipeline.persist import persist_graph_nodes
 
-                await persist_graph_nodes(session, repo_id, graph_builder)
+                with timed(timings, "persist.graph_nodes"):
+                    await persist_graph_nodes(session, repo_id, graph_builder)
             except Exception as exc:
                 _skip("Graph nodes persist", exc)
 
@@ -932,9 +974,10 @@ async def _persist_full_update_async(
             try:
                 from repowise.core.pipeline.persist import persist_incremental_symbols
 
-                await persist_incremental_symbols(
-                    session, repo_id, parsed_files, [fd.path for fd in file_diffs]
-                )
+                with timed(timings, "persist.symbols"):
+                    await persist_incremental_symbols(
+                        session, repo_id, parsed_files, [fd.path for fd in file_diffs]
+                    )
             except Exception as exc:
                 _skip("Symbol persist", exc)
 
@@ -945,9 +988,14 @@ async def _persist_full_update_async(
             try:
                 from repowise.core.pipeline.persist import persist_incremental_edges
 
-                await persist_incremental_edges(
-                    session, repo_id, graph_builder, parsed_files, [fd.path for fd in file_diffs]
-                )
+                with timed(timings, "persist.edges"):
+                    await persist_incremental_edges(
+                        session,
+                        repo_id,
+                        graph_builder,
+                        parsed_files,
+                        [fd.path for fd in file_diffs],
+                    )
             except Exception as exc:
                 _skip("Graph edges persist", exc)
 
@@ -957,7 +1005,8 @@ async def _persist_full_update_async(
             try:
                 from repowise.core.pipeline.incremental import refresh_external_systems
 
-                await refresh_external_systems(session, repo_id, repo_path, file_diffs)
+                with timed(timings, "persist.external_systems"):
+                    await refresh_external_systems(session, repo_id, repo_path, file_diffs)
             except Exception as exc:
                 _skip("External systems refresh", exc)
 
@@ -1009,6 +1058,8 @@ async def _persist_full_update_async(
 
         # FTS outside the transaction — rebuildable, and its writer manages
         # its own connection state.
+        if timings is not None:
+            timings.start("persist.fts")
         try:
             fts = FullTextSearch(engine)
             await fts.ensure_index()
@@ -1034,6 +1085,9 @@ async def _persist_full_update_async(
                 await fts.delete_many(swept_page_ids)
         except Exception as exc:
             _skip("Full-text search indexing", exc)
+        finally:
+            if timings is not None:
+                timings.stop("persist.fts")
         return total_pages
     finally:
         await engine.dispose()

--- a/packages/core/src/repowise/core/pipeline/incremental.py
+++ b/packages/core/src/repowise/core/pipeline/incremental.py
@@ -26,6 +26,8 @@ from typing import Any
 
 import structlog
 
+from repowise.core.pipeline.phase_timing import PhaseTimings, timed
+
 logger = structlog.get_logger(__name__)
 
 LogFn = Callable[[str], None]
@@ -54,6 +56,7 @@ def build_repo_graph(
     include_submodules: bool = False,
     include_nested_repos: bool = False,
     log: LogFn | None = None,
+    timings: PhaseTimings | None = None,
 ) -> tuple[list, dict[str, bytes], Any, Any, int]:
     """Traverse + parse the repo and build the graph (+ framework-aware edges).
 
@@ -64,6 +67,9 @@ def build_repo_graph(
     Files that fail to read/parse are skipped and reported as a count rather than
     swallowed silently. ``source_map`` is populated only when ``collect_sources``
     is set (the re-score path doesn't need the raw bytes).
+
+    ``timings`` is the run's shared :class:`PhaseTimings` table; each step
+    below records into it under a ``rebuild.*`` name. ``None`` records nothing.
 
     Returns ``(parsed_files, source_map, graph_builder, repo_structure,
     file_count)``.
@@ -85,12 +91,13 @@ def build_repo_graph(
     # A serial traverse() pays per-file I/O latency sequentially; on a cold
     # OS file cache that was ~50s of every PowerToys-scale update. Passing
     # the file_infos into get_repo_structure also avoids its re-walk.
-    all_paths = list(traverser._walk())
-    io_workers = min(32, max(4, (os.cpu_count() or 4) * 2))
-    with ThreadPoolExecutor(max_workers=io_workers) as io_pool:
-        maybe_infos = list(io_pool.map(traverser._build_file_info, all_paths))
-    file_infos = [fi for fi in maybe_infos if fi is not None]
-    repo_structure = traverser.get_repo_structure(file_infos)
+    with timed(timings, "rebuild.traverse"):
+        all_paths = list(traverser._walk())
+        io_workers = min(32, max(4, (os.cpu_count() or 4) * 2))
+        with ThreadPoolExecutor(max_workers=io_workers) as io_pool:
+            maybe_infos = list(io_pool.map(traverser._build_file_info, all_paths))
+        file_infos = [fi for fi in maybe_infos if fi is not None]
+        repo_structure = traverser.get_repo_structure(file_infos)
 
     # Structural episodes, minus the formatter check: this path is the hot one
     # (every update, plus the config-triggered re-score), so it derives only
@@ -112,8 +119,9 @@ def build_repo_graph(
     )
     from repowise.core.workspace.update import get_head_commit
 
-    fi_and_bytes = _read_sources(file_infos, None)
-    parse_cache, cached_hits, to_parse = _split_cached(Path(repo_path), fi_and_bytes, None)
+    with timed(timings, "rebuild.read"):
+        fi_and_bytes = _read_sources(file_infos, None)
+        parse_cache, cached_hits, to_parse = _split_cached(Path(repo_path), fi_and_bytes, None)
 
     parser: Any = None  # constructed lazily — every-file-cached updates skip query compilation
     parsed_files: list = []
@@ -136,18 +144,23 @@ def build_repo_graph(
     # core; routing large miss counts through init's process pool would lift
     # it, at the cost of Windows spawn overhead on every routine update.)
     merged: dict[int, Any] = dict(cached_hits)
-    for idx, (fi, source), content_hash in to_parse:
-        try:
-            if parser is None:
-                parser = ASTParser()
-            parsed = parser.parse_file(fi, source)
-        except Exception:
-            continue
-        merged[idx] = parsed
-        if content_hash:
-            _cache_parsed(parse_cache, parsed, content_hash)
+    with timed(timings, "rebuild.parse"):
+        for idx, (fi, source), content_hash in to_parse:
+            try:
+                if parser is None:
+                    parser = ASTParser()
+                parsed = parser.parse_file(fi, source)
+            except Exception:
+                continue
+            merged[idx] = parsed
+            if content_hash:
+                _cache_parsed(parse_cache, parsed, content_hash)
 
     skipped = len(file_infos) - len(fi_and_bytes)  # unreadable files
+    # Opened here and closed after build(): graph construction is the add_file
+    # loop plus the resolver, and the tsconfig wiring sits between them.
+    if timings is not None:
+        timings.start("rebuild.graph")
     for idx, (fi, source) in enumerate(fi_and_bytes):
         parsed = merged.get(idx)
         if parsed is None:
@@ -173,8 +186,11 @@ def build_repo_graph(
     )
     graph_builder.set_source_map(source_map)
     graph_builder.build()
+    if timings is not None:
+        timings.stop("rebuild.graph")
     if parse_cache is not None:
-        parse_cache.save()
+        with timed(timings, "rebuild.cache_save"):
+            parse_cache.save()
 
     if skipped:
         log(f"[yellow]Skipped {skipped} file(s) that failed to parse.[/yellow]")
@@ -186,8 +202,9 @@ def build_repo_graph(
     try:
         from repowise.core.generation.editor_files.tech_stack import detect_tech_stack
 
-        tech_items = detect_tech_stack(repo_path)
-        fw_count = graph_builder.add_framework_edges([item.name for item in tech_items])
+        with timed(timings, "rebuild.framework"):
+            tech_items = detect_tech_stack(repo_path)
+            fw_count = graph_builder.add_framework_edges([item.name for item in tech_items])
         if fw_count:
             log(f"Framework edges added: [cyan]{fw_count}[/cyan]")
     except Exception as fw_exc:
@@ -204,12 +221,13 @@ def build_repo_graph(
     try:
         from repowise.core.ingestion.dynamic_hints import HintRegistry
 
-        dynamic_edges = HintRegistry().extract_all(
-            Path(repo_path),
-            dotnet_index=graph_builder.dotnet_index,
-            file_paths=[fi.path for fi in file_infos],
-        )
-        graph_builder.add_dynamic_edges(dynamic_edges)
+        with timed(timings, "rebuild.dynamic_hints"):
+            dynamic_edges = HintRegistry().extract_all(
+                Path(repo_path),
+                dotnet_index=graph_builder.dotnet_index,
+                file_paths=[fi.path for fi in file_infos],
+            )
+            graph_builder.add_dynamic_edges(dynamic_edges)
         if dynamic_edges:
             log(f"Dynamic hint edges added: [cyan]{len(dynamic_edges)}[/cyan]")
 
@@ -234,9 +252,13 @@ async def rebuild_graph_and_git(
     include_nested_repos: bool = False,
     idle_decay_sink: dict[str, dict] | None = None,
     log: LogFn | None = None,
+    timings: PhaseTimings | None = None,
 ) -> tuple[list, dict[str, bytes], Any, Any, int, dict[str, dict]]:
     """Re-traverse + parse the repo, rebuild the graph (+ framework edges), and
     re-index git metadata for the changed files.
+
+    ``timings`` records the whole step as ``rebuild`` plus one ``rebuild.*``
+    row per sub-step, so a slow update names the stage that made it slow.
 
     ``idle_decay_sink``, when provided, is filled with a decay-only partial
     metadata row for every idle (unchanged) file whose time-decayed history
@@ -259,6 +281,8 @@ async def rebuild_graph_and_git(
     file_count, git_meta_map)``.
     """
     log = log or _noop_log
+    if timings is not None:
+        timings.start("rebuild")
 
     # Full re-ingest for graph (needed for cascade analysis)
     parsed_files, source_map, graph_builder, repo_structure, file_count = build_repo_graph(
@@ -268,10 +292,13 @@ async def rebuild_graph_and_git(
         include_submodules=include_submodules,
         include_nested_repos=include_nested_repos,
         log=log,
+        timings=timings,
     )
 
     # Re-index git metadata for changed files
     git_meta_map: dict[str, dict] = {}
+    if timings is not None:
+        timings.start("rebuild.git")
     try:
         from repowise.core.ingestion.git_indexer import GitIndexer
         from repowise.core.ingestion.git_indexer.tiers import GitIndexTier
@@ -322,6 +349,9 @@ async def rebuild_graph_and_git(
             graph_builder.update_co_change_edges(git_meta_map)
     except Exception as exc:
         log(f"[yellow]Git re-index skipped: {exc}[/yellow]")
+    finally:
+        if timings is not None:
+            timings.stop("rebuild.git")
 
     # Pre-compute centrality/community metrics with the init path's fan-out
     # parallelism. Without this, persist_graph_nodes computes the same
@@ -329,10 +359,13 @@ async def rebuild_graph_and_git(
     # the cached subgraphs reflect the final structure. Best-effort: every
     # metric still falls back to lazy computation.
     try:
-        await graph_builder.compute_metrics_parallel()
+        with timed(timings, "rebuild.metrics"):
+            await graph_builder.compute_metrics_parallel()
     except Exception as exc:
         log(f"[yellow]Metric pre-computation skipped: {exc}[/yellow]")
 
+    if timings is not None:
+        timings.stop("rebuild")
     return parsed_files, source_map, graph_builder, repo_structure, file_count, git_meta_map
 
 
@@ -583,6 +616,7 @@ def run_partial_analysis(
     repo_function_mod_p80: int | None = None,
     coverage_map: dict[str, dict] | None = None,
     log: LogFn | None = None,
+    timings: PhaseTimings | None = None,
 ) -> tuple[Any, Any]:
     """Run partial code-health + repo-wide dead-code analysis.
 
@@ -615,6 +649,10 @@ def run_partial_analysis(
     ``None`` means the store could not be read, which is different from an
     empty mapping and narrows what the resulting report is allowed to
     overwrite. See ``load_stored_git_meta``.
+
+    ``timings`` records the two analyses as ``analysis.health`` and
+    ``analysis.dead_code``. Their costs move independently with the edit, so
+    they are never folded into one row.
     """
     log = log or _noop_log
 
@@ -623,6 +661,8 @@ def run_partial_analysis(
     # The full file-list is needed because duplication is cross-file —
     # but only files in ``changed_paths`` produce new findings/metrics.
     partial_health_report = None
+    if timings is not None:
+        timings.start("analysis.health")
     try:
         # Performance is interprocedural. Recompute one bounded bidirectional
         # execution closure so a changed caller can still see an unchanged sink
@@ -697,12 +737,17 @@ def run_partial_analysis(
             )
     except Exception as exc:
         log(f"[yellow]Health analysis skipped: {exc}[/yellow]")
+    finally:
+        if timings is not None:
+            timings.stop("analysis.health")
 
     # Run dead-code analysis up front so both branches can persist its
     # results. Previously this sat below the ``if index_only``
     # short-circuit, which left the closure's reference to
     # ``dead_code_report`` unbound and crashed every ``--index-only`` run.
     dead_code_report = None
+    if timings is not None:
+        timings.start("analysis.dead_code")
     try:
         from repowise.core.analysis.dead_code import DeadCodeAnalyzer
 
@@ -772,6 +817,9 @@ def run_partial_analysis(
             log(f"Dead code findings: [yellow]{dead_code_report.total_findings}[/yellow]")
     except Exception as exc:
         log(f"[yellow]Dead code analysis skipped: {exc}[/yellow]")
+    finally:
+        if timings is not None:
+            timings.stop("analysis.dead_code")
 
     return partial_health_report, dead_code_report
 
@@ -1391,6 +1439,7 @@ async def persist_incremental_index(
     log: LogFn | None = None,
     degraded: list[str] | None = None,
     failed_steps: list[str] | None = None,
+    timings: PhaseTimings | None = None,
 ) -> None:
     """Persist an incremental index refresh (graph + symbols + git + dead-code + health).
 
@@ -1417,6 +1466,10 @@ async def persist_incremental_index(
     looks range-scoped and is not: it bounds its walk by the newest
     ``committed_at`` already in the table, so a run it skipped is re-walked by
     the next one whatever the diff base says.
+
+    ``timings`` records the whole write as ``persist`` and each step as a
+    ``persist.*`` row. A step that did not run records nothing, so an absent
+    row means skipped rather than free.
     """
     from repowise.core.persistence import (
         create_engine,
@@ -1443,12 +1496,18 @@ async def persist_incremental_index(
     tombstoned_page_ids: list[str] = []
     # Same contract, for rows of a page that has been retired outright.
     swept_page_ids: list[str] = []
+    if timings is not None:
+        timings.start("persist")
     try:
-        await init_db(engine)
-        sf = create_session_factory(engine)
+        with timed(timings, "persist.open"):
+            await init_db(engine)
+            sf = create_session_factory(engine)
 
         async with get_session(sf) as session:
-            repo = await upsert_repository(session, name=repo_path.name, local_path=str(repo_path))
+            with timed(timings, "persist.open"):
+                repo = await upsert_repository(
+                    session, name=repo_path.name, local_path=str(repo_path)
+                )
             repo_id = repo.id
 
             # Delete rows of pages retired since this index was built. This
@@ -1462,12 +1521,16 @@ async def persist_incremental_index(
                     sweep_retired_pages,
                 )
 
-                swept_page_ids = await sweep_retired_pages(session, repo_id)
-                # Same reasoning as the retirement sweep above: this path never
-                # regenerates a cycle page, so asking the rebuilt graph whether
-                # the cycle still exists is the only way a fixed cycle's page
-                # can ever be retired for a user who only runs `update`.
-                swept_page_ids += await sweep_absent_cycle_pages(session, repo_id, graph_builder)
+                with timed(timings, "persist.sweeps"):
+                    swept_page_ids = await sweep_retired_pages(session, repo_id)
+                    # Same reasoning as the retirement sweep above: this path
+                    # never regenerates a cycle page, so asking the rebuilt
+                    # graph whether the cycle still exists is the only way a
+                    # fixed cycle's page can ever be retired for a user who
+                    # only runs `update`.
+                    swept_page_ids += await sweep_absent_cycle_pages(
+                        session, repo_id, graph_builder
+                    )
             except Exception as exc:
                 _skip("Retired page sweep", exc)
 
@@ -1481,9 +1544,10 @@ async def persist_incremental_index(
                         tombstone_candidates,
                     )
 
-                    tombstoned_page_ids = await mark_tombstone_pages(
-                        session, repo_id, tombstone_candidates(file_diffs)
-                    )
+                    with timed(timings, "persist.tombstones"):
+                        tombstoned_page_ids = await mark_tombstone_pages(
+                            session, repo_id, tombstone_candidates(file_diffs)
+                        )
                 except Exception as exc:
                     _skip("Tombstone marking", exc, range_scoped=True)
 
@@ -1492,7 +1556,8 @@ async def persist_incremental_index(
             try:
                 from repowise.core.pipeline.page_tree_sync import rebuild_page_tree
 
-                await rebuild_page_tree(session, repo_id)
+                with timed(timings, "persist.page_tree"):
+                    await rebuild_page_tree(session, repo_id)
             except Exception as exc:
                 _skip("Page tree rebuild", exc)
 
@@ -1506,17 +1571,19 @@ async def persist_incremental_index(
                     # Idle files' decay-only rows upsert alongside the changed
                     # files' full rows; the percentile re-rank then runs over
                     # every row against the freshly decayed scores (#728).
-                    await upsert_git_metadata_bulk(
-                        session,
-                        repo_id,
-                        [*git_meta_map.values(), *(git_decay_map or {}).values()],
-                    )
-                    await recompute_git_percentiles(session, repo_id)
+                    with timed(timings, "persist.git"):
+                        await upsert_git_metadata_bulk(
+                            session,
+                            repo_id,
+                            [*git_meta_map.values(), *(git_decay_map or {}).values()],
+                        )
+                        await recompute_git_percentiles(session, repo_id)
                 except Exception as exc:
                     _skip("Git persist", exc, range_scoped=True)
 
                 try:
-                    await persist_incremental_commits(session, repo_id, repo_path)
+                    with timed(timings, "persist.commits"):
+                        await persist_incremental_commits(session, repo_id, repo_path)
                 except Exception as exc:
                     _skip("Commit capture", exc)
 
@@ -1531,18 +1598,20 @@ async def persist_incremental_index(
                     # verdict the change flipped outside the change set. The
                     # scope is the set of files whose confidence was scored on
                     # real git metadata; the rest keep what they had.
-                    await replace_dead_code_findings(
-                        session,
-                        repo_id,
-                        dead_code_report.findings,
-                        scope=dead_code_report.authoritative_paths,
-                    )
+                    with timed(timings, "persist.dead_code"):
+                        await replace_dead_code_findings(
+                            session,
+                            repo_id,
+                            dead_code_report.findings,
+                            scope=dead_code_report.authoritative_paths,
+                        )
                 except Exception as exc:
                     _skip("Dead-code persist", exc, range_scoped=True)
 
             if partial_health_report is not None:
                 try:
-                    await persist_partial_health(session, repo_id, partial_health_report)
+                    with timed(timings, "persist.health"):
+                        await persist_partial_health(session, repo_id, partial_health_report)
                 except Exception as exc:
                     _skip("Health persist", exc, range_scoped=True)
 
@@ -1555,7 +1624,8 @@ async def persist_incremental_index(
             try:
                 from repowise.core.pipeline.persist import persist_graph_nodes
 
-                await persist_graph_nodes(session, repo_id, graph_builder)
+                with timed(timings, "persist.graph_nodes"):
+                    await persist_graph_nodes(session, repo_id, graph_builder)
             except Exception as exc:
                 _skip("Graph nodes persist", exc)
 
@@ -1567,7 +1637,10 @@ async def persist_incremental_index(
             try:
                 from repowise.core.pipeline.persist import persist_incremental_symbols
 
-                await persist_incremental_symbols(session, repo_id, parsed_files, changed_paths)
+                with timed(timings, "persist.symbols"):
+                    await persist_incremental_symbols(
+                        session, repo_id, parsed_files, changed_paths
+                    )
             except Exception as exc:
                 _skip("Symbol persist", exc, range_scoped=True)
 
@@ -1579,9 +1652,10 @@ async def persist_incremental_index(
             try:
                 from repowise.core.pipeline.persist import persist_incremental_edges
 
-                await persist_incremental_edges(
-                    session, repo_id, graph_builder, parsed_files, changed_paths
-                )
+                with timed(timings, "persist.edges"):
+                    await persist_incremental_edges(
+                        session, repo_id, graph_builder, parsed_files, changed_paths
+                    )
             except Exception as exc:
                 _skip("Graph edges persist", exc, range_scoped=True)
 
@@ -1592,13 +1666,14 @@ async def persist_incremental_index(
                 from repowise.core.generation.related_pages import file_import_edges
                 from repowise.core.persistence.crud import backfill_related_pages
 
-                changed_rel = await backfill_related_pages(
-                    session,
-                    repo_id,
-                    import_edges=file_import_edges(graph_builder),
-                    git_meta_map=git_meta_map,
-                    pagerank=graph_builder.pagerank(),
-                )
+                with timed(timings, "persist.related_pages"):
+                    changed_rel = await backfill_related_pages(
+                        session,
+                        repo_id,
+                        import_edges=file_import_edges(graph_builder),
+                        git_meta_map=git_meta_map,
+                        pagerank=graph_builder.pagerank(),
+                    )
                 if changed_rel:
                     log(f"Related pages refreshed on {changed_rel} pages")
             except Exception as exc:
@@ -1608,7 +1683,8 @@ async def persist_incremental_index(
                 try:
                     from repowise.core.pipeline.persist import persist_kg
 
-                    await persist_kg(knowledge_graph_result, session, repo_id)
+                    with timed(timings, "persist.kg"):
+                        await persist_kg(knowledge_graph_result, session, repo_id)
                 except Exception as exc:
                     _skip("Knowledge-graph persist", exc)
 
@@ -1617,7 +1693,10 @@ async def persist_incremental_index(
             # dep list forever. Gated + no LLM (see refresh_external_systems).
             if file_diffs:
                 try:
-                    await refresh_external_systems(session, repo_id, repo_path, file_diffs, log=log)
+                    with timed(timings, "persist.external_systems"):
+                        await refresh_external_systems(
+                            session, repo_id, repo_path, file_diffs, log=log
+                        )
                 except Exception as exc:
                     _skip("External systems refresh", exc, range_scoped=True)
 
@@ -1678,9 +1757,10 @@ async def persist_incremental_index(
                     for node, data in graph.nodes(data=True)
                     if data.get("node_type", "file") == "file"
                 }
-                pruned, refusals = await prune_deleted_file_rows(
-                    session, repo_id, repo_path, live_hint=live_hint
-                )
+                with timed(timings, "persist.prune"):
+                    pruned, refusals = await prune_deleted_file_rows(
+                        session, repo_id, repo_path, live_hint=live_hint
+                    )
                 if pruned:
                     log(f"Pruned rows for [cyan]{pruned}[/cyan] deleted file(s)")
                 for refusal in refusals:
@@ -1735,11 +1815,12 @@ async def persist_incremental_index(
                 from repowise.core.persistence.search import FullTextSearch
 
                 fts = FullTextSearch(engine)
-                await fts.ensure_index()
-                if tombstoned_page_ids:
-                    await fts.delete_many(tombstoned_page_ids)
-                if swept_page_ids:
-                    await fts.delete_many(swept_page_ids)
+                with timed(timings, "persist.fts"):
+                    await fts.ensure_index()
+                    if tombstoned_page_ids:
+                        await fts.delete_many(tombstoned_page_ids)
+                    if swept_page_ids:
+                        await fts.delete_many(swept_page_ids)
             except Exception as exc:
                 # Range-scoped for the tombstone half: mark_tombstone_pages
                 # re-marks and re-returns pages that are already tombstones, so
@@ -1759,3 +1840,5 @@ async def persist_incremental_index(
         # (which does delete it) or a reindex.
     finally:
         await engine.dispose()
+        if timings is not None:
+            timings.stop("persist")

--- a/tests/unit/cli/test_update_phase_timings.py
+++ b/tests/unit/cli/test_update_phase_timings.py
@@ -1,0 +1,83 @@
+"""``repowise update`` writes its phase timings to ``state.json``.
+
+The index-only persist is where the state write happens on the hook's hot
+path, so it is where the run's table lands and where its ``run`` row closes.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+from repowise.core.pipeline import PhaseTimings, timed
+
+
+def _quiet(monkeypatch) -> None:
+    from repowise.cli.commands.update_cmd import persistence, reporting
+    from repowise.core.pipeline import incremental as core_incremental
+
+    async def fake_persist(*_args, timings=None, **_kwargs):
+        with timed(timings, "persist.graph_nodes"):
+            pass
+
+    monkeypatch.setattr(core_incremental, "persist_incremental_index", fake_persist)
+    monkeypatch.setattr(persistence, "full_rescore_due", lambda *_a, **_k: False)
+    monkeypatch.setattr(reporting, "show_index_only_completion", lambda **_k: None)
+
+
+def _persist(tmp_path: Path, timings: PhaseTimings | None) -> dict:
+    from repowise.cli.commands.update_cmd.persistence import _persist_index_only_update
+
+    _persist_index_only_update(
+        tmp_path,
+        object(),
+        {},
+        None,
+        None,
+        {"last_sync_commit": "0" * 40},
+        "1" * 40,
+        time.monotonic(),
+        [],
+        timings=timings,
+    )
+    return json.loads((tmp_path / ".repowise" / "state.json").read_text(encoding="utf-8"))
+
+
+def test_index_only_update_writes_phase_timings(tmp_path: Path, monkeypatch) -> None:
+    (tmp_path / ".repowise").mkdir()
+    _quiet(monkeypatch)
+    timings = PhaseTimings()
+    timings.start("run")
+
+    state = _persist(tmp_path, timings)
+
+    rows = state["phase_timings"]
+    assert "run" in rows and "persist.graph_nodes" in rows
+    # ``run`` is the denominator: closed at the write, so it bounds every row.
+    assert all(v <= rows["run"] for v in rows.values())
+
+
+def test_no_table_leaves_state_without_the_key(tmp_path: Path, monkeypatch) -> None:
+    (tmp_path / ".repowise").mkdir()
+    _quiet(monkeypatch)
+
+    state = _persist(tmp_path, None)
+
+    assert "phase_timings" not in state
+
+
+def test_rescore_gets_its_own_row(tmp_path: Path, monkeypatch) -> None:
+    from repowise.cli.commands.update_cmd import persistence
+
+    (tmp_path / ".repowise").mkdir()
+    _quiet(monkeypatch)
+    monkeypatch.setattr(persistence, "full_rescore_due", lambda *_a, **_k: True)
+    monkeypatch.setattr(persistence, "run_decay_health_rescore", lambda *_a, **_k: True)
+    timings = PhaseTimings()
+    timings.start("run")
+
+    state = _persist(tmp_path, timings)
+
+    assert "rescore" in state["phase_timings"]
+    assert state["health_analyzer_version"]

--- a/tests/unit/pipeline/test_update_phase_timings.py
+++ b/tests/unit/pipeline/test_update_phase_timings.py
@@ -1,0 +1,154 @@
+"""The update path records one timing row per stage.
+
+``init`` has recorded ``phase_timings`` for a while; ``update`` recorded
+nothing, so a slow update could not say which stage made it slow. These pin
+the rows each core step writes when handed the run's table, and that a caller
+with no table gets exactly the behaviour it had before.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from repowise.core.pipeline import PhaseTimings
+from repowise.core.pipeline.incremental import (
+    persist_incremental_index,
+    rebuild_graph_and_git,
+    run_partial_analysis,
+)
+
+
+def _git_repo_with_one_file(tmp_path: Path) -> Path:
+    import git as gitpython
+
+    repo = gitpython.Repo.init(tmp_path)
+    with repo.config_writer() as cw:
+        cw.set_value("user", "name", "Alice")
+        cw.set_value("user", "email", "alice@example.com")
+    (tmp_path / "a.py").write_text("def f():\n    return 1\n")
+    repo.index.add(["a.py"])
+    repo.index.commit("feat: add a")
+    repo.close()
+    (tmp_path / ".repowise").mkdir()
+    return tmp_path
+
+
+async def test_rebuild_records_every_sub_stage(tmp_path: Path) -> None:
+    repo = _git_repo_with_one_file(tmp_path)
+    timings = PhaseTimings()
+
+    _pf, _sm, builder, _rs, _count, _meta = await rebuild_graph_and_git(
+        repo, [], {}, [], timings=timings
+    )
+
+    rows = timings.totals
+    assert {
+        "rebuild",
+        "rebuild.traverse",
+        "rebuild.read",
+        "rebuild.parse",
+        "rebuild.graph",
+        "rebuild.git",
+        "rebuild.metrics",
+    } <= set(rows)
+    # Every sub-stage is inside the parent's span.
+    assert all(rows[k] <= rows["rebuild"] for k in rows if k.startswith("rebuild."))
+
+    # Partial analysis writes its two rows on the same table.
+    run_partial_analysis(
+        repo,
+        builder,
+        {},
+        _pf,
+        [],
+        stored_git_meta={},
+        timings=timings,
+    )
+    assert {"analysis.health", "analysis.dead_code"} <= set(timings.totals)
+
+
+async def test_persist_records_the_steps_that_ran(tmp_path: Path) -> None:
+    """A skipped step leaves no row: absent means skipped, not free."""
+    import networkx as nx
+
+    (tmp_path / ".repowise").mkdir()
+
+    class FakeBuilder:
+        def graph(self):
+            return nx.DiGraph()
+
+    timings = PhaseTimings()
+    await persist_incremental_index(
+        tmp_path,
+        FakeBuilder(),
+        {},
+        None,
+        None,
+        [],
+        log=lambda _msg: None,
+        parsed_files=[],
+        timings=timings,
+    )
+
+    rows = timings.totals
+    assert {"persist", "persist.open", "persist.page_tree", "persist.graph_nodes"} <= set(rows)
+    # No git rows, no dead-code report, no health report: those steps did not run.
+    assert not {"persist.git", "persist.commits", "persist.dead_code", "persist.health"} & set(
+        rows
+    )
+    assert all(rows[k] <= rows["persist"] for k in rows if k.startswith("persist."))
+
+
+async def test_no_table_records_nothing_and_changes_nothing(tmp_path: Path) -> None:
+    """Callers that pass no table (workspace update, tests) are untouched."""
+    import networkx as nx
+
+    (tmp_path / ".repowise").mkdir()
+
+    class FakeBuilder:
+        def graph(self):
+            return nx.DiGraph()
+
+    degraded: list[str] = []
+    await persist_incremental_index(
+        tmp_path,
+        FakeBuilder(),
+        {},
+        None,
+        None,
+        [],
+        log=lambda _msg: None,
+        parsed_files=[],
+        degraded=degraded,
+    )
+    # The same degradations as before the table existed, none about timing.
+    assert all("timing" not in entry.lower() for entry in degraded)
+
+
+@pytest.mark.parametrize("stage", ["analysis.health", "analysis.dead_code"])
+def test_analysis_rows_close_when_the_analyzer_raises(monkeypatch, tmp_path: Path, stage: str):
+    """Both analyses are best-effort; a failure must still close its row."""
+    import networkx as nx
+
+    from repowise.core.analysis import health as health_mod
+    from repowise.core.analysis.dead_code import analyzer as dead_code_mod
+
+    class Boom:
+        def __init__(self, *a, **k):
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr(health_mod, "HealthAnalyzer", Boom)
+    monkeypatch.setattr(dead_code_mod, "DeadCodeAnalyzer", Boom)
+
+    class FakeBuilder:
+        def __init__(self):
+            self._parsed_files: list = []
+
+        def graph(self):
+            return nx.DiGraph()
+
+    timings = PhaseTimings()
+    run_partial_analysis(tmp_path, FakeBuilder(), {}, [], [], timings=timings)
+    assert stage in timings.totals


### PR DESCRIPTION
## Summary

`repowise init` has written `phase_timings` to `state.json` since #2050, and two page-proportional bugs only became visible once it did. `repowise update` wrote nothing, so a slow update could not say which stage made it slow. This carries the same `PhaseTimings` table through the update path and writes it to `state.json` on both the index-only and docs-mode paths.

## What is recorded

One row per stage, named by what runs:

- `rebuild` with `rebuild.traverse`, `rebuild.read`, `rebuild.parse`, `rebuild.graph`, `rebuild.cache_save`, `rebuild.framework`, `rebuild.dynamic_hints`, `rebuild.git`, `rebuild.metrics`
- `analysis.health`, `analysis.dead_code`, `analysis.stored_reads`
- `knowledge_graph`, and `knowledge_graph.enrich` in docs mode
- `render` and `render.persist` for the template re-render
- `persist` with one `persist.*` row per step: open, sweeps, tombstones, page tree, git, commits, dead code, health, graph nodes, symbols, edges, related pages, knowledge graph, external systems, prune, full text; docs mode adds pages, stale pages, decisions, governance
- `decisions`, `generate`, `rescore`, `editor_files` where those run
- `run`, the denominator, opened at the top of `run_update` and closed at the state write on both paths

Stages nest and overlap, so each row compares against `run`, never against the sum. A step that did not run leaves no row, so an absent row means skipped rather than free. The table is optional everywhere and `timed()` is a no-op on `None`, so callers that pass nothing (the workspace update among them) are unchanged. The fast paths (already up to date, no changed files, config-only re-score) do not record, so they never overwrite a real run's numbers.

## Baseline these rows produce

One-file update, store settled, warm second round, `REPOWISE_PARSE_WORKERS=2`. Seconds.

| stage | hugo body-only | hugo symbol-adding | flask body-only | flask symbol-adding |
|---|---:|---:|---:|---:|
| `run` | 59.86 | 50.02 | 7.95 | 7.84 |
| `rebuild` | 24.20 | 19.96 | 2.42 | 2.10 |
| `rebuild.git` | 12.23 | 10.41 | 1.29 | 1.03 |
| `rebuild.graph` | 6.12 | 4.86 | 0.16 | 0.11 |
| `rebuild.metrics` | 2.02 | 1.71 | 0.38 | 0.49 |
| `analysis.health` | 20.85 | 15.69 | 1.41 | 1.42 |
| `analysis.dead_code` | 1.91 | 1.13 | 0.17 | 0.16 |
| `persist` | 7.96 | 9.59 | 2.29 | 2.45 |
| `persist.commits` | 4.54 | 3.67 | 1.89 | 1.91 |
| `persist.graph_nodes` | 1.16 | 4.30 | 0.04 | 0.23 |
| `render` + `render.persist` | 2.20 | 1.31 | 0.57 | 0.51 |

Three things the rows say that a wall clock could not: health is a third of a hugo update because the partial analysis widens one changed file to 249 performance-affected ones; `rebuild.metrics` costs the same on both edit shapes, so the symbol-adding penalty measured before #2066 is gone; and `persist.graph_nodes` is the one stage that is edit-shape dependent, 1.2 s against 4.3 s. The 9 to 14 s between the two hugo legs sits in stages that do not depend on the edit and is the machine's between-run band, not a shape effect.

## Tests

- `tests/unit/pipeline/test_update_phase_timings.py`: the rebuild writes every sub-stage row inside the parent's span; the partial analysis writes its two rows and closes them when an analyzer raises; the persist writes rows only for the steps that ran; a caller with no table is unchanged.
- `tests/unit/cli/test_update_phase_timings.py`: the index-only persist writes `phase_timings` with `run` bounding every row, writes no key without a table, and gives the periodic re-score its own row.

`pytest tests/unit/pipeline tests/unit/persistence tests/unit/cli` and `ruff check packages/ tests/` green.
