### PR TITLE
feat(risk): say when a diff is several changes the index does not connect

### DIFF
--- a/packages/cli/src/repowise/cli/commands/risk_cmd.py
+++ b/packages/cli/src/repowise/cli/commands/risk_cmd.py
@@ -26,12 +26,13 @@ Examples:
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 import click
 from rich.table import Table
 
 from repowise.cli.commands import _tool_adapters as _ta
-from repowise.cli.helpers import console, err_console
+from repowise.cli.helpers import console, err_console, repo_index_session, run_async
 from repowise.cli.output import emit_json, format_option, full_option
 from repowise.core.analysis.change_risk import (
     change_risk_payload,
@@ -384,6 +385,65 @@ def _print_records(label: str, values: list, key: str, truncated: int = 0) -> No
         console.print(f"    [dim]... and {truncated} more[/dim]")
 
 
+def _independent_changes_for(repo_path: str, result, revspec: str | None) -> dict | None:
+    """How this diff splits, per the index, or ``None`` when it cannot be read."""
+    from sqlalchemy.exc import SQLAlchemyError
+
+    from repowise.core import git_refs
+    from repowise.core.analysis.independent_changes import independent_changes
+
+    paths = [path for path, _ in result.features.file_churn]
+    if len(paths) < 2:
+        return None
+    # A diff names paths from the repository root, so a command run in a
+    # subdirectory has to score against that root, not against the given path.
+    root = Path(git_refs.toplevel(repo_path) or repo_path).resolve()
+    # One commit touching two files links them harder than any edge does. Read
+    # git before the store opens: no subprocess while a connection is held.
+    sets = git_refs.commit_file_sets(str(root), revspec)
+
+    async def read() -> dict | None:
+        found = None
+        async with repo_index_session(root) as opened:
+            if opened is not None:
+                session, repo_id = opened
+                try:
+                    found = await independent_changes(session, repo_id, paths, commit_sets=sets)
+                except (SQLAlchemyError, OSError, LookupError):
+                    # An index written by an older version can fail the query itself.
+                    return None
+        return found.to_dict() if found else None
+
+    return run_async(read())
+
+
+#: How many ungrouped names the table prints. The summary already states the
+#: count, so a docs-heavy diff need not spell out hundreds of paths.
+_UNGROUPED_SHOWN = 10
+
+
+def _print_independent_changes(block: dict) -> None:
+    """The groups, plainly: no score, no percentage, no adjective."""
+    from rich.markup import escape
+
+    console.print(f"\n[bold]{escape(str(block.get('summary') or ''))}[/bold]")
+    for number, group in enumerate(block.get("groups") or [], start=1):
+        files = [str(f) for f in group.get("files") or []]
+        plural = "" if len(files) == 1 else "s"
+        console.print(f"  {number}. {len(files)} file{plural}: {escape(', '.join(files))}")
+        bridging = [str(f) for f in group.get("bridging_files") or []]
+        if bridging:
+            # Naming these files says where the group would split if one moved out.
+            console.print(f"     [dim]held together by: {escape(', '.join(bridging))}[/dim]")
+    ungrouped = [str(f) for f in block.get("ungrouped_files") or []]
+    if ungrouped:
+        shown = escape(", ".join(ungrouped[:_UNGROUPED_SHOWN]))
+        cut = len(ungrouped) - _UNGROUPED_SHOWN
+        more = f" and {cut} more" if cut > 0 else ""
+        console.print(f"  Left out of the grouping: {shown}{more}")
+    console.print(f"  [dim]Basis: {escape(str(block.get('basis') or ''))}.[/dim]")
+
+
 def _ordinal(n: int) -> str:
     """1 -> '1st', 2 -> '2nd', 93 -> '93rd', 11 -> '11th'."""
     suffix = "th" if 10 <= n % 100 <= 20 else {1: "st", 2: "nd", 3: "rd"}.get(n % 10, "th")
@@ -501,7 +561,11 @@ def risk_command(
         )
 
     if fmt == "json":
-        click.echo(json.dumps(change_risk_payload(result, scales=True), indent=2))
+        payload = change_risk_payload(result, scales=True)
+        groups = _independent_changes_for(repo_path, result, revspec)
+        if groups:
+            payload["independent_changes"] = groups
+        click.echo(json.dumps(payload, indent=2))
         return
 
     # Lead with the benchmarked population-relative authority. Without a usable
@@ -586,3 +650,7 @@ def risk_command(
             f"[{push_color}]{sign}{d.contribution:.2f}[/{push_color}]",
         )
     console.print(table)
+
+    groups = _independent_changes_for(repo_path, result, revspec)
+    if groups:
+        _print_independent_changes(groups)

--- a/packages/cli/src/repowise/cli/helpers.py
+++ b/packages/cli/src/repowise/cli/helpers.py
@@ -9,7 +9,7 @@ import os
 import sys
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Literal, TypeVar
+from typing import TYPE_CHECKING, Any, Literal, TypeVar
 
 import click
 from rich.console import Console
@@ -43,6 +43,11 @@ from repowise.core.update_lock import (
 from repowise.core.update_lock import (
     try_acquire_update_lock as try_acquire_update_lock,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+    from sqlalchemy.ext.asyncio import AsyncSession
 
 T = TypeVar("T")
 
@@ -198,6 +203,38 @@ def get_db_url_for_repo(repo_path: Path) -> str:
     from repowise.core.persistence.database import resolve_db_url
 
     return resolve_db_url(repo_path)
+
+
+@contextlib.asynccontextmanager
+async def repo_index_session(root: Path) -> AsyncIterator[tuple[AsyncSession, str] | None]:
+    """Open the repo-local store, yielding ``(session, repo_id)`` or ``None``.
+
+    A scoring or scanning command must never fail because the index is absent,
+    stale or locked, so every storage error yields ``None`` instead.
+    """
+    from sqlalchemy.exc import SQLAlchemyError
+
+    from repowise.core.persistence import create_engine, create_session_factory, get_session
+    from repowise.core.persistence.crud import get_repository_by_path
+
+    if not (root / REPOWISE_DIR / "wiki.db").is_file():
+        yield None
+        return
+    # The stack keeps the session open across the yield and disposes the engine
+    # on the way out, whether the caller left the block or raised inside it.
+    async with contextlib.AsyncExitStack() as stack:
+        opened: tuple[AsyncSession, str] | None = None
+        try:
+            engine = create_engine(get_db_url_for_repo(root))
+            stack.push_async_callback(engine.dispose)
+            factory = create_session_factory(engine)
+            session = await stack.enter_async_context(get_session(factory))
+            repo = await get_repository_by_path(session, str(root))
+            if repo is not None:
+                opened = (session, repo.id)
+        except (SQLAlchemyError, OSError, LookupError):
+            opened = None
+        yield opened
 
 
 #: Busy timeout for the reconcile's own connection. The engine default is 30s,

--- a/packages/core/src/repowise/core/analysis/graph_view.py
+++ b/packages/core/src/repowise/core/analysis/graph_view.py
@@ -17,7 +17,7 @@ from typing import Any, Protocol
 from ..ingestion.languages import REGISTRY
 from ..ingestion.models import FILE_DEPENDENCY_EDGE_TYPES
 
-__all__ = ["HasEdge", "ImportEdgeView"]
+__all__ = ["HasEdge", "ImportEdgeView", "can_carry_dependency"]
 
 
 def _language_of(path: str) -> str:
@@ -26,6 +26,24 @@ def _language_of(path: str) -> str:
     return REGISTRY.from_filename(name) or REGISTRY.from_extension(
         PurePosixPath(name).suffix.lower()
     )
+
+
+def can_carry_dependency(path: str, language: str | None = None) -> bool:
+    """Whether an absent edge at *path* would mean anything.
+
+    ``pyproject.toml`` and ``README.md`` are both ingested and both become
+    nodes, yet no resolver can ever emit an edge for them, so "no edge found"
+    is a fact about the language rather than about the repository. The registry
+    grades this per language as ``import_support``; ``"none"`` is the generic
+    stem-lookup fallback, which is not a mechanism a finding can rest on.
+
+    *language* is optional because it is not always recorded: a node
+    synthesised for a dynamic edge target carries none and persistence drops
+    null columns on rehydrate. The path answers the same question.
+    """
+    if not isinstance(language, str) or not language:
+        language = _language_of(path)
+    return REGISTRY.import_support_for(language) != "none"
 
 
 class HasEdge(Protocol):
@@ -90,17 +108,10 @@ class ImportEdgeView:
         return kind if kind in FILE_DEPENDENCY_EDGE_TYPES else None
 
     def can_carry_dependency(self, path: str) -> bool:
-        """Whether an absent edge at *path* would mean anything.
+        """Whether an absent edge at *path* would mean anything, per the graph.
 
-        Being a node is not enough. ``pyproject.toml`` and ``README.md`` are
-        both ingested and both become nodes, yet no resolver can ever emit an
-        edge for them, so "no edge found" is a fact about the language rather
-        than about the repository. The registry already grades this per
-        language as ``import_support``; ``"none"`` is the generic stem-lookup
-        fallback, which is not a mechanism a finding can rest on.
-
-        A file the parser never saw fails here too: a lockfile in a blocked
-        directory has no edge to look for either.
+        Being a node is not enough, and a file the parser never saw fails here
+        too: a lockfile in a blocked directory has no edge to look for either.
         """
         g = self._graph
         if g is None:
@@ -109,10 +120,4 @@ class ImportEdgeView:
             attrs = g.nodes[path]
         except Exception:
             return False
-        language = attrs.get("language")
-        if not isinstance(language, str):
-            # Not every node carries the attribute: a node synthesised for a
-            # dynamic edge target has none, and persistence drops null
-            # columns on rehydrate. The path answers the same question.
-            language = _language_of(path)
-        return REGISTRY.import_support_for(language) != "none"
+        return can_carry_dependency(path, attrs.get("language"))

--- a/packages/core/src/repowise/core/analysis/independent_changes.py
+++ b/packages/core/src/repowise/core/analysis/independent_changes.py
@@ -1,0 +1,317 @@
+"""Split a diff into groups of changed files that the index does not connect.
+
+Grouping is connected components over index edges, stored co-change pairs and
+the files each commit of the range touched. Not Leiden or Louvain: a diff is
+tens of files and the question is plain connectivity. Only source files a
+resolver can link are grouped; docs, config, tests and files the index has
+never linked are reported rather than claimed as changes of their own.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import Any
+
+import networkx as nx
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from repowise.core.analysis.graph_view import can_carry_dependency
+from repowise.core.co_change import parse_partners
+from repowise.core.persistence.batches import chunked
+from repowise.core.persistence.models import GitMetadata, GraphEdge, GraphNode
+
+# Under three files a group has no articulation point worth naming: removing
+# either end of a pair leaves one file, which is not a split.
+_MIN_FILES_FOR_BRIDGE = 3
+
+# Node-id prefix of a dependency outside the repository. An edge to one is not
+# a link to another file of this change.
+_EXTERNAL_PREFIX = "external:"
+
+# What was actually checked, which is not the same sentence when the commits of
+# the range were available to check.
+_BASIS = (
+    "no import, call, type reference or co-change pair in the index links "
+    "one group to another"
+)
+_BASIS_WITH_COMMITS = (
+    "no import, call, type reference, co-change pair or shared commit in the "
+    "index and this range links one group to another"
+)
+
+_Pairs = set[tuple[str, str]]
+
+
+@dataclass(frozen=True)
+class ChangeGroup:
+    """One set of changed files that the index links together."""
+
+    files: tuple[str, ...]
+    bridging_files: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class IndependentChanges:
+    """A diff seen as several changes that share no link in the index."""
+
+    groups: tuple[ChangeGroup, ...]
+    ungrouped_files: tuple[str, ...]
+    # Whether the commits of the range were available, which the basis states.
+    commits_known: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "count": len(self.groups),
+            "groups": [
+                {"files": list(g.files), "bridging_files": list(g.bridging_files)}
+                for g in self.groups
+            ],
+            "ungrouped_files": list(self.ungrouped_files),
+            "basis": _BASIS_WITH_COMMITS if self.commits_known else _BASIS,
+            "summary": self._summary(),
+        }
+
+    def _summary(self) -> str:
+        """One sentence per claim: the split, then what the index could not see."""
+        sizes = _join([_files(len(g.files)) for g in self.groups])
+        text = f"This diff is {len(self.groups)} independent changes: {sizes}."
+        loose = len(self.ungrouped_files)
+        if loose:
+            subject = "1 changed file is" if loose == 1 else f"{loose} changed files are"
+            text += (
+                f" {subject} left out of the grouping: docs, config, tests, "
+                "files not in the index, or files it has never linked."
+            )
+        return text
+
+
+def _files(n: int) -> str:
+    return "1 file" if n == 1 else f"{n} files"
+
+
+def _join(parts: list[str]) -> str:
+    """``"a, b and c"``: the last two joined by "and", the rest by commas."""
+    if len(parts) < 2:
+        return "".join(parts)
+    return f"{', '.join(parts[:-1])} and {parts[-1]}"
+
+
+def _pair(a: str, b: str) -> tuple[str, str]:
+    return (a, b) if a < b else (b, a)
+
+
+async def _read_nodes(
+    session: AsyncSession, repo_id: str, paths: list[str]
+) -> tuple[dict[str, str], set[str], set[str]]:
+    """``(node id -> owning changed file, indexed files, files that can be grouped)``.
+
+    Two seeks rather than one ``OR``: a file node is found by ``node_id`` and
+    the symbols it owns by ``file_path``, and each has its own index.
+    """
+    rows: list[tuple[str, str, str | None, str | None, bool]] = []
+    for column in (GraphNode.node_id, GraphNode.file_path):
+        for chunk in chunked(paths):
+            result = await session.execute(
+                select(
+                    GraphNode.node_id,
+                    GraphNode.node_type,
+                    GraphNode.file_path,
+                    GraphNode.language,
+                    GraphNode.is_test,
+                ).where(GraphNode.repository_id == repo_id, column.in_(chunk))
+            )
+            rows.extend(result.all())
+
+    changed = set(paths)
+    files = [
+        (n, lang, is_test)
+        for n, node_type, _fp, lang, is_test in rows
+        if node_type == "file" and n in changed
+    ]
+    indexed = {n for n, _lang, _test in files}
+    # A test attaches to whatever shared harness the diff holds rather than to
+    # the code it exercises, and a page co-changes with whatever shipped beside
+    # it, so neither can be the file a group rests on.
+    groupable = {n for n, lang, is_test in files if not is_test and can_carry_dependency(n, lang)}
+    owner: dict[str, str] = {}
+    for node_id, node_type, file_path, _lang, _is_test in rows:
+        own = node_id if node_type == "file" else file_path
+        if own in indexed:
+            owner[node_id] = own
+    return owner, indexed, groupable
+
+
+async def _read_pairs(
+    session: AsyncSession, repo_id: str, owner: dict[str, str]
+) -> tuple[_Pairs, set[str]]:
+    """``(file pairs inside the diff, changed files with a link leaving them)``.
+
+    Distinct ends rather than every edge: a hot file carries thousands of call
+    edges to a handful of neighbours. Same-file ends are dropped, which removes
+    the containment types (``defines``, ``has_method``) without listing them.
+    """
+    pairs: _Pairs = set()
+    linked: set[str] = set()
+    for chunk in chunked(sorted(owner)):
+        result = await session.execute(
+            select(GraphEdge.source_node_id, GraphEdge.target_node_id)
+            .distinct()
+            .where(
+                GraphEdge.repository_id == repo_id,
+                GraphEdge.source_node_id.in_(chunk),
+                GraphEdge.target_node_id.not_like(f"{_EXTERNAL_PREFIX}%"),
+            )
+        )
+        for source, target in result.all():
+            near, far = owner[source], owner.get(target, target)
+            if near == far:
+                continue
+            linked.add(near)
+            if target in owner:
+                pairs.add(_pair(near, far))
+    return pairs, linked
+
+
+async def _read_inbound_links(
+    session: AsyncSession, repo_id: str, owner: dict[str, str]
+) -> set[str]:
+    """Changed files that a file outside the diff links to.
+
+    Only the arrows coming in: the pairs read already answers the outward
+    direction, and a far end that is one of our own nodes is either a pair or
+    one of a file's own symbols.
+    """
+    node_ids = sorted(owner)
+    not_ours = [GraphEdge.source_node_id.not_in(piece) for piece in chunked(node_ids)]
+    linked: set[str] = set()
+    for chunk in chunked(node_ids):
+        result = await session.execute(
+            select(GraphEdge.target_node_id)
+            .distinct()
+            .where(
+                GraphEdge.repository_id == repo_id,
+                GraphEdge.target_node_id.in_(chunk),
+                GraphEdge.source_node_id.not_like(f"{_EXTERNAL_PREFIX}%"),
+                *not_ours,
+            )
+        )
+        linked.update(owner[node_id] for (node_id,) in result.all())
+    return linked
+
+
+async def _read_co_change(
+    session: AsyncSession, repo_id: str, indexed: set[str]
+) -> tuple[_Pairs, set[str]]:
+    """``(pairs where both ends changed, changed files carrying any partner)``."""
+    pairs: _Pairs = set()
+    partnered: set[str] = set()
+    for chunk in chunked(sorted(indexed)):
+        result = await session.execute(
+            select(GitMetadata.file_path, GitMetadata.co_change_partners_json).where(
+                GitMetadata.repository_id == repo_id,
+                GitMetadata.file_path.in_(chunk),
+            )
+        )
+        for file_path, raw in result.all():
+            partners = parse_partners(raw)
+            if partners:
+                partnered.add(file_path)
+            for partner in partners:
+                if partner.file_path in indexed and partner.file_path != file_path:
+                    pairs.add(_pair(file_path, partner.file_path))
+    return pairs, partnered
+
+
+def _commit_pairs(commit_sets: Iterable[Iterable[str]], groupable: set[str]) -> _Pairs:
+    """Pairs of groupable files one commit of this range touched.
+
+    An author putting two files in one commit says more than any edge. A set
+    covering every groupable file is the diff restated and says nothing about
+    which files belong together, so it is skipped.
+    """
+    pairs: _Pairs = set()
+    for touched in commit_sets:
+        members = groupable.intersection(touched)
+        if len(members) == len(groupable):
+            continue
+        ordered = sorted(members)
+        for i, first in enumerate(ordered):
+            for second in ordered[i + 1 :]:
+                pairs.add((first, second))
+    return pairs
+
+
+def _partition(
+    groupable: set[str], linked: set[str], pairs: _Pairs
+) -> tuple[list[ChangeGroup], list[str]]:
+    """``(groups largest first, files left ungrouped)``.
+
+    A component has to carry one file something has in fact linked, because
+    elsewhere an absent edge is not evidence of independence.
+    """
+    graph = nx.Graph()
+    graph.add_nodes_from(sorted(groupable))
+    graph.add_edges_from(sorted(pairs))
+
+    groups: list[ChangeGroup] = []
+    ungrouped: list[str] = []
+    for component in nx.connected_components(graph):
+        files = sorted(component)
+        if not linked.intersection(files):
+            ungrouped.extend(files)
+            continue
+        bridging: tuple[str, ...] = ()
+        if len(files) >= _MIN_FILES_FOR_BRIDGE:
+            bridging = tuple(sorted(nx.articulation_points(graph.subgraph(files))))
+        groups.append(ChangeGroup(files=tuple(files), bridging_files=bridging))
+    groups.sort(key=lambda g: (-len(g.files), g.files[0]))
+    return groups, ungrouped
+
+
+async def independent_changes(
+    session: AsyncSession,
+    repo_id: str,
+    changed_files: Iterable[str],
+    *,
+    commit_sets: Iterable[Iterable[str]] = (),
+) -> IndependentChanges | None:
+    """The changed files split into groups nothing connects.
+
+    *commit_sets* is the files each commit of the range touched. ``None`` when
+    fewer than two groups survive: one change gets no report.
+    """
+    paths = sorted({p for p in changed_files if p})
+    if len(paths) < 2:
+        return None
+    # Materialised once: the caller may hand over a generator, and the basis
+    # states whether there was anything to check.
+    known_commits = [list(touched) for touched in commit_sets]
+
+    owner, indexed, groupable = await _read_nodes(session, repo_id, paths)
+    if len(groupable) < 2:
+        return None
+
+    pairs, linked = await _read_pairs(session, repo_id, owner)
+    linked |= await _read_inbound_links(session, repo_id, owner)
+    linked |= {f for pair in pairs for f in pair}
+    co_pairs, partnered = await _read_co_change(session, repo_id, indexed)
+    commit_linked = _commit_pairs(known_commits, groupable)
+    pairs |= co_pairs | commit_linked
+    linked |= partnered | {f for pair in commit_linked for f in pair}
+
+    # Only groupable files are graph nodes, so an edge touching a doc or a test
+    # must not survive to bridge two groups through it.
+    pairs = {(a, b) for a, b in pairs if a in groupable and b in groupable}
+
+    groups, ungrouped = _partition(groupable, linked, pairs)
+    if len(groups) < 2:
+        return None
+
+    ungrouped.extend(p for p in paths if p not in groupable)
+    return IndependentChanges(
+        groups=tuple(groups),
+        ungrouped_files=tuple(sorted(ungrouped)),
+        commits_known=bool(known_commits),
+    )

--- a/packages/core/src/repowise/core/git_refs.py
+++ b/packages/core/src/repowise/core/git_refs.py
@@ -1,0 +1,247 @@
+"""Read-only git ref queries: branches, revisions, diffs, ahead/behind.
+
+One helper because the pieces were scattered or missing: listing branch tips
+with their dates existed nowhere, and ahead/behind existed only one way. Query
+time only: it reads a live repository, never writes, never walks the tree.
+Every call degrades to an empty value instead of raising.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+from .analysis.change_risk.features import _git
+
+__all__ = [
+    "BranchRef",
+    "ahead_behind",
+    "ahead_behind_many",
+    "changed_files",
+    "commit_file_sets",
+    "current_branch",
+    "default_base",
+    "files_by_ref",
+    "list_branches",
+    "refs_containing",
+    "refs_merged_into",
+    "resolve",
+    "toplevel",
+]
+
+#: Subprocess failures that mean "no answer", not "bug": a wedged or missing
+#: git, a path that is not a repository, a bad revspec.
+_GIT_FAILURES = (subprocess.TimeoutExpired, subprocess.CalledProcessError, OSError)
+
+#: Candidate trunks, in the order a repository without ``origin/HEAD`` names one.
+_FALLBACK_BASES = ("main", "master")
+
+
+def _read(repo_path: str, args: list[str]) -> str:
+    """One git call, stripped stdout, ``""`` when git cannot answer."""
+    try:
+        return _git(args, cwd=repo_path, check=False).strip()
+    except _GIT_FAILURES:
+        return ""
+
+
+@dataclass(frozen=True)
+class BranchRef:
+    """One branch tip: the short ref, its commit, and when that commit landed."""
+
+    name: str  # short ref: "feat/x" or "origin/feat/x"
+    sha: str
+    committed_at: str  # committerdate:iso-strict, "" if unknown
+    is_remote: bool
+    # The same instant as an epoch, so callers order without parsing a date.
+    committed_unix: int = 0
+    ref: str = ""  # full refname, which is what for-each-ref takes as a pattern
+
+
+def toplevel(repo_path: str) -> str:
+    """The repository root holding *repo_path*, ``""`` when it is not a repo.
+
+    Paths in a diff are relative to this, so a caller given a subdirectory has
+    to resolve it before it can match a path against an index.
+    """
+    return _read(repo_path, ["rev-parse", "--show-toplevel"])
+
+
+def current_branch(repo_path: str) -> str | None:
+    """The checked-out branch, or ``None`` when detached or unreadable."""
+    name = _read(repo_path, ["rev-parse", "--abbrev-ref", "HEAD"])
+    # A detached HEAD reports the literal "HEAD", which names no branch.
+    return name if name and name != "HEAD" else None
+
+
+def resolve(repo_path: str, rev: str) -> str:
+    """The commit *rev* names, ``""`` when it names none."""
+    return _read(repo_path, ["rev-parse", "--verify", "--quiet", f"{rev}^{{commit}}"])
+
+
+def default_base(repo_path: str) -> str:
+    """The branch a change is most likely cut from, else ``HEAD``."""
+    head = _read(repo_path, ["symbolic-ref", "--short", "refs/remotes/origin/HEAD"])
+    if head:
+        return head
+    for name in _FALLBACK_BASES:
+        if resolve(repo_path, name):
+            return name
+    return "HEAD"
+
+
+def _parse_ref_line(line: str) -> BranchRef | None:
+    """One ``for-each-ref`` row, or ``None`` when it names no usable branch."""
+    parts = line.split("\t")
+    if len(parts) != 5:
+        return None
+    short, sha, committed_at, unix, refname = parts
+    # refs/remotes/origin/HEAD aliases another ref already in this list.
+    if not short or not sha or refname.endswith("/HEAD"):
+        return None
+    return BranchRef(
+        name=short,
+        sha=sha,
+        committed_at=committed_at,
+        is_remote=refname.startswith("refs/remotes/"),
+        committed_unix=int(unix) if unix.strip().isdigit() else 0,
+        ref=refname,
+    )
+
+
+def list_branches(repo_path: str) -> list[BranchRef]:
+    """Local and remote-tracking branch tips, newest committer date first."""
+    out = _read(
+        repo_path,
+        [
+            "for-each-ref",
+            "--sort=-committerdate",
+            "--format=%(refname:short)%09%(objectname)%09%(committerdate:iso-strict)%09%(committerdate:unix)%09%(refname)",
+            "refs/heads",
+            "refs/remotes",
+        ],
+    )
+    refs: list[BranchRef] = []
+    for line in out.splitlines():
+        ref = _parse_ref_line(line)
+        if ref is None:
+            continue
+        refs.append(ref)
+    return refs
+
+
+def ahead_behind_many(
+    repo_path: str, base: str, refs: Sequence[str]
+) -> dict[str, tuple[int, int]]:
+    """``(ahead, behind)`` against *base* for each full refname, in one call.
+
+    ``%(ahead-behind:...)`` needs git 2.36, so an older git yields ``{}`` and
+    the caller falls back to asking per ref.
+    """
+    if not refs:
+        return {}
+    out = _read(
+        repo_path,
+        ["for-each-ref", f"--format=%(refname:short)%09%(ahead-behind:{base})", *refs],
+    )
+    counts: dict[str, tuple[int, int]] = {}
+    for line in out.splitlines():
+        name, _, pair = line.partition("\t")
+        parts = pair.split()
+        if not name or len(parts) != 2 or not all(p.isdigit() for p in parts):
+            continue
+        counts[name] = (int(parts[0]), int(parts[1]))
+    return counts
+
+
+def _reachable_refs(repo_path: str, flag: str, rev: str) -> set[str]:
+    """Short names of the branches ``for-each-ref <flag> <rev>`` selects."""
+    out = _read(
+        repo_path,
+        ["for-each-ref", flag, rev, "--format=%(refname:short)", "refs/heads", "refs/remotes"],
+    )
+    return {line.strip() for line in out.splitlines() if line.strip()}
+
+
+def refs_containing(repo_path: str, rev: str) -> set[str]:
+    """Branches whose history already holds *rev*: work stacked on top of it."""
+    return _reachable_refs(repo_path, "--contains", rev)
+
+
+def refs_merged_into(repo_path: str, rev: str) -> set[str]:
+    """Branches *rev* already holds: what it was stacked on, and what merged in."""
+    return _reachable_refs(repo_path, "--merged", rev)
+
+
+def changed_files(repo_path: str, base: str, head: str) -> list[str]:
+    """Paths ``head`` changed since it forked from ``base``, sorted and deduped."""
+    # Three dots: what head did, not what base did in the meantime.
+    out = _read(repo_path, ["diff", "--name-only", f"{base}...{head}"])
+    return sorted({line.strip() for line in out.splitlines() if line.strip()})
+
+
+def _short_ref(name: str) -> str:
+    """``%S`` echoes the command-line argument, but a full refname can arrive."""
+    for prefix in ("refs/heads/", "refs/remotes/"):
+        if name.startswith(prefix):
+            return name[len(prefix) :]
+    return name
+
+
+def files_by_ref(repo_path: str, base: str, refs: Sequence[str]) -> dict[str, frozenset[str]]:
+    """Paths each ref changed since *base*, from one walk over all of them.
+
+    ``%S`` credits a commit to the ref that reached it first, so two refs
+    sharing a commit see it once. A ref with no commits of its own is absent.
+    ``%S`` needs git 2.21; an older git yields ``{}``.
+    """
+    if not refs:
+        return {}
+    out = _read(
+        repo_path,
+        ["log", "--source", "--format=%x00%S", "--name-only", *refs, f"^{base}"],
+    )
+    by_ref: dict[str, set[str]] = {}
+    for block in out.split("\x00")[1:]:
+        lines = block.splitlines()
+        if not lines:
+            continue
+        paths = by_ref.setdefault(_short_ref(lines[0].strip()), set())
+        paths.update(line.strip() for line in lines[1:] if line.strip())
+    return {name: frozenset(paths) for name, paths in by_ref.items()}
+
+
+def commit_file_sets(repo_path: str, revspec: str | None) -> list[frozenset[str]]:
+    """The files each commit of a range touched, oldest first.
+
+    Only a range carries the information: a single revision names one commit,
+    and one commit says nothing about what moves with what.
+    """
+    if not revspec:
+        return []
+    # The commits of "a...b" are "a..b"; three dots is diff syntax, not a range.
+    if "..." in revspec:
+        revspec = revspec.replace("...", "..")
+    elif ".." not in revspec:
+        return []
+    out = _read(repo_path, ["log", "--reverse", "--format=%x00%H", "--name-only", revspec])
+    sets: list[frozenset[str]] = []
+    for block in out.split("\x00"):
+        paths = {line.strip() for line in block.splitlines()[1:] if line.strip()}
+        if paths:
+            sets.append(frozenset(paths))
+    return sets
+
+
+def ahead_behind(repo_path: str, base: str, head: str) -> tuple[int, int]:
+    """``(ahead, behind)``: commits only on ``head``, then only on ``base``."""
+    parts = _read(repo_path, ["rev-list", "--left-right", "--count", f"{base}...{head}"]).split()
+    if len(parts) != 2:
+        return (0, 0)
+    try:
+        # git prints left (only in base) first, the caller wants head first.
+        behind, ahead = int(parts[0]), int(parts[1])
+    except ValueError:
+        return (0, 0)
+    return (ahead, behind)

--- a/packages/core/src/repowise/core/persistence/batches.py
+++ b/packages/core/src/repowise/core/persistence/batches.py
@@ -1,0 +1,18 @@
+"""Fixed-size pieces for the ``IN`` lists a batched read is built from."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator, Sequence
+from typing import TypeVar
+
+# SQLite caps bound parameters per statement, so every ``IN`` list is issued in
+# fixed-size pieces rather than one query per item.
+_IN_CLAUSE_CHUNK = 500
+
+T = TypeVar("T")
+
+
+def chunked(items: Sequence[T]) -> Iterator[Sequence[T]]:
+    """Slice *items* into pieces of at most ``_IN_CLAUSE_CHUNK``, in order."""
+    for start in range(0, len(items), _IN_CLAUSE_CHUNK):
+        yield items[start : start + _IN_CLAUSE_CHUNK]

--- a/packages/core/src/repowise/core/persistence/models.py
+++ b/packages/core/src/repowise/core/persistence/models.py
@@ -298,6 +298,11 @@ class GraphNode(Base):
         # Audited for the LIMIT-without-ORDER-BY hazard 0046 records — every
         # ``node_type``-filtered query in the tree that limits also orders.
         Index("ix_graph_nodes_repo_type", "repository_id", "node_type"),
+        # Nothing covered ``file_path``, so "the symbols these few files own" —
+        # what a changed-file read asks — walked the whole table instead of
+        # seeking. Additive, so ``_reconcile_schema`` creates it on existing
+        # databases at the next ``init_db``.
+        Index("ix_graph_nodes_repo_file", "repository_id", "file_path"),
     )
 
 

--- a/tests/unit/analysis/test_independent_changes.py
+++ b/tests/unit/analysis/test_independent_changes.py
@@ -1,0 +1,509 @@
+"""Partitioning a diff into changes the index does not connect.
+
+Every test seeds a real wiki.db, because the whole question is what the stored
+graph and git rows say: a fake session would only assert that the fake agrees
+with itself.
+"""
+
+from __future__ import annotations
+
+import json
+
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlalchemy.pool import NullPool
+
+from repowise.core.analysis.independent_changes import independent_changes
+from repowise.core.persistence.database import init_db
+from repowise.core.persistence.models import (
+    GitMetadata,
+    GraphEdge,
+    GraphNode,
+    Repository,
+    _new_uuid,
+)
+
+_REPO_ID = "repo1"
+
+
+async def _seed(
+    tmp_path,
+    *,
+    files: list[str],
+    test_files: tuple[str, ...] = (),
+    symbols: tuple[tuple[str, str], ...] = (),
+    edges: tuple[tuple[str, str, str], ...] = (),
+    co_change: dict[str, list[tuple[str, float]]] | None = None,
+):
+    """A session factory over a wiki.db holding the given nodes, edges and history."""
+    db_path = tmp_path / "wiki.db"
+    # NullPool so each session closes its connection inside the running loop:
+    # a pooled one is finalised after the loop is gone and warns on the way out.
+    engine = create_async_engine(f"sqlite+aiosqlite:///{db_path.as_posix()}", poolclass=NullPool)
+    await init_db(engine)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    async with factory() as session:
+        session.add(Repository(id=_REPO_ID, name="repo", local_path=str(tmp_path)))
+        for path in [*files, *test_files]:
+            session.add(
+                GraphNode(
+                    id=_new_uuid(),
+                    repository_id=_REPO_ID,
+                    node_id=path,
+                    node_type="file",
+                    is_test=path in test_files,
+                )
+            )
+        for symbol_id, owner in symbols:
+            session.add(
+                GraphNode(
+                    id=_new_uuid(),
+                    repository_id=_REPO_ID,
+                    node_id=symbol_id,
+                    node_type="symbol",
+                    file_path=owner,
+                )
+            )
+        for source, target, edge_type in edges:
+            session.add(
+                GraphEdge(
+                    id=_new_uuid(),
+                    repository_id=_REPO_ID,
+                    source_node_id=source,
+                    target_node_id=target,
+                    edge_type=edge_type,
+                )
+            )
+        for path, partners in (co_change or {}).items():
+            session.add(
+                GitMetadata(
+                    id=_new_uuid(),
+                    repository_id=_REPO_ID,
+                    file_path=path,
+                    co_change_partners_json=json.dumps(
+                        [
+                            {"file_path": partner, "co_change_count": weight, "frequency": 4}
+                            for partner, weight in partners
+                        ]
+                    ),
+                )
+            )
+        await session.commit()
+    return factory
+
+
+async def test_two_groups_with_nothing_between_them(tmp_path):
+    """The headline case: one diff, two changes, biggest first."""
+    factory = await _seed(
+        tmp_path,
+        files=["a.py", "b.py", "c.py", "x.py", "y.py"],
+        edges=(
+            ("a.py", "b.py", "imports"),
+            ("b.py", "c.py", "imports"),
+            ("x.py", "y.py", "imports"),
+        ),
+    )
+    async with factory() as session:
+        result = await independent_changes(
+            session, _REPO_ID, ["a.py", "b.py", "c.py", "x.py", "y.py"]
+        )
+
+    assert result is not None
+    assert [g.files for g in result.groups] == [("a.py", "b.py", "c.py"), ("x.py", "y.py")]
+    assert result.ungrouped_files == ()
+
+
+async def test_a_call_between_symbols_merges_their_files(tmp_path):
+    """Edges are stored symbol to symbol; the grouping is over files."""
+    factory = await _seed(
+        tmp_path,
+        files=["a.py", "b.py", "x.py", "other.py"],
+        symbols=(("a.py::run", "a.py"), ("b.py::helper", "b.py")),
+        edges=(("a.py::run", "b.py::helper", "calls"), ("x.py", "other.py", "imports")),
+    )
+    async with factory() as session:
+        result = await independent_changes(session, _REPO_ID, ["a.py", "b.py", "x.py"])
+
+    assert result is not None
+    assert [g.files for g in result.groups] == [("a.py", "b.py"), ("x.py",)]
+
+
+async def test_a_co_change_pair_merges_files_with_no_graph_edge(tmp_path):
+    """History links files no import does: templates, configs, generated pairs."""
+    factory = await _seed(
+        tmp_path,
+        files=["a.py", "b.py", "x.py"],
+        co_change={"a.py": [("b.py", 4.0)], "x.py": [("other.py", 2.0)]},
+    )
+    async with factory() as session:
+        result = await independent_changes(session, _REPO_ID, ["a.py", "b.py", "x.py"])
+
+    assert result is not None
+    assert [g.files for g in result.groups] == [("a.py", "b.py"), ("x.py",)]
+
+
+async def test_containment_edges_link_nothing(tmp_path):
+    """A file defining its own symbol is not a link between two changes."""
+    factory = await _seed(
+        tmp_path,
+        files=["a.py", "b.py", "other.py"],
+        symbols=(("a.py::run", "a.py"), ("b.py::helper", "b.py")),
+        edges=(
+            ("a.py", "a.py::run", "defines"),
+            ("b.py", "b.py::helper", "defines"),
+            ("a.py", "other.py", "imports"),
+            ("b.py", "other.py", "imports"),
+        ),
+    )
+    async with factory() as session:
+        result = await independent_changes(session, _REPO_ID, ["a.py", "b.py"])
+
+    assert result is not None
+    assert [g.files for g in result.groups] == [("a.py",), ("b.py",)]
+
+
+async def test_a_file_with_no_node_is_reported_and_never_grouped(tmp_path):
+    factory = await _seed(
+        tmp_path,
+        files=["a.py", "b.py", "other.py"],
+        edges=(("a.py", "other.py", "imports"), ("b.py", "other.py", "imports")),
+    )
+    async with factory() as session:
+        result = await independent_changes(session, _REPO_ID, ["a.py", "b.py", "README.md"])
+
+    assert result is not None
+    assert result.ungrouped_files == ("README.md",)
+    assert all("README.md" not in g.files for g in result.groups)
+
+
+async def test_one_group_says_nothing(tmp_path):
+    factory = await _seed(
+        tmp_path,
+        files=["a.py", "b.py"],
+        edges=(("a.py", "b.py", "imports"),),
+    )
+    async with factory() as session:
+        assert await independent_changes(session, _REPO_ID, ["a.py", "b.py"]) is None
+
+
+async def test_fewer_than_two_indexed_files_says_nothing(tmp_path):
+    factory = await _seed(tmp_path, files=["a.py"])
+    async with factory() as session:
+        assert await independent_changes(session, _REPO_ID, ["a.py", "README.md"]) is None
+        assert await independent_changes(session, _REPO_ID, ["a.py"]) is None
+
+
+async def test_an_edge_leaving_the_diff_does_not_count(tmp_path):
+    """``other.py`` is indexed but unchanged, so it cannot join two groups."""
+    factory = await _seed(
+        tmp_path,
+        files=["a.py", "b.py", "other.py"],
+        edges=(("a.py", "other.py", "imports"), ("b.py", "other.py", "imports")),
+    )
+    async with factory() as session:
+        result = await independent_changes(session, _REPO_ID, ["a.py", "b.py"])
+
+    assert result is not None
+    assert [g.files for g in result.groups] == [("a.py",), ("b.py",)]
+
+
+async def test_bridging_files_name_the_file_holding_a_group_together(tmp_path):
+    """a - b - c: take b out and the group splits. A pair has no such file."""
+    factory = await _seed(
+        tmp_path,
+        files=["a.py", "b.py", "c.py", "x.py", "y.py"],
+        edges=(
+            ("a.py", "b.py", "imports"),
+            ("b.py", "c.py", "imports"),
+            ("x.py", "y.py", "imports"),
+        ),
+    )
+    async with factory() as session:
+        result = await independent_changes(
+            session, _REPO_ID, ["a.py", "b.py", "c.py", "x.py", "y.py"]
+        )
+
+    assert result is not None
+    chain, pair = result.groups
+    assert chain.bridging_files == ("b.py",)
+    assert pair.bridging_files == ()
+
+
+async def test_to_dict_keys_and_summary(tmp_path):
+    factory = await _seed(
+        tmp_path,
+        files=["a.py", "b.py", "c.py", "d.py", "e.py", "x.py", "y.py"],
+        edges=(
+            ("a.py", "b.py", "imports"),
+            ("b.py", "c.py", "imports"),
+            ("c.py", "d.py", "imports"),
+            ("d.py", "e.py", "imports"),
+            ("x.py", "y.py", "imports"),
+        ),
+    )
+    async with factory() as session:
+        result = await independent_changes(
+            session,
+            _REPO_ID,
+            ["a.py", "b.py", "c.py", "d.py", "e.py", "x.py", "y.py", "notes.txt"],
+        )
+
+    assert result is not None
+    payload = result.to_dict()
+    assert set(payload) == {"count", "groups", "ungrouped_files", "basis", "summary"}
+    assert set(payload["groups"][0]) == {"files", "bridging_files"}
+    assert payload["count"] == 2
+    assert payload["ungrouped_files"] == ["notes.txt"]
+    assert result.commits_known is False
+    assert payload["basis"] == (
+        "no import, call, type reference or co-change pair in the index links "
+        "one group to another"
+    )
+    assert payload["summary"] == (
+        "This diff is 2 independent changes: 5 files and 2 files. "
+        "1 changed file is left out of the grouping: docs, config, tests, "
+        "files not in the index, or files it has never linked."
+    )
+
+
+async def test_the_basis_names_shared_commits_once_they_were_checked(tmp_path):
+    """The basis states what was looked at, so it changes when the commits are."""
+    factory = await _seed(
+        tmp_path,
+        files=["a.py", "b.py", "x.py", "y.py"],
+        edges=(("a.py", "b.py", "imports"), ("x.py", "y.py", "imports")),
+    )
+    async with factory() as session:
+        result = await independent_changes(
+            session,
+            _REPO_ID,
+            ["a.py", "b.py", "x.py", "y.py"],
+            commit_sets=[["a.py", "b.py"]],
+        )
+
+    assert result is not None
+    assert result.commits_known is True
+    payload = result.to_dict()
+    assert set(payload) == {"count", "groups", "ungrouped_files", "basis", "summary"}
+    assert payload["basis"] == (
+        "no import, call, type reference, co-change pair or shared commit in the "
+        "index and this range links one group to another"
+    )
+
+
+async def test_the_same_diff_gives_the_same_answer_twice(tmp_path):
+    factory = await _seed(
+        tmp_path,
+        files=["a.py", "b.py", "c.py", "x.py", "y.py", "z.py"],
+        symbols=(("x.py::run", "x.py"),),
+        edges=(
+            ("a.py", "b.py", "imports"),
+            ("b.py", "c.py", "imports"),
+            ("x.py::run", "y.py", "calls"),
+        ),
+        co_change={"y.py": [("z.py", 3.0)]},
+    )
+    paths = ["a.py", "b.py", "c.py", "x.py", "y.py", "z.py"]
+    async with factory() as session:
+        first = await independent_changes(session, _REPO_ID, paths)
+        second = await independent_changes(session, _REPO_ID, list(reversed(paths)))
+
+    assert first is not None and second is not None
+    assert first.to_dict() == second.to_dict()
+    assert [g.files for g in first.groups] == [("a.py", "b.py", "c.py"), ("x.py", "y.py", "z.py")]
+
+
+async def test_a_page_no_resolver_can_link_is_not_a_second_change(tmp_path):
+    """A lone markdown page beside one code change is not two changes."""
+    factory = await _seed(
+        tmp_path,
+        files=["a.py", "b.py", "docs/guide.md"],
+        edges=(("a.py", "b.py", "imports"),),
+    )
+    async with factory() as session:
+        result = await independent_changes(session, _REPO_ID, ["a.py", "b.py", "docs/guide.md"])
+
+    assert result is None
+
+
+async def test_a_co_changed_page_is_still_left_out(tmp_path):
+    """A page co-changes with whatever shipped beside it, which is not a link."""
+    factory = await _seed(
+        tmp_path,
+        files=["a.py", "b.py", "x.py", "other.py", "docs/guide.md"],
+        edges=(("a.py", "b.py", "imports"), ("x.py", "other.py", "imports")),
+        co_change={"a.py": [("docs/guide.md", 5.0)]},
+    )
+    async with factory() as session:
+        result = await independent_changes(
+            session, _REPO_ID, ["a.py", "b.py", "x.py", "docs/guide.md"]
+        )
+
+    assert result is not None
+    assert [g.files for g in result.groups] == [("a.py", "b.py"), ("x.py",)]
+    assert result.ungrouped_files == ("docs/guide.md",)
+
+
+async def test_a_manifest_alone_is_reported_rather_than_grouped(tmp_path):
+    factory = await _seed(
+        tmp_path,
+        files=["a.py", "b.py", "x.py", "y.py", "pyproject.toml"],
+        edges=(("a.py", "b.py", "imports"), ("x.py", "y.py", "imports")),
+    )
+    async with factory() as session:
+        result = await independent_changes(
+            session, _REPO_ID, ["a.py", "b.py", "x.py", "y.py", "pyproject.toml"]
+        )
+
+    assert result is not None
+    assert result.to_dict()["count"] == 2
+    assert result.ungrouped_files == ("pyproject.toml",)
+    assert all("pyproject.toml" not in g.files for g in result.groups)
+
+
+async def test_a_lone_test_file_is_not_a_second_change(tmp_path):
+    """No index sees the tie from a test to the code it exercises.
+
+    The test file carries a real import edge here, so it is its test-ness alone
+    that keeps it out of a group.
+    """
+    factory = await _seed(
+        tmp_path,
+        files=["a.py", "b.py", "other.py"],
+        test_files=("tests/test_a.py",),
+        edges=(("a.py", "b.py", "imports"), ("tests/test_a.py", "other.py", "imports")),
+    )
+    async with factory() as session:
+        result = await independent_changes(session, _REPO_ID, ["a.py", "b.py", "tests/test_a.py"])
+
+    assert result is None
+
+
+async def test_a_file_whose_only_edge_leaves_the_repository_is_not_a_change(tmp_path):
+    """An import of a third-party package links this file to nothing here."""
+    factory = await _seed(
+        tmp_path,
+        files=["a.py", "b.py", "c.py"],
+        edges=(("a.py", "b.py", "imports"), ("c.py", "external:requests", "imports")),
+    )
+    async with factory() as session:
+        result = await independent_changes(session, _REPO_ID, ["a.py", "b.py", "c.py"])
+
+    assert result is None
+
+
+async def test_a_test_file_neither_joins_a_group_nor_merges_two(tmp_path):
+    """An integration test imports both sides; that is not one change."""
+    factory = await _seed(
+        tmp_path,
+        files=["a.py", "b.py", "x.py", "y.py"],
+        test_files=("tests/test_all.py",),
+        edges=(
+            ("a.py", "b.py", "imports"),
+            ("x.py", "y.py", "imports"),
+            ("tests/test_all.py", "a.py", "imports"),
+            ("tests/test_all.py", "x.py", "imports"),
+        ),
+    )
+    async with factory() as session:
+        result = await independent_changes(
+            session, _REPO_ID, ["a.py", "b.py", "x.py", "y.py", "tests/test_all.py"]
+        )
+
+    assert result is not None
+    assert [g.files for g in result.groups] == [("a.py", "b.py"), ("x.py", "y.py")]
+    assert result.ungrouped_files == ("tests/test_all.py",)
+
+
+async def test_a_commit_set_covering_the_whole_diff_adds_nothing(tmp_path):
+    """A range of one commit restates the diff, which is evidence about nothing."""
+    factory = await _seed(
+        tmp_path,
+        files=["a.py", "b.py", "x.py", "y.py"],
+        edges=(("a.py", "b.py", "imports"), ("x.py", "y.py", "imports")),
+    )
+    async with factory() as session:
+        result = await independent_changes(
+            session,
+            _REPO_ID,
+            ["a.py", "b.py", "x.py", "y.py"],
+            commit_sets=[["a.py", "b.py", "x.py", "y.py"]],
+        )
+
+    assert result is not None
+    assert [g.files for g in result.groups] == [("a.py", "b.py"), ("x.py", "y.py")]
+
+
+async def test_one_shared_commit_groups_files_the_index_never_linked(tmp_path):
+    """The author put them in one commit, which outranks a missing edge."""
+    factory = await _seed(
+        tmp_path,
+        files=["a.py", "b.py", "x.py", "y.py"],
+        edges=(("x.py", "y.py", "imports"),),
+    )
+    async with factory() as session:
+        result = await independent_changes(
+            session,
+            _REPO_ID,
+            ["a.py", "b.py", "x.py", "y.py"],
+            commit_sets=[["a.py", "b.py"]],
+        )
+
+    assert result is not None
+    assert [g.files for g in result.groups] == [("a.py", "b.py"), ("x.py", "y.py")]
+
+
+async def test_a_commit_set_naming_files_outside_the_grouping_adds_nothing(tmp_path):
+    """A commit that also touched a page or a file this range never changed."""
+    factory = await _seed(
+        tmp_path,
+        files=["a.py", "b.py", "x.py", "y.py", "docs/guide.md"],
+        edges=(("a.py", "b.py", "imports"), ("x.py", "y.py", "imports")),
+    )
+    async with factory() as session:
+        result = await independent_changes(
+            session,
+            _REPO_ID,
+            ["a.py", "b.py", "x.py", "y.py", "docs/guide.md"],
+            commit_sets=[["a.py", "unrelated.py"], ["x.py", "docs/guide.md"]],
+        )
+
+    assert result is not None
+    assert [g.files for g in result.groups] == [("a.py", "b.py"), ("x.py", "y.py")]
+    assert result.ungrouped_files == ("docs/guide.md",)
+
+
+async def test_a_shared_file_is_the_bridge_between_two_commits(tmp_path):
+    """Two commits meeting on one file make one group that file holds together."""
+    factory = await _seed(
+        tmp_path,
+        files=["a.py", "shared.py", "b.py", "x.py", "y.py"],
+        edges=(("x.py", "y.py", "imports"),),
+    )
+    async with factory() as session:
+        result = await independent_changes(
+            session,
+            _REPO_ID,
+            ["a.py", "shared.py", "b.py", "x.py", "y.py"],
+            commit_sets=[["a.py", "shared.py"], ["shared.py", "b.py"]],
+        )
+
+    assert result is not None
+    joined, pair = result.groups
+    assert joined.files == ("a.py", "b.py", "shared.py")
+    assert joined.bridging_files == ("shared.py",)
+    assert pair.files == ("x.py", "y.py")
+
+
+async def test_an_inbound_link_from_outside_the_diff_still_counts(tmp_path):
+    """``c.py`` has edges, they just point the other way, so it is a real change."""
+    factory = await _seed(
+        tmp_path,
+        files=["a.py", "b.py", "c.py", "other.py"],
+        edges=(("a.py", "b.py", "imports"), ("other.py", "c.py", "imports")),
+    )
+    async with factory() as session:
+        result = await independent_changes(session, _REPO_ID, ["a.py", "b.py", "c.py"])
+
+    assert result is not None
+    assert [g.files for g in result.groups] == [("a.py", "b.py"), ("c.py",)]
+    assert result.ungrouped_files == ()

--- a/tests/unit/cli/test_risk_independent_changes.py
+++ b/tests/unit/cli/test_risk_independent_changes.py
@@ -1,0 +1,221 @@
+"""``repowise risk REVSPEC`` reporting how a diff splits into separate changes."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from repowise.cli.commands.risk_cmd import risk_command
+from repowise.core.persistence.database import init_db
+from repowise.core.persistence.models import GraphEdge, GraphNode, Repository, _new_uuid
+
+#: The last one is a markdown page: a node the graph never links, so it is
+#: reported beside the groups rather than grouped alone.
+_FILES = ("a.py", "b.py", "x.py", "y.py", "notes.md")
+
+
+@pytest.fixture(autouse=True)
+def _repo_local_db(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The command must open ``<repo>/.repowise/wiki.db``, not an inherited URL."""
+    monkeypatch.delenv("REPOWISE_DB_URL", raising=False)
+    monkeypatch.delenv("REPOWISE_DATABASE_URL", raising=False)
+
+
+def _git(args: list[str], cwd: Path) -> None:
+    subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True, text=True)
+
+
+def _repo_with_one_commit(tmp_path: Path, name: str, files: tuple[str, ...] = _FILES) -> Path:
+    repo = tmp_path / name
+    repo.mkdir()
+    _git(["init", "-q"], repo)
+    (repo / "README.md").write_text("# seed\n", encoding="utf-8")
+    _git(["add", "README.md"], repo)
+    _git(["-c", "user.name=Dev", "-c", "user.email=dev@example.com", "commit", "-m", "seed"], repo)
+    for relative_path in files:
+        (repo / relative_path).write_text("value = 1\n", encoding="utf-8")
+        _git(["add", relative_path], repo)
+    _git(["-c", "user.name=Dev", "-c", "user.email=dev@example.com", "commit", "-m", "work"], repo)
+    return repo
+
+
+async def _write_index(
+    repo: Path, edges: tuple[tuple[str, str], ...], files: tuple[str, ...] = _FILES
+) -> None:
+    """Seed the repo-local store with a file node each and the given import edges."""
+    db_path = repo / ".repowise" / "wiki.db"
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    engine = create_async_engine(f"sqlite+aiosqlite:///{db_path.as_posix()}")
+    await init_db(engine)
+    async with async_sessionmaker(engine, expire_on_commit=False)() as session:
+        session.add(Repository(id="repo1", name="repo", local_path=str(repo.resolve())))
+        for relative_path in files:
+            session.add(
+                GraphNode(
+                    id=_new_uuid(),
+                    repository_id="repo1",
+                    node_id=relative_path,
+                    node_type="file",
+                )
+            )
+        for source, target in edges:
+            session.add(
+                GraphEdge(
+                    id=_new_uuid(),
+                    repository_id="repo1",
+                    source_node_id=source,
+                    target_node_id=target,
+                    edge_type="imports",
+                )
+            )
+        await session.commit()
+    await engine.dispose()
+
+
+def _run(repo: Path, fmt: str, revspec: str = "HEAD", path: Path | None = None):
+    return CliRunner().invoke(
+        risk_command,
+        [revspec, "--path", str(path or repo), "--baseline", "0", "--format", fmt],
+    )
+
+
+def test_two_unconnected_groups_are_named_in_the_table(tmp_path: Path) -> None:
+    repo = _repo_with_one_commit(tmp_path, "split")
+    asyncio.run(_write_index(repo, (("a.py", "b.py"), ("x.py", "y.py"))))
+
+    result = _run(repo, "table")
+
+    assert result.exit_code == 0, result.output
+    assert "This diff is 2 independent changes" in result.output
+    assert "1. 2 files: a.py, b.py" in result.output
+    assert "2. 2 files: x.py, y.py" in result.output
+    assert "Left out of the grouping: notes.md" in result.output
+    assert "Basis:" in result.output
+
+
+def test_json_carries_the_same_split(tmp_path: Path) -> None:
+    repo = _repo_with_one_commit(tmp_path, "split-json")
+    asyncio.run(_write_index(repo, (("a.py", "b.py"), ("x.py", "y.py"))))
+
+    result = _run(repo, "json")
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    block = payload["independent_changes"]
+    assert block["count"] == 2
+    assert [group["files"] for group in block["groups"]] == [["a.py", "b.py"], ["x.py", "y.py"]]
+    assert block["ungrouped_files"] == ["notes.md"]
+
+
+def test_a_connected_diff_prints_nothing_extra(tmp_path: Path) -> None:
+    repo = _repo_with_one_commit(tmp_path, "connected")
+    asyncio.run(_write_index(repo, (("a.py", "b.py"), ("b.py", "x.py"), ("x.py", "y.py"))))
+
+    result = _run(repo, "table")
+
+    assert result.exit_code == 0, result.output
+    assert "independent changes" not in result.output
+
+
+def test_an_unindexed_repo_is_scored_without_the_section(tmp_path: Path) -> None:
+    repo = _repo_with_one_commit(tmp_path, "bare")
+
+    table = _run(repo, "table")
+    assert table.exit_code == 0, table.output
+    assert "independent changes" not in table.output
+
+    machine = _run(repo, "json")
+    assert machine.exit_code == 0, machine.output
+    assert "independent_changes" not in json.loads(machine.output)
+
+
+def test_a_long_ungrouped_list_is_cut(tmp_path: Path) -> None:
+    pages = tuple(f"d{index:02d}.md" for index in range(12))
+    repo = _repo_with_one_commit(tmp_path, "many-pages", ("a.py", "b.py", "x.py", "y.py", *pages))
+    asyncio.run(
+        _write_index(
+            repo, (("a.py", "b.py"), ("x.py", "y.py")), ("a.py", "b.py", "x.py", "y.py", *pages)
+        )
+    )
+
+    result = _run(repo, "table")
+
+    assert result.exit_code == 0, result.output
+    line = next(t for t in result.output.splitlines() if t.startswith("  Left out of the grouping"))
+    assert line.endswith("and 2 more")
+
+
+_RANGE_FILES = ("a.py", "b.py", "x.py", "y.py")
+_RANGE_EDGES = (("a.py", "b.py"), ("x.py", "y.py"))
+
+
+def _commit(repo: Path, paths: tuple[str, ...], message: str) -> None:
+    for relative_path in paths:
+        (repo / relative_path).write_text(f"value = 1  # {message}\n", encoding="utf-8")
+        _git(["add", relative_path], repo)
+    _git(["-c", "user.name=Dev", "-c", "user.email=dev@example.com", "commit", "-m", message], repo)
+
+
+def _repo_with_two_changes(tmp_path: Path, name: str, *, shared: bool) -> Path:
+    """Three commits: a seed, then two changes the index links to nothing shared."""
+    repo = tmp_path / name
+    repo.mkdir()
+    _git(["init", "-q"], repo)
+    (repo / "README.md").write_text("# seed\n", encoding="utf-8")
+    _git(["add", "README.md"], repo)
+    _git(["-c", "user.name=Dev", "-c", "user.email=dev@example.com", "commit", "-m", "seed"], repo)
+    _commit(repo, ("a.py", "b.py"), "first")
+    _commit(repo, ("x.py", "y.py", *(("a.py",) if shared else ())), "second")
+    return repo
+
+
+def test_a_commit_touching_both_sides_makes_them_one_change(tmp_path: Path) -> None:
+    joined = _repo_with_two_changes(tmp_path, "joined", shared=True)
+    asyncio.run(_write_index(joined, _RANGE_EDGES, _RANGE_FILES))
+    split = _repo_with_two_changes(tmp_path, "split-range", shared=False)
+    asyncio.run(_write_index(split, _RANGE_EDGES, _RANGE_FILES))
+
+    together = _run(joined, "table", "HEAD~2..HEAD")
+    apart = _run(split, "table", "HEAD~2..HEAD")
+
+    assert together.exit_code == 0, together.output
+    assert "independent changes" not in together.output
+    assert apart.exit_code == 0, apart.output
+    assert "This diff is 2 independent changes" in apart.output
+
+
+def test_a_subdirectory_path_still_reports_the_split(tmp_path: Path) -> None:
+    repo = _repo_with_one_commit(tmp_path, "from-subdir")
+    asyncio.run(_write_index(repo, _RANGE_EDGES))
+    package = repo / "pkg"
+    package.mkdir()
+
+    result = _run(repo, "table", path=package)
+
+    assert result.exit_code == 0, result.output
+    assert "This diff is 2 independent changes" in result.output
+
+
+def test_an_index_the_query_cannot_read_drops_the_section(tmp_path, monkeypatch) -> None:
+    """An index written by an older version can fail the query, not the command."""
+    from sqlalchemy.exc import SQLAlchemyError
+
+    from repowise.core.analysis import independent_changes as module
+
+    repo = _repo_with_one_commit(tmp_path, "old-schema")
+    asyncio.run(_write_index(repo, _RANGE_EDGES))
+
+    async def _fail(*args, **kwargs):
+        raise SQLAlchemyError("old schema")
+
+    monkeypatch.setattr(module, "independent_changes", _fail)
+    result = _run(repo, "table")
+
+    assert result.exit_code == 0, result.output
+    assert "independent changes" not in result.output

--- a/tests/unit/cli/test_search_collapse.py
+++ b/tests/unit/cli/test_search_collapse.py
@@ -818,6 +818,7 @@ class _FakeFeatures:
     entropy = 0.5
     exp = 40
     is_fix = False
+    file_churn = ()
 
 
 class _FakeChangeResult:

--- a/tests/unit/persistence/test_graph_nodes_type_index.py
+++ b/tests/unit/persistence/test_graph_nodes_type_index.py
@@ -12,6 +12,10 @@ model half, which is what ``init_db`` builds from.
 
 Also covers the ``paths=`` scoping ``get_test_file_paths`` grew for it, since
 that read is the reason the index was measured in the first place.
+
+``ix_graph_nodes_repo_file`` is pinned here for the same reason: nothing
+covered ``file_path``, so reading the symbols a few named files own walked the
+table rather than seeking.
 """
 
 from __future__ import annotations
@@ -23,12 +27,35 @@ from repowise.core.persistence.models import GraphNode
 from tests.unit.persistence.helpers import insert_repo
 
 _INDEX_NAME = "ix_graph_nodes_repo_type"
+_FILE_INDEX_NAME = "ix_graph_nodes_repo_file"
 
 
 def test_index_is_declared_on_the_model() -> None:
     by_name = {ix.name: ix for ix in GraphNode.__table__.indexes}
     assert _INDEX_NAME in by_name, "init_db-created stores would lack the index"
     assert [c.name for c in by_name[_INDEX_NAME].columns] == ["repository_id", "node_type"]
+
+
+def test_file_path_index_is_declared_on_the_model() -> None:
+    by_name = {ix.name: ix for ix in GraphNode.__table__.indexes}
+    assert _FILE_INDEX_NAME in by_name, "init_db-created stores would lack the index"
+    assert [c.name for c in by_name[_FILE_INDEX_NAME].columns] == ["repository_id", "file_path"]
+
+
+async def test_the_symbols_a_file_owns_are_seeked_instead_of_scanned(async_session) -> None:
+    """"The symbols these few files own" is what a changed-file read asks."""
+    plan = (
+        await async_session.execute(
+            text(
+                "EXPLAIN QUERY PLAN SELECT node_id FROM graph_nodes "
+                "WHERE repository_id = :r AND file_path IN ('a.py', 'b.py')"
+            ),
+            {"r": "repo"},
+        )
+    ).all()
+
+    detail = " ".join(str(row[-1]) for row in plan)
+    assert _FILE_INDEX_NAME in detail, f"expected a seek on {_FILE_INDEX_NAME}, got: {detail}"
 
 
 async def test_a_file_node_read_seeks_instead_of_scanning(async_session) -> None:

--- a/tests/unit/test_git_refs.py
+++ b/tests/unit/test_git_refs.py
@@ -1,0 +1,195 @@
+"""Read-only git ref queries, against a real repository built under tmp_path."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from repowise.core.git_refs import (
+    BranchRef,
+    ahead_behind,
+    changed_files,
+    commit_file_sets,
+    current_branch,
+    default_base,
+    list_branches,
+    resolve,
+)
+
+
+def _run(repo: Path, *args: str) -> str:
+    proc = subprocess.run(
+        ["git", *args],
+        cwd=str(repo),
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        stdin=subprocess.DEVNULL,
+        check=True,
+    )
+    return proc.stdout
+
+
+def _commit(repo: Path, name: str, body: str, message: str) -> None:
+    (repo / name).write_text(body, encoding="utf-8")
+    _run(repo, "add", name)
+    _run(repo, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-m", message)
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    """main with two commits, a feat branch forked after the first, remote refs."""
+    root = tmp_path / "repo"
+    root.mkdir()
+    _run(root, "init", "-b", "main")
+    _commit(root, "base.txt", "base\n", "base")
+
+    _run(root, "checkout", "-b", "feat")
+    _commit(root, "feat_one.txt", "one\n", "feat one")
+    _commit(root, "feat_two.txt", "two\n", "feat two")
+
+    _run(root, "checkout", "main")
+    # A commit on main after the fork: three-dot diffs must not attribute it
+    # to feat, and it makes feat one commit behind.
+    _commit(root, "main_only.txt", "later\n", "main moves on")
+
+    _run(root, "checkout", "-b", "other")
+    _commit(root, "feat_one.txt", "other edit\n", "other touches a feat file")
+    _run(root, "checkout", "main")
+
+    _run(root, "update-ref", "refs/remotes/origin/main", "main")
+    _run(root, "update-ref", "refs/remotes/origin/feat", "refs/heads/feat")
+    _run(root, "symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/main")
+    return root
+
+
+class TestListBranches:
+    def test_lists_local_and_remote_tips_newest_first(self, repo: Path) -> None:
+        refs = list_branches(str(repo))
+        names = [ref.name for ref in refs]
+        assert set(names) == {"main", "feat", "other", "origin/main", "origin/feat"}
+        dates = [ref.committed_at for ref in refs]
+        assert dates == sorted(dates, reverse=True)
+        assert all(isinstance(ref, BranchRef) for ref in refs)
+
+    def test_symbolic_remote_head_is_skipped(self, repo: Path) -> None:
+        assert "origin/HEAD" not in {ref.name for ref in list_branches(str(repo))}
+
+    def test_is_remote_separates_tracking_refs(self, repo: Path) -> None:
+        by_name = {ref.name: ref for ref in list_branches(str(repo))}
+        assert by_name["origin/feat"].is_remote is True
+        assert by_name["feat"].is_remote is False
+        # The tracking ref was made to point at the local branch, same commit.
+        assert by_name["origin/feat"].sha == by_name["feat"].sha
+
+    def test_a_non_repository_yields_nothing(self, tmp_path: Path) -> None:
+        assert list_branches(str(tmp_path / "nowhere_at_all")) == []
+
+
+class TestCurrentBranch:
+    def test_reports_the_checked_out_branch(self, repo: Path) -> None:
+        assert current_branch(str(repo)) == "main"
+
+    def test_detached_head_is_none(self, repo: Path) -> None:
+        sha = _run(repo, "rev-parse", "HEAD").strip()
+        _run(repo, "checkout", "--detach", sha)
+        assert current_branch(str(repo)) is None
+
+    def test_a_non_repository_is_none(self, tmp_path: Path) -> None:
+        assert current_branch(str(tmp_path / "nowhere_at_all")) is None
+
+
+class TestDefaultBase:
+    def test_prefers_the_origin_head_symbolic_ref(self, repo: Path) -> None:
+        assert default_base(str(repo)) == "origin/main"
+
+    def test_falls_back_to_a_local_trunk(self, repo: Path) -> None:
+        _run(repo, "symbolic-ref", "-d", "refs/remotes/origin/HEAD")
+        assert default_base(str(repo)) == "main"
+
+    def test_falls_back_to_head_when_no_trunk_exists(self, tmp_path: Path) -> None:
+        root = tmp_path / "trunkless"
+        root.mkdir()
+        _run(root, "init", "-b", "topic")
+        _commit(root, "a.txt", "a\n", "a")
+        assert default_base(str(root)) == "HEAD"
+
+    def test_a_non_repository_is_head(self, tmp_path: Path) -> None:
+        assert default_base(str(tmp_path / "nowhere_at_all")) == "HEAD"
+
+
+class TestChangedFiles:
+    def test_three_dot_semantics_exclude_the_base_side(self, repo: Path) -> None:
+        files = changed_files(str(repo), "main", "feat")
+        assert files == ["feat_one.txt", "feat_two.txt"]
+        assert "main_only.txt" not in files
+
+    def test_the_same_revision_changes_nothing(self, repo: Path) -> None:
+        assert changed_files(str(repo), "main", "main") == []
+
+    def test_an_unknown_revision_yields_nothing(self, repo: Path) -> None:
+        assert changed_files(str(repo), "main", "no-such-branch") == []
+
+    def test_a_non_repository_yields_nothing(self, tmp_path: Path) -> None:
+        assert changed_files(str(tmp_path / "nowhere_at_all"), "main", "feat") == []
+
+
+class TestAheadBehind:
+    def test_ahead_counts_commits_only_on_the_branch(self, repo: Path) -> None:
+        assert ahead_behind(str(repo), "main", "feat") == (2, 1)
+
+    def test_the_orientation_reverses_with_the_arguments(self, repo: Path) -> None:
+        assert ahead_behind(str(repo), "feat", "main") == (1, 2)
+
+    def test_an_unknown_revision_is_zero(self, repo: Path) -> None:
+        assert ahead_behind(str(repo), "main", "no-such-branch") == (0, 0)
+
+    def test_a_non_repository_is_zero(self, tmp_path: Path) -> None:
+        assert ahead_behind(str(tmp_path / "nowhere_at_all"), "main", "feat") == (0, 0)
+
+
+class TestResolve:
+    def test_names_the_commit_a_branch_points_at(self, repo: Path) -> None:
+        assert resolve(str(repo), "feat") == _run(repo, "rev-parse", "feat").strip()
+
+    def test_an_unknown_revision_yields_nothing(self, repo: Path) -> None:
+        assert resolve(str(repo), "no-such-branch") == ""
+
+    def test_a_non_repository_yields_nothing(self, tmp_path: Path) -> None:
+        assert resolve(str(tmp_path / "nowhere_at_all"), "main") == ""
+
+
+class TestCommitFileSets:
+    def test_a_range_yields_one_set_per_commit_oldest_first(self, tmp_path: Path) -> None:
+        root = tmp_path / "ranged"
+        root.mkdir()
+        _run(root, "init", "-b", "main")
+        _commit(root, "base.txt", "base\n", "base")
+        _run(root, "checkout", "-b", "work")
+        _commit(root, "one.txt", "1\n", "one")
+        (root / "two.txt").write_text("2\n", encoding="utf-8")
+        (root / "one.txt").write_text("1b\n", encoding="utf-8")
+        _run(root, "add", "-A")
+        _run(root, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-m", "middle")
+        _commit(root, "three.txt", "3\n", "three")
+
+        assert commit_file_sets(str(root), "main..work") == [
+            frozenset({"one.txt"}),
+            frozenset({"one.txt", "two.txt"}),
+            frozenset({"three.txt"}),
+        ]
+
+    def test_the_three_dot_form_reads_as_the_same_range(self, repo: Path) -> None:
+        assert commit_file_sets(str(repo), "main...feat") == commit_file_sets(
+            str(repo), "main..feat"
+        )
+
+    def test_a_single_revision_carries_nothing(self, repo: Path) -> None:
+        assert commit_file_sets(str(repo), "HEAD") == []
+        assert commit_file_sets(str(repo), None) == []
+
+    def test_a_non_repository_yields_nothing(self, tmp_path: Path) -> None:
+        assert commit_file_sets(str(tmp_path / "nowhere_at_all"), "main..feat") == []


### PR DESCRIPTION
## What

`repowise risk <revspec>` now ends with a section that says whether the diff in front of you is one change or several. The changed files are grouped by connectivity in the index (imports, calls projected to files, type references, framework and dynamic edges) unioned with stored co-change pairs and, for a `base..head` range, membership in the same commit. Groups that share no link are reported as independent changes; `bridging_files` names the file that alone holds a group together.

Silence is the default: a diff that is one change prints nothing extra, and `--format json` carries `independent_changes` only when there is something to say.

## Precision

A wrong partition is worse than none, so a group is only claimed when the evidence supports it:

- docs, config and data (a language whose resolver emits no import edge) and test files are never grouped and never bridge two groups;
- a group has to hold a file the index has linked to something, or the range's commits have;
- a missing edge is a claim about the index, and the `basis` sentence says so.

Hand-read on 10 three- and four-commit windows of this repository and of hugo against per-commit `git show` and the graph: 10 of 10 defensible. An earlier cut without the test and commit rules scored 6 of 10; the three wrong reads were one commit torn across groups by a docs or test file, which is what the rules above close.

## Also

- `repowise.core.git_refs`: one small helper for branch and range reads (`current_branch`, `default_base`, `list_branches`, `changed_files`, `ahead_behind`, `commit_file_sets`, and friends), on the same `stdin=DEVNULL` and 60s timeout as the change-risk git wrapper.
- `repowise.core.persistence.batches.chunked` for the `IN (...)` chunking both analyses use.
- `ix_graph_nodes_repo_file`, an additive index on `graph_nodes(repository_id, file_path)`, so the symbol-to-file read seeks instead of scanning; created on existing stores by the schema reconcile.
- `repo_index_session` in the CLI helpers, one place that opens the repo-local index and degrades an absent, stale or locked store to "no section".

## Measured

Partition cost on this repository's index (47k nodes, 149k edges), 43 changed files, warm: about 50ms.
