### PR TITLE
feat(mcp): branch_overlap and independent_changes on get_change_risk

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ Full guide: **[docs/agent/DISTILL.md →](docs/agent/DISTILL.md)**
 
 ## Know what's dangerous before you merge
 
-Three deterministic signals, all computed from the graph and git history, no LLM:
+Four deterministic signals, all computed from the graph and git history, no LLM:
 
 - **Change risk.** Score any commit or `base..HEAD` range **0-10** from the shape of
   the diff, ranked against your repo's own recent commits. PR mode returns directives
@@ -213,6 +213,12 @@ Three deterministic signals, all computed from the graph and git history, no LLM
   tests reach a file and which ones a diff actually exercises, from the call graph,
   with or without a coverage report.
   ([reference →](docs/layers/TEST_INTELLIGENCE.md))
+- **Change coordination.** Which other open branches edit the files you are editing,
+  every row saying why it is listed (`same file`, or a co-change pair with the commit
+  counts behind it), and whether the diff in front of you is one change or several
+  groups the index links nothing between. Both stay quiet when there is nothing to
+  report. `repowise overlap` and `repowise risk`.
+  ([reference →](docs/layers/CHANGE_RISK.md#branch-overlap))
 
 Plus the free **[Repowise PR Bot](#the-pr-bot)**, which puts all of it on every pull
 request. Zero LLM calls.

--- a/docs/agent/MCP_TOOLS.md
+++ b/docs/agent/MCP_TOOLS.md
@@ -662,6 +662,79 @@ precision on this repo's frozen judgments, which is enough to count fixes and
 not enough to accuse one commit of causing them. The block is absent entirely
 on an index with no fix history.
 
+In workspace mode the response also holds `cross_repo`, built from the artifacts
+of the last `repowise update --workspace` rather than from a graph traversal. It
+appears when the commit touches a file that provides a contract some other repo
+consumes, or when the breaking-change report attributes a break to one of the
+changed files. `consumers[]` names each link with its `provider_file`, the
+consumer's `repo`, `file` and `contract_id`, the `contract_type` and the
+`match_type` that joined them, plus `provider_symbol_id` and `symbol_id` when the
+link is symbol-level; `consumer_repos` lists the other repos in one place.
+`breaking_changes[]` carries the `contract_id`, `type`, `kind`, `severity`,
+`detail`, `provider_file` and `impacted_repos` of each contract that changed
+incompatibly. `breaking_changes_available` says whether a detection pass ran at
+all, so an empty list reads as silence rather than as an all-clear, and
+`breaking_changes_as_of` stamps that half only. `consumers` is capped at ten and
+`breaking_changes` at five, with `consumers_truncated` and
+`breaking_changes_truncated` counting what the caps left out; the block answers
+whether this commit crosses a repo boundary, and `get_blast_radius` is the tool
+for the full traversal. It is absent outside workspace mode, without contract
+artifacts, and when the commit touches no published file.
+
+`branch_overlap` names the other open branches editing the files this change
+edits. It is git-only, so it appears whether or not the repo is indexed; an index
+only orders the shared files and adds the history rows. `base` and `current` name
+the two ends of the comparison, and each `branches[]` entry carries the branch
+name, `ahead` and `behind` commit counts, `last_commit` (the date), and `files[]`.
+Every file row states its `basis` in words, either `same file` or
+`co-change pair, N of M commits`, the second carrying the `partner` file of this
+change it pairs with and appearing only under a branch that already shares a file
+directly, at most three per branch. `scanned`, `total` and `truncated` report the
+branch scan itself, which is bounded to the newest 50 branches by committer date.
+There is no score and no percentage in the block. `branches` is capped at five and
+each entry's `files` at ten, both through the shared response budget: a capped
+list gains `<key>_total`, `<key>_emitted`, `<key>_truncated`, `<key>_omitted` and
+`<key>_reduced_reason` beside it, and the omitted rows go to the omission store,
+so on `branches_truncated` or `files_truncated` the response carries an
+`omission_marker` and `repowise expand <ref>` returns the rest. `truncated` is a
+different fact: it reports the branch scan bound, not a cap. The block is absent when the change has
+no counted files, when no other branch edits a shared file, and when the scan
+exceeds its 20-second ceiling or git cannot answer.
+
+`change_shape.independent_changes` says when the diff is several changes rather
+than one. It groups the changed files by connectivity, over index edges (imports,
+calls, type references, framework and dynamic edges), stored co-change pairs, and,
+when `revspec` is a `base..head` range, the files each commit of that range
+touched, which links them to each other. A single commit and uncommitted work
+carry no commit evidence, so only a range reads it. Only a changed file that is in
+the index, is not a test, and is written in a language whose resolver can emit an
+import edge is eligible to be grouped: docs, config and data files are never in a
+group, not even through a co-change pair, and tests never join or connect one.
+`count` is the number of groups; each `groups[]` entry lists its `files` and its
+`bridging_files`, the files that alone hold the group together, where moving one
+out would split it (named only for groups of three or more files, and most often
+the file two commits of the range share). `ungrouped_files` carries every changed
+file left out of the grouping, and `summary` names the reasons in those terms:
+docs, config, tests, files not in the index, or files it has never linked. `basis` states in words
+what was actually checked, and its sentence changes with the subject: it names a
+shared commit alongside the import, call, type reference and co-change pair when
+the commits of a range were read, and omits it when there were none to read. Under
+either wording it is a claim about this index and not about the code. There is no
+separate key saying which sentence you got; the sentence itself says it.
+`ungrouped_files` is capped at ten through the shared response budget, so a capped
+list gains `ungrouped_files_total`, `_emitted`, `_truncated`, `_omitted` and
+`_reduced_reason` beside it and the omitted names go to the omission store,
+recoverable with `repowise expand <ref>`; nothing else in the block is capped. The
+block needs an index and is absent without one, and it is absent whenever the diff
+is one change: fewer than two changed files, fewer than two of them eligible to be
+grouped, or fewer than two groups surviving. Under a response over budget it is
+the first thing shed, ahead of the rest of `change_shape`; `branch_overlap` sheds
+after `prior_fixes` and before `cross_repo`.
+
+The freshness envelope is scoped to the files this change edits, whether or not
+the repo is indexed: `branch_overlap` reads files on other branches, and that
+never widens what the response is about.
+
 **When to use:** Before merging a commit or PR range, especially when you need
 to assess the change itself rather than the risk of an already-indexed file.
 

--- a/docs/layers/CHANGE_RISK.md
+++ b/docs/layers/CHANGE_RISK.md
@@ -232,6 +232,77 @@ once and answers subsequent `get_change_risk` calls without repeating it. A new
 commit, a moved branch, or a different set of filters produces a different
 anchor or a different filter set, and so a fresh walk.
 
+## Independent changes
+
+This is a structural property of the diff, not a score: it answers whether the
+files in front of you are one change or several. The changed files are grouped by
+connectivity, and one group is separate from another only because nothing
+connected them.
+
+Not every changed file is eligible to be grouped. A file is grouped only when it
+has a file node in the index, is not a test file, and is written in a language
+whose resolver can emit an import edge at all. That rules out documentation,
+configuration and data files: a lockfile or a markdown page is a node with no
+edges, so "nothing links it" is a fact about the language rather than about this
+change. It rules out test files too, because no index records the tie from a test
+to the code it exercises, and an integration test otherwise attaches to whichever
+shared harness the diff happens to contain. Files that fail either test are never
+placed in a group, not even through a co-change pair, and they never bridge two
+groups: only eligible files are in the graph at all, and any link with one end
+outside that set is dropped before grouping.
+
+Three kinds of link connect two eligible files:
+
+- **Index edges.** Every non-containment edge whose two ends belong to two
+  different changed files: imports, calls projected to the files that own them,
+  type references, framework and dynamic edges, and reads. Edges whose ends belong
+  to the same file are dropped, which is how the containment types (`defines`,
+  `has_method`) stay out without being enumerated, and an edge to a dependency
+  outside the repository links nothing.
+- **Stored co-change pairs.** Two files history moves together are one change even
+  when nothing imports anything.
+- **Commit co-membership, for a `base..head` range only.** The files one commit
+  touched are linked to each other, so a file two commits share joins them. That
+  is the author's own statement that the files belong together, which is stronger
+  evidence than any edge, and it is what `bridging_files` most often names. A
+  single commit and the working tree carry no such evidence: one commit says
+  nothing about what moves with what, so the range's commit list is read only when
+  the subject is a range.
+
+A group also has to carry at least one file the index has in fact linked to
+something, whether through an edge, a stored co-change partner, or a shared
+commit. Elsewhere, an absent edge is not evidence, so the files fall out of the
+grouping instead.
+
+Everything not grouped is reported as `ungrouped_files` and never counted as an
+independent change, and the summary says so in those terms: *N changed file(s)
+is/are left out of the grouping: docs, config, tests, files not in the index, or files it has never
+linked.* `bridging_files` names the articulation points of a group's own subgraph,
+the files that alone hold the group together: move one out and the group splits.
+It is computed only for groups of three or more files, since removing either end
+of a pair leaves one file, which is not a split.
+
+There is no score, no percentage, and no adjective on the result. The `basis`
+field states in words what was actually checked, and it is not the same sentence
+in both cases. When the commits of a range were read, it is *no import, call, type
+reference, co-change pair or shared commit in the index and this range links one
+group to another*; when there were no commits to read, the shared commit drops out
+of the sentence and it is *no import, call, type reference or co-change pair in
+the index links one group to another*. That wording is deliberate in either form:
+a missing edge is a claim about this index, not about the code, and the sentence
+never claims a check that did not happen.
+
+The report is silent unless it has something to say. Nothing is produced when
+fewer than two changed files exist, when fewer than two of them are eligible to be
+grouped, or when fewer than two groups survive. A change that is one change gets
+no report.
+
+It surfaces in two places. `repowise risk` prints the groups under the driver
+table, naming each group's files, its bridging files, and the first ten ungrouped
+paths; `--format json` carries the same object under `independent_changes`. In
+`get_change_risk` it is `change_shape.independent_changes`, which needs an index
+and is absent without one.
+
 ## Calibration & accuracy
 
 Constants are learned offline against the defect corpus (AG-SZZ bug-inducing
@@ -354,3 +425,60 @@ current contracts against the previously-indexed set during
 `repowise update --workspace`; non-breaking changes (an added optional field, a
 new endpoint) never appear. See
 [Breaking-Change Guard](../scale/WORKSPACES.md#breaking-change-guard) for the full model.
+
+## Branch overlap
+
+Branch overlap answers one question: which other open branches edit the files
+this change edits. It is git first, so it works in a fresh clone with no index.
+
+The scan starts from one `git for-each-ref` over `refs/heads` and
+`refs/remotes`, sorted by committer date, newest first. Symbolic remote heads
+are skipped, refs sharing a tip commit collapse to one entry (the local name
+where there is one, otherwise the shortest remote name), and the base ref, the
+change's own ref, and any ref whose tip is the base's or the change's commit are
+dropped. Branches stacked on the current one, and the ones it is stacked on, are
+dropped too: either shares every file by construction, which is one change split
+over two refs rather than two changes racing. The scan is bounded to the newest
+50 branches by committer date, raised or lowered with `--limit`, and what was
+left out is reported through `scanned` and `total` rather than dropped silently.
+
+For each scanned branch the file list is `git diff --name-only base...branch`,
+which is what that branch did since it forked, not what the base did in the
+meantime. That list is intersected with the change's own changed files. Noise
+paths (workflows, lockfiles, generated and vendored files, localization blobs)
+are removed from both sides by the shared noise filter, and dependency manifests
+(`package.json`, `pyproject.toml`, `go.mod`, `Cargo.toml`, `Gemfile`,
+`composer.json`, `requirements.txt`, `setup.py`, `pom.xml`, `build.gradle`,
+`build.gradle.kts`) are removed with them, because every dependency bump edits
+the manifest and sharing one says nothing about the work. A branch with no shared
+file after that filtering produces no entry, ever.
+
+Every row states its basis in words, and there are exactly two:
+
+- **`same file`.** A direct hit: both branches change that path.
+- **`co-change pair, N of M commits`.** A secondary row, shown only beneath a
+  branch that already has a direct hit. It names a file the other branch edits
+  that is not itself a direct hit and that the index's stored co-change record
+  pairs with one of this change's files, with that file carried as `partner`. It
+  is made only when both counts are recorded and the pair moved together at least
+  half the time (`N * 2 >= M`), and at most three appear per branch, so one file
+  that pairs with everything cannot drown out the files truly shared.
+
+An entry also carries `ahead` and `behind` (commits only on the branch, then only
+on the base, from one `git rev-list --left-right --count`) and the date of its
+last commit. Branches are ordered by how many files they share directly, then by
+most recent commit, then by name; the co-change rows are appended afterwards and
+never reorder the list. There is no score and no percentage anywhere in the
+output. With an index, the shared files inside an entry are ordered by the same
+hub metric the PR blast radius uses (temporal hotspot and pagerank of the file);
+that metric orders rows and is never rendered. Without an index the git answer
+stands and the shared files are alphabetical, with no co-change rows.
+
+What it does not claim: it compares paths, not hunks, so a shared file is a
+reason to talk to the other branch's author and not a predicted merge conflict.
+The co-change rows are historical correlation, never a structural link.
+
+Silence is the default. `repowise overlap` prints one line when no other branch
+edits a shared file, naming how many branches were scanned of how many exist, and
+`get_change_risk` omits the `branch_overlap` block entirely in that case. The
+block is also omitted when the branch scan times out.

--- a/docs/reference/CLI_REFERENCE.md
+++ b/docs/reference/CLI_REFERENCE.md
@@ -2,7 +2,7 @@
 
 Complete reference for all `repowise` commands. For a guided introduction, see the [Quickstart](../start/QUICKSTART.md).
 
-Command list (in registration order): `augment`, `init`, `delete`, `generate-claude-md`, `costs`, `update`, `generate`, `dead-code`, `health`, `risk`, `decision`, `coverage`, `impacted-tests`, `search`, `ask`, `context`, `symbol`, `why`, `distill`, `expand`, `saved`, `security`, `corrections`, `export`, `hook`, `agents`, `uninstall`, `status`, `doctor`, `watch`, `serve`, `mcp`, `reindex`, `restyle`, `wiki-styles`, `whats-new`, `telemetry`, `login`, `logout`, `whoami`, `workspace`. Two more ship as separate console scripts, not subcommands: `repowise-augment`, `repowise-rewrite` (both hook entry points, not meant to be run by hand).
+Command list (in registration order): `augment`, `init`, `delete`, `generate-claude-md`, `costs`, `update`, `generate`, `dead-code`, `health`, `risk`, `overlap`, `decision`, `coverage`, `impacted-tests`, `search`, `ask`, `context`, `symbol`, `why`, `distill`, `expand`, `saved`, `security`, `corrections`, `export`, `hook`, `agents`, `uninstall`, `status`, `doctor`, `watch`, `serve`, `mcp`, `reindex`, `restyle`, `wiki-styles`, `whats-new`, `telemetry`, `login`, `logout`, `whoami`, `workspace`. Two more ship as separate console scripts, not subcommands: `repowise-augment`, `repowise-rewrite` (both hook entry points, not meant to be run by hand).
 
 **Do you need an LLM key?** Most commands are pure index/analysis and never call an LLM. `init` never requires a key: without one it renders the wiki from structure. It calls an LLM only when a provider is resolvable or `--prose` is passed. The exceptions: `update` (unless `--index-only` or `--no-docs`), `generate`, `restyle`, `watch` (when it regenerates a page), `health --generate-code`, and `workspace add --docs`. Everything else, `search`, `dead-code`, `health`, `risk`, `impacted-tests`, `decision`, `coverage`, `security`, `export`, `mcp`, `reindex`, `doctor`, and so on, works index-only, with no provider configured.
 
@@ -31,6 +31,7 @@ Grouped by what you're trying to do, not alphabetically. `PATH` and flag details
 **Health and risk**
 [`health`](#repowise-health-path) ·
 [`risk`](#repowise-risk-revspec) ·
+[`overlap`](#repowise-overlap) ·
 [`dead-code`](#repowise-dead-code-path) ·
 [`security`](#repowise-security) ·
 [`impacted-tests`](#repowise-impacted-tests-revspec) ·
@@ -779,7 +780,55 @@ repowise risk -t src/auth.py --changed-file src/auth.py  # PR mode + directive
 Note `--path` on this command already means "the git repository", which is why
 the files are named with `--target`.
 
+**Independent changes.** When the index can be read, the command also prints
+whether the diff is one change or several: the changed files grouped by what
+connects them, which is the links the index holds (imports, calls, type
+references, stored co-change pairs) plus, for a `base..head` range, the files each
+commit touched, since putting two files in one commit is the author's own
+statement that they belong together. Only indexed, non-test source files a
+resolver can link are grouped; docs, config, data and tests are always printed
+under `Left out of the grouping:`, never as a change of their own, and only the
+first ten names are listed. Each group prints its files and the files that alone
+hold it together, where moving one out would split the group. A closing `Basis:`
+line says what was checked, naming a shared commit only when there were commits to
+read. It is silent when the diff is one change, and it carries no score.
+`--format json` puts the same object under `independent_changes`. See
+[Independent changes](../layers/CHANGE_RISK.md#independent-changes).
+
 See [`docs/layers/CHANGE_RISK.md`](../layers/CHANGE_RISK.md) for the scoring model.
+
+---
+
+### `repowise overlap`
+
+Which other open branches edit the files this change edits. Pure git for the
+answer, so it works in a fresh clone with no index; when an index is readable it
+orders the shared files and adds the files history pairs with them. Every row
+states its basis in words, `same file` or `co-change pair, N of M commits`, and
+there is no score anywhere in the output.
+
+Branches stacked on the current one (and the ones it is stacked on) are skipped,
+as are noise paths and dependency manifests, which every branch touches. A branch
+that shares no file produces no row. The scan is bounded to the newest branches by
+committer date and reports how many it scanned of how many exist.
+
+**Options:**
+
+| Flag | Description |
+|------|-------------|
+| `--base` | Base ref to diff both sides against (default: the repository's trunk, from `origin/HEAD`, else `main` or `master`) |
+| `--branch` | The change to compare (default: `HEAD`) |
+| `--path` | Path to the git repository (default: current directory) |
+| `--limit` | How many branches to diff, newest committer date first (default 50) |
+| `--format` | Output format: `table` (default) or `json` |
+
+```bash
+repowise overlap                             # who else is editing what you are editing
+repowise overlap --base main --limit 100     # a wider scan against an explicit base
+```
+
+When nothing overlaps, the command prints one line saying so with the scan
+counts. See [Branch overlap](../layers/CHANGE_RISK.md#branch-overlap).
 
 ---
 

--- a/packages/server/src/repowise/server/mcp_server/_budget/contracts.py
+++ b/packages/server/src/repowise/server/mcp_server/_budget/contracts.py
@@ -69,11 +69,13 @@ _CONTRACTS: dict[str, ResponseBudgetContract] = {
             # Cheapest loss first. Diff-shape context and history go before the
             # delta and the tests, so what to do survives what the diff weighs.
             "exclude_patterns",
+            "change_shape.independent_changes",
             "change_shape",
             "fix_history.files[]",
             "fix_history.files",
             "fix_history",
             "prior_fixes",
+            "branch_overlap",
             "cross_repo",
             "impacted_tests",
             "health_delta.limits",

--- a/packages/server/src/repowise/server/mcp_server/tool_change_risk.py
+++ b/packages/server/src/repowise/server/mcp_server/tool_change_risk.py
@@ -28,7 +28,7 @@ from repowise.core.analysis.change_risk import (
 )
 from repowise.core.analysis.pr_blast import rank_tests_by_reach
 from repowise.core.registry import mcp_tool_registry as mcp
-from repowise.server.mcp_server._budget import OmissionCollector
+from repowise.server.mcp_server._budget import OmissionCollector, cap_collection
 from repowise.server.mcp_server._budget.contracts import response_budget_shed_order
 from repowise.server.mcp_server._change_health import (
     directive as _directive,
@@ -70,6 +70,20 @@ _PRIOR_FIXES_LIMIT = 10
 #: full traversal, so both lists stay short and report their own overflow.
 _CROSS_REPO_BREAKING_LIMIT = 5
 _CROSS_REPO_CONSUMER_LIMIT = 10
+
+#: Ceiling on the branch scan, bounded so a repository with hundreds of refs
+#: cannot hold the response.
+_BRANCH_OVERLAP_TIMEOUT_SECONDS = 20
+
+#: Caps on the branch-overlap block. It answers "is anyone else editing these
+#: files", not "list every branch", so both lists stay short and their tails go
+#: to the omission store.
+_BRANCH_OVERLAP_LIMIT = 5
+_BRANCH_OVERLAP_FILES_LIMIT = 10
+
+#: Cap on the files the index cannot link. The count is already in the block's
+#: summary, so the names are supporting detail and their tail is recoverable.
+_UNGROUPED_FILES_LIMIT = 10
 
 # Compatibility projection for direct callers and older tests. The shared
 # response contract remains the single source of truth for this order.
@@ -131,6 +145,10 @@ async def get_change_risk(
     ``prior_fixes`` counts past fixes overlapping this diff. ``change_shape``
     ranks the diff's size and spread against recent commits.
 
+    ``branch_overlap`` names other open branches editing the same files, each
+    row stating its basis. ``change_shape.independent_changes`` says when the
+    diff is several changes the index does not connect.
+
     Args:
         revspec: Commit or ``base..head`` range. Omit to review uncommitted
             work, or ``HEAD`` when the tree is clean.
@@ -183,19 +201,16 @@ async def get_change_risk(
     # extensions + riskignore + request excludes), so nothing downstream
     # disagrees with the score about which files the change touches. Read once
     # and shared: both blocks below need it and git is the expensive part.
-    # The test and fix blocks need the index; the cross-repo block needs only
-    # workspace contracts, so an unindexed member still gets one rather than
-    # going silently blind. Nothing else pays the git call.
-    changed: dict[str, set[int]] = {}
-    changed_error: tuple[str, str] | None = None
-    if getattr(ctx, "session_factory", None) is not None or _has_contract_data():
-        changed, changed_error = await _changed_in_scope(
-            str(ctx.path),
-            revspec,
-            normalize_extensions(tuple(extensions or ())),
-            result.riskignore_excludes + result.request_excludes,
-            working_tree=result.working_tree,
-        )
+    # The test and fix blocks need the index and the cross-repo block needs
+    # workspace contracts, but the branch-overlap block needs only git, so every
+    # call pays this read rather than an unindexed repo going blind.
+    changed, changed_error = await _changed_in_scope(
+        str(ctx.path),
+        revspec,
+        normalize_extensions(tuple(extensions or ())),
+        result.riskignore_excludes + result.request_excludes,
+        working_tree=result.working_tree,
+    )
     collector = OmissionCollector("get_change_risk", repo_root=ctx.path)
     # The delta is the expensive half and needs nothing the enrichments need,
     # so it runs alongside them rather than after.
@@ -222,6 +237,14 @@ async def get_change_risk(
         cross_repo = _cross_repo_block(alias, sorted(changed), impact, collector)
         if cross_repo is not None:
             payload["cross_repo"] = cross_repo
+        # A drill-down returns one finding and nothing else, so neither block
+        # would reach the caller; both are pure cost on that path.
+        overlap = independent = None
+        if finding_id is None:
+            overlap = await _branch_overlap_block(ctx, changed, collector)
+            if overlap is not None:
+                payload["branch_overlap"] = overlap
+            independent = await _independent_changes_block(ctx, changed, collector, revspec)
     except BaseException:
         # Never leave the comparison running for a request that is already over.
         delta_task.cancel()
@@ -231,7 +254,7 @@ async def get_change_risk(
     if finding_id is not None:
         return _drill_down(payload, delta, finding_id, revspec)
     _attach_health(payload, delta, revspec, expand="findings" in include_set)
-    payload["change_shape"] = _change_shape(payload, diagnostics)
+    payload["change_shape"] = _change_shape(payload, diagnostics, independent)
     # source: live_git marks that the *score* is computed from the working
     # checkout's git. The two blocks above are index-backed, so the freshness
     # fields do apply to them, scoped to the change's files. None (not []) when
@@ -387,10 +410,15 @@ def _attach_health(payload: dict, delta: Any, revspec: str | None, *, expand: bo
     payload.update(ordered)
 
 
-def _change_shape(payload: dict, diagnostics: dict) -> dict[str, Any]:
+def _change_shape(
+    payload: dict, diagnostics: dict, independent: dict[str, Any] | None = None
+) -> dict[str, Any]:
     """The ranked diff-shape reading, kept compact and clearly supporting."""
     shape = {f: payload[f] for f in _CHANGE_SHAPE_FIELDS if f in payload}
     shape["measures"] = "diff size and spread, not danger"
+    # How many changes this diff is belongs beside its size, not above it.
+    if independent is not None:
+        shape["independent_changes"] = independent
     if diagnostics:
         shape["diagnostics_via"] = "get_change_risk(include=['diagnostics'])"
     return shape
@@ -469,16 +497,6 @@ def _filter_changed(
             continue
         out[path] = lines
     return out
-
-
-def _has_contract_data() -> bool:
-    """Whether workspace contracts are loaded, so the cross-repo block can speak."""
-    from repowise.server.mcp_server import _state
-
-    if not _is_workspace_mode():
-        return False
-    enricher = _state._cross_repo_enricher
-    return bool(enricher is not None and getattr(enricher, "has_contract_data", False))
 
 
 def _cross_repo_block(
@@ -817,6 +835,123 @@ async def _prior_fixes_block(ctx: Any, changed: dict[str, set[int]]) -> dict[str
     concentration = _concentration(files[:_PRIOR_FIXES_LIMIT])
     if concentration is not None:
         block["concentration"] = concentration
+    return block
+
+
+async def _independent_changes_block(
+    ctx: Any,
+    changed: dict[str, set[int]],
+    collector: OmissionCollector,
+    revspec: str | None = None,
+) -> dict[str, Any] | None:
+    """The changed files split into groups nothing in the index links, or ``None``.
+
+    Silent for a single changed file and without an index: the split is a claim
+    about what the index holds, so an unindexed repo makes no claim at all.
+    """
+    from repowise.core.analysis.independent_changes import independent_changes
+    from repowise.core.git_refs import commit_file_sets
+    from repowise.core.persistence.database import get_session
+
+    session_factory = getattr(ctx, "session_factory", None)
+    if session_factory is None or len(changed) < 2:
+        return None
+    # Returns [] without a git call for anything that is not a range, so the
+    # range test lives in one place rather than here as well.
+    sets = await asyncio.to_thread(
+        commit_file_sets, str(ctx.path), _normalize_revspec(revspec)
+    )
+    try:
+        async with get_session(session_factory) as session:
+            repo_id = (await _get_repo(session)).id
+            result = await independent_changes(
+                session, repo_id, list(changed), commit_sets=sets
+            )
+    except (LookupError, SQLAlchemyError):
+        return None
+    if result is None:
+        return None
+    block = result.to_dict()
+    cap_collection(
+        block,
+        "ungrouped_files",
+        block["ungrouped_files"],
+        _UNGROUPED_FILES_LIMIT,
+        collector,
+        label=(
+            "change_shape.independent_changes.ungrouped_files "
+            f"beyond cap={_UNGROUPED_FILES_LIMIT}"
+        ),
+    )
+    return block
+
+
+def _scan_from_trunk(path: str, files: list[str]) -> Any:
+    """The base lookup and the scan, both git, in one hop off the event loop."""
+    from repowise.core.analysis.branch_overlap import scan_branches
+    from repowise.core.git_refs import default_base
+
+    return scan_branches(path, files, base=default_base(path))
+
+
+async def _scan_overlap(ctx: Any, files: list[str]) -> Any:
+    """Run the branch scan, with the index when one opens and without when it does not."""
+    from repowise.core.analysis.branch_overlap import rank_with_index
+    from repowise.core.persistence.database import get_session
+
+    path = str(ctx.path)
+    scan = await asyncio.to_thread(_scan_from_trunk, path, files)
+    session_factory = getattr(ctx, "session_factory", None)
+    if session_factory is not None:
+        try:
+            # The session opens only for the index step, never across the git work.
+            async with get_session(session_factory) as session:
+                return await rank_with_index(session, (await _get_repo(session)).id, scan)
+        except (LookupError, SQLAlchemyError):
+            pass
+    return scan.overlap
+
+
+async def _branch_overlap_block(
+    ctx: Any, changed: dict[str, set[int]], collector: OmissionCollector
+) -> dict[str, Any] | None:
+    """Other open branches editing the files this change edits, or ``None``.
+
+    Git alone answers it, so a repo without an index still gets the block; an
+    index only ranks the shared files and adds the history rows. ``None`` when
+    no other branch overlaps, because an all-clear block is noise.
+    """
+    if not changed:
+        return None
+    try:
+        overlap = await asyncio.wait_for(
+            _scan_overlap(ctx, sorted(changed)), timeout=_BRANCH_OVERLAP_TIMEOUT_SECONDS
+        )
+    except (TimeoutError, subprocess.SubprocessError, OSError):
+        return None
+
+    block = overlap.to_dict()
+    if not block["branches"]:
+        return None
+    # Branches first: an entry the cap drops goes to the store whole, and only
+    # the entries that survive can carry an index the reader can find.
+    kept = cap_collection(
+        block,
+        "branches",
+        block["branches"],
+        _BRANCH_OVERLAP_LIMIT,
+        collector,
+        label=f"branch_overlap.branches beyond cap={_BRANCH_OVERLAP_LIMIT}",
+    )
+    for i, entry in enumerate(kept):
+        cap_collection(
+            entry,
+            "files",
+            entry["files"],
+            _BRANCH_OVERLAP_FILES_LIMIT,
+            collector,
+            label=f"branch_overlap.branches[{i}].files beyond cap={_BRANCH_OVERLAP_FILES_LIMIT}",
+        )
     return block
 
 

--- a/packages/types/src/chat.ts
+++ b/packages/types/src/chat.ts
@@ -241,7 +241,17 @@ export interface RiskReportArtifactData {
   /** `get_change_risk` action-first blocks. */
   directive?: ChangeRiskDirective;
   health_delta?: ChangeHealthDeltaData;
-  change_shape?: Record<string, unknown>;
+  change_shape?: {
+    independent_changes?: {
+      count?: number;
+      summary?: string;
+      basis?: string;
+      ungrouped_files?: string[];
+      groups?: Array<{ files: string[]; bridging_files?: string[] }>;
+      [k: string]: unknown;
+    };
+    [k: string]: unknown;
+  };
   impacted_tests?: { tests_to_run?: string[]; status?: string; summary?: string };
   /** Bug-fix record of the touched files: the "historically fragile" signal. */
   fix_history?: {
@@ -249,6 +259,24 @@ export interface RiskReportArtifactData {
     files?: Array<{ path: string; churn: number; fix_pressure: number }>;
   };
   prior_fixes?: { files_with_fixes?: number; total_fixes?: number };
+  /** Other open branches editing the files this change edits. */
+  branch_overlap?: {
+    base?: string;
+    current?: string;
+    scanned?: number;
+    total?: number;
+    truncated?: boolean;
+    summary?: string;
+    branches?: Array<{
+      branch: string;
+      ahead?: number;
+      behind?: number;
+      last_commit?: string;
+      files?: Array<{ file: string; basis: string; partner?: string }>;
+      [k: string]: unknown;
+    }>;
+    [k: string]: unknown;
+  };
   [k: string]: unknown;
 }
 

--- a/tests/fixtures/mcp/tool_response_shapes.json
+++ b/tests/fixtures/mcp/tool_response_shapes.json
@@ -136,9 +136,33 @@
       "source": null,
       "timing_ms": null
     },
+    "branch_overlap": {
+      "base": null,
+      "branches": [
+        {
+          "ahead": null,
+          "behind": null,
+          "branch": null,
+          "files": [
+            {
+              "basis": null,
+              "file": null,
+              "partner": null
+            }
+          ],
+          "last_commit": null
+        }
+      ],
+      "current": null,
+      "scanned": null,
+      "summary": null,
+      "total": null,
+      "truncated": null
+    },
     "change_shape": {
       "classification": null,
       "diagnostics_via": null,
+      "independent_changes": null,
       "fallback_band": null,
       "is_fix": null,
       "measures": null,

--- a/tests/unit/server/mcp/test_branch_overlap_block.py
+++ b/tests/unit/server/mcp/test_branch_overlap_block.py
@@ -1,0 +1,323 @@
+"""get_change_risk's branch_overlap block: who else is editing these files.
+
+Git alone answers it, so the block appears without an index. It is silent when
+no other branch shares a file, every row states its basis in words, and the
+caps say by how much they cut.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+
+from repowise.server.mcp_server._budget import OmissionCollector
+from repowise.server.mcp_server.tool_change_risk import (
+    _BRANCH_OVERLAP_FILES_LIMIT,
+    _BRANCH_OVERLAP_LIMIT,
+    _SHED_ORDER,
+    _branch_overlap_block,
+)
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", "-c", "user.email=t@e.st", "-c", "user.name=T", *args],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+    )
+
+
+def _commit(repo: Path, files: dict[str, str], message: str) -> None:
+    for name, body in files.items():
+        path = repo / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(body, encoding="utf-8")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-m", message)
+
+
+def _repo(tmp_path: Path, *, others: dict[str, dict[str, str]]) -> Path:
+    """A repo on ``main`` plus one branch per entry of *others*, then back on a work branch."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-b", "main")
+    _commit(repo, {"a.py": "a\n", "b.py": "b\n", "c.py": "c\n"}, "base")
+    for branch, files in others.items():
+        _git(repo, "checkout", "-b", branch, "main")
+        _commit(repo, files, f"work on {branch}")
+    _git(repo, "checkout", "-b", "work", "main")
+    _commit(repo, {"a.py": "a mine\n"}, "our change")
+    return repo
+
+
+def _ctx(repo: Path) -> SimpleNamespace:
+    """A context with no session factory: the git-only block."""
+    return SimpleNamespace(path=str(repo))
+
+
+async def test_block_is_silent_with_nothing_changed(tmp_path):
+    repo = _repo(tmp_path, others={"other": {"a.py": "a theirs\n"}})
+    collector = OmissionCollector("t", repo_root=tmp_path)
+    assert await _branch_overlap_block(_ctx(repo), {}, collector) is None
+
+
+async def test_block_is_silent_when_no_branch_shares_a_file(tmp_path):
+    repo = _repo(tmp_path, others={"elsewhere": {"c.py": "c theirs\n"}})
+    block = await _branch_overlap_block(
+        _ctx(repo), {"a.py": {1}}, OmissionCollector("t", repo_root=tmp_path)
+    )
+    assert block is None
+
+
+async def test_block_names_only_the_overlapping_branch_and_states_its_basis(tmp_path):
+    repo = _repo(
+        tmp_path,
+        others={"overlapping": {"a.py": "a theirs\n"}, "elsewhere": {"c.py": "c theirs\n"}},
+    )
+
+    block = await _branch_overlap_block(
+        _ctx(repo), {"a.py": {1}}, OmissionCollector("t", repo_root=tmp_path)
+    )
+
+    assert block is not None
+    assert [entry["branch"] for entry in block["branches"]] == ["overlapping"]
+    entry = block["branches"][0]
+    assert [row["file"] for row in entry["files"]] == ["a.py"]
+    # Every row says in words why it is listed, and nothing carries a score.
+    assert all(row["basis"] for row in entry["files"])
+    assert all("score" not in row for row in entry["files"])
+    assert block["base"] == "main"
+    assert block["current"] == "work"
+    assert block["scanned"] >= 2
+    assert "edit files this change also edits" in block["summary"]
+
+
+async def test_branch_list_is_capped_and_says_by_how_much(tmp_path):
+    over = _BRANCH_OVERLAP_LIMIT + 2
+    repo = _repo(
+        tmp_path,
+        others={f"branch{i}": {"a.py": f"a from {i}\n"} for i in range(over)},
+    )
+
+    block = await _branch_overlap_block(
+        _ctx(repo), {"a.py": {1}}, OmissionCollector("t", repo_root=tmp_path)
+    )
+
+    assert block is not None
+    assert len(block["branches"]) == _BRANCH_OVERLAP_LIMIT
+    assert block["branches_total"] == over
+    assert block["branches_truncated"] is True
+    assert block["branches_emitted"] == _BRANCH_OVERLAP_LIMIT
+
+
+async def test_an_uncut_block_carries_no_truncation_fields(tmp_path):
+    repo = _repo(tmp_path, others={"overlapping": {"a.py": "a theirs\n"}})
+    block = await _branch_overlap_block(
+        _ctx(repo), {"a.py": {1}}, OmissionCollector("t", repo_root=tmp_path)
+    )
+    assert block is not None
+    assert "branches_total" not in block
+    assert "files_total" not in block["branches"][0]
+
+
+async def test_the_per_branch_file_list_is_capped(tmp_path):
+    over = _BRANCH_OVERLAP_FILES_LIMIT + 3
+    shared = {f"src/f{i}.py": f"{i}\n" for i in range(over)}
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-b", "main")
+    _commit(repo, shared, "base")
+    _git(repo, "checkout", "-b", "overlapping", "main")
+    _commit(repo, {name: "theirs\n" for name in shared}, "their change")
+    _git(repo, "checkout", "-b", "work", "main")
+    _commit(repo, {name: "mine\n" for name in shared}, "our change")
+
+    block = await _branch_overlap_block(
+        _ctx(repo),
+        {name: {1} for name in shared},
+        OmissionCollector("t", repo_root=tmp_path),
+    )
+
+    assert block is not None
+    entry = block["branches"][0]
+    assert len(entry["files"]) == _BRANCH_OVERLAP_FILES_LIMIT
+    assert entry["files_total"] == over
+    assert entry["files_truncated"] is True
+
+
+async def test_a_dropped_branch_reaches_the_store_with_its_files_intact(tmp_path):
+    """The branch cap runs first, so a dropped entry is stored whole."""
+    over_files = _BRANCH_OVERLAP_FILES_LIMIT + 2
+    shared = {f"src/f{i}.py": f"{i}\n" for i in range(over_files)}
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-b", "main")
+    _commit(repo, shared, "base")
+    for i in range(_BRANCH_OVERLAP_LIMIT + 1):
+        _git(repo, "checkout", "-b", f"branch{i}", "main")
+        _commit(repo, {name: f"theirs {i}\n" for name in shared}, f"work {i}")
+    _git(repo, "checkout", "-b", "work", "main")
+    _commit(repo, {name: "mine\n" for name in shared}, "our change")
+
+    collector = OmissionCollector("get_change_risk", repo_root=tmp_path)
+    block = await _branch_overlap_block(
+        _ctx(repo), {name: {1} for name in shared}, collector
+    )
+
+    assert block is not None
+    assert block["branches_truncated"] is True
+    payload: dict = {"branch_overlap": block}
+    collector.attach(payload)
+
+    stored = _stored_text(tmp_path, payload)
+    # The dropped entry keeps every file: it was never cut in place, and the
+    # per-entry labels only name indexes the response actually carries.
+    assert stored.count(f"src/f{over_files - 1}.py") >= 1
+    for entry in block["branches"]:
+        assert len(entry["files"]) == _BRANCH_OVERLAP_FILES_LIMIT
+        assert entry["files_total"] == over_files
+
+
+def _stored_text(tmp_path: Path, payload: dict) -> str:
+    """Everything this response pushed to the omission store, as one string."""
+    from repowise.core.distill.store import OmissionStore, default_store_path
+
+    refs = payload["_meta"]["omitted"]["refs"]
+    store = OmissionStore(default_store_path(tmp_path))
+    try:
+        return "\n".join(store.get(ref) or "" for ref in refs)
+    finally:
+        store.close()
+
+
+async def test_a_scan_that_cannot_answer_yields_no_block(tmp_path, monkeypatch):
+    """A timeout or a wedged git is silence, never a half-built block."""
+    from repowise.server.mcp_server import tool_change_risk as module
+
+    repo = _repo(tmp_path, others={"overlapping": {"a.py": "a theirs\n"}})
+
+    async def _raises(*_args, **_kwargs):
+        raise OSError("git is gone")
+
+    monkeypatch.setattr(module, "_scan_overlap", _raises)
+    collector = OmissionCollector("t", repo_root=tmp_path)
+    assert await _branch_overlap_block(_ctx(repo), {"a.py": {1}}, collector) is None
+
+    async def _never_returns(*_args, **_kwargs):
+        raise TimeoutError
+
+    monkeypatch.setattr(module, "_scan_overlap", _never_returns)
+    assert await _branch_overlap_block(_ctx(repo), {"a.py": {1}}, collector) is None
+
+
+def test_branch_overlap_participates_in_the_response_ceiling(tmp_path):
+    """A block outside the shed order can never be shed, so it has to be in it."""
+    from repowise.server.mcp_server._budget import fit_to_budget
+
+    # Shed after the fix record and before the consumer list: who else is in
+    # these files outlives what the diff weighs and is cheaper than what breaks.
+    assert _SHED_ORDER.index("prior_fixes") < _SHED_ORDER.index("branch_overlap")
+    assert _SHED_ORDER.index("branch_overlap") < _SHED_ORDER.index("cross_repo")
+    assert _SHED_ORDER.index("change_shape.independent_changes") < _SHED_ORDER.index("change_shape")
+
+    payload = {
+        "score": 7.0,
+        "branch_overlap": {"branches": [{"branch": "b", "pad": "x" * 400}] * 200},
+        "cross_repo": {"consumers": [{"repo": "frontend"}]},
+    }
+    collector = OmissionCollector("get_change_risk", repo_root=tmp_path)
+    fit_to_budget(payload, _SHED_ORDER, collector)
+
+    assert "branch_overlap" not in payload
+    assert payload["truncated"] is True
+    assert payload["cross_repo"]["consumers"] == [{"repo": "frontend"}]
+
+
+async def test_get_change_risk_carries_the_block_end_to_end(tmp_path, monkeypatch):
+    from repowise.server.mcp_server import tool_change_risk as module
+
+    repo = _repo(tmp_path, others={"overlapping": {"a.py": "a theirs\n"}})
+
+    async def _context(_: str | None) -> SimpleNamespace:
+        return SimpleNamespace(path=str(repo))
+
+    monkeypatch.setattr(module, "_resolve_repo_context", _context)
+    payload = await module.get_change_risk("HEAD", baseline=0)
+
+    assert [e["branch"] for e in payload["branch_overlap"]["branches"]] == ["overlapping"]
+    # No index, so the diff is never split into changes the index cannot see.
+    assert "independent_changes" not in payload["change_shape"]
+
+
+async def test_reading_other_branches_does_not_widen_the_response_targets(tmp_path, monkeypatch):
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    from repowise.core.persistence.database import init_db
+    from repowise.core.persistence.models import Repository
+    from repowise.server.mcp_server import tool_change_risk as module
+
+    repo = _repo(tmp_path, others={"overlapping": {"a.py": "a theirs\n"}})
+    engine = create_async_engine(f"sqlite+aiosqlite:///{(tmp_path / 'wiki.db').as_posix()}")
+    await init_db(engine)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    async with factory() as session:
+        session.add(Repository(id="repo1", name="repo", local_path=str(repo)))
+        await session.commit()
+
+    async def _context(_: str | None) -> SimpleNamespace:
+        return SimpleNamespace(path=str(repo), session_factory=factory)
+
+    monkeypatch.setattr(module, "_resolve_repo_context", _context)
+    seen: dict = {}
+    build_meta = module._build_meta
+
+    def _capture(**kwargs):
+        seen.update(kwargs)
+        return build_meta(**kwargs)
+
+    monkeypatch.setattr(module, "_build_meta", _capture)
+    payload = await module.get_change_risk("HEAD", baseline=0)
+
+    assert payload["branch_overlap"]["branches"][0]["branch"] == "overlapping"
+    # The block reads files on other branches; what the response is about, and
+    # what its freshness is scoped to, is still only the files this change edits.
+    assert seen["targets"] == ["a.py"]
+
+
+async def test_targets_are_the_changed_files_without_an_index(tmp_path, monkeypatch):
+    """The block needs only git, so an unindexed call now scopes freshness too."""
+    from repowise.server.mcp_server import tool_change_risk as module
+
+    repo = _repo(tmp_path, others={})
+
+    async def _context(_: str | None) -> SimpleNamespace:
+        return SimpleNamespace(path=str(repo))
+
+    monkeypatch.setattr(module, "_resolve_repo_context", _context)
+    seen: dict = {}
+    build_meta = module._build_meta
+
+    def _capture(**kwargs):
+        seen.update(kwargs)
+        return build_meta(**kwargs)
+
+    monkeypatch.setattr(module, "_build_meta", _capture)
+    await module.get_change_risk("HEAD", baseline=0)
+
+    assert seen["targets"] == ["a.py"]
+
+
+async def test_get_change_risk_omits_the_block_without_another_branch(tmp_path, monkeypatch):
+    from repowise.server.mcp_server import tool_change_risk as module
+
+    repo = _repo(tmp_path, others={})
+
+    async def _context(_: str | None) -> SimpleNamespace:
+        return SimpleNamespace(path=str(repo))
+
+    monkeypatch.setattr(module, "_resolve_repo_context", _context)
+    payload = await module.get_change_risk("HEAD", baseline=0)
+
+    assert "branch_overlap" not in payload

--- a/tests/unit/server/mcp/test_independent_changes_block.py
+++ b/tests/unit/server/mcp/test_independent_changes_block.py
@@ -1,0 +1,233 @@
+"""get_change_risk's change_shape.independent_changes block.
+
+The block says a diff is several changes the index does not connect. It is
+silent without an index, for a single changed file, and whenever the changed
+files hang together, so an ordinary change grows no new block.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from repowise.core.persistence.database import init_db
+from repowise.core.persistence.models import GraphEdge, GraphNode, Repository, _new_uuid
+from repowise.server.mcp_server._budget import OmissionCollector
+from repowise.server.mcp_server.tool_change_risk import (
+    _UNGROUPED_FILES_LIMIT,
+    _change_shape,
+    _independent_changes_block,
+)
+
+_REPO_ID = "repo1"
+
+
+def _collector(tmp_path) -> OmissionCollector:
+    return OmissionCollector("get_change_risk", repo_root=tmp_path)
+
+
+async def _ctx(tmp_path, files: list[str], edges: list[tuple[str, str]]) -> SimpleNamespace:
+    """A context over a real wiki.db holding *files* as file nodes and *edges* between them."""
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    db_path = tmp_path / "wiki.db"
+    engine = create_async_engine(f"sqlite+aiosqlite:///{db_path.as_posix()}")
+    await init_db(engine)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    async with factory() as session:
+        session.add(Repository(id=_REPO_ID, name="repo", local_path=str(tmp_path)))
+        for path in files:
+            session.add(
+                GraphNode(
+                    id=_new_uuid(),
+                    repository_id=_REPO_ID,
+                    node_id=path,
+                    node_type="file",
+                    name=path,
+                    file_path=path,
+                    language="python",
+                )
+            )
+        for source, target in edges:
+            session.add(
+                GraphEdge(
+                    id=_new_uuid(),
+                    repository_id=_REPO_ID,
+                    source_node_id=source,
+                    target_node_id=target,
+                    edge_type="imports",
+                )
+            )
+        await session.commit()
+    return SimpleNamespace(path=str(tmp_path), session_factory=factory)
+
+
+async def test_block_is_silent_without_an_index(tmp_path):
+    ctx = SimpleNamespace(path="/repo")
+    changed = {"a.py": {1}, "b.py": {2}}
+    assert await _independent_changes_block(ctx, changed, _collector(tmp_path)) is None
+
+
+async def test_block_is_silent_for_fewer_than_two_changed_files(tmp_path):
+    ctx = SimpleNamespace(path="/repo", session_factory=object())
+    assert await _independent_changes_block(ctx, {}, _collector(tmp_path)) is None
+    assert await _independent_changes_block(ctx, {"a.py": {1}}, _collector(tmp_path)) is None
+
+
+async def test_block_is_silent_when_the_index_connects_the_changed_files(tmp_path):
+    ctx = await _ctx(tmp_path, ["a.py", "b.py"], [("a.py", "b.py")])
+    changed = {"a.py": {1}, "b.py": {2}}
+    assert await _independent_changes_block(ctx, changed, _collector(tmp_path)) is None
+
+
+async def test_block_reports_the_groups_and_states_its_basis(tmp_path):
+    """Two connected pairs with nothing between them are two changes, not one."""
+    ctx = await _ctx(
+        tmp_path,
+        ["a.py", "b.py", "c.py", "d.py"],
+        [("a.py", "b.py"), ("c.py", "d.py")],
+    )
+
+    block = await _independent_changes_block(
+        ctx, {"a.py": {1}, "b.py": {1}, "c.py": {1}, "d.py": {1}}, _collector(tmp_path)
+    )
+
+    assert block is not None
+    assert block["count"] == 2
+    assert sorted(g["files"] for g in block["groups"]) == [["a.py", "b.py"], ["c.py", "d.py"]]
+    # The claim is about the index, and the block says so rather than implying
+    # the code itself has no connection.
+    assert "index" in block["basis"]
+    assert "independent changes" in block["summary"]
+    # No score, percentage or adjective anywhere on the wire.
+    assert "score" not in block
+
+
+async def test_a_file_the_index_does_not_hold_is_never_grouped(tmp_path):
+    ctx = await _ctx(
+        tmp_path,
+        ["a.py", "b.py", "c.py", "d.py"],
+        [("a.py", "b.py"), ("c.py", "d.py")],
+    )
+
+    block = await _independent_changes_block(
+        ctx,
+        {"a.py": {1}, "b.py": {1}, "c.py": {1}, "d.py": {1}, "new.py": {1}},
+        _collector(tmp_path),
+    )
+
+    assert block is not None
+    assert block["ungrouped_files"] == ["new.py"]
+    assert all("new.py" not in g["files"] for g in block["groups"])
+
+
+async def test_the_ungrouped_file_list_is_capped_and_says_by_how_much(tmp_path):
+    """A docs-heavy release commit can leave hundreds of unlinkable files."""
+    over = _UNGROUPED_FILES_LIMIT + 3
+    loose = [f"docs/page{i}.md" for i in range(over)]
+    ctx = await _ctx(
+        tmp_path,
+        ["a.py", "b.py", "c.py", "d.py"],
+        [("a.py", "b.py"), ("c.py", "d.py")],
+    )
+
+    changed = {p: {1} for p in ["a.py", "b.py", "c.py", "d.py", *loose]}
+    block = await _independent_changes_block(ctx, changed, _collector(tmp_path))
+
+    assert block is not None
+    assert len(block["ungrouped_files"]) == _UNGROUPED_FILES_LIMIT
+    assert block["ungrouped_files_total"] == over
+    assert block["ungrouped_files_truncated"] is True
+
+
+async def test_a_range_hands_the_core_what_each_commit_touched(tmp_path, monkeypatch):
+    """Which files moved together across the range is the strongest link there is."""
+    import subprocess
+
+    from repowise.core.analysis import independent_changes as core
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    def _git(*args: str) -> None:
+        subprocess.run(
+            ["git", "-c", "user.email=t@e.st", "-c", "user.name=T", *args],
+            cwd=repo,
+            check=True,
+            capture_output=True,
+        )
+
+    _git("init", "-b", "main")
+    for i, files in enumerate([["a.py", "b.py"], ["c.py"]]):
+        for name in files:
+            (repo / name).write_text(f"{name} {i}\n", encoding="utf-8")
+        _git("add", "-A")
+        _git("commit", "-m", f"c{i}")
+
+    ctx = await _ctx(tmp_path / "index", ["a.py", "b.py", "c.py"], [])
+    ctx.path = str(repo)
+    seen: dict = {}
+
+    async def _capture(session, repo_id, changed_files, *, commit_sets=()):
+        seen["commit_sets"] = [set(s) for s in commit_sets]
+        return None
+
+    monkeypatch.setattr(core, "independent_changes", _capture)
+    await _independent_changes_block(
+        ctx, {"a.py": {1}, "b.py": {1}, "c.py": {1}}, _collector(tmp_path), "HEAD~1..HEAD"
+    )
+
+    assert seen["commit_sets"] == [{"c.py"}]
+
+
+async def test_get_change_risk_carries_the_split_end_to_end(tmp_path, monkeypatch):
+    """Two changed files the index links to nothing become two changes."""
+    import subprocess
+
+    from repowise.server.mcp_server import tool_change_risk as module
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    def _git(*args: str) -> None:
+        subprocess.run(
+            ["git", "-c", "user.email=t@e.st", "-c", "user.name=T", *args],
+            cwd=repo,
+            check=True,
+            capture_output=True,
+        )
+
+    _git("init", "-b", "main")
+    for name in ("a.py", "b.py"):
+        (repo / name).write_text("start" + chr(10), encoding="utf-8")
+    _git("add", "-A")
+    _git("commit", "-m", "base")
+    for name in ("a.py", "b.py"):
+        (repo / name).write_text("changed" + chr(10), encoding="utf-8")
+    _git("add", "-A")
+    _git("commit", "-m", "two unrelated edits")
+
+    # Each changed file is linked to a file outside the diff and to nothing
+    # inside it, which is what makes them two changes rather than two unknowns.
+    ctx = await _ctx(
+        tmp_path / "index",
+        ["a.py", "b.py", "lib/one.py", "lib/two.py"],
+        [("a.py", "lib/one.py"), ("b.py", "lib/two.py")],
+    )
+
+    async def _context(_: str | None) -> SimpleNamespace:
+        return SimpleNamespace(path=str(repo), session_factory=ctx.session_factory)
+
+    monkeypatch.setattr(module, "_resolve_repo_context", _context)
+    payload = await module.get_change_risk("HEAD", baseline=0)
+
+    split = payload["change_shape"]["independent_changes"]
+    assert split["count"] == 2
+    assert sorted(g["files"] for g in split["groups"]) == [["a.py"], ["b.py"]]
+
+
+def test_change_shape_carries_the_block_only_when_there_is_one():
+    payload = {"score": 3.0, "classification": "moderate"}
+    assert "independent_changes" not in _change_shape(payload, {})
+    shape = _change_shape(payload, {}, {"count": 2})
+    assert shape["independent_changes"] == {"count": 2}

--- a/website/cli-reference.md
+++ b/website/cli-reference.md
@@ -562,6 +562,47 @@ repowise risk main..HEAD      # score a branch / PR range
 repowise risk --ext .ts,.tsx
 ```
 
+With a readable index the command also prints whether the diff is one change or
+several: the changed files grouped by the links the index holds plus, for a
+`base..head` range, the files each commit touched. Only indexed, non-test source
+files a resolver can link are grouped; docs, config, data and tests are always
+printed under `Left out of the grouping:`. Each group names its files and the
+files that alone hold it together, and a closing `Basis:` line says what was
+checked. Silent when the diff is one change, and it carries no score.
+
+---
+
+## `overlap`
+
+Which other open branches edit the files this change edits. Git answers it, so it
+works with no index; an index orders the shared files and adds the files history
+pairs with them. Every row states its basis in words, `same file` or
+`co-change pair, N of M commits`. No score. Branches stacked on the current one
+are skipped, as are noise paths and dependency manifests.
+
+```bash
+repowise overlap [OPTIONS]
+```
+
+### Options
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--base` | ref | trunk | Base ref both sides are diffed against (`origin/HEAD`, else `main` or `master`) |
+| `--branch` | ref | HEAD | The change to compare |
+| `--path` | path | cwd | Git repository path |
+| `--limit` | int | 50 | How many branches to diff, newest committer date first |
+| `--format` | choice | table | `table` or `json` |
+
+### Examples
+
+```bash
+repowise overlap                          # who else is editing what you are editing
+repowise overlap --base main --limit 100  # a wider scan against an explicit base
+```
+
+When nothing overlaps, the command prints one line saying so with the scan counts.
+
 ---
 
 ## `security`


### PR DESCRIPTION
## What

Two additive blocks on `get_change_risk`, both silent (absent) when they have nothing to say, following the `prior_fixes` and `cross_repo` contract:

- `branch_overlap`: the other open branches editing the files this change edits, git-only so it appears whether or not the repo is indexed; capped at five branches and ten files each through the shared response budget, with the tail in the omission store.
- `change_shape.independent_changes`: the diff's groups when it is several changes the index does not connect; `ungrouped_files` capped at ten.

Both join the `get_change_risk` shed order (`change_shape.independent_changes` before `change_shape`, `branch_overlap` between `prior_fixes` and `cross_repo`). `_meta.targets` stays the files this change touched. The branch scan runs off the event loop under a 20-second ceiling. Both builders are skipped on a `finding_id` drill-down.

`RiskReportArtifactData` in `packages/types` mirrors both blocks.

## Docs

`docs/layers/CHANGE_RISK.md` gains Independent changes and Branch overlap sections; `docs/agent/MCP_TOOLS.md` documents both blocks and backfills the missing `cross_repo` paragraph; the CLI references gain `overlap`; README lists change coordination as the fourth pre-merge signal.

## Measured

`get_change_risk` warm wall on this repository, `HEAD` and `HEAD~3..HEAD`: 0.9s before, about 2.1s and 2.4s after; the difference is the branch scan on 1,049 candidate refs with 16 hits.

Based on #2131.
