### PR TITLE
feat(languages): parse F# to a full AST and move it to Good

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,7 +474,7 @@ the orchestrators. Full matrix and the contributor recipe:
 
 ## Supported languages
 
-**23 languages parsed to AST · 39 on a five-rung ladder · framework-aware across
+**24 languages parsed to AST · 39 on a five-rung ladder · framework-aware across
 all of them.**
 
 "Do you support X" has five useful answers, not two, so languages land on a
@@ -509,6 +509,7 @@ ladder and every rung says what it buys you.
   <img src="https://img.shields.io/badge/GDScript-478CBF?style=flat-square&logo=godotengine&logoColor=white" alt="GDScript / Godot" />
   <img src="https://img.shields.io/badge/VB.NET-945DB7?style=flat-square&logo=dotnet&logoColor=white" alt="VB.NET" />
   <img src="https://img.shields.io/badge/Elixir-6E4A7E?style=flat-square&logo=elixir&logoColor=white" alt="Elixir" />
+  <img src="https://img.shields.io/badge/F%23-378BBA?style=flat-square&logo=fsharp&logoColor=white" alt="F#" />
   &nbsp;<strong>· Partial &nbsp;</strong>
   <img src="https://img.shields.io/badge/Luau-00A2FF?style=flat-square&logo=lua&logoColor=white" alt="Luau" />
   <img src="https://img.shields.io/badge/Razor-512BD4?style=flat-square&logo=blazor&logoColor=white" alt="Razor / Blazor" />
@@ -520,10 +521,10 @@ still doing real work rather than being ignored:
 | Rung | Languages | What you get |
 |---|---|---|
 | **Full** (13) | Python · TypeScript · JavaScript · Svelte · Vue · Java · Kotlin · Go · Rust · C++ · C# · Scala · Ruby | The whole pipeline: AST symbols, import resolution, a resolved call graph, heritage, docstrings, framework edges, **and code-health markers** |
-| **Good** (8) | C · Swift · PHP · Dart · Object Pascal · GDScript · VB.NET · Elixir | All of the above except the full health suite |
+| **Good** (9) | C · Swift · PHP · Dart · Object Pascal · GDScript · VB.NET · Elixir · F# | All of the above except the full health suite |
 | **Partial** (2) | Luau / Roblox · Razor / Blazor | Luau: AST symbols and `require()` resolution, Rojo and `.luaurc` aware. Razor: component symbols, `@code` and component-tag call edges, C# health markers; no import resolution yet |
 | | | ⎯⎯ *tree-sitter parsing stops here; the rungs below come from git and imports* ⎯⎯ |
-| **Lightweight** (7) | Clojure · Haskell · Lean 4 · Erlang · F# · HTML · QML | A real file-to-file import graph, and no symbol-level claims |
+| **Lightweight** (6) | Clojure · Haskell · Lean 4 · Erlang · HTML · QML | A real file-to-file import graph, and no symbol-level claims |
 | **Structural** (9) | Objective-C · R · Zig · Julia · Elm · OCaml · Crystal · Nim · D | Git history: blame, hotspots, co-change, ownership, bug history |
 
 **Every language ships in the open-source distribution.** None is gated behind

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -34,7 +34,7 @@ Languages land on a five-rung ladder rather than a yes/no list, because "do you
 support X" has five different useful answers. Each rung is defined, with what it
 buys you, in
 [docs/layers/LANGUAGE_SUPPORT.md](docs/layers/LANGUAGE_SUPPORT.md). Today that
-ladder covers **39 languages, 23 of them parsed to a full AST**.
+ladder covers **39 languages, 24 of them parsed to a full AST**.
 
 ### New languages
 
@@ -48,7 +48,6 @@ ladder covers **39 languages, 23 of them parsed to a full AST**.
 | **Apex** | Planned | Salesforce estates, where the org is often the least documented system a company runs. Apex is Java-shaped, and Lightning Web Components are already covered as JavaScript and HTML. |
 | **Ada** | Exploring | Defense and aerospace, long-lived and thinly documented, and usually in the same estates asking about COBOL. |
 | **Objective-C** | Planned | Currently Structural, meaning history only. The grammar is mature, so this is a climb up the ladder rather than new ground. |
-| **F#** | Planned | Currently Lightweight, meaning file-to-file imports. The grammar is already on PyPI, so this is an AST upgrade rather than new ground. |
 | **Template dialects** (Django/Jinja, ERB, Blade, Thymeleaf, Go templates) | Planned | Today they parse cleanly as HTML and yield nothing, because `{% extends "base.html" %}` is plain text to an HTML parser. A stated ceiling, not an oversight. |
 
 ### Deepening languages we already parse
@@ -62,6 +61,7 @@ ladder covers **39 languages, 23 of them parsed to a full AST**.
 | SQL / dbt | Planned | Column-level blast radius |
 | Object Pascal | Planned | Assertion and performance markers, a dedicated `uses` resolver |
 | Elixir | Planned | Health markers, and a call-resolution strategy so a bare-name call reaches beyond its own file |
+| F# | Planned | Health markers, and a resolver that reads the AST index instead of the declared-name regex |
 | Razor / Blazor | Planned | `@using` and `@inject` edges so component tags resolve through imports, `@code` members as symbols rather than call edges only |
 
 ### Need a language that is not here

--- a/docs/README.md
+++ b/docs/README.md
@@ -59,7 +59,7 @@ your agent in under five minutes, with no API key.
 | [layers/DECISIONS.md](layers/DECISIONS.md) | Architectural decisions mined from your repo and from your own agent sessions |
 | [layers/DEAD_CODE.md](layers/DEAD_CODE.md) | Unreachable files, unused exports, and zombie packages by confidence tier |
 | [layers/SECURITY.md](layers/SECURITY.md) | The local pattern scan: what the sixteen patterns catch, what they do not, and how far to trust the result |
-| [layers/LANGUAGE_SUPPORT.md](layers/LANGUAGE_SUPPORT.md) | What works per language: 23 parsed to a full AST, 39 on the five-rung ladder |
+| [layers/LANGUAGE_SUPPORT.md](layers/LANGUAGE_SUPPORT.md) | What works per language: 24 parsed to a full AST, 39 on the five-rung ladder |
 | [layers/WIKI.md](layers/WIKI.md) | The generated wiki: page types, what `update` re-renders, styles, output language |
 
 ## Scale it

--- a/docs/architecture/language-support.md
+++ b/docs/architecture/language-support.md
@@ -13,8 +13,8 @@ in that subpackage's dispatcher. No edits are needed to `graph.py`,
 `traverser.py`, or any analysis core file. `parser.py` holds a short per-language
 block for a handful of languages whose grammar shape the generic path cannot
 read (C++ qualified definitions, Dart mixins, Object Pascal out-of-line methods,
-[Elixir](#elixir)); each is a few lines calling into a helper, and a new language
-needs one only when it hits the same kind of wall.
+[Elixir](#elixir), [F#](#f)); each is a few lines calling into a helper, and a
+new language needs one only when it hits the same kind of wall.
 
 ---
 
@@ -32,7 +32,7 @@ needs one only when it hits the same kind of wall.
 - [Call resolution](#call-resolution) · [the strategy seam](#the-per-language-strategy-seam) · [resolution origins](#resolution-origins) · [receiver typing](#receiver-typing) · [inherited dispatch](#inherited-dispatch)
 - [The edge vocabulary](#the-edge-vocabulary)
 - [Multi-language files (the SFC pattern)](#multi-language-files-the-sfc-pattern)
-- [Per-language mechanics](#per-language-mechanics) · [Elixir](#elixir) · [GDScript / Godot](#gdscript--godot) · [VB.NET](#vbnet) · [QML](#qml) · [Flutter widget trees](#flutter-widget-trees)
+- [Per-language mechanics](#per-language-mechanics) · [Elixir](#elixir) · [F#](#f) · [GDScript / Godot](#gdscript--godot) · [VB.NET](#vbnet) · [QML](#qml) · [Flutter widget trees](#flutter-widget-trees)
 - [Optional language-specific passes](#optional-language-specific-passes)
 - [The three code-health dialect registries](#the-three-code-health-dialect-registries)
 - [Workspace contract extraction](#workspace-contract-extraction)
@@ -80,7 +80,7 @@ Extension/filename -> LanguageTag  (via LanguageRegistry)
           C/C++:  compile_commands.json include directories
           Dart:   package:/dart:/relative URIs via the pubspec name map +
                   library-name index (dotted part-of)
-          Lightweight tier (Clojure/Haskell/Lean 4/Erlang/F#):
+          Lightweight tier (Clojure/Haskell/Lean 4/Erlang):
                   regex-extracted imports vs a declared-module-name index
           dbt:    ref()/source() vs a per-project model-name index
           Other:  stem-map fallback (filename matching)
@@ -707,6 +707,48 @@ dedup-by-statement-text the generic path applies. No heritage is emitted: `use`
 and `@behaviour` are the nearest things Elixir has to inheritance and neither is
 one, and both already produce a module dependency through the import and
 type-reference captures.
+
+### F#
+
+F# has no field named on any of its type nodes and no shape shared between a
+type body and a member the way Elixir shares `call` across everything, so its
+per-language block is about extending and locating rather than reclassifying:
+
+- **A `let rec f ... and g ...` group is one grammar node for every clause**, so
+  `@symbol.def` sits on each clause's left-hand side and `parser.py` extends its
+  span forward to the next clause (or the file end), stepping over a return-type
+  annotation sitting between the two. The same left-hand side node also marks a
+  binding local to another binding's body, which the generic callable-ancestor
+  filter cannot see because it looks for an ancestor's *type*, never the
+  captured node's own nesting, so `_fsharp_binding_is_nested` walks that
+  ancestry directly.
+- **Parent detection reads a `type_name` child instead of a `name` field**, in
+  `_fsharp_parent_name`, and joins every enclosing nested module into a dotted
+  owner path: one file may hold two modules each declaring the same type with
+  the same member, and a symbol id is path plus parent plus name. A nested
+  module is a parent but not a type, so the generic function-to-method
+  promotion is gated on `_fsharp_parent_is_type` to keep a `let` inside a
+  nested module a function rather than a member.
+- **A dotted static call (`Path.Combine(a, b)`) is one identifier node**, with no
+  dot node to capture a receiver from, so the receiver/target split happens on
+  the joined text after the query fires.
+
+A bare name in F# is lexically scoped, so `fsharp` joins `elixir` in
+`_LEXICAL_BARE_NAME_LANGUAGES`: the resolver refuses the repo-wide-uniqueness
+tier for one and merges names only from `open`, which carries the wildcard
+sentinel because that is what `open` binds. `open type A.B.C` names a type, so
+its module dependency is recorded as `A.B`. An unqualified call target
+beginning with a capital is dropped: F# reserves an initial capital for union
+cases, types and constructors, which share the node shape of an ordinary
+application and would otherwise bind to any same-named function.
+
+`.fsi` signature files load a second grammar (`language_signature`) that a spec
+cannot select per-file, and the implementation grammar mis-parses a signature
+body's `val` bindings into ERROR recovery, so `.fsi` is routed to the regex
+import tier instead of a symbol tree built on invented nodes. Where a project
+splits one namespace across many single-file assemblies, most `open` targets
+are ambiguous and stay unresolved by design, which puts that repo's F#
+unused-export findings at the review tier rather than the asserted one.
 
 ### GDScript / Godot
 

--- a/docs/business/COMMERCIAL.md
+++ b/docs/business/COMMERCIAL.md
@@ -42,7 +42,7 @@ scale, in a regulated or security-sensitive environment**:
 All of the following ship in `pip install repowise` today, free for internal use.
 
 - **[Five intelligence layers](../layers/INTELLIGENCE_LAYERS.md)**: Graph
-  (tree-sitter AST across 23 languages, two-tier dependency graph, call
+  (tree-sitter AST across 24 languages, two-tier dependency graph, call
   resolution, heritage extraction, Leiden communities, PageRank / betweenness /
   SCC), Git (hotspots, ownership, co-change pairs, bus factor, significant
   commits, contributor profiles, module health), Documentation (a wiki page per
@@ -99,22 +99,22 @@ All of the following ship in `pip install repowise` today, free for internal use
 
 ## 3. First-class language coverage
 
-Repowise parses **23 languages to a full AST** and places **39 on a five-rung
+Repowise parses **24 languages to a full AST** and places **39 on a five-rung
 ladder**, so "do you support X" gets the rung as its answer rather than a yes or a
 no. Both numbers matter and neither is worth quoting alone.
 
-The 23 are the top three rungs. At **Full tier sit 13** (Python, TypeScript,
+The 24 are the top three rungs. At **Full tier sit 13** (Python, TypeScript,
 JavaScript, Svelte, Vue, Java, Kotlin, Go, Rust, C++, **C#**, Scala, and Ruby) with
 AST parsing, import resolution, named bindings, call resolution, heritage
 extraction, multi-project workspace resolvers, framework-aware edges, per-language
-dynamic-hint extractors, and code-health markers. A further **8 at Good tier** (C,
-Swift, PHP, Dart, Object Pascal/Delphi, GDScript, VB.NET, Elixir) get all of that except the full
-health suite, with GDScript also lacking framework edges and named bindings, and Luau
+dynamic-hint extractors, and code-health markers. A further **9 at Good tier** (C,
+Swift, PHP, Dart, Object Pascal/Delphi, GDScript, VB.NET, Elixir, F#) get all of that except the full
+health suite, with GDScript and F# also lacking framework edges and named bindings, and Luau
 and Razor/Blazor are partial. SQL/dbt, shell, HTML, and the config formats are
 handled by dedicated extractors on top of that.
 
-Below the AST line the ladder continues rather than stopping: **7 at Lightweight**
-(Clojure, Haskell, Lean 4, Erlang, F#, HTML, QML) get a real file-to-file import
+Below the AST line the ladder continues rather than stopping: **6 at Lightweight**
+(Clojure, Haskell, Lean 4, Erlang, HTML, QML) get a real file-to-file import
 graph with no symbol-level claims, and **9 at Structural** (Objective-C, R, Zig,
 Julia, Elm, OCaml, Crystal, Nim, D) get the git intelligence layer only: blame,
 hotspots, co-change, ownership and bug history, with no parsing. Stating the rung

--- a/docs/layers/GRAPH.md
+++ b/docs/layers/GRAPH.md
@@ -11,7 +11,7 @@ that **every edge carries its own evidence**.
 <p>
   <img src="https://img.shields.io/badge/17-edge_types-3178C6?style=flat-square&labelColor=0A0A0A" alt="17 edge types" />
   <img src="https://img.shields.io/badge/29-resolution_origins-059669?style=flat-square&labelColor=0A0A0A" alt="29 resolution origins" />
-  <img src="https://img.shields.io/badge/23-languages-F59520?style=flat-square&labelColor=0A0A0A" alt="23 languages" />
+  <img src="https://img.shields.io/badge/24-languages-F59520?style=flat-square&labelColor=0A0A0A" alt="24 languages" />
   <img src="https://img.shields.io/badge/22-framework_detectors-7F52FF?style=flat-square&labelColor=0A0A0A" alt="22 framework detectors" />
   <img src="https://img.shields.io/badge/0-LLM_calls-1E293B?style=flat-square&labelColor=0A0A0A" alt="zero LLM calls" />
   <img src="https://img.shields.io/badge/compiler_graded-7_of_7_cells_undominated-DC2626?style=flat-square&labelColor=0A0A0A" alt="no tool is both more precise and more complete, in 7 of 7 compiler-graded cells" />

--- a/docs/layers/INTELLIGENCE_LAYERS.md
+++ b/docs/layers/INTELLIGENCE_LAYERS.md
@@ -43,7 +43,7 @@ requirement for the index.
 ## Graph Intelligence
 
 tree-sitter parses your source into a **two-tier dependency graph**: file nodes
-and symbol nodes (functions, classes, methods). 23 languages parse to a full
+and symbol nodes (functions, classes, methods). 24 languages parse to a full
 AST; see [`LANGUAGE_SUPPORT.md`](LANGUAGE_SUPPORT.md) for per-language tiers.
 
 A **confidence-scored call resolver** handles import aliases, barrel

--- a/docs/layers/LANGUAGE_SUPPORT.md
+++ b/docs/layers/LANGUAGE_SUPPORT.md
@@ -1,6 +1,6 @@
 # Language Support
 
-**23 languages parsed to a full AST · 39 on the five-rung ladder ·
+**24 languages parsed to a full AST · 39 on the five-rung ladder ·
 framework-aware across all of them.** "Do you support X" has five useful answers
 rather than two, so every language lands on a rung and the rung says what it
 buys you. Everything else in your repo still appears in the wiki and is tracked
@@ -33,6 +33,7 @@ reference.
   <img src="https://img.shields.io/badge/GDScript-478CBF?style=flat-square&logo=godotengine&logoColor=white" alt="GDScript / Godot" />
   <img src="https://img.shields.io/badge/VB.NET-945DB7?style=flat-square&logo=dotnet&logoColor=white" alt="VB.NET" />
   <img src="https://img.shields.io/badge/Elixir-6E4A7E?style=flat-square&logo=elixir&logoColor=white" alt="Elixir" />
+  <img src="https://img.shields.io/badge/F%23-378BBA?style=flat-square&logo=fsharp&logoColor=white" alt="F#" />
   &nbsp;<strong>· Partial &nbsp;</strong>
   <img src="https://img.shields.io/badge/Luau-00A2FF?style=flat-square&logo=lua&logoColor=white" alt="Luau" />
   <img src="https://img.shields.io/badge/Razor-512BD4?style=flat-square&logo=blazor&logoColor=white" alt="Razor / Blazor" />
@@ -56,13 +57,13 @@ produce meaningful output.
 | Tier | Languages | What you get |
 |------|-----------|--------------|
 | **Full** (13) | Python · TypeScript · JavaScript · Svelte · Vue · Java · Kotlin · Go · Rust · C++ · C# · Scala · Ruby | The whole pipeline: AST symbols, import resolution, a resolved call graph, heritage, docstrings, framework edges, **and code-health markers** |
-| **Good** (8) | C · Swift · PHP · Dart · Object Pascal · GDScript · VB.NET · Elixir | Everything above except the full health suite. Dart and Object Pascal *do* get health markers; C, Swift, PHP, GDScript, VB.NET and Elixir don't yet. GDScript has a dedicated import resolver and Godot-specific framework edges but no named bindings (see [Known gaps](../architecture/language-support.md#gdscript--godot)) |
+| **Good** (9) | C · Swift · PHP · Dart · Object Pascal · GDScript · VB.NET · Elixir · F# | Everything above except the full health suite. Dart and Object Pascal *do* get health markers; C, Swift, PHP, GDScript, VB.NET, Elixir and F# don't yet. GDScript has a dedicated import resolver and Godot-specific framework edges but no named bindings (see [Known gaps](../architecture/language-support.md#gdscript--godot)) |
 | **Partial** (2) | Luau / Roblox · Razor / Blazor | Luau: AST symbols and `require()` resolution (Rojo / `.luaurc` aware), no health markers yet. Razor: a component symbol per file, call edges from `@code` blocks and component tags, C# health markers; no import resolution yet |
 | | | ⎯⎯ *tree-sitter parsing stops here. The rungs below are derived from git and imports, not from an AST.* ⎯⎯ |
-| **Lightweight** (7) | Clojure · Haskell · Lean 4 · Erlang · F# · HTML · QML | A real file-to-file import graph, no symbol-level claims |
+| **Lightweight** (6) | Clojure · Haskell · Lean 4 · Erlang · HTML · QML | A real file-to-file import graph, no symbol-level claims |
 | **Structural** (9) | Objective-C · R · Zig · Julia · Elm · OCaml · Crystal · Nim · D | Git history only: blame, hotspots, co-change. No AST parsing |
 
-The first three rungs are the **23 languages parsed to a full AST**; all five are
+The first three rungs are the **24 languages parsed to a full AST**; all five are
 the **39** on the ladder. Both numbers are worth stating and neither is worth
 stating alone, so if you only take one thing from this page, take the rung your
 language sits on rather than either count.
@@ -253,6 +254,7 @@ bindings and heritage, with a dedicated workspace resolver per language.
 | **GDScript** | `.gd` | `preload(...)` / `load(...)` / `extends "res://..."` resolved as absolute paths from the nearest `project.godot`, so a repo holding many Godot projects keeps each project's `res://` namespace separate, plus scene, autoload and `class_name` edges (see [GDScript / Godot](../architecture/language-support.md#gdscript--godot)) |
 | **VB.NET** | `.vb` | `Imports` through the same MSBuild project index C# uses: `.vbproj` / `.sln` parsing, `<RootNamespace>`-aware namespace lookup, NuGet package references |
 | **Elixir** | `.ex` `.exs` | `alias` / `import` / `require` / `use` against a `defmodule` index, with the Mix `lib/foo/bar.ex` → `Foo.Bar` convention as the fallback; `alias Foo.{Bar, Baz}` names both modules (no heritage: `use` and `@behaviour` are not inheritance) |
+| **F#** | `.fs` `.fsx` `.fsi` | `open` / `open type` against a declared-name index (namespace/module headers), plus the fsproj `<Compile Include>` compile order. `.fsi` signature files contribute imports only, no symbols. A layout that shares one namespace across many single-file projects leaves most `open` targets ambiguous by design, so unused-export findings there sit at the review tier (0.4) rather than being asserted |
 
 ---
 
@@ -299,11 +301,10 @@ meaningless.
 
 ### Lightweight tier
 
-Clojure, Haskell, Lean 4, Erlang, F# and HTML get a real file-level
-import graph: imports extracted per language and resolved against a declared
-module-name index. The knowledge graph runs in flow/sparse mode on the result:
-honest file-to-file dependencies, no symbol-level claims. F# additionally honours
-the fsproj `<Compile Include>` compile order.
+Clojure, Haskell, Lean 4, Erlang and HTML get a real file-level import graph:
+imports extracted per language and resolved against a declared module-name
+index. The knowledge graph runs in flow/sparse mode on the result: honest
+file-to-file dependencies, no symbol-level claims.
 
 **QML** joins the lightweight tier with imports only: module specs resolve
 against a `qmldir`-declared module index and quoted references resolve relative
@@ -410,7 +411,7 @@ Per-language mechanics behind these:
 | Object Pascal | Good | Assertion and performance markers, a dedicated `uses` resolver |
 | VB.NET | Good | Health markers, project-level `<Import Include=...>` as implicit imports |
 | Elixir | Good | Health markers, and a call-resolution strategy beyond same-file |
-| F# | Good | AST upgrade (the grammar is available on PyPI) |
+| F# | Good | Health markers, and a resolver that reads the AST index instead of the declared-name regex |
 | SQL / dbt | — | Column-level blast radius |
 | Shell | — | Shebang detection for extensionless executables |
 | HTML | Lightweight | A regex import tier for template dialects, gated on a framework manifest |

--- a/packages/core/src/repowise/core/ingestion/call_resolver.py
+++ b/packages/core/src/repowise/core/ingestion/call_resolver.py
@@ -87,10 +87,13 @@ _IMPLICIT_RECEIVER_LANGUAGES = frozenset({"java", "csharp", "cpp", "kotlin"})
 _INHERITED_LANGUAGES = frozenset({"kotlin", "python", "typescript", "swift", "csharp"})
 
 # Languages where a bare name is scoped lexically: it can only mean the
-# caller's own module, an explicit ``import``, or the prelude. ``alias`` /
-# ``require`` / ``use`` bind a module name, never a function name, so repo-wide
-# uniqueness is no evidence and only wildcard imports may merge names.
-_LEXICAL_BARE_NAME_LANGUAGES = frozenset({"elixir"})
+# caller's own module, an explicit ``import``, or the prelude. Elixir's
+# ``alias`` / ``require`` / ``use`` bind a module name, never a function name,
+# so repo-wide uniqueness is no evidence and only wildcard imports may merge
+# names. F# is the same rule with different spelling: a bare name means the
+# enclosing scope, a module the file has ``open``ed, or FSharp.Core, and
+# nothing else -- a name unique across the repo is not thereby in scope.
+_LEXICAL_BARE_NAME_LANGUAGES = frozenset({"elixir", "fsharp"})
 
 # The sentinel an import that binds a whole module's public names carries.
 _WILDCARD_IMPORTED_NAMES = ["*"]

--- a/packages/core/src/repowise/core/ingestion/extractors/__init__.py
+++ b/packages/core/src/repowise/core/ingestion/extractors/__init__.py
@@ -4,8 +4,10 @@ from .bindings import extract_import_bindings
 from .docstrings import extract_module_docstring, extract_symbol_docstring
 from .helpers import (
     extract_go_receiver_type,
+    fsharp_type_name,
     node_text,
     refine_elixir_call_kind,
+    refine_fsharp_type_kind,
     refine_go_type_kind,
     refine_kotlin_class_kind,
     refine_pascal_type_kind,
@@ -23,8 +25,10 @@ __all__ = [
     "extract_import_bindings",
     "extract_module_docstring",
     "extract_symbol_docstring",
+    "fsharp_type_name",
     "node_text",
     "refine_elixir_call_kind",
+    "refine_fsharp_type_kind",
     "refine_go_type_kind",
     "refine_kotlin_class_kind",
     "refine_pascal_type_kind",

--- a/packages/core/src/repowise/core/ingestion/extractors/docstrings.py
+++ b/packages/core/src/repowise/core/ingestion/extractors/docstrings.py
@@ -66,6 +66,40 @@ def _elixir_attribute_doc(node: Node, src: str, names: tuple[str, ...]) -> str |
         if child.type == "string":
             return clean_string_literal(node_text(child, src)) or None
     return None
+def _fsharp_doc_text(xml_doc_nodes: list[Node], src: str) -> str | None:
+    """Join a run of ``///`` lines and strip the XML the way C# does.
+
+    F# borrows .NET's XML doc comments verbatim, tags and all, so the
+    cleaner written for C# is the right one rather than a second copy.
+    """
+    lines = [node_text(node, src).strip().lstrip("/").strip() for node in xml_doc_nodes]
+    joined = "\n".join(line for line in lines if line)
+    if not joined:
+        return None
+    return _csharp_clean_xml_doc(joined) or None
+
+
+def _fsharp_preceding_doc(node: Node, src: str) -> list[Node]:
+    """The ``xml_doc`` run immediately before *node* among its siblings.
+
+    Attributes and keywords may sit between the doc comment and what it
+    documents -- an ``and`` clause of a ``let rec`` group is separated from
+    its own doc by the ``and`` token -- so both are stepped over the way
+    Rust's ``#[...]`` items are.
+    """
+    parent = node.parent
+    if parent is None:
+        return []
+    siblings = list(parent.children)
+    idx = next((i for i, sib in enumerate(siblings) if sib.id == node.id), -1)
+    i = idx - 1
+    while i >= 0 and (siblings[i].type == "attributes" or not siblings[i].is_named):
+        i -= 1
+    docs: list[Node] = []
+    while i >= 0 and siblings[i].type == "xml_doc":
+        docs.insert(0, siblings[i])
+        i -= 1
+    return docs
 
 
 def extract_module_docstring(root: Node, src: str, lang: str) -> str | None:
@@ -103,6 +137,23 @@ def extract_module_docstring(root: Node, src: str, lang: str) -> str | None:
             elif child.type == "package_clause":
                 break
         return "\n".join(lines) if lines else None
+    elif lang == "fsharp":
+        # The file's own doc sits above (or just inside) the `module` /
+        # `namespace` header, which is itself the first node of the file.
+        head = root
+        while head.named_child_count and head.named_children[0].type in (
+            "named_module",
+            "namespace",
+        ):
+            head = head.named_children[0]
+        docs: list[Node] = []
+        for child in head.children:
+            if child.type == "xml_doc":
+                docs.append(child)
+            elif docs or child.type not in ("module", "namespace", "long_identifier"):
+                break
+        return _fsharp_doc_text(docs, src) if docs else None
+
     elif lang == "rust":
         # //! inner doc comments or /*! block inner doc comments at top
         inner_lines: list[str] = []
@@ -293,6 +344,33 @@ def extract_symbol_docstring(def_node: Node, src: str, lang: str) -> str | None:
             lines.insert(0, node_text(siblings[i], src).lstrip("/ ").strip())
             i -= 1
         return "\n".join(lines) if lines else None
+
+    elif lang == "fsharp":
+        # `xml_doc` is a preceding SIBLING of the statement, and the captured
+        # node is usually nested inside that statement (a binding's left-hand
+        # side inside its `declaration_expression`, a type body inside its
+        # `type_definition`). Climb only while the node is still the first
+        # thing in its parent: the second clause of a `let rec f ... and g`
+        # is not, and must not inherit the first clause's doc.
+        node: Node | None = def_node
+        for _ in range(4):
+            if node is None:
+                break
+            docs = _fsharp_preceding_doc(node, src)
+            if docs:
+                return _fsharp_doc_text(docs, src)
+            parent = node.parent
+            if parent is None:
+                break
+            leading = [
+                sib
+                for sib in parent.named_children
+                if sib.id != node.id and sib.start_byte < node.start_byte
+            ]
+            if any(sib.type not in ("attributes", "xml_doc") for sib in leading):
+                break
+            node = parent
+        return None
 
     elif lang == "rust":
         # /// doc comments or /** block doc comments before the item.

--- a/packages/core/src/repowise/core/ingestion/extractors/helpers.py
+++ b/packages/core/src/repowise/core/ingestion/extractors/helpers.py
@@ -136,6 +136,55 @@ def refine_pascal_type_kind(decl_type_node: Node) -> str:
     return "class"
 
 
+def fsharp_type_name(simple_type_node: Node, src: str) -> str | None:
+    """The bare name of an F# ``simple_type``, qualifier dropped.
+
+    ``inherit System.Exception()`` names the same type as ``inherit
+    Exception()`` and F# writes the type name last, so the last segment of
+    the dotted path is the name the symbol index is keyed by. Shared by the
+    heritage extractor and the type-reference head walk, which ask the same
+    question of the same node.
+    """
+    head = simple_type_node
+    if head.type == "simple_type":
+        head = next(iter(head.named_children), None)
+        if head is None:
+            return None
+    if head.type == "long_identifier":
+        idents = [c for c in head.named_children if c.type == "identifier"]
+        if not idents:
+            return None
+        head = idents[-1]
+    if head.type != "identifier":
+        return None
+    return node_text(head, src).strip() or None
+
+
+def refine_fsharp_type_kind(anon_type_defn_node: Node) -> str:
+    """Tell an F# interface apart from a class inside ``anon_type_defn``.
+
+    The grammar gives classes, structs and interfaces the same node: an
+    interface is written ``type IFoo = abstract member Bar: ...`` with no
+    constructor and nothing but abstract members. Those two facts together
+    are what F# itself compiles to an interface, so both are required; a
+    class with one abstract member and a constructor stays a class.
+    """
+    members = [
+        node
+        for child in anon_type_defn_node.named_children
+        for node in ([child] if child.type == "member_defn" else child.named_children)
+        if node.type == "member_defn"
+    ]
+    if not members:
+        return "class"
+    if any(child.type == "primary_constr_args" for child in anon_type_defn_node.named_children):
+        return "class"
+    for member in members:
+        if not any(child.type == "abstract" for child in member.children):
+            return "class"
+    return "interface"
+
+
 def clean_string_literal(text: str) -> str:
     """Strip quote characters from a Python string literal."""
     text = text.strip()

--- a/packages/core/src/repowise/core/ingestion/extractors/heritage/__init__.py
+++ b/packages/core/src/repowise/core/ingestion/extractors/heritage/__init__.py
@@ -24,6 +24,7 @@ from ..helpers import node_text
 from .cpp import _extract_cpp_heritage
 from .csharp import _extract_csharp_heritage
 from .dart import _extract_dart_heritage
+from .fsharp import _extract_fsharp_heritage
 from .gdscript import _extract_gdscript_heritage
 from .go import _extract_go_heritage
 from .java import _extract_java_heritage
@@ -66,6 +67,7 @@ HERITAGE_EXTRACTORS: dict[str, Callable[..., None]] = {
     "pascal": _extract_pascal_heritage,
     "gdscript": _extract_gdscript_heritage,
     "vbnet": _extract_vbnet_heritage,
+    "fsharp": _extract_fsharp_heritage,
 }
 
 

--- a/packages/core/src/repowise/core/ingestion/extractors/heritage/fsharp.py
+++ b/packages/core/src/repowise/core/ingestion/extractors/heritage/fsharp.py
@@ -1,0 +1,47 @@
+"""F# heritage extraction."""
+
+from __future__ import annotations
+
+from tree_sitter import Node
+
+from ...models import HeritageRelation
+from ..helpers import fsharp_type_name
+
+
+def _extract_fsharp_heritage(
+    def_node: Node, name: str, line: int, src: str, out: list[HeritageRelation]
+) -> None:
+    """F#: ``inherit Base(...)`` is extends, ``interface IFoo with`` is implements.
+
+    ``def_node`` is the ``anon_type_defn`` the query captured. F# allows at
+    most one ``inherit`` per type and states it explicitly, so unlike Pascal
+    there is no first-entry-is-the-base guess: the grammar names both
+    relations. A body element is wrapped in its own
+    ``type_extension_elements`` node, except ``class_inherits_decl``, which
+    is a direct child, so both depths are walked.
+    """
+    for child in def_node.named_children:
+        candidates = (
+            [child] if child.type != "type_extension_elements" else list(child.named_children)
+        )
+        for node in candidates:
+            if node.type == "class_inherits_decl":
+                kind = "extends"
+            elif node.type == "interface_implementation":
+                kind = "implements"
+            else:
+                continue
+            base = next(
+                (grand for grand in node.named_children if grand.type == "simple_type"),
+                None,
+            )
+            if base is None:
+                continue
+            # Same walk the type-reference head uses.
+            parent = fsharp_type_name(base, src)
+            if parent and parent != name:
+                out.append(
+                    HeritageRelation(
+                        child_name=name, parent_name=parent, kind=kind, line=line
+                    )
+                )

--- a/packages/core/src/repowise/core/ingestion/extractors/visibility.py
+++ b/packages/core/src/repowise/core/ingestion/extractors/visibility.py
@@ -528,4 +528,7 @@ VISIBILITY_FNS: dict[str, Callable[[str, list[str]], str]] = {
     "scala": scala_visibility,
     "php": php_visibility,
     "elixir": elixir_visibility,
+    # F# has no `protected` binding form and spells assembly scope
+    # `internal`, which is exactly what kotlin_visibility answers.
+    "fsharp": kotlin_visibility,
 }

--- a/packages/core/src/repowise/core/ingestion/language_configs.py
+++ b/packages/core/src/repowise/core/ingestion/language_configs.py
@@ -412,6 +412,49 @@ LANGUAGE_CONFIGS: dict[str, LanguageConfig] = {
         # _elixir_module_parent instead.
         parent_class_types=frozenset(),
     ),
+    "fsharp": LanguageConfig(
+        symbol_node_types={
+            # `module Foo.Bar` / `namespace Foo.Bar` head the file;
+            # `module X =` nests inside one.
+            "named_module": "module",
+            "namespace": "module",
+            "module_defn": "module",
+            # The captured node is the binding's left-hand side, not the
+            # enclosing function_or_value_defn: that one node holds every
+            # clause of a `let rec f ... and g ...` group, so capturing it
+            # would give every clause the same span. parser.py extends each
+            # symbol over its own clause and filters the nested ones.
+            "function_declaration_left": "function",
+            "value_declaration_left": "variable",
+            # A record is a named product of fields, the same concept Go and
+            # Rust spell "struct". A discriminated union is a sum type, which
+            # is what "enum" means everywhere else in this table -- a
+            # single-case union written `type Alias = string` parses as one
+            # too, and reads as an enum; the grammar offers nothing to tell
+            # the abbreviation from the union.
+            "record_type_defn": "struct",
+            "union_type_defn": "enum",
+            "enum_type_defn": "enum",
+            "delegate_type_defn": "type_alias",
+            "type_abbrev_defn": "type_alias",
+            # Classes, structs and interfaces share this node; refined by
+            # refine_fsharp_type_kind.
+            "anon_type_defn": "class",
+            "exception_definition": "class",
+            "member_defn": "method",
+        },
+        import_node_types=["import_decl"],
+        export_node_types=[],  # F# has no re-export syntax
+        # F# spells assembly scope `internal` the way Kotlin does and has no
+        # `protected` binding form, so kotlin_visibility answers both.
+        visibility_fn=kotlin_visibility,
+        parent_extraction="nesting",
+        # Deliberately empty: no F# type node carries a `name` field, so the
+        # generic walk in _find_parent would match an ancestor and then read
+        # nothing off it. The parent walk is language-gated in parser.py --
+        # see _fsharp_parent_name.
+        parent_class_types=frozenset(),
+    ),
     "pascal": LanguageConfig(
         symbol_node_types={
             # declType wraps class/record/interface/helper/enum/set/array/alias

--- a/packages/core/src/repowise/core/ingestion/languages/specs/fsharp.py
+++ b/packages/core/src/repowise/core/ingestion/languages/specs/fsharp.py
@@ -1,4 +1,21 @@
-"""LanguageSpec for fsharp (extracted from the registry data table)."""
+"""LanguageSpec for F#.
+
+Grammar: tree-sitter-fsharp (PyPI ``tree-sitter-fsharp``, import name
+``tree_sitter_fsharp``), the ionide project's grammar.
+
+The wheel ships two grammars: ``language()`` for ``.fs``/``.fsx`` and
+``language_signature()`` for ``.fsi``. ``grammar_loader`` is chosen per
+language tag, not per extension, and the implementation grammar hits ERROR
+recovery on a signature file's ``val`` and member-signature bodies, so
+``.fsi`` keeps the regex import tier instead of an unreliable tree; see
+the ``signature_file`` branch in ``parser.py``.
+
+``heritage_node_types`` is ``anon_type_defn`` alone because that is the only
+type shape that can carry ``inherit`` or ``interface ... with``; records,
+unions, enums and delegates have neither. Unlike Pascal, the node carrying
+the heritage is the same node the query captures, so no one-level-deeper
+walk is needed on the heritage side.
+"""
 
 from ..spec import LanguageSpec
 
@@ -8,8 +25,63 @@ SPEC = LanguageSpec(
     extensions=frozenset({".fs", ".fsi", ".fsx"}),
     # .NET convention shared with C#: Program.fs.
     entry_point_patterns=("Program.fs",),
-    is_passthrough=True,
-    # Lightweight regex resolver: open → namespace/module declaration index,
-    # plus the fsproj compile-order dependency spine.
+    grammar_package="tree_sitter_fsharp",
+    scm_file="fsharp.scm",
+    heritage_node_types=frozenset({"anon_type_defn"}),
+    # AST symbols and calls now, but ``open`` still resolves through the
+    # declared-name regex index in resolvers/fsharp.py plus the fsproj
+    # compile-order spine, so the resolver's reach is unchanged, only the
+    # accuracy of what reaches it.
     import_support="partial",
+    # FSharp.Core names in scope in every file without an ``open``. Two
+    # groups: the union cases F# expressions are full of (``Some x`` and
+    # ``Ok v`` are applications, syntactically identical to a call), and the
+    # Operators functions whose names mean the same thing everywhere. This
+    # set is matched receiver-blind and deletes the call site outright, so
+    # ordinary library functions a project could plausibly own stay out.
+    builtin_calls=frozenset({
+        "Some", "None", "Ok", "Error",
+        "printf", "printfn", "sprintf", "eprintf", "eprintfn", "failwithf",
+        "failwith", "raise", "reraise", "invalidArg", "invalidOp", "nullArg",
+        "ignore", "id", "not", "ref", "fst", "snd",
+        "nameof", "typeof", "typedefof", "sizeof", "defaultArg",
+        "box", "unbox", "isNull", "incr", "decr", "max", "min", "abs",
+        "lock", "async", "seq", "task", "compare", "hash",
+        "string", "int", "float", "bool", "char", "byte", "sbyte",
+        "int16", "uint16", "int32", "uint32", "int64", "uint64",
+        "decimal", "single", "double", "enum",
+        # Reserved words. None of these can name a function, so a capture of
+        # one is always grammar recovery inventing an application out of a
+        # construct it could not parse, and the offside rule makes that a real
+        # possibility rather than a theoretical one.
+        "let", "member", "static", "abstract", "override", "default",
+        "if", "then", "else", "elif", "match", "when", "with", "and",
+        "rec", "mutable", "new", "val", "do", "in", "of", "type",
+        "module", "namespace", "open", "inherit", "interface", "use",
+        "yield", "return", "begin", "end", "try", "finally", "while",
+        "for", "to", "downto", "function", "fun", "base", "null",
+        "extern", "inline", "private", "public", "internal", "struct",
+        "class", "assert", "lazy", "upcast", "downcast", "as",
+    }),
+    # .NET roots plus the interfaces every class implements and no repo
+    # declares, the same filter C# applies to the same names.
+    builtin_parents=frozenset({
+        "Object", "ValueType", "Enum", "Delegate", "Attribute", "Array",
+        "Exception", "SystemException", "ApplicationException", "EventArgs",
+        "MarshalByRefObject",
+        "IDisposable", "IEnumerable", "IEnumerator", "IComparable",
+        "IEquatable", "ICloneable", "IFormattable", "ISerializable",
+    }),
+    # Primitives and the FSharp.Core type constructors. None of these ever
+    # has an in-repo declaration, so resolving one as a type reference is a
+    # guaranteed miss. Read back through is_resolvable_type_name.
+    builtin_types=frozenset({
+        "int", "int8", "int16", "int32", "int64", "uint", "uint8", "uint16",
+        "uint32", "uint64", "nativeint", "unativeint", "byte", "sbyte",
+        "float", "float32", "double", "single", "decimal", "bigint",
+        "bool", "char", "string", "unit", "obj", "exn", "void",
+        "list", "array", "option", "voption", "seq", "Result", "Choice",
+        "Map", "Set", "Async", "Task", "Lazy", "Nullable",
+        "Object", "String", "Boolean", "Int32", "Int64", "Double", "Single",
+    }),
 )

--- a/packages/core/src/repowise/core/ingestion/lightweight_imports/fsharp.py
+++ b/packages/core/src/repowise/core/ingestion/lightweight_imports/fsharp.py
@@ -17,14 +17,24 @@ import re
 
 from ..models import Import
 
-_OPEN_RE = re.compile(r"^[ \t]*open[ \t]+(?:type[ \t]+)?([A-Z][A-Za-z0-9_.]*)", re.M)
+_OPEN_RE = re.compile(r"^[ \t]*open[ \t]+(type[ \t]+)?([A-Z][A-Za-z0-9_.]*)", re.M)
 
 
 def extract_fsharp_imports(text: str) -> list[Import]:
     imports: list[Import] = []
     seen: set[str] = set()
     for match in _OPEN_RE.finditer(text):
-        module = match.group(1)
+        module = match.group(2)
+        # ``open`` binds every public name in the module, which is what the
+        # wildcard sentinel says. ``open type`` binds one type's static
+        # members, so the dependency is on the path that holds the type.
+        names = ["*"]
+        if match.group(1):
+            head, _, type_name = module.rpartition(".")
+            if head:
+                module, names = head, [type_name]
+            else:
+                names = []
         if module in seen:
             continue
         seen.add(module)
@@ -32,7 +42,7 @@ def extract_fsharp_imports(text: str) -> list[Import]:
             Import(
                 raw_statement=match.group(0).strip(),
                 module_path=module,
-                imported_names=[],
+                imported_names=names,
                 is_relative=False,
                 resolved_file=None,
             )

--- a/packages/core/src/repowise/core/ingestion/parser.py
+++ b/packages/core/src/repowise/core/ingestion/parser.py
@@ -46,6 +46,7 @@ from .extractors import (
     extract_symbol_docstring,
     node_text,
     refine_elixir_call_kind,
+    refine_fsharp_type_kind,
     refine_go_type_kind,
     refine_kotlin_class_kind,
     refine_pascal_type_kind,
@@ -88,6 +89,11 @@ from .parser_helpers import (
     _elixir_module_parent,
     _elixir_symbol_name,
     _find_enclosing_symbol,
+    _fsharp_binding_end_line,
+    _fsharp_binding_has_params,
+    _fsharp_binding_is_nested,
+    _fsharp_parent_is_type,
+    _fsharp_parent_name,
     _has_callable_ancestor,
     _head_type_identifier,
     _is_async_node,
@@ -948,7 +954,16 @@ class ASTParser:
         grammar_tag = "tsx" if lang == "typescript" and file_info.path.endswith(".tsx") else lang
         language = _get_language(grammar_tag)
 
-        if config is None or language is None:
+        # tree-sitter-fsharp ships a second grammar (``language_signature``)
+        # for .fsi signature files, and a spec loads exactly one. Read with
+        # the implementation grammar, a signature file's ``val`` and member
+        # signatures land in ERROR recovery, which hoists whatever the
+        # recovery invents into the symbol list. The regex tier still gives
+        # these files their ``open`` imports, which is all a signature file
+        # contributes that another file does not also state.
+        signature_file = lang == "fsharp" and file_info.path.endswith(".fsi")
+
+        if config is None or language is None or signature_file:
             if config is not None and language is None and lang not in _MISSING_GRAMMAR_REPORTED:
                 # Once per language, not once per file: the fact is about the
                 # environment, and it does not become truer on the four
@@ -1293,6 +1308,25 @@ class ASTParser:
             ):
                 continue
 
+            # F#: a ``let`` nested in another binding's body has the same node
+            # shape as a top-level one, so the ancestor filter above cannot
+            # see it -- what it captures is the binding's left-hand side, and
+            # a nested binding's left-hand side has no callable ancestor
+            # either. A ``let`` inside a type body is a field and stays.
+            if file_info.language == "fsharp" and node_type in (
+                "function_declaration_left",
+                "value_declaration_left",
+            ):
+                if _fsharp_binding_is_nested(def_node):
+                    continue
+                # A value binding that carries parameter patterns beside its
+                # name is a function the grammar reparsed as a value because
+                # of its return-type annotation.
+                if node_type == "value_declaration_left" and _fsharp_binding_has_params(
+                    def_node
+                ):
+                    kind = "function"
+
             # Refine "struct" kind for Go type_spec (check if struct or interface body)
             if kind == "struct" and config.parent_extraction == "receiver":
                 kind = refine_go_type_kind(def_node, src)
@@ -1320,6 +1354,15 @@ class ASTParser:
             if file_info.language == "elixir" and def_node.type == "call":
                 kind = refine_elixir_call_kind(def_node, src)
 
+            # F# writes a class, a struct and an interface with the same
+            # ``anon_type_defn`` node; only the body says which it is.
+            if (
+                kind == "class"
+                and file_info.language == "fsharp"
+                and def_node.type == "anon_type_defn"
+            ):
+                kind = refine_fsharp_type_kind(def_node)
+
             # Dart: a function is a ``function_signature`` whose BODY is a
             # sibling ``function_body`` node (members wrap the signature in
             # ``method_signature``). Two consequences the generic path can't
@@ -1331,6 +1374,15 @@ class ASTParser:
             end_line = def_node.end_point[0] + 1
             if export_type is not None:
                 end_line = export_type.range_node.end_point[0] + 1
+            # F#: the captured node is the binding's left-hand side, so its
+            # own span stops at the parameter list. Extend it over the body
+            # (and any return-type annotation between the two) or every call
+            # in the body is attributed to whatever encloses the binding.
+            if file_info.language == "fsharp" and node_type in (
+                "function_declaration_left",
+                "value_declaration_left",
+            ):
+                end_line = _fsharp_binding_end_line(def_node)
             if file_info.language == "dart" and node_type in (
                 "function_signature",
                 "getter_signature",
@@ -1473,6 +1525,12 @@ class ASTParser:
                         break
                     ancestor = ancestor.parent
 
+            # F#: no type node carries a ``name`` field -- the name hangs off
+            # a ``type_name`` child -- so the generic walk finds the ancestor
+            # and then reads nothing off it.
+            if parent_name is None and file_info.language == "fsharp":
+                parent_name = _fsharp_parent_name(def_node, src)
+
             # C/C++ qualified definitions: ``void Foo::method() { … }``
             # carries the class as the scope of a ``qualified_identifier``
             # parent of the name node. Without this resolution, every
@@ -1502,8 +1560,12 @@ class ASTParser:
             if node_type == "function_declarator" and parent_name is None:
                 continue
 
-            # Upgrade function → method when a parent class is detected
-            if parent_name and kind == "function":
+            # Upgrade function → method when a parent class is detected.
+            # F#: a nested module is a parent too (for id uniqueness), but it
+            # is not a type, so a `let` inside one stays a function.
+            if parent_name and kind == "function" and (
+                file_info.language != "fsharp" or _fsharp_parent_is_type(def_node)
+            ):
                 kind = "method"
 
             # Build signature
@@ -1704,6 +1766,40 @@ class ASTParser:
                             is_reexport=False,
                         )
                     )
+                continue
+
+            # F#: `open Foo.Bar` binds every public name in Foo.Bar, which is
+            # the wildcard sentinel this codebase already uses -- and which
+            # the call resolver reads to decide which imports a bare name may
+            # be looked up in (F# bare names are lexically scoped).
+            # `open type Foo.Bar.Baz` binds a TYPE's static members instead,
+            # so the module the file depends on is the path holding the type.
+            if file_info.language == "fsharp":
+                raw = _node_text(stmt_node, src).strip()
+                if raw in seen_raws:
+                    continue
+                seen_raws.add(raw)
+                module_path = _node_text(module_nodes[0], src).strip()
+                if not module_path:
+                    continue
+                names: list[str] = ["*"]
+                if any(child.type == "type" for child in stmt_node.children):
+                    head, _, type_name = module_path.rpartition(".")
+                    if head:
+                        module_path, names = head, [type_name]
+                    else:
+                        names = []
+                imports.append(
+                    Import(
+                        raw_statement=raw,
+                        module_path=module_path,
+                        imported_names=names,
+                        is_relative=False,
+                        resolved_file=None,
+                        bindings=[],
+                        is_reexport=False,
+                    )
+                )
                 continue
 
             raw = _node_text(stmt_node, src).strip()
@@ -1949,6 +2045,16 @@ class ASTParser:
             receiver_name = _node_text(receiver_nodes[0], src).strip() if receiver_nodes else None
             if receiver_name and file_info.language == "php":
                 receiver_name = _normalize_php_receiver(receiver_name)
+            # F#: a dotted static path (``Path.Combine(a, b)``) collapses into
+            # one identifier node in this grammar -- there is no dot node to
+            # capture a receiver from -- so the split happens on the text.
+            # After the builtin check above, so a name is filtered as written.
+            if file_info.language == "fsharp" and receiver_name is None and "." in target_name:
+                receiver_name, _, target_name = target_name.rpartition(".")
+                receiver_name = receiver_name.strip()
+                target_name = target_name.strip()
+                if not target_name:
+                    continue
             receiver_call = (
                 _call_receiver_from_node(receiver_call_nodes[0], src)
                 if receiver_call_nodes

--- a/packages/core/src/repowise/core/ingestion/parser_helpers.py
+++ b/packages/core/src/repowise/core/ingestion/parser_helpers.py
@@ -17,7 +17,7 @@ from typing import TYPE_CHECKING
 import structlog
 from tree_sitter import Node
 
-from .extractors import node_text
+from .extractors import fsharp_type_name, node_text
 from .language_data import get_builtin_types
 from .type_names import is_resolvable_type_name
 
@@ -1164,6 +1164,172 @@ def _pascal_head_type_identifier(type_node: Node, src: str) -> str | None:
     return text
 
 
+# ---------------------------------------------------------------------------
+# F# binding, parent and type-head helpers
+# ---------------------------------------------------------------------------
+
+# The two nodes fsharp.scm captures as @symbol.def for a `let` binding. One
+# `function_or_value_defn` holds every clause of a `let rec f ... and g ...`
+# group, so a clause is delimited by the next one of these, not by the node.
+_FSHARP_BINDING_LEFT = ("function_declaration_left", "value_declaration_left")
+
+# A binding whose ancestors include one of these sits inside another
+# binding's body, so it is a local, not a member of the module or type.
+_FSHARP_BODY_OWNERS = (
+    "function_or_value_defn",
+    "method_or_prop_defn",
+    "fun_expression",
+    # A top-level `do` block is executed code, not a declaration site.
+    "do",
+    "do_expression",
+)
+
+# Type shapes whose `type_name` child names the enclosing type of a member.
+_FSHARP_TYPE_OWNERS = (
+    "anon_type_defn",
+    "record_type_defn",
+    "union_type_defn",
+    "enum_type_defn",
+    "delegate_type_defn",
+    "type_abbrev_defn",
+    "type_extension",
+)
+
+
+def _fsharp_binding_is_nested(left_node: Node) -> bool:
+    """True when a ``let`` binding is local to another binding's body.
+
+    A nested ``let`` has the same node shape as a top-level one -- the
+    grammar distinguishes them only by what encloses them -- so the generic
+    callable-ancestor filter cannot see it: that filter looks for an
+    ancestor whose *own* type is a captured callable, and the captured node
+    here is the binding's left-hand side, never an ancestor of anything.
+    A ``let`` directly inside a type body is deliberately not nested: it is
+    that type's field.
+    """
+    ancestor = left_node.parent  # the binding's own function_or_value_defn
+    ancestor = ancestor.parent if ancestor is not None else None
+    while ancestor is not None:
+        if ancestor.type in _FSHARP_BODY_OWNERS:
+            return True
+        ancestor = ancestor.parent
+    return False
+
+
+def _fsharp_binding_end_line(left_node: Node) -> int:
+    """Last line of the clause introduced by *left_node*, 1-indexed.
+
+    Walks forward to the next clause's left-hand side rather than taking the
+    left node's next sibling, because a return-type annotation
+    (``let f x : int = ...``) sits between the left node and the body.
+    """
+    parent = left_node.parent
+    if parent is None:
+        return left_node.end_point[0] + 1
+    end = left_node.end_point[0] + 1
+    seen = False
+    for child in parent.named_children:
+        if child.id == left_node.id:
+            seen = True
+            continue
+        if not seen:
+            continue
+        if child.type in _FSHARP_BINDING_LEFT or child.type == "xml_doc":
+            # A doc comment inside the defn belongs to the clause after it.
+            break
+        end = max(end, child.end_point[0] + 1)
+    return end
+
+
+def _fsharp_binding_has_params(left_node: Node) -> bool:
+    """True when a value_declaration_left actually binds a function.
+
+    let total (xs: int list) : int = ... has parameters, but the return
+    type makes the grammar read the whole head as one value pattern: the
+    name and every parameter pattern become siblings inside a single
+    identifier_pattern. A plain let x: int = 5 leaves that node with
+    the name alone, which is what separates the two.
+    """
+    holder = next(
+        (c for c in left_node.named_children if c.type == "identifier_pattern"), None
+    )
+    return holder is not None and holder.named_child_count > 1
+
+
+def _fsharp_parent_is_type(def_node: Node) -> bool:
+    """True when the innermost owner enclosing an F# symbol is a type rather
+    than a nested module.
+
+    A ``let`` inside ``module Inner = ...`` is still a plain function, not a
+    method -- only a type body turns a binding into a member. The generic
+    function-to-method promotion in parser.py has no notion of "module", so
+    it needs this to tell the two owners apart before promoting.
+    """
+    ancestor = def_node.parent
+    while ancestor is not None:
+        if ancestor.type in _FSHARP_TYPE_OWNERS:
+            return True
+        if ancestor.type == "module_defn":
+            return False
+        ancestor = ancestor.parent
+    return False
+
+
+def _fsharp_owner_name(owner: Node, src: str) -> str | None:
+    """The declared name of one F# type or nested-module node."""
+    if owner.type == "module_defn":
+        ident = next((c for c in owner.named_children if c.type == "identifier"), None)
+        return node_text(ident, src).strip() if ident is not None else None
+    name_node = owner.child_by_field_name("type_name")
+    if name_node is None:
+        holder = next((c for c in owner.named_children if c.type == "type_name"), None)
+        name_node = holder.child_by_field_name("type_name") if holder else None
+    if name_node is None:
+        return None
+    if name_node.type == "long_identifier":
+        idents = [c for c in name_node.named_children if c.type == "identifier"]
+        name_node = idents[-1] if idents else name_node
+    return node_text(name_node, src).strip() or None
+
+
+def _fsharp_parent_name(def_node: Node, src: str) -> str | None:
+    """Return the dotted owner path of an F# symbol.
+
+    No F# type node carries a ``name`` field -- the name lives on a
+    ``type_name`` child, tagged with a ``type_name`` field of its own -- so
+    the generic nesting walk in ``_find_parent`` finds nothing to read.
+
+    Every enclosing nested module joins the path, not just the nearest
+    owner: one file may hold ``module A`` and ``module B`` each declaring a
+    ``type Dup`` with a ``Go`` member, and a symbol id is path plus parent
+    plus name, so a nearest-owner parent would give both members one id.
+    A file-level ``module``/``namespace`` header is skipped, since it is the
+    whole file and distinguishes nothing within it.
+    """
+    parts: list[str] = []
+    ancestor = def_node.parent
+    while ancestor is not None:
+        if ancestor.type in _FSHARP_TYPE_OWNERS or ancestor.type == "module_defn":
+            name = _fsharp_owner_name(ancestor, src)
+            if name:
+                parts.append(name)
+        ancestor = ancestor.parent
+    return ".".join(reversed(parts)) or None
+
+
+def _fsharp_head_type_identifier(type_node: Node, src: str) -> str | None:
+    """The resolvable head of an F# type annotation.
+
+    ``fsharp_type_name`` does the walk; this adds the filter the type-
+    reference pass needs, since a primitive or an FSharp.Core type
+    constructor never has an in-repo declaration.
+    """
+    text = fsharp_type_name(type_node, src)
+    if not text or text in get_builtin_types("fsharp"):
+        return None
+    return text
+
+
 # Per-language head-identifier extractor for ``@param.type`` captures.
 # Defaults to the C#-shaped extractor; languages with a differently-shaped
 # type grammar register their own here.
@@ -1192,6 +1358,7 @@ TYPE_HEAD_EXTRACTORS: dict[str, Callable[[Node, str], str | None]] = {
     "rust": _rust_head_type_identifier,
     "pascal": _pascal_head_type_identifier,
     "elixir": _elixir_head_type_identifier,
+    "fsharp": _fsharp_head_type_identifier,
 }
 
 

--- a/packages/core/src/repowise/core/ingestion/queries/fsharp.scm
+++ b/packages/core/src/repowise/core/ingestion/queries/fsharp.scm
@@ -1,0 +1,266 @@
+; =============================================================================
+; repowise -- F# symbol, import, call and type-reference queries
+; tree-sitter-fsharp (ionide/tree-sitter-fsharp) >= 0.3.11, implementation
+; grammar (`language()`); .fsi signature files use a separate grammar and are
+; routed to the regex import tier instead; see parser.py.
+; =============================================================================
+;
+; Node-shape reference (read off the installed grammar, not the docs):
+;   named_module        := 'module' name:(long_identifier) decl*
+;                          -- top-level `module Foo.Bar`, no '='; the rest of
+;                             the file hangs off it directly
+;   module_defn         := attributes? 'module' (identifier) '=' block:(_)+
+;                          -- nested `module X =`; the name is a bare
+;                             identifier, never a long_identifier
+;   namespace           := 'namespace' name:(long_identifier) decl*
+;   function_or_value_defn
+;                       := 'let' 'rec'? LEFT '='? type? body:(_)
+;                          ('and' LEFT '=' body:(_))*
+;                          -- LEFT is function_declaration_left (has params) or
+;                             value_declaration_left (plain value). ONE node
+;                             holds every clause of a `let rec ... and ...` group,
+;                             which is why @symbol.def sits on the LEFT node:
+;                             each clause has to be its own symbol.
+;   type_definition     := 'type' (record_type_defn | union_type_defn |
+;                                  anon_type_defn | enum_type_defn |
+;                                  delegate_type_defn | type_extension | ...)
+;                          -- the name is `type_name: (identifier|long_identifier)`
+;                             inside a `type_name` node, and the outer
+;                             type_definition carries no name of its own, so
+;                             @symbol.def sits on the inner defn node (which
+;                             also lets each shape map to its own kind)
+;   member_defn         := 'static'? 'abstract'? 'member' 'val'?
+;                          (method_or_prop_defn | member_signature | property_or_ident)
+;   application_expression
+;                       := LEFT-CURRIED, one node per argument and no field
+;                          names: `add 1 2` is application(application(add,1),2)
+;   import_decl         := 'open' 'type'? (long_identifier)
+
+; ---------------------------------------------------------------
+; Modules and namespaces
+; ---------------------------------------------------------------
+
+(named_module
+  name: (long_identifier) @symbol.name) @symbol.def
+
+(namespace
+  name: (long_identifier) @symbol.name) @symbol.def
+
+(module_defn
+  (identifier) @symbol.name) @symbol.def
+
+; ---------------------------------------------------------------
+; let bindings -- one symbol per clause.
+; The def capture is the LEFT node, not the enclosing
+; function_or_value_defn: a `let rec f ... and g ...` group is a single
+; defn node holding both clauses, so capturing the defn would give
+; two symbols the same span. parser.py extends each symbol's end
+; line over its own clause (return-type annotation included).
+; ---------------------------------------------------------------
+
+(function_or_value_defn
+  (function_declaration_left
+    (access_modifier)? @symbol.modifiers
+    (identifier) @symbol.name
+    (argument_patterns)? @symbol.params) @symbol.def)
+
+; Active pattern `let (|Even|Odd|) n = ...` defines one name per case,
+; so this fires once per case name and mints one symbol for each.
+(function_or_value_defn
+  (function_declaration_left
+    (access_modifier)? @symbol.modifiers
+    (active_pattern
+      (active_pattern_op_name) @symbol.name)) @symbol.def)
+
+; Plain value binding. Only the single-name shape is captured:
+; `let a, b = ...` nests both names in a repeat_pattern, where nothing
+; in the grammar says which span belongs to which name.
+(function_or_value_defn
+  (value_declaration_left
+    (access_modifier)? @symbol.modifiers
+    (identifier_pattern
+      (long_identifier_or_op
+        (identifier) @symbol.name))) @symbol.def)
+
+; A binding that has BOTH parameters and a return-type annotation
+; (`let total (xs: int list) : int = ...`) reparses as a value binding whose
+; name sits one level deeper, with the parameter patterns as siblings of the
+; name inside the same identifier_pattern. That extra nesting is the only
+; thing that tells this shape apart from a plain value, and parser.py reads
+; the kind back off it.
+(function_or_value_defn
+  (value_declaration_left
+    (access_modifier)? @symbol.modifiers
+    (identifier_pattern
+      (long_identifier_or_op
+        (long_identifier (identifier) @symbol.name .)))) @symbol.def)
+
+; ---------------------------------------------------------------
+; Type definitions. One pattern pair per shape so each keeps its own
+; kind; the name is either a bare identifier or a long_identifier (a
+; generic head), and the last segment of the latter is the type's own
+; name. `type Foo with ...` (type_extension) is deliberately absent: it
+; augments a type declared elsewhere rather than declaring one, and
+; capturing it minted a second symbol under the id of the type it
+; augments. Its members still find `Foo` as their parent, because the
+; parent walk in parser.py reads type_extension as an owner.
+; ---------------------------------------------------------------
+
+(record_type_defn
+  (type_name (access_modifier)? @symbol.modifiers
+    type_name: (identifier) @symbol.name)) @symbol.def
+(record_type_defn
+  (type_name (access_modifier)? @symbol.modifiers
+    type_name: (long_identifier (identifier) @symbol.name .))) @symbol.def
+
+(union_type_defn
+  (type_name (access_modifier)? @symbol.modifiers
+    type_name: (identifier) @symbol.name)) @symbol.def
+(union_type_defn
+  (type_name (access_modifier)? @symbol.modifiers
+    type_name: (long_identifier (identifier) @symbol.name .))) @symbol.def
+
+(enum_type_defn
+  (type_name (access_modifier)? @symbol.modifiers
+    type_name: (identifier) @symbol.name)) @symbol.def
+(enum_type_defn
+  (type_name (access_modifier)? @symbol.modifiers
+    type_name: (long_identifier (identifier) @symbol.name .))) @symbol.def
+
+(delegate_type_defn
+  (type_name (access_modifier)? @symbol.modifiers
+    type_name: (identifier) @symbol.name)) @symbol.def
+(delegate_type_defn
+  (type_name (access_modifier)? @symbol.modifiers
+    type_name: (long_identifier (identifier) @symbol.name .))) @symbol.def
+
+(type_abbrev_defn
+  (type_name (access_modifier)? @symbol.modifiers
+    type_name: (identifier) @symbol.name)) @symbol.def
+(type_abbrev_defn
+  (type_name (access_modifier)? @symbol.modifiers
+    type_name: (long_identifier (identifier) @symbol.name .))) @symbol.def
+
+; Classes, interfaces and structs all share anon_type_defn; the kind is
+; refined in the parser by looking at whether every member is abstract.
+(anon_type_defn
+  (type_name (access_modifier)? @symbol.modifiers
+    type_name: (identifier) @symbol.name)) @symbol.def
+(anon_type_defn
+  (type_name (access_modifier)? @symbol.modifiers
+    type_name: (long_identifier (identifier) @symbol.name .))) @symbol.def
+
+(exception_definition
+  exception_name: (long_identifier (identifier) @symbol.name .)) @symbol.def
+
+; ---------------------------------------------------------------
+; Members. `this.Foo` / `_.Foo` put the receiver under `instance` and
+; the name under `method`; `static member Create()` and
+; `member val Data = 0` carry a bare property_or_ident instead, and an
+; abstract member carries a member_signature.
+; ---------------------------------------------------------------
+
+(member_defn
+  (method_or_prop_defn
+    name: (property_or_ident
+      method: (identifier) @symbol.name)
+    args: (_)? @symbol.params)) @symbol.def
+
+(member_defn
+  (method_or_prop_defn
+    name: (property_or_ident
+      . (identifier) @symbol.name .)
+    args: (_)? @symbol.params)) @symbol.def
+
+(member_defn
+  (property_or_ident
+    . (identifier) @symbol.name .)) @symbol.def
+
+(member_defn
+  (member_signature
+    (identifier) @symbol.name)) @symbol.def
+
+; ---------------------------------------------------------------
+; Imports -- `open Foo.Bar`, `open type Foo.Bar.Baz`. Both forms put the
+; whole dotted path in one long_identifier; parser.py reads the `type`
+; token back off the statement, because `open type` names a TYPE and the
+; module the file depends on is the path that contains it.
+; `#load "x.fsx"` is a script directive, not an open; the regex tier never
+; emitted it either, so it stays out rather than arriving in one tier only.
+; ---------------------------------------------------------------
+
+(import_decl
+  (long_identifier) @import.module) @import.statement
+
+; ---------------------------------------------------------------
+; Call graph.
+; The callee must be an identifier or a dotted identifier: a literal, a
+; lambda or a parenthesised expression in callee position is not a name
+; anyone can resolve, so it mints nothing. `Path.Combine(a, b)` collapses
+; the whole dotted path into one long_identifier (there is no dot_expression
+; for a static path), so the receiver/target split happens in parser.py.
+; No @call.arguments: currying means each argument is a separate
+; application_expression node, so an argument count read off any single one
+; would be wrong.
+; ---------------------------------------------------------------
+
+; Bare application -- `add 1 2`, `helper x`. The callee must start
+; lowercase: F# spells functions camelCase and reserves an initial capital
+; for union cases, types and constructors, none of which is a call to a
+; function symbol. `Wrapper 5` and `add 1 2` are the same node shape, so
+; the naming convention is the only thing that separates them, and minting
+; the union case would bind it to whatever same-named function exists.
+((application_expression
+   . (long_identifier_or_op
+       (identifier) @call.target)) @call.site
+ (#not-match? @call.target "^[A-Z]"))
+
+; Dotted static path -- `List.map f xs`, `Path.Combine(a, b)`.
+(application_expression
+  . (long_identifier_or_op
+      (long_identifier) @call.target)) @call.site
+
+; Instance method -- `sb.Append x`. The base is restricted to a plain name:
+; a base that is itself an expression (`Counter(1).Increment()`) names no
+; receiver the resolver could use, and a wrong receiver is worse than none.
+(application_expression
+  . (dot_expression
+      base: (long_identifier_or_op) @call.receiver
+      field: (long_identifier_or_op
+        (identifier) @call.target))) @call.site
+
+; Pipe -- `xs |> reverse`. Keyed on the operator text because every other
+; infix expression has an ordinary value on its right-hand side; only `|>`
+; makes that value the thing being applied.
+((infix_expression
+   (infix_op) @_op
+   .
+   (long_identifier_or_op
+     (identifier) @call.target) .) @call.site
+ (#eq? @_op "|>")
+ (#not-match? @call.target "^[A-Z]"))
+
+((infix_expression
+   (infix_op) @_op
+   .
+   (long_identifier_or_op
+     (long_identifier) @call.target) .) @call.site
+ (#eq? @_op "|>"))
+
+; ---------------------------------------------------------------
+; Type references. Declaration positions only, and captured as
+; @param.type -- never as a call. A type in an annotation is named, not
+; invoked, and letting one through as a call target is how a constructor
+; and its type end up sharing an edge.
+; ---------------------------------------------------------------
+
+(typed_pattern (simple_type) @param.type)
+(argument_spec (simple_type) @param.type)
+(record_field (simple_type) @param.type)
+(union_type_field (simple_type) @param.type)
+(curried_spec (simple_type) @param.type)
+(function_type (simple_type) @param.type)
+(postfix_type (simple_type) @param.type)
+(function_or_value_defn (simple_type) @param.type)
+(class_inherits_decl (simple_type) @param.type)
+(interface_implementation (simple_type) @param.type)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ dependencies = [
     "tree-sitter-gdscript>=6.1,<7",
     "tree-sitter-vb-dotnet>=0.3,<1",
     "tree-sitter-elixir>=0.3.5,<1",
+    "tree-sitter-fsharp>=0.3.11,<1",
     # Markup grammars for single-file components: these locate <script> blocks
     # and markup expressions only; the JS inside them is parsed with the
     # TypeScript grammar (see sfc_source.py). There is no tree-sitter-vue on

--- a/tests/unit/ingestion/parser/test_fsharp.py
+++ b/tests/unit/ingestion/parser/test_fsharp.py
@@ -1,0 +1,545 @@
+"""Unit tests for the F# language pipeline.
+
+Tests parse inline byte strings so no filesystem I/O is needed. Covers
+symbols (including each clause of a ``let rec ... and`` group), the nested
+binding filter, imports, calls, type references, docstrings and heritage --
+see docs/architecture/language-support.md's "one .scm file + one
+LanguageConfig" recipe.
+"""
+
+from __future__ import annotations
+
+from repowise.core.ingestion.parser import ASTParser
+from tests.unit.ingestion.parser._helpers import _make_file_info
+
+
+def _fs(path: str = "src/Sample.fs") -> object:
+    return _make_file_info(path, "fsharp")
+
+
+MODULE_SOURCE = b"""\
+module Acme.Widgets
+
+open System
+open System.IO
+open type System.Math
+
+/// <summary>Adds two numbers.</summary>
+let add a b = a + b
+
+let rec countDown n = countUp n
+and countUp n = countDown n
+
+let private secret = 42
+
+type Person = { Name: string; Age: int }
+
+type Shape =
+    | Circle of float
+    | Square of float
+
+type Palette =
+    | Red = 1
+    | Blue = 2
+
+type IShape =
+    abstract member Area: unit -> float
+
+type Counter(start: int) =
+    let mutable count = start
+    member this.Increment() = count <- count + 1
+    static member Create() = Counter(0)
+
+exception WidgetError of string
+
+let (|Even|Odd|) n = if n % 2 = 0 then Even else Odd
+
+let outer x =
+    let inner y = y + x
+    inner 3
+"""
+
+
+class TestFsharpSymbols:
+    def test_module_header_is_a_symbol(self, parser: ASTParser) -> None:
+        result = parser.parse_file(_fs(), MODULE_SOURCE)
+        assert ("Acme.Widgets", "module") in {(s.name, s.kind) for s in result.symbols}
+
+    def test_namespace_and_nested_module(self, parser: ASTParser) -> None:
+        src = b"""\
+namespace Acme.Domain
+
+module Helpers =
+    let ping () = 1
+"""
+        result = parser.parse_file(_fs(), src)
+        kinds = {(s.name, s.kind) for s in result.symbols}
+        assert ("Acme.Domain", "module") in kinds
+        assert ("Helpers", "module") in kinds
+
+    def test_let_bindings_split_function_from_value(self, parser: ASTParser) -> None:
+        result = parser.parse_file(_fs(), MODULE_SOURCE)
+        kinds = {(s.name, s.kind) for s in result.symbols}
+        assert ("add", "function") in kinds
+        assert ("secret", "variable") in kinds
+
+    def test_each_and_clause_is_its_own_symbol(self, parser: ASTParser) -> None:
+        # `let rec f ... and g ...` is ONE grammar node holding both clauses.
+        result = parser.parse_file(_fs(), MODULE_SOURCE)
+        by_name = {s.name: s for s in result.symbols}
+        assert "countDown" in by_name
+        assert "countUp" in by_name
+        assert by_name["countDown"].start_line != by_name["countUp"].start_line
+
+    def test_binding_span_covers_its_body(self, parser: ASTParser) -> None:
+        # Without this the call sites in the body belong to whatever encloses
+        # the binding, because the captured node stops at the parameter list.
+        result = parser.parse_file(_fs(), MODULE_SOURCE)
+        outer = next(s for s in result.symbols if s.name == "outer")
+        assert outer.end_line > outer.start_line
+
+    def test_return_type_annotation_does_not_truncate_the_span(
+        self, parser: ASTParser
+    ) -> None:
+        src = b"""\
+module Acme.Widgets
+
+let total (xs: int list) : int =
+    let seed = 0
+    List.sum xs
+"""
+        result = parser.parse_file(_fs(), src)
+        total = next(s for s in result.symbols if s.name == "total")
+        assert total.start_line == 3
+        assert total.end_line == 5
+
+    def test_members_are_methods_of_their_type(self, parser: ASTParser) -> None:
+        result = parser.parse_file(_fs(), MODULE_SOURCE)
+        members = {(s.name, s.kind, s.parent_name) for s in result.symbols}
+        assert ("Increment", "method", "Counter") in members
+        assert ("Create", "method", "Counter") in members
+        assert ("Area", "method", "IShape") in members
+
+    def test_class_let_binding_is_a_field_of_the_type(self, parser: ASTParser) -> None:
+        result = parser.parse_file(_fs(), MODULE_SOURCE)
+        count = next(s for s in result.symbols if s.name == "count")
+        assert count.parent_name == "Counter"
+        assert count.kind == "variable"
+
+    def test_active_pattern_names_every_case(self, parser: ASTParser) -> None:
+        result = parser.parse_file(_fs(), MODULE_SOURCE)
+        names = {s.name for s in result.symbols}
+        assert {"Even", "Odd"} <= names
+
+    def test_nested_let_is_not_a_top_level_symbol(self, parser: ASTParser) -> None:
+        result = parser.parse_file(_fs(), MODULE_SOURCE)
+        assert "inner" not in {s.name for s in result.symbols}
+
+    def test_same_name_in_two_nested_modules_keeps_distinct_ids(
+        self, parser: ASTParser
+    ) -> None:
+        src = b"""\
+namespace Acme.Domain
+
+module Reader =
+    let run () = 1
+
+module Writer =
+    let run () = 2
+"""
+        result = parser.parse_file(_fs(), src)
+        ids = {s.id for s in result.symbols if s.name == "run"}
+        assert len(ids) == 2
+
+    def test_private_binding_is_private(self, parser: ASTParser) -> None:
+        result = parser.parse_file(_fs(), MODULE_SOURCE)
+        secret = next(s for s in result.symbols if s.name == "secret")
+        assert secret.visibility == "private"
+
+    def test_internal_binding_is_internal(self, parser: ASTParser) -> None:
+        src = b"module Acme.Widgets\n\nlet internal cache = 1\n"
+        result = parser.parse_file(_fs(), src)
+        cache = next(s for s in result.symbols if s.name == "cache")
+        assert cache.visibility == "internal"
+
+    def test_script_file_parses(self, parser: ASTParser) -> None:
+        src = b"""\
+#r "nuget: Acme.Widgets"
+open Acme.Widgets
+
+let greet name = printfn "%s" name
+greet "world"
+"""
+        result = parser.parse_file(_make_file_info("build.fsx", "fsharp"), src)
+        assert "greet" in {s.name for s in result.symbols}
+
+
+    def test_parent_is_qualified_through_enclosing_modules(
+        self, parser: ASTParser
+    ) -> None:
+        # Two modules in one file may each declare the same type with the
+        # same member; a nearest-owner parent would give both members one id.
+        src = b"""namespace Acme.Domain
+
+module Reader =
+    type Dup() =
+        member this.Go() = 1
+
+module Writer =
+    type Dup() =
+        member this.Go() = 2
+"""
+        result = parser.parse_file(_fs(), src)
+        parents = {s.parent_name for s in result.symbols if s.name == "Go"}
+        assert parents == {"Reader.Dup", "Writer.Dup"}
+        assert len({s.id for s in result.symbols if s.name == "Go"}) == 2
+
+    def test_type_extension_does_not_mint_a_second_type_symbol(
+        self, parser: ASTParser
+    ) -> None:
+        # `type Circle with ...` augments a type declared elsewhere; capturing
+        # it as a symbol put a second `Circle` under the id of the first.
+        src = b"""module Acme.Widgets
+
+type Circle() =
+    member _.Area = 1.0
+
+type Circle with
+    member _.Perimeter = 2.0
+"""
+        result = parser.parse_file(_fs(), src)
+        assert len([s for s in result.symbols if s.name == "Circle"]) == 1
+        perimeter = next(s for s in result.symbols if s.name == "Perimeter")
+        assert perimeter.parent_name == "Circle"
+
+    def test_let_inside_a_do_block_is_not_a_module_symbol(
+        self, parser: ASTParser
+    ) -> None:
+        src = b"""module Acme.Widgets
+
+do
+    let scratch = 1
+    ignore scratch
+"""
+        result = parser.parse_file(_fs(), src)
+        assert "scratch" not in {s.name for s in result.symbols}
+
+
+class TestFsharpTypeKinds:
+    def test_type_kinds(self, parser: ASTParser) -> None:
+        result = parser.parse_file(_fs(), MODULE_SOURCE)
+        kinds = {(s.name, s.kind) for s in result.symbols}
+        assert ("Person", "struct") in kinds
+        assert ("Shape", "enum") in kinds
+        assert ("Palette", "enum") in kinds
+        assert ("Counter", "class") in kinds
+        assert ("WidgetError", "class") in kinds
+
+    def test_all_abstract_type_is_an_interface(self, parser: ASTParser) -> None:
+        result = parser.parse_file(_fs(), MODULE_SOURCE)
+        assert ("IShape", "interface") in {(s.name, s.kind) for s in result.symbols}
+
+    def test_a_class_with_a_constructor_stays_a_class(self, parser: ASTParser) -> None:
+        src = b"""\
+module Acme.Widgets
+
+type Handle(id: int) =
+    abstract member Close: unit -> unit
+    default _.Close() = ()
+"""
+        result = parser.parse_file(_fs(), src)
+        assert ("Handle", "class") in {(s.name, s.kind) for s in result.symbols}
+
+
+    def test_type_access_modifiers_are_read(self, parser: ASTParser) -> None:
+        src = b"""module Acme.Widgets
+
+type private Hidden = { A: int }
+
+type internal Shared() =
+    member _.X = 1
+
+type Open = { B: int }
+"""
+        result = parser.parse_file(_fs(), src)
+        visibility = {s.name: s.visibility for s in result.symbols}
+        assert visibility["Hidden"] == "private"
+        assert visibility["Shared"] == "internal"
+        assert visibility["Open"] == "public"
+
+
+class TestFsharpEncoding:
+    def test_non_ascii_source_round_trips(self, parser: ASTParser) -> None:
+        src = "module Acme.Widgets\n\n/// Grusse aus Munchen\nlet gruss () = \"Munchen\"\n".replace(
+            "u", "ü"
+        ).encode("utf-8")
+        result = parser.parse_file(_fs(), src)
+        names = {s.name for s in result.symbols}
+        assert any(name.startswith("gr") for name in names)
+
+
+class TestFsharpSignatureFiles:
+    def test_fsi_keeps_imports_and_claims_no_symbols(self, parser: ASTParser) -> None:
+        # The implementation grammar mis-parses a signature file, so .fsi
+        # takes the regex import tier instead of an invented tree.
+        src = b"""\
+namespace Acme.Domain
+
+open System
+
+module Helpers =
+    val add: int -> int -> int
+"""
+        result = parser.parse_file(_make_file_info("src/Helpers.fsi", "fsharp"), src)
+        assert result.symbols == []
+        assert [i.module_path for i in result.imports] == ["System"]
+
+
+class TestFsharpImports:
+    def test_open_binds_a_whole_module(self, parser: ASTParser) -> None:
+        # The wildcard sentinel is what `open` means, and it is what the call
+        # resolver reads to decide where a bare name may be looked up.
+        result = parser.parse_file(_fs(), MODULE_SOURCE)
+        opens = [i for i in result.imports if not i.raw_statement.startswith("open type")]
+        assert [i.module_path for i in opens] == ["System", "System.IO"]
+        assert all(i.imported_names == ["*"] for i in opens)
+
+    def test_open_type_names_the_module_holding_the_type(
+        self, parser: ASTParser
+    ) -> None:
+        result = parser.parse_file(_fs(), MODULE_SOURCE)
+        typed = next(i for i in result.imports if i.raw_statement.startswith("open type"))
+        assert typed.module_path == "System"
+        assert typed.imported_names == ["Math"]
+
+    def test_load_directive_is_not_an_import(self, parser: ASTParser) -> None:
+        # `#load` names a file, not a module, and the regex tier never emitted
+        # one either; a directive arriving in only one tier is worse than none.
+        src = b'#load "Other.fsx"\nopen Acme.Widgets\n'
+        result = parser.parse_file(_make_file_info("build.fsx", "fsharp"), src)
+        assert [i.module_path for i in result.imports] == ["Acme.Widgets"]
+
+
+CALL_SOURCE = b"""\
+module Acme.Widgets
+
+open System.IO
+
+let add a b = a + b
+
+let bare () = add 1 2
+let qualified () = Path.Combine("a", "b")
+let piped xs = xs |> List.rev
+let instance (sb: System.Text.StringBuilder) = sb.Append "x"
+"""
+
+
+class TestFsharpCalls:
+    def test_bare_application(self, parser: ASTParser) -> None:
+        result = parser.parse_file(_fs(), CALL_SOURCE)
+        assert ("add", None) in {(c.target_name, c.receiver_name) for c in result.calls}
+
+    def test_dotted_path_splits_into_receiver_and_target(
+        self, parser: ASTParser
+    ) -> None:
+        result = parser.parse_file(_fs(), CALL_SOURCE)
+        assert ("Combine", "Path") in {
+            (c.target_name, c.receiver_name) for c in result.calls
+        }
+
+    def test_pipe_right_hand_side_is_a_call(self, parser: ASTParser) -> None:
+        result = parser.parse_file(_fs(), CALL_SOURCE)
+        assert ("rev", "List") in {
+            (c.target_name, c.receiver_name) for c in result.calls
+        }
+
+    def test_instance_method_keeps_its_receiver(self, parser: ASTParser) -> None:
+        result = parser.parse_file(_fs(), CALL_SOURCE)
+        assert ("Append", "sb") in {
+            (c.target_name, c.receiver_name) for c in result.calls
+        }
+
+    def test_ordinary_infix_operand_is_not_a_call(self, parser: ASTParser) -> None:
+        # Only `|>` applies its right-hand side; `a + b` must mint nothing.
+        result = parser.parse_file(_fs(), CALL_SOURCE)
+        targets = {c.target_name for c in result.calls}
+        assert "b" not in targets
+
+    def test_binding_heads_are_not_calls(self, parser: ASTParser) -> None:
+        result = parser.parse_file(_fs(), CALL_SOURCE)
+        targets = {c.target_name for c in result.calls}
+        assert targets.isdisjoint({"let", "bare", "qualified", "piped", "instance"})
+
+    def test_calls_belong_to_the_binding_they_sit_in(self, parser: ASTParser) -> None:
+        result = parser.parse_file(_fs(), CALL_SOURCE)
+        call = next(c for c in result.calls if c.target_name == "add")
+        assert call.caller_symbol_id == "src/Sample.fs::bare"
+
+    def test_core_names_are_filtered(self, parser: ASTParser) -> None:
+        src = b"""\
+module Acme.Widgets
+
+let report x =
+    printfn "%d" x
+    Some x
+"""
+        result = parser.parse_file(_fs(), src)
+        assert {c.target_name for c in result.calls}.isdisjoint({"printfn", "Some"})
+
+
+    def test_uppercase_bare_callee_is_not_a_call(self, parser: ASTParser) -> None:
+        # `Wrapper 5` builds a union case and `Buffer()` a constructor; both
+        # are the node shape of `add 1 2`, and F# reserves an initial capital
+        # for cases, types and constructors, so neither names a function.
+        src = b"""module Acme.Widgets
+
+type Boxed = Wrapper of int
+
+let wrap n = Wrapper n
+let make () = Buffer()
+"""
+        result = parser.parse_file(_fs(), src)
+        assert {c.target_name for c in result.calls}.isdisjoint({"Wrapper", "Buffer"})
+
+    def test_qualified_uppercase_callee_still_resolves(
+        self, parser: ASTParser
+    ) -> None:
+        # The convention only speaks about BARE names: a receiver already
+        # says where the name lives.
+        src = b"module Acme.Widgets\n\nlet run () = Acme.Runner.Start()\n"
+        result = parser.parse_file(_fs(), src)
+        assert ("Start", "Acme.Runner") in {
+            (c.target_name, c.receiver_name) for c in result.calls
+        }
+
+
+class TestFsharpTypeReferences:
+    def test_annotation_is_a_type_reference_and_never_a_call(
+        self, parser: ASTParser
+    ) -> None:
+        src = b"""\
+module Acme.Widgets
+
+let load (source: WidgetSource) = source
+
+type Holder = { Widget: WidgetSource }
+"""
+        result = parser.parse_file(_fs(), src)
+        assert "WidgetSource" in {t.type_name for t in result.type_refs}
+        assert "WidgetSource" not in {c.target_name for c in result.calls}
+
+    def test_builtin_types_are_not_references(self, parser: ASTParser) -> None:
+        src = b"module Acme.Widgets\n\nlet count (n: int) (s: string) = n\n"
+        result = parser.parse_file(_fs(), src)
+        assert {t.type_name for t in result.type_refs}.isdisjoint({"int", "string"})
+
+    def test_qualified_annotation_keeps_the_last_segment(
+        self, parser: ASTParser
+    ) -> None:
+        src = b"module Acme.Widgets\n\nlet render (w: Acme.Core.Widget) = w\n"
+        result = parser.parse_file(_fs(), src)
+        assert "Widget" in {t.type_name for t in result.type_refs}
+
+
+class TestFsharpDocstrings:
+    def test_xml_doc_above_a_binding(self, parser: ASTParser) -> None:
+        result = parser.parse_file(_fs(), MODULE_SOURCE)
+        add = next(s for s in result.symbols if s.name == "add")
+        assert add.docstring == "Adds two numbers."
+
+    def test_each_and_clause_keeps_its_own_doc(self, parser: ASTParser) -> None:
+        src = b"""\
+module Acme.Widgets
+
+/// First clause.
+let rec ping x = pong x
+/// Second clause.
+and pong x = ping x
+"""
+        result = parser.parse_file(_fs(), src)
+        docs = {s.name: s.docstring for s in result.symbols}
+        assert docs["ping"] == "First clause."
+        assert docs["pong"] == "Second clause."
+
+    def test_file_level_doc_becomes_the_module_docstring(
+        self, parser: ASTParser
+    ) -> None:
+        src = b"""\
+/// <summary>Widget helpers.</summary>
+module Acme.Widgets
+
+let noop () = ()
+"""
+        result = parser.parse_file(_fs(), src)
+        assert result.docstring == "Widget helpers."
+
+
+class TestFsharpHeritage:
+    def test_inherit_and_interface_implementation(self, parser: ASTParser) -> None:
+        src = b"""\
+module Acme.Widgets
+
+type Widget() =
+    member _.Ping() = 1
+
+type Gadget() =
+    inherit Widget()
+    interface IRenderable with
+        member _.Render() = ()
+"""
+        result = parser.parse_file(_fs(), src)
+        relations = {(h.child_name, h.kind, h.parent_name) for h in result.heritage}
+        assert ("Gadget", "extends", "Widget") in relations
+        assert ("Gadget", "implements", "IRenderable") in relations
+
+    def test_qualified_base_keeps_the_last_segment(self, parser: ASTParser) -> None:
+        src = b"""\
+module Acme.Widgets
+
+type Gadget() =
+    inherit Acme.Core.Widget()
+"""
+        result = parser.parse_file(_fs(), src)
+        assert ("Gadget", "extends", "Widget") in {
+            (h.child_name, h.kind, h.parent_name) for h in result.heritage
+        }
+
+    def test_framework_roots_are_filtered(self, parser: ASTParser) -> None:
+        src = b"""\
+module Acme.Widgets
+
+type WidgetError() =
+    inherit System.Exception()
+"""
+        result = parser.parse_file(_fs(), src)
+        assert result.heritage == []
+
+
+class TestPipelineRegistration:
+    """F# reaches symbols through the pipeline's own parse entry point, not
+    only through a direct ``ASTParser`` call.
+    """
+
+    def test_pipeline_worker_yields_symbols(self, tmp_path) -> None:
+        from repowise.core.pipeline.phases.ingestion import _parse_one
+
+        src = b"""\
+module Acme.Widgets
+
+open System
+
+let add a b = a + b
+
+type Person = { Name: string; Age: int }
+"""
+        target = tmp_path / "Sample.fs"
+        target.write_bytes(src)
+        file_info = _make_file_info("Sample.fs", "fsharp")
+        file_info.abs_path = str(target)
+
+        result = _parse_one((file_info, src))
+
+        assert not isinstance(result, tuple), result
+        names = {s.name for s in result.symbols}
+        assert {"add", "Person"} <= names
+        assert any(i.module_path == "System" for i in result.imports)

--- a/tests/unit/ingestion/test_elixir_bare_name_scope.py
+++ b/tests/unit/ingestion/test_elixir_bare_name_scope.py
@@ -1,9 +1,13 @@
-"""Elixir bare-name call scope.
+"""Lexically scoped bare-name call resolution.
 
 A bare, receiver-less name in Elixir can only mean the caller's own module, a
 module an explicit ``import`` brought in, or Kernel. ``alias`` / ``require`` /
 ``use`` bind a module name and never a function name, so the resolver must not
 answer such a call from repo-wide uniqueness or from a non-import edge.
+
+F# is the same rule with different spelling: a bare name means the enclosing
+scope, a module the file has ``open``ed, or FSharp.Core. Both languages are in
+``_LEXICAL_BARE_NAME_LANGUAGES``, so both are exercised here.
 """
 
 from __future__ import annotations
@@ -16,11 +20,11 @@ from repowise.core.ingestion.models import FileInfo, ParsedFile
 from repowise.core.ingestion.parser import parse_file
 
 
-def _file_info(rel: str, abs_: Path) -> FileInfo:
+def _file_info(rel: str, abs_: Path, language: str = "elixir") -> FileInfo:
     return FileInfo(
         path=rel,
         abs_path=str(abs_),
-        language="elixir",
+        language=language,
         size_bytes=abs_.stat().st_size,
         git_hash="",
         last_modified=datetime.now(),
@@ -31,13 +35,15 @@ def _file_info(rel: str, abs_: Path) -> FileInfo:
     )
 
 
-def _parse_all(tmp_path: Path, files: dict[str, str]) -> dict[str, ParsedFile]:
+def _parse_all(
+    tmp_path: Path, files: dict[str, str], language: str = "elixir"
+) -> dict[str, ParsedFile]:
     out: dict[str, ParsedFile] = {}
     for rel, content in files.items():
         abs_ = tmp_path / rel
         abs_.parent.mkdir(parents=True, exist_ok=True)
         abs_.write_text(content, encoding="utf-8")
-        out[rel] = parse_file(_file_info(rel, abs_), content.encode("utf-8"))
+        out[rel] = parse_file(_file_info(rel, abs_, language), content.encode("utf-8"))
     return out
 
 
@@ -185,5 +191,69 @@ end
         assert (
             "lib/app.ex::Shop.Application::start",
             "lib/app.ex::Shop.Application::setup_region_mapping",
+            "same_file",
+        ) in edges, edges
+
+
+TOKENS = """module Acme.Tokens
+
+let parseToken (raw: string) = raw
+"""
+
+
+class TestFsharpBareNameScope:
+    def test_a_uniquely_named_function_elsewhere_is_not_the_answer(
+        self, tmp_path: Path
+    ) -> None:
+        # Nothing in Reader.fs brings `parseToken` into scope. That exactly
+        # one other file defines the name is a coincidence, not evidence.
+        files = {
+            "src/Tokens.fs": TOKENS,
+            "src/Reader.fs": """module Acme.Reader
+
+let read raw = parseToken raw
+""",
+        }
+        parsed = _parse_all(tmp_path, files, "fsharp")
+        edges = _edges(parsed, tmp_path, {})
+        assert not [e for e in edges if e[1].endswith("::parseToken")], edges
+
+    def test_an_open_module_does_answer_it(self, tmp_path: Path) -> None:
+        # The control: `open` binds every public name in the module, which is
+        # the wildcard sentinel the merged-import tier reads.
+        files = {
+            "src/Tokens.fs": TOKENS,
+            "src/Reader.fs": """module Acme.Reader
+
+open Acme.Tokens
+
+let read raw = parseToken raw
+""",
+        }
+        parsed = _parse_all(tmp_path, files, "fsharp")
+        _link(parsed, "src/Reader.fs", "Acme.Tokens", "src/Tokens.fs")
+        edges = _edges(
+            parsed, tmp_path, {"src/Reader.fs": {"src/Tokens.fs"}, "src/Tokens.fs": set()}
+        )
+        assert (
+            "src/Reader.fs::read",
+            "src/Tokens.fs::parseToken",
+            "import_merged",
+        ) in edges, edges
+
+    def test_a_same_file_bare_call_still_resolves(self, tmp_path: Path) -> None:
+        files = {
+            "src/Tokens.fs": """module Acme.Tokens
+
+let private normalise raw = raw
+
+let parseToken raw = normalise raw
+""",
+        }
+        parsed = _parse_all(tmp_path, files, "fsharp")
+        edges = _edges(parsed, tmp_path, {})
+        assert (
+            "src/Tokens.fs::parseToken",
+            "src/Tokens.fs::normalise",
             "same_file",
         ) in edges, edges

--- a/tests/unit/ingestion/test_language_capabilities.py
+++ b/tests/unit/ingestion/test_language_capabilities.py
@@ -194,6 +194,35 @@ _PARTIAL = {
 }
 
 
+class TestAstRegistration:
+    """A non-passthrough code language must be wired all the way through.
+
+    Driving ``ASTParser`` directly in a per-language test proves the query
+    and the config, but not the registration: a spec left
+    ``is_passthrough=True``, a missing ``LANGUAGE_CONFIGS`` entry or a
+    ``scm_file`` naming a file that is not on disk all yield zero symbols
+    *silently* -- the files index, their regex-tier imports resolve, and
+    only ``symbol_count=0`` in the graph says anything is wrong.
+    """
+
+    def test_every_ast_language_has_grammar_config_and_query(self) -> None:
+        from repowise.core.ingestion.language_configs import LANGUAGE_CONFIGS
+        from repowise.core.ingestion.parser import QUERIES_DIR
+
+        code_languages = REGISTRY.code_languages()
+        for spec in REGISTRY.all_specs():
+            if spec.is_passthrough or spec.tag not in code_languages:
+                continue
+            if spec.shares_grammar_with:
+                # C reads C++'s grammar and query; it declares neither.
+                continue
+            assert spec.grammar_package, spec.tag
+            assert spec.scm_file, spec.tag
+            assert (QUERIES_DIR / spec.scm_file).is_file(), spec.tag
+            assert spec.tag in LANGUAGE_CONFIGS, spec.tag
+            assert spec.tag not in REGISTRY.unparseable_or_unknown_languages(), spec.tag
+
+
 class TestImportSupportTiers:
     def test_every_spec_declares_a_valid_tier(self) -> None:
         for spec in REGISTRY.all_specs():

--- a/tests/unit/ingestion/test_lightweight_resolvers.py
+++ b/tests/unit/ingestion/test_lightweight_resolvers.py
@@ -678,11 +678,11 @@ class TestFSharpExtraction:
             "open type System.Math\n"
             "let x = 1\n"
         )
-        assert _modules(extract_fsharp_imports(src)) == [
-            "System",
-            "MyApp.Domain",
-            "System.Math",
-        ]
+        # `open type System.Math` names a TYPE, so the module the file
+        # depends on is System, already imported by the plain `open`.
+        imports = extract_fsharp_imports(src)
+        assert _modules(imports) == ["System", "MyApp.Domain"]
+        assert [i.imported_names for i in imports] == [["*"], ["*"]]
 
 
 class TestFSharpResolution:

--- a/uv.lock
+++ b/uv.lock
@@ -3085,6 +3085,7 @@ dependencies = [
     { name = "tree-sitter-cpp" },
     { name = "tree-sitter-dart" },
     { name = "tree-sitter-elixir" },
+    { name = "tree-sitter-fsharp" },
     { name = "tree-sitter-gdscript" },
     { name = "tree-sitter-go" },
     { name = "tree-sitter-html" },
@@ -3183,6 +3184,7 @@ requires-dist = [
     { name = "tree-sitter-cpp", specifier = ">=0.23,<1" },
     { name = "tree-sitter-dart", specifier = ">=0.1,<1" },
     { name = "tree-sitter-elixir", specifier = ">=0.3.5,<1" },
+    { name = "tree-sitter-fsharp", specifier = ">=0.3.11,<1" },
     { name = "tree-sitter-gdscript", specifier = ">=6.1,<7" },
     { name = "tree-sitter-go", specifier = ">=0.23,<1" },
     { name = "tree-sitter-html", specifier = ">=0.23,<1" },
@@ -4053,6 +4055,22 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b4/4a/f78454d228835a619db173f816090ab0c86f865987e2504280ced7fdbd5c/tree_sitter_elixir-0.3.5-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b5d5d8aa077ff244d24406b1fb5a17c03a2919c5183c51ca35654870d08b239b", size = 182618, upload-time = "2026-03-02T13:31:06.018Z" },
     { url = "https://files.pythonhosted.org/packages/c6/a5/634b505a4c349becc753c1faef5350f32ca027297c16a45fb0942967db2a/tree_sitter_elixir-0.3.5-cp39-abi3-win_amd64.whl", hash = "sha256:c0b5df229405d42ba5c94254d92e414b1f200be8422561d243ae5b3558e84f76", size = 167219, upload-time = "2026-03-02T13:31:07.071Z" },
     { url = "https://files.pythonhosted.org/packages/77/f2/711baae88f98e3a30efee9383fbcb603a3188c20941643c71d3d3b936d66/tree_sitter_elixir-0.3.5-cp39-abi3-win_arm64.whl", hash = "sha256:fee42b90962e1e131cc31720f3038410291b2196ed231e00c1721597fc0567df", size = 164003, upload-time = "2026-03-02T13:31:08.013Z" },
+]
+
+[[package]]
+name = "tree-sitter-fsharp"
+version = "0.3.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/bf/ff2f4ab3cf4e574a491c2d30811f90fbdf6110044f955aab842bf4227155/tree_sitter_fsharp-0.3.11.tar.gz", hash = "sha256:cd3ab061850df53bd1b98a20832256252a3a80acabfd51dda36990c8eadeee15", size = 4154593, upload-time = "2026-07-30T13:05:45.475Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/f7/6a4b052fe746a31a783cf4ae8a2fc09f722d616663bba2e9feb3079d01af/tree_sitter_fsharp-0.3.11-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:a0de87dc58e1617c927857f3b9d225a6cecaa05fa2222a702745cf5fd4077763", size = 1308147, upload-time = "2026-07-30T13:05:36.247Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/72/0d92c8a4f822e04ef598fe56a9f9c7c5f4124fd8f852a83367bb24c22c47/tree_sitter_fsharp-0.3.11-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:87c3abca2f8b9ef7c591f01a30556b4d409db1b20374abe7c5ebf69e95615bb2", size = 1420693, upload-time = "2026-07-30T13:05:37.394Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/59/5fd60b4014a58418a9a486beaa059f7cf8316836446d80ef0fd63f05edc9/tree_sitter_fsharp-0.3.11-cp310-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:feb7e8c380a1f682310875559bfa1297d1643dfc5ec30c5dfd9d54310a4c7717", size = 1419754, upload-time = "2026-07-30T13:05:38.629Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/b0/344f72a5e9b75f8f1e8b81b116303c268948782fdbc2b6af245d2573da43/tree_sitter_fsharp-0.3.11-cp310-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:de053d7b182e64c5a961690be69e8c27961360be3539198a2ac64c6d71e8b48f", size = 1422265, upload-time = "2026-07-30T13:05:39.721Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/9e/8471950cb7169954fdd62dea22ed2300844e3fc4bd90fe1896ef46fbb2db/tree_sitter_fsharp-0.3.11-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:d31390e1d9b162c1bef091d441772824e109c4f95aab11a527533a2794ce5e7c", size = 1413629, upload-time = "2026-07-30T13:05:40.733Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/9e/3151d41dc3a2098be7a18999a4540d1aeefdcab2cee5c98506be64bf8e03/tree_sitter_fsharp-0.3.11-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a700d8c765e1c850b5c7afb42966936d99b4607e4df896bcf8a15f3971858d30", size = 1415594, upload-time = "2026-07-30T13:05:41.864Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/db/e175931c551c9e3cafb1058a0195e909148f5abea527baf7b68e098f66c1/tree_sitter_fsharp-0.3.11-cp310-abi3-win_amd64.whl", hash = "sha256:a238e3eeb1da24ad8364f250973178ff5ea265aeadbd31a372c5b0d7bd28f946", size = 1308869, upload-time = "2026-07-30T13:05:43.153Z" },
+    { url = "https://files.pythonhosted.org/packages/09/18/c8b2b66f14f755e3ee8a60dade772d9319ea242b0a920ea8cab31ebfe172/tree_sitter_fsharp-0.3.11-cp310-abi3-win_arm64.whl", hash = "sha256:a88a15c392a644d4ea55e88eacc7d058bae5b6ebf7b2cfa723816a5f9d03ec3f", size = 1301250, upload-time = "2026-07-30T13:05:44.281Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
F# moves from the Lightweight rung to Good. `tree-sitter-fsharp` 0.3.11 parses `.fs` and `.fsx` to a full AST: modules, namespaces, `let` bindings including each `and` continuation, records, unions, classes, interfaces, members and exceptions become symbols; `///` comments become docstrings; `inherit` and `interface ... with` become heritage edges. Imports keep the existing resolver and its `.fsproj` compile-order leg. Signature files (`.fsi`) stay on the import-only path, since the implementation grammar mis-parses them and one grammar per language cannot select the signature grammar.

Validated on fsprojects/FSharp.Data (131 files) and fsharp/FAKE (438 files): 130 and 419 symbol-bearing files, 5 and 13 files with a localized parse error (attributed optional parameters and code quotations, grammar gaps), import counts unchanged from the regex tier, and a 30-row hand-read of resolved calls at 27/30 before the lexical-scope fix and 30/30 after it.

Design notes:

- A bare name in F# is lexically scoped: its own scope, enclosing modules, `open`ed modules, `[<AutoOpen>]`, then the prelude. The first hand-read found every repo-wide-unique guess wrong, so F# joins the resolver's lexical set: the global-unique tier is refused and bare names merge only through `open`. Qualified access and constructor calls resolve as before.
- `.fsi` handling is a language-gated path check in `parser.py` beside the `.tsx` one; a `let` nested in a body is not a symbol; a `let` in a nested module keeps function kind with the module as parent.
- A registry-parity test now pins that every non-passthrough language has a grammar, a query file and a config, and a pipeline-worker test drives the real parse entry point over a `.fs` file. Both would have caught a spec that says "parsed" while the pipeline silently takes the no-grammar path.

Follow-ups, not in this PR: health markers; a resolver that reads the project graph so one-file-per-assembly layouts sharing a namespace resolve `open` lines (today the resolver refuses the ambiguity, which also keeps `unused_export` findings on such repos at the review tier).

Docs: 24 languages parsed to a full AST, 39 on the ladder; F# leaves the Lightweight row and the roadmap upgrade row.
