### PR TITLE
feat(ingestion): register unresolved Python imports as external nodes

### DIFF
--- a/packages/core/src/repowise/core/ingestion/resolvers/python.py
+++ b/packages/core/src/repowise/core/ingestion/resolvers/python.py
@@ -71,11 +71,13 @@ def resolve_python_import(module_path: str, importer_path: str, ctx: ResolverCon
         if c in ctx.path_set:
             return c
 
-    # Stem-only fallback
+    # Stem-only fallback, Python files only. The stem map holds every indexed
+    # file, so without the suffix guard ``import httpx`` resolved to a
+    # ``baselines/httpx.json`` fixture; Ruby and PHP guard theirs the same way.
     stem = module_path.split(".")[-1].lower()
-    hit = ctx.stem_lookup(stem)
-    if hit:
-        return hit
+    for candidate in ctx.stem_map.get(stem, ()):
+        if candidate.endswith((".py", ".pyi")):
+            return candidate
 
     # Nothing in the repo defines this module, so register it the way every
     # other language resolver does: the packages tab and the import counts can

--- a/packages/core/src/repowise/core/ingestion/resolvers/python.py
+++ b/packages/core/src/repowise/core/ingestion/resolvers/python.py
@@ -73,7 +73,16 @@ def resolve_python_import(module_path: str, importer_path: str, ctx: ResolverCon
 
     # Stem-only fallback
     stem = module_path.split(".")[-1].lower()
-    return ctx.stem_lookup(stem)
+    hit = ctx.stem_lookup(stem)
+    if hit:
+        return hit
+
+    # Nothing in the repo defines this module, so register it the way every
+    # other language resolver does: the packages tab and the import counts can
+    # only see a third-party or stdlib dependency if the miss becomes a node.
+    # Stdlib is included on purpose, as Go and TypeScript already do, and
+    # io_kind.py seeds stdlib names for exactly this consumer.
+    return ctx.add_external_node(module_path)
 
 
 def resolve_python_import_all(

--- a/packages/core/src/repowise/core/upgrade/version.py
+++ b/packages/core/src/repowise/core/upgrade/version.py
@@ -48,7 +48,13 @@ STORE_FORMAT_VERSION: int = 2
 #: a Rust macro invocation stopped being extracted as a call. A cache written
 #: before that carries neither field, so the scoped-call, chained-call and
 #: macro fixes would resolve against stale rows instead of firing.
-PARSER_SCHEMA_VERSION: int = 2
+#:
+#: v3: a Python import that resolves to no repo file now becomes an
+#: ``external:`` node and edge instead of resolving to nothing. The fingerprint
+#: change makes ``persist_incremental_edges`` reconcile every file's edges once
+#: on the next update, so an existing index does not keep half its Python files
+#: without external edges.
+PARSER_SCHEMA_VERSION: int = 3
 
 #: state.json key holding the store format version that wrote the store.
 STORE_FORMAT_VERSION_KEY = "store_format_version"

--- a/tests/unit/ingestion/test_graph.py
+++ b/tests/unit/ingestion/test_graph.py
@@ -338,12 +338,12 @@ class TestStemDisambiguation:
         b.add_file(_parsed("__init__.py"))
         b.add_file(_parsed("main.py", imports=[_imp("anything")]))
         b.build()  # must not raise
-        # No import edge — stem "anything" is unresolvable
+        # The stem "anything" resolves to no file, so it lands on an external node.
         import_edges = [
             (u, v) for u, v, d in b.graph().edges(data=True)
             if d.get("edge_type") == "imports"
         ]
-        assert len(import_edges) == 0
+        assert import_edges == [("main.py", "external:anything")]
 
     def test_go_stem_collision_prefers_parent_match(self) -> None:
         """Go: `import .../calculator` prefers calculator/calculator.go

--- a/tests/unit/ingestion/test_graph.py
+++ b/tests/unit/ingestion/test_graph.py
@@ -209,17 +209,16 @@ class TestPythonImports:
         b.build()
         assert b.graph().has_edge("main.py", "src/calculator.py")
 
-    def test_unresolvable_import_no_edge(self) -> None:
-        """Unresolvable import produces no import edge (no crash)."""
+    def test_unresolvable_import_becomes_external(self) -> None:
+        """An absolute import no repo file defines lands on an external node."""
         b = GraphBuilder()
         b.add_file(_parsed("main.py", imports=[_imp("nonexistent_external_lib")]))
         b.build()
-        # Only the defines edge for the synthetic __module__ symbol
         import_edges = [
             (u, v) for u, v, d in b.graph().edges(data=True)
             if d.get("edge_type") == "imports"
         ]
-        assert len(import_edges) == 0
+        assert import_edges == [("main.py", "external:nonexistent_external_lib")]
 
     def test_imported_names_on_edge(self) -> None:
         """Imported names are stored on the edge."""

--- a/tests/unit/ingestion/test_python_resolver_external.py
+++ b/tests/unit/ingestion/test_python_resolver_external.py
@@ -1,0 +1,71 @@
+"""Unresolvable absolute Python imports become ``external:`` nodes.
+
+Pins the tail of ``resolve_python_import``: an absolute import no repo file
+defines registers an external node, a relative miss stays None, and a
+resolvable import is untouched.
+"""
+
+from __future__ import annotations
+
+import networkx as nx
+
+from repowise.core.ingestion.models import Import
+from repowise.core.ingestion.resolvers.context import ResolverContext
+from repowise.core.ingestion.resolvers.python import (
+    resolve_python_import,
+    resolve_python_import_all,
+)
+
+PATHS = {"app.py", "pkg/__init__.py", "pkg/mod.py"}
+
+
+def _ctx() -> ResolverContext:
+    return ResolverContext(path_set=set(PATHS), stem_map={}, graph=nx.DiGraph())
+
+
+def _imp(module_path: str, names: list[str]) -> Import:
+    return Import(
+        raw_statement="",
+        module_path=module_path,
+        imported_names=names,
+        is_relative=False,
+        resolved_file=None,
+        bindings=[],
+    )
+
+
+def test_absolute_miss_registers_external_node() -> None:
+    ctx = _ctx()
+    assert resolve_python_import("requests", "app.py", ctx) == "external:requests"
+    assert ctx.graph.nodes["external:requests"]["language"] == "external"
+
+
+def test_dotted_miss_keeps_the_full_module_path() -> None:
+    ctx = _ctx()
+    resolved = resolve_python_import("requests.adapters", "app.py", ctx)
+    assert resolved == "external:requests.adapters"
+    assert "external:requests.adapters" in ctx.graph.nodes
+
+
+def test_stdlib_miss_is_external_too() -> None:
+    ctx = _ctx()
+    assert resolve_python_import("subprocess", "app.py", ctx) == "external:subprocess"
+    assert ctx.graph.nodes["external:subprocess"]["language"] == "external"
+
+
+def test_relative_miss_stays_none_and_adds_nothing() -> None:
+    ctx = _ctx()
+    assert resolve_python_import(".missing", "app.py", ctx) is None
+    assert list(ctx.graph.nodes) == []
+
+
+def test_resolvable_absolute_import_is_untouched() -> None:
+    ctx = _ctx()
+    assert resolve_python_import("pkg.mod", "app.py", ctx) == "pkg/mod.py"
+    assert list(ctx.graph.nodes) == []
+
+
+def test_resolve_all_returns_the_external_key_without_probing() -> None:
+    ctx = _ctx()
+    targets = resolve_python_import_all(_imp("requests", ["adapters", "Session"]), "app.py", ctx)
+    assert targets == ("external:requests",)

--- a/tests/unit/ingestion/test_python_resolver_external.py
+++ b/tests/unit/ingestion/test_python_resolver_external.py
@@ -69,3 +69,19 @@ def test_resolve_all_returns_the_external_key_without_probing() -> None:
     ctx = _ctx()
     targets = resolve_python_import_all(_imp("requests", ["adapters", "Session"]), "app.py", ctx)
     assert targets == ("external:requests",)
+
+
+def test_stem_fallback_never_lands_on_a_non_python_file() -> None:
+    ctx = ResolverContext(
+        path_set={"app.py", "baselines/httpx.json", "vendor/httpx.py"},
+        stem_map={"httpx": ["baselines/httpx.json", "vendor/httpx.py"]},
+        graph=nx.DiGraph(),
+    )
+    assert resolve_python_import("httpx", "app.py", ctx) == "vendor/httpx.py"
+
+    only_fixture = ResolverContext(
+        path_set={"app.py", "baselines/httpx.json"},
+        stem_map={"httpx": ["baselines/httpx.json"]},
+        graph=nx.DiGraph(),
+    )
+    assert resolve_python_import("httpx", "app.py", only_fixture) == "external:httpx"

--- a/tests/unit/ingestion/test_python_resolver_fanout.py
+++ b/tests/unit/ingestion/test_python_resolver_fanout.py
@@ -87,8 +87,11 @@ def test_relative_package_import_fans_out() -> None:
     assert targets == ("pkg/sub/__init__.py", "pkg/sub/handlers.py")
 
 
-def test_unresolvable_import_returns_empty() -> None:
-    imp = _imp("nonexistent", ["thing"])
+def test_unresolvable_relative_import_returns_empty() -> None:
+    # A relative miss is a repo-local miss and stays unresolved. An absolute
+    # miss becomes an ``external:`` target instead; see
+    # ``test_python_resolver_external.py``.
+    imp = _imp(".nonexistent", ["thing"], relative=True)
     assert resolve_python_import_all(imp, "app.py", _ctx(PATHS)) == ()
 
 


### PR DESCRIPTION
## What

`resolve_python_import` returned `None` for an absolute import that no repo file defines, so a Python file's third-party and stdlib imports never became `external:` nodes or import edges. Every other language resolver registers the miss through `ctx.add_external_node`; Python now makes the same call after the module index, the layout probes and the stem fallback all miss. Relative misses stay `None`. Stdlib is included, as it already is for Go and TypeScript, so the stdlib names `io_kind.py` seeds finally have a consumer.

The stem fallback is also guarded by suffix, the way Ruby and PHP guard theirs. The stem map holds every indexed file, and `import httpx` in five production modules of this repository resolved to `scripts/kg_validate/baselines/httpx.json`, so httpx had zero external edges in every index of this repo.

`PARSER_SCHEMA_VERSION` moves from 2 to 3. `persist_incremental_edges` rewrites only changed files' edges unless the stored parser fingerprint differs from the running one; without the bump an updated index would carry the new edges for changed Python files only, and a partial count is a wrong count. The cost is one full reparse per existing index on its next update.

## Measured

Read from each store through raw sqlite, import edges whose target is an `external:` node, grouped by the importing file's language.

| index | external nodes (linked to a declared package) | Python edges / files / targets | TypeScript edges | JavaScript edges |
|---|---|---|---|---|
| this repo, before | 113 (72) | 0 / 0 / 0 | 1,540 | 5 |
| this repo, after | 245 (116) | 6,125 / 2,078 / 132 | 1,550 | 5 |
| flask, before | 1 (0) | 0 / 0 / 0 | 0 | 0 |
| flask, after | 78 (22) | 230 / 55 / 77 | 0 | 0 |

After the fix, zero Python imports in this repository land on a non-Python file.

## What an updated index gets

Edges arrive on the next `repowise update` for every file (the fingerprint change widens the reconcile once). Links from the new nodes to `external_systems` rows are written at init and, on update, only when a manifest changed, so the packages tab shows the new Python edges as linked after a manifest change or a full init.

## Tests

`tests/unit/ingestion/test_python_resolver_external.py` pins the external node on an absolute miss, a dotted miss, a stdlib miss, the unchanged `None` on a relative miss, an untouched resolvable import, the one-element tuple from `resolve_python_import_all`, and the suffix guard on the stem fallback. Two existing tests that asserted the old gap now assert the external edge.
