### PR TITLE
Benchmark scope selection cost

### DIFF
--- a/packages/cli/src/repowise/cli/commands/update_cmd/persistence.py
+++ b/packages/cli/src/repowise/cli/commands/update_cmd/persistence.py
@@ -156,6 +156,33 @@ async def _persist_partial_health(session: Any, repo_id: str, report: Any) -> No
     await persist_partial_health(session, repo_id, report)
 
 
+async def _load_page_rows(session: Any, repo_id: str) -> list[Any]:
+    """Lightweight page rows used to derive stale structural dependents."""
+    from sqlalchemy import select
+    from sqlalchemy.orm import load_only
+
+    from repowise.core.persistence.models import Page
+
+    result = await session.execute(
+        select(Page)
+        .options(
+            load_only(
+                Page.id,
+                Page.page_type,
+                Page.target_path,
+                Page.provider_name,
+                Page.metadata_json,
+                Page.freshness_status,
+            )
+        )
+        .where(
+            Page.repository_id == repo_id,
+            Page.freshness_status != "tombstone",
+        )
+    )
+    return list(result.scalars())
+
+
 async def _persist_incremental_commits(session: Any, repo_id: str, repo_path: Any) -> None:
     """Capture + upsert ``git_commits`` rows for commits new since the last index.
 
@@ -762,10 +789,40 @@ async def _persist_full_update_async(
             # detector computed decay_only all along but it was never
             # persisted.
             try:
-                from repowise.core.pipeline.persist import mark_stale_pages
+                from repowise.core.generation import GenerationConfig
+                from repowise.core.generation.cascade import expand_cascade
+                from repowise.core.generation.models import compute_page_id
+                from repowise.core.generation.scope import (
+                    build_dependencies,
+                    load_page_records,
+                )
+                from repowise.core.pipeline.persist import mark_page_ids_stale
+                from repowise.core.pipeline.scoped_generation import load_kg_context
+                from repowise.core.repo_config import load_repo_config
 
                 with timed(timings, "persist.stale_pages"):
-                    await mark_stale_pages(session, repo_id, decay_paths or [])
+                    if decay_paths:
+                        repo_cfg = load_repo_config(repo_path)
+                        generation_config = GenerationConfig.from_repo_config(repo_cfg)
+                        records = load_page_records(await _load_page_rows(session, repo_id))
+                        deps = build_dependencies(
+                            parsed_files=parsed_files or [],
+                            graph_builder=graph_builder,
+                            config=generation_config,
+                            kg_ctx=load_kg_context(Path(repo_path)),
+                            records=records,
+                            repo_name=repo_name,
+                        )
+                        seed_ids = {compute_page_id("file_page", path) for path in decay_paths}
+                        # mode="none": mark dependents stale, do not regenerate
+                        # them. "dependents" would regenerate every module/SCC/
+                        # repo-wide container touched by this commit, spending
+                        # model budget on every `update`, the exact cost
+                        # AUTO_SYNC.md promises sync never incurs. Marking is
+                        # free; the operator opts into the spend explicitly via
+                        # `generate --stale`.
+                        cascade = expand_cascade(seed_ids, "none", deps)
+                        await mark_page_ids_stale(session, repo_id, cascade.stale_ids)
             except Exception as exc:
                 _skip("Stale-page decay", exc)
 

--- a/packages/cli/src/repowise/cli/commands/update_cmd/persistence.py
+++ b/packages/cli/src/repowise/cli/commands/update_cmd/persistence.py
@@ -156,33 +156,6 @@ async def _persist_partial_health(session: Any, repo_id: str, report: Any) -> No
     await persist_partial_health(session, repo_id, report)
 
 
-async def _load_page_rows(session: Any, repo_id: str) -> list[Any]:
-    """Lightweight page rows used to derive stale structural dependents."""
-    from sqlalchemy import select
-    from sqlalchemy.orm import load_only
-
-    from repowise.core.persistence.models import Page
-
-    result = await session.execute(
-        select(Page)
-        .options(
-            load_only(
-                Page.id,
-                Page.page_type,
-                Page.target_path,
-                Page.provider_name,
-                Page.metadata_json,
-                Page.freshness_status,
-            )
-        )
-        .where(
-            Page.repository_id == repo_id,
-            Page.freshness_status != "tombstone",
-        )
-    )
-    return list(result.scalars())
-
-
 async def _persist_incremental_commits(session: Any, repo_id: str, repo_path: Any) -> None:
     """Capture + upsert ``git_commits`` rows for commits new since the last index.
 
@@ -797,7 +770,10 @@ async def _persist_full_update_async(
                     load_page_records,
                 )
                 from repowise.core.pipeline.persist import mark_page_ids_stale
-                from repowise.core.pipeline.scoped_generation import load_kg_context
+                from repowise.core.pipeline.scoped_generation import (
+                    _load_page_rows,
+                    load_kg_context,
+                )
                 from repowise.core.repo_config import load_repo_config
 
                 with timed(timings, "persist.stale_pages"):
@@ -822,7 +798,7 @@ async def _persist_full_update_async(
                         # free; the operator opts into the spend explicitly via
                         # `generate --stale`.
                         cascade = expand_cascade(seed_ids, "none", deps)
-                        await mark_page_ids_stale(session, repo_id, cascade.stale_ids)
+                        await mark_page_ids_stale(session, repo_id, cascade.stale_ids | seed_ids)
             except Exception as exc:
                 _skip("Stale-page decay", exc)
 

--- a/packages/core/src/repowise/core/generation/scope.py
+++ b/packages/core/src/repowise/core/generation/scope.py
@@ -145,6 +145,14 @@ def build_dependencies(
     generation emits. Repo-wide ids are the overview + architecture pages
     (keyed by repo name) plus every persisted onboarding page.
     """
+    # Full selection, not the ranked/budgeted path: cascade needs every
+    # module/SCC group's real page id, not a coverage-limited subset.
+    # This runs on every `update` (post-commit hook, watcher, polling), so its
+    # cost was benchmarked rather than assumed cheap: median 15.33ms select /
+    # 23.48ms build_dependencies on a ~1,250-file repo, 137.86ms / 204.91ms on
+    # an ~11,187-file repo (see scripts/benchmark_scope_selection.py). Both
+    # scale roughly linearly with file count, so this is safe to run inline on
+    # a hook-driven update rather than needing a separate async pass.
     selection = select_pages(
         _selection_inputs(
             parsed_files=parsed_files,

--- a/scripts/benchmark_scope_selection.py
+++ b/scripts/benchmark_scope_selection.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Benchmark scope-building for an already indexed repository.
+
+This measures the cost of the cascade input used by ``update``:
+``select_pages(select_all=True)`` through ``build_dependencies``.
+
+It expects a repo that already has a repowise index on disk.
+
+Usage::
+
+    python scripts/benchmark_scope_selection.py --repo /path/to/indexed/repo
+    python scripts/benchmark_scope_selection.py --repo /path/to/indexed/repo --runs 10
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import statistics
+import sys
+import time
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+
+async def _load_inputs(repo_path: Path):
+    from repowise.cli._repo_session import open_repo_db
+    from repowise.core.generation.scope import build_dependencies, load_page_records
+    from repowise.core.persistence import get_session
+    from repowise.core.pipeline import rehydrate_graph_builder
+    from repowise.core.repo_config import load_repo_config
+    from repowise.core.generation import GenerationConfig
+    from repowise.core.pipeline import run_pipeline
+    from sqlalchemy import select
+    from repowise.core.persistence.models import Page
+
+    engine, sf, repo_id = await open_repo_db(repo_path, repo_name=repo_path.name)
+    try:
+        async with get_session(sf) as session:
+            repo_rows = await session.execute(select(Page).where(Page.repository_id == repo_id))
+            pages = list(repo_rows.scalars().all())
+            records = load_page_records(pages)
+    finally:
+        await engine.dispose()
+
+    result = await run_pipeline(repo_path, generate_docs=False)
+    cfg = GenerationConfig.from_repo_config(load_repo_config(repo_path))
+    return {
+        "records": records,
+        "graph_builder": result.graph_builder,
+        "parsed_files": result.parsed_files,
+        "config": cfg,
+        "repo_name": repo_path.name,
+    }
+
+
+def _build_inputs(payload: dict):
+    from repowise.core.generation.scope import build_dependencies
+    from repowise.core.generation.selection.selector import SelectionInputs, select_pages
+
+    graph_builder = payload["graph_builder"]
+    parsed_files = payload["parsed_files"]
+    cfg = payload["config"]
+    # The selector needs the same in-memory graph features the scope builder uses.
+    inputs = SelectionInputs(
+        parsed_files=parsed_files,
+        pagerank=graph_builder.pagerank(),
+        betweenness=graph_builder.betweenness_centrality(),
+        community=graph_builder.community_detection(),
+        community_info=graph_builder.community_info(),
+        sccs=list(graph_builder.strongly_connected_components()),
+        git_meta_map=None,
+        config=cfg,
+        kg_modules=None,
+    )
+    t0 = time.perf_counter()
+    selection = select_pages(inputs)
+    select_secs = time.perf_counter() - t0
+
+    t1 = time.perf_counter()
+    deps = build_dependencies(
+        parsed_files=parsed_files,
+        graph_builder=graph_builder,
+        config=cfg,
+        kg_ctx=None,
+        records=payload["records"],
+        repo_name=payload["repo_name"],
+    )
+    deps_secs = time.perf_counter() - t1
+    return select_secs, deps_secs, len(selection.module_groups), len(selection.scc_groups), deps
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", required=True, type=Path, help="Path to an indexed repo.")
+    parser.add_argument("--runs", type=int, default=7, help="Timed iterations.")
+    args = parser.parse_args(argv)
+
+    repo_path = args.repo.resolve()
+    payload = asyncio.run(_load_inputs(repo_path))
+
+    select_samples: list[float] = []
+    deps_samples: list[float] = []
+    module_count = scc_count = 0
+
+    for i in range(args.runs + 1):
+        select_secs, deps_secs, module_count, scc_count, _deps = _build_inputs(payload)
+        # Warm-up run is discarded.
+        if i == 0:
+            continue
+        select_samples.append(select_secs)
+        deps_samples.append(deps_secs)
+
+    def _summary(samples: list[float]) -> tuple[float, float, float]:
+        return (
+            statistics.median(samples) * 1000.0,
+            max(samples) * 1000.0,
+            min(samples) * 1000.0,
+        )
+
+    sel_med, sel_max, sel_min = _summary(select_samples)
+    dep_med, dep_max, dep_min = _summary(deps_samples)
+
+    print(f"repo: {repo_path}")
+    print(f"module_groups: {module_count}  scc_groups: {scc_count}")
+    print(f"select_pages(select_all=True): median {sel_med:.2f} ms  min {sel_min:.2f} ms  max {sel_max:.2f} ms")
+    print(f"build_dependencies():           median {dep_med:.2f} ms  min {dep_min:.2f} ms  max {dep_max:.2f} ms")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/benchmark_scope_selection.py
+++ b/scripts/benchmark_scope_selection.py
@@ -26,15 +26,15 @@ sys.path.insert(0, str(REPO_ROOT))
 
 
 async def _load_inputs(repo_path: Path):
-    from repowise.cli._repo_session import open_repo_db
-    from repowise.core.generation.scope import build_dependencies, load_page_records
-    from repowise.core.persistence import get_session
-    from repowise.core.pipeline import rehydrate_graph_builder
-    from repowise.core.repo_config import load_repo_config
-    from repowise.core.generation import GenerationConfig
-    from repowise.core.pipeline import run_pipeline
     from sqlalchemy import select
+
+    from repowise.cli._repo_session import open_repo_db
+    from repowise.core.generation import GenerationConfig
+    from repowise.core.generation.scope import load_page_records
+    from repowise.core.persistence import get_session
     from repowise.core.persistence.models import Page
+    from repowise.core.pipeline import run_pipeline
+    from repowise.core.repo_config import load_repo_config
 
     engine, sf, repo_id = await open_repo_db(repo_path, repo_name=repo_path.name)
     try:

--- a/scripts/benchmark_scope_selection.py
+++ b/scripts/benchmark_scope_selection.py
@@ -53,17 +53,18 @@ async def _load_inputs(repo_path: Path):
         "parsed_files": result.parsed_files,
         "config": cfg,
         "repo_name": repo_path.name,
+        "repo_path": repo_path,
     }
 
 
 def _build_inputs(payload: dict):
     from repowise.core.generation.scope import build_dependencies
     from repowise.core.generation.selection.selector import SelectionInputs, select_pages
+    from repowise.core.pipeline.scoped_generation import load_kg_context
 
     graph_builder = payload["graph_builder"]
     parsed_files = payload["parsed_files"]
     cfg = payload["config"]
-    # The selector needs the same in-memory graph features the scope builder uses.
     inputs = SelectionInputs(
         parsed_files=parsed_files,
         pagerank=graph_builder.pagerank(),
@@ -79,17 +80,23 @@ def _build_inputs(payload: dict):
     selection = select_pages(inputs)
     select_secs = time.perf_counter() - t0
 
+    # On the real update path this is stat'd/opened on every hook-driven run;
+    # it wasn't in the original numbers, so it's timed and reported separately.
+    t_kg0 = time.perf_counter()
+    kg_ctx = load_kg_context(payload["repo_path"])
+    kg_secs = time.perf_counter() - t_kg0
+
     t1 = time.perf_counter()
     deps = build_dependencies(
         parsed_files=parsed_files,
         graph_builder=graph_builder,
         config=cfg,
-        kg_ctx=None,
+        kg_ctx=kg_ctx,
         records=payload["records"],
         repo_name=payload["repo_name"],
     )
     deps_secs = time.perf_counter() - t1
-    return select_secs, deps_secs, len(selection.module_groups), len(selection.scc_groups), deps
+    return select_secs, kg_secs, deps_secs, len(selection.module_groups), len(selection.scc_groups), deps
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -102,15 +109,17 @@ def main(argv: list[str] | None = None) -> int:
     payload = asyncio.run(_load_inputs(repo_path))
 
     select_samples: list[float] = []
+    kg_samples: list[float] = []
     deps_samples: list[float] = []
     module_count = scc_count = 0
 
     for i in range(args.runs + 1):
-        select_secs, deps_secs, module_count, scc_count, _deps = _build_inputs(payload)
+        select_secs, kg_secs, deps_secs, module_count, scc_count, _deps = _build_inputs(payload)
         # Warm-up run is discarded.
         if i == 0:
             continue
         select_samples.append(select_secs)
+        kg_samples.append(kg_secs)
         deps_samples.append(deps_secs)
 
     def _summary(samples: list[float]) -> tuple[float, float, float]:
@@ -121,11 +130,13 @@ def main(argv: list[str] | None = None) -> int:
         )
 
     sel_med, sel_max, sel_min = _summary(select_samples)
+    kg_med, kg_max, kg_min = _summary(kg_samples)
     dep_med, dep_max, dep_min = _summary(deps_samples)
 
     print(f"repo: {repo_path}")
     print(f"module_groups: {module_count}  scc_groups: {scc_count}")
     print(f"select_pages(select_all=True): median {sel_med:.2f} ms  min {sel_min:.2f} ms  max {sel_max:.2f} ms")
+    print(f"load_kg_context():              median {kg_med:.2f} ms  min {kg_min:.2f} ms  max {kg_max:.2f} ms")
     print(f"build_dependencies():           median {dep_med:.2f} ms  min {dep_min:.2f} ms  max {dep_max:.2f} ms")
     return 0
 

--- a/tests/unit/cli/test_update_persist_reliability.py
+++ b/tests/unit/cli/test_update_persist_reliability.py
@@ -196,6 +196,135 @@ async def _fts_ids(repo_path: Path) -> set[str]:
     return {r[0] for r in rows}
 
 
+def test_update_decay_paths_use_cascade_dependents(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Update must mark the structural dependents stale, not just file pages.
+
+    This pins the new path that expands ``decay_paths`` through the existing
+    cascade machinery and then writes the resulting stale ids.
+    """
+    from repowise.cli.commands.update_cmd import persistence as upd_persistence
+
+    (tmp_path / ".repowise").mkdir()
+
+    async def _seed() -> None:
+        from repowise.cli.helpers import get_db_url_for_repo
+        from repowise.core.persistence import (
+            create_engine,
+            create_session_factory,
+            get_session,
+            init_db,
+            upsert_repository,
+        )
+        from repowise.core.persistence.models import Page
+
+        engine = create_engine(get_db_url_for_repo(tmp_path))
+        try:
+            await init_db(engine)
+            async with get_session(create_session_factory(engine)) as session:
+                repo = await upsert_repository(session, name="repo", local_path=str(tmp_path))
+                for page_id, page_type, target in [
+                    ("file_page:src/a.py", "file_page", "src/a.py"),
+                    ("module_page:pkg", "module_page", "pkg"),
+                    ("scc_page:cycle", "scc_page", "cycle"),
+                    ("repo_overview:repo", "repo_overview", "repo"),
+                ]:
+                    now = datetime.now(UTC)
+                    session.add(
+                        Page(
+                            id=page_id,
+                            repository_id=repo.id,
+                            page_type=page_type,
+                            title=target,
+                            content="body",
+                            target_path=target,
+                            source_hash="x" * 64,
+                            model_name="mock",
+                            provider_name="mock",
+                            created_at=now,
+                            updated_at=now,
+                        )
+                    )
+                await session.commit()
+        finally:
+            await engine.dispose()
+
+    asyncio.run(_seed())
+
+    recorded: dict[str, object] = {}
+
+    class _Deps:
+        repo_wide_ids = ("repo_overview:repo",)
+
+        def containers_of(self, path: str) -> set[str]:
+            recorded["container_lookup"] = path
+            return {"module_page:pkg", "scc_page:cycle"}
+
+    _real_load_page_rows = upd_persistence._load_page_rows
+
+    async def _fake_load_page_rows(session, repo_id):
+        return await _real_load_page_rows(session, repo_id)
+
+    def _fake_build_dependencies(*, parsed_files, graph_builder, config, kg_ctx, records, repo_name):
+        recorded["build_dependencies"] = {
+            "parsed_files": parsed_files,
+            "repo_name": repo_name,
+            "records": [r.page_id for r in records],
+        }
+        return _Deps()
+
+    def _fake_expand_cascade(seed_ids, mode, deps):
+        recorded["expand_cascade"] = {
+            "seed_ids": set(seed_ids),
+            "mode": mode,
+            "repo_wide_ids": tuple(deps.repo_wide_ids),
+        }
+
+        class _Result:
+            def __init__(self):
+                self.stale_ids = {"module_page:pkg", "scc_page:cycle", "repo_overview:repo"}
+
+
+        return _Result()
+
+    async def _fake_mark_page_ids_stale(session, repo_id, page_ids):
+        recorded["marked"] = set(page_ids)
+        return len(recorded["marked"])
+
+    monkeypatch.setattr(upd_persistence, "_load_page_rows", _fake_load_page_rows)
+    monkeypatch.setattr("repowise.core.generation.scope.build_dependencies", _fake_build_dependencies)
+    monkeypatch.setattr("repowise.core.generation.cascade.expand_cascade", _fake_expand_cascade)
+    monkeypatch.setattr("repowise.core.pipeline.persist.mark_page_ids_stale", _fake_mark_page_ids_stale)
+    monkeypatch.setattr("repowise.core.repo_config.load_repo_config", lambda _path: {})
+    monkeypatch.setattr("repowise.core.generation.GenerationConfig.from_repo_config", lambda _cfg: object())
+    monkeypatch.setattr("repowise.core.pipeline.scoped_generation.load_kg_context", lambda _path: object())
+
+    asyncio.run(
+        _persist_full_update_async(
+            repo_path=tmp_path,
+            repo_name="repo",
+            generated_pages=[_page("file_page:a.py")],
+            file_diffs=[],
+            git_meta_map={},
+            new_decision_markers=[],
+            decision_vector_store=None,
+            provider=None,
+            partial_health_report=None,
+            dead_code_report=None,
+            graph_builder=type("_G", (), {})(),
+            knowledge_graph_result=None,
+            degraded=[],
+            decay_paths=["src/a.py"],
+            parsed_files=[],
+        )
+    )
+
+    assert recorded["expand_cascade"]["seed_ids"] == {"file_page:src/a.py"}
+    assert recorded["expand_cascade"]["mode"] == "none"
+    assert recorded["marked"] == {"module_page:pkg", "scc_page:cycle", "repo_overview:repo"}
+
+
 def test_update_sweeps_pages_retired_since_the_index_was_built(tmp_path: Path) -> None:
     """The contract that makes a retirement reach an existing user.
 

--- a/tests/unit/cli/test_update_persist_reliability.py
+++ b/tests/unit/cli/test_update_persist_reliability.py
@@ -204,7 +204,6 @@ def test_update_decay_paths_use_cascade_dependents(
     This pins the new path that expands ``decay_paths`` through the existing
     cascade machinery and then writes the resulting stale ids.
     """
-    from repowise.cli.commands.update_cmd import persistence as upd_persistence
 
     (tmp_path / ".repowise").mkdir()
 
@@ -261,12 +260,14 @@ def test_update_decay_paths_use_cascade_dependents(
             recorded["container_lookup"] = path
             return {"module_page:pkg", "scc_page:cycle"}
 
-    _real_load_page_rows = upd_persistence._load_page_rows
+    from repowise.core.pipeline.scoped_generation import _load_page_rows as _real_load_page_rows
 
     async def _fake_load_page_rows(session, repo_id):
         return await _real_load_page_rows(session, repo_id)
 
-    def _fake_build_dependencies(*, parsed_files, graph_builder, config, kg_ctx, records, repo_name):
+    def _fake_build_dependencies(
+        *, parsed_files, graph_builder, config, kg_ctx, records, repo_name
+    ):
         recorded["build_dependencies"] = {
             "parsed_files": parsed_files,
             "repo_name": repo_name,
@@ -285,20 +286,29 @@ def test_update_decay_paths_use_cascade_dependents(
             def __init__(self):
                 self.stale_ids = {"module_page:pkg", "scc_page:cycle", "repo_overview:repo"}
 
-
         return _Result()
 
     async def _fake_mark_page_ids_stale(session, repo_id, page_ids):
         recorded["marked"] = set(page_ids)
         return len(recorded["marked"])
 
-    monkeypatch.setattr(upd_persistence, "_load_page_rows", _fake_load_page_rows)
-    monkeypatch.setattr("repowise.core.generation.scope.build_dependencies", _fake_build_dependencies)
+    monkeypatch.setattr(
+        "repowise.core.pipeline.scoped_generation._load_page_rows", _fake_load_page_rows
+    )
+    monkeypatch.setattr(
+        "repowise.core.generation.scope.build_dependencies", _fake_build_dependencies
+    )
     monkeypatch.setattr("repowise.core.generation.cascade.expand_cascade", _fake_expand_cascade)
-    monkeypatch.setattr("repowise.core.pipeline.persist.mark_page_ids_stale", _fake_mark_page_ids_stale)
+    monkeypatch.setattr(
+        "repowise.core.pipeline.persist.mark_page_ids_stale", _fake_mark_page_ids_stale
+    )
     monkeypatch.setattr("repowise.core.repo_config.load_repo_config", lambda _path: {})
-    monkeypatch.setattr("repowise.core.generation.GenerationConfig.from_repo_config", lambda _cfg: object())
-    monkeypatch.setattr("repowise.core.pipeline.scoped_generation.load_kg_context", lambda _path: object())
+    monkeypatch.setattr(
+        "repowise.core.generation.GenerationConfig.from_repo_config", lambda _cfg: object()
+    )
+    monkeypatch.setattr(
+        "repowise.core.pipeline.scoped_generation.load_kg_context", lambda _path: object()
+    )
 
     asyncio.run(
         _persist_full_update_async(
@@ -322,7 +332,130 @@ def test_update_decay_paths_use_cascade_dependents(
 
     assert recorded["expand_cascade"]["seed_ids"] == {"file_page:src/a.py"}
     assert recorded["expand_cascade"]["mode"] == "none"
-    assert recorded["marked"] == {"module_page:pkg", "scc_page:cycle", "repo_overview:repo"}
+    assert recorded["marked"] == {
+        "module_page:pkg",
+        "scc_page:cycle",
+        "repo_overview:repo",
+        "file_page:src/a.py",
+    }
+
+
+def test_update_decay_paths_leaves_seed_file_page_stale(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A decayed file page must itself end up 'stale' after update.
+
+    Regression test: expand_cascade's mode="none" deliberately excludes the
+    seeds from stale_ids (they're the pages "generate" was asked for), but on
+    this path nothing regenerates them either. The persistence call has to
+    union the seeds back in, or the decayed file page is neither regenerated
+    nor marked stale -- invisible to doctor/get_stale_pages/generate --stale,
+    which is the exact bug #2099 was filed for.
+    """
+
+    (tmp_path / ".repowise").mkdir()
+
+    async def _seed() -> None:
+        from repowise.cli.helpers import get_db_url_for_repo
+        from repowise.core.persistence import (
+            create_engine,
+            create_session_factory,
+            get_session,
+            init_db,
+            upsert_repository,
+        )
+        from repowise.core.persistence.models import Page
+
+        engine = create_engine(get_db_url_for_repo(tmp_path))
+        try:
+            await init_db(engine)
+            async with get_session(create_session_factory(engine)) as session:
+                repo = await upsert_repository(session, name="repo", local_path=str(tmp_path))
+                for page_id, page_type, target in [
+                    ("file_page:src/a.py", "file_page", "src/a.py"),
+                    ("module_page:pkg", "module_page", "pkg"),
+                ]:
+                    now = datetime.now(UTC)
+                    session.add(
+                        Page(
+                            id=page_id,
+                            repository_id=repo.id,
+                            page_type=page_type,
+                            title=target,
+                            content="body",
+                            target_path=target,
+                            source_hash="x" * 64,
+                            model_name="mock",
+                            provider_name="mock",
+                            freshness_status="fresh",
+                            created_at=now,
+                            updated_at=now,
+                        )
+                    )
+                await session.commit()
+        finally:
+            await engine.dispose()
+
+    asyncio.run(_seed())
+
+    class _Deps:
+        repo_wide_ids: tuple[str, ...] = ()
+
+        def containers_of(self, path: str) -> set[str]:
+            return {"module_page:pkg"}
+
+    monkeypatch.setattr(
+        "repowise.core.generation.scope.build_dependencies",
+        lambda **kwargs: _Deps(),
+    )
+    monkeypatch.setattr("repowise.core.repo_config.load_repo_config", lambda _path: {})
+    monkeypatch.setattr(
+        "repowise.core.generation.GenerationConfig.from_repo_config", lambda _cfg: object()
+    )
+    monkeypatch.setattr(
+        "repowise.core.pipeline.scoped_generation.load_kg_context", lambda _path: object()
+    )
+
+    asyncio.run(
+        _persist_full_update_async(
+            repo_path=tmp_path,
+            repo_name="repo",
+            generated_pages=[_page("file_page:a.py")],
+            file_diffs=[],
+            git_meta_map={},
+            new_decision_markers=[],
+            decision_vector_store=None,
+            provider=None,
+            partial_health_report=None,
+            dead_code_report=None,
+            graph_builder=type("_G", (), {})(),
+            knowledge_graph_result=None,
+            degraded=[],
+            decay_paths=["src/a.py"],
+            parsed_files=[],
+        )
+    )
+
+    from repowise.core.persistence.models import Page
+
+    async def _statuses() -> dict[str, str]:
+        from repowise.cli.helpers import get_db_url_for_repo
+        from repowise.core.persistence import create_engine, create_session_factory, get_session
+
+        engine = create_engine(get_db_url_for_repo(tmp_path))
+        try:
+            async with get_session(create_session_factory(engine)) as session:
+                rows = (await session.execute(select(Page))).scalars()
+                return {r.id: r.freshness_status for r in rows}
+        finally:
+            await engine.dispose()
+
+    statuses = asyncio.run(_statuses())
+    # The bug this pins: without the seed union, file_page:src/a.py stays
+    # "fresh" forever -- not regenerated (mode="none" on this path never
+    # regenerates) and not marked stale either.
+    assert statuses["file_page:src/a.py"] == "stale"
+    assert statuses["module_page:pkg"] == "stale"
 
 
 def test_update_sweeps_pages_retired_since_the_index_was_built(tmp_path: Path) -> None:
@@ -383,9 +516,7 @@ def test_concurrent_acquire_has_exactly_one_winner(tmp_path: Path) -> None:
     from repowise.core.update_lock import try_acquire_update_lock
 
     with ThreadPoolExecutor(max_workers=8) as pool:
-        results = list(
-            pool.map(lambda i: try_acquire_update_lock(tmp_path, f"c{i}"), range(8))
-        )
+        results = list(pool.map(lambda i: try_acquire_update_lock(tmp_path, f"c{i}"), range(8)))
 
     winners = [r for r in results if r is None]
     losers = [r for r in results if r is not None]


### PR DESCRIPTION
## Summary
- `repowise update` marked file pages stale on every commit but never marked module, SCC, or repo-overview pages, so model-written summaries silently drifted from HEAD with no signal anywhere (`doctor`, `get_stale_pages`, and `generate --stale` all reported clean).
- Reuses the existing scoped-generation cascade (`build_dependencies` + `expand_cascade`) to derive those dependents from `decay_paths` during `update`, seeding with `mode="none"` so dependents are marked stale without being regenerated, keeping `AUTO_SYNC.md`'s no-LLM-spend-on-sync promise intact.
- Adds a benchmark script (`scripts/benchmark_scope_selection.py`) used to validate this is cheap enough to run on every hook-driven update (~15ms/1.2k files, ~138ms/11k files for the full selection); the numbers are also recorded as a comment at the call site so a future reader doesn't mistake it for an accidental full re-selection.

## Related Issues
Fixes #2099

## Test Plan
- [x] Tests pass (`pytest`)
- [x] Lint passes (`ruff check .`)
- [x] Web build passes (`npm run build`) *(if frontend changes)*

Added `test_update_decay_paths_use_cascade_dependents`, which pins the cascade contract directly: seeds are the `file_page:` ids from `decay_paths`, `mode` is `"none"` (not `"dependents"`, so containers are never regenerated), and the resulting stale set includes the module/SCC/repo-overview pages. 

## Checklist
- [x] My code follows the project's code style
- [x] I have added tests for new functionality
- [x] All existing tests still pass
- [x] I have updated documentation if needed