### PR TITLE
release: v0.49.0 - five languages to Good, a Map you can drill into, and an update that sizes itself

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "name": "repowise",
       "source": "./plugins/claude-code",
       "description": "Codebase intelligence for Claude Code. Indexes your repo into five layers (Graph, Git, Docs, Decisions, Code Health) and gives Claude deep understanding of architecture, ownership, hotspots, decisions, and defect risk — fewer greps, fewer file reads, lower cost per query.",
-      "version": "0.48.0",
+      "version": "0.49.0",
       "category": "productivity",
       "keywords": [
         "codebase",

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ local, all deterministic, no extra LLM calls.
 
 | Foundation | What it contributes |
 |---|---|
-| **Graph** | File + symbol dependencies across 19 AST-parsed languages, confidence-stamped call resolution, communities, centrality, cycles, and execution flows |
+| **Graph** | File + symbol dependencies across 25 AST-parsed languages, confidence-stamped call resolution, communities, centrality, cycles, and execution flows |
 | **Git** | Hotspots, ownership, co-change, bus factor, and bug-fix history: behavioral signals static analysis cannot see |
 | **Docs** | A wiki for every module and file, rebuilt incrementally with freshness and confidence scoring plus hybrid search |
 | **Decisions** | Architectural rationale mined from five index-time sources plus human and agent capture, each claim traced to evidence |

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,60 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.49.0] - 2026-09-05
+
+The largest language release so far: Elixir, F#, Objective-C, VB.NET and GDScript all move to the Good tier with real ASTs behind them, QML arrives at the import tier, and Razor/Blazor markup enters the graph. Alongside that, the Architecture Map stops being a picture and becomes somewhere you can drill into, `update` learns to size itself by what actually changed and reports which stage took the time, and the MCP tools stop returning bare zeros: every empty answer now says what it was measured against. Workspace mode gains cross-repo test impact and consumer contracts for five more languages.
+
+### Added
+
+- **Five languages reach the Good tier.** Elixir (#2127), F# (#2133) and Objective-C (#2135) each get a full AST parse rather than a regex skim. VB.NET arrives at Good with its own published grammar (#2048), and GDScript joins it (#1620). Symbol extraction and same-file call resolution work in all five.
+- **QML at the lightweight import tier** (#2039), and **Razor/Blazor markup** (`.razor`, `.cshtml`) is indexed into the graph (#1962).
+- **Flutter widget trees are edges.** `build()` bodies emit widget-tree edges, so a widget's children are reachable from the graph rather than buried in a method body (#2049).
+- **Godot scripts are reachable through the project.** Scenes, autoloads and `class_name` declarations connect scripts that no import statement ever linked (#1624).
+- **The Architecture Map is a place you can drill into** (#2104), with the map chrome moved off the canvas and given a ground to sit on (#2102). Communities count production files, read conductance, and name the group that was previously just "ungrouped" (#2112).
+- **File pages render the history they already carried.** The data was indexed and never shown (#2082).
+- **Cross-repo test impact.** Workspace mode works out which tests in other repos a change can break (#2008), and surfaces it on `get_change_risk`, `get_blast_radius`, the API and the contract page (#2123).
+- **HTTP consumer contracts for Go, Ruby, Java, Kotlin and PHP** (#2114), **provider contracts for Flask, Micronaut and Remix** (#2115), and breaking changes on the contracts page behind a contract drawer (#2116).
+- **Branch overlap on `get_risk`**: the other open branches editing the files you are editing (#2131).
+- **`get_change_risk` says when a diff is several changes** the index cannot connect to each other (#2130).
+- **Conventions the import graph proves** are proposed as decisions, rather than waiting for someone to write them down (#2141).
+- **Unresolved Python imports become external nodes.** `resolve_python_import` returned `None` for any absolute import no repo file defines, so a Python file's third-party and stdlib dependencies never became `external:` nodes or import edges, the way every other language resolver already registered them (#2136).
+- **A C complexity node map.** `LANGUAGE_NODE_MAPS` had no `c` entry, so C files got no complexity or maintainability signal at all (#2113).
+
+### Changed
+
+- **`HEALTH_ANALYZER_VERSION` is 9.** The C node map above changes `max_ccn` and the maintainability index for every C file, which were previously computed against an empty node set and persisted that way. A repo containing C re-scores on its next update; a repo without C is unaffected, and neither is asked to re-index.
+- **`PARSER_SCHEMA_VERSION` is 3**, so the Python external-node change reconciles every file's edges once instead of leaving an updated index with new edges on changed files only (#2136). The cost is one reparse per existing index. `STORE_FORMAT_VERSION` is unchanged.
+- **`update` sizes itself by what changed.** A one-file commit no longer pays for a whole-repo shaped update (#2134).
+- **`update` records a phase timing row per stage**, the way `init` has since 0.47.0, so a slow update can say which stage was slow (#2128).
+- **MCP responses account for themselves.** Every zero carries the basis it was measured against, scope hints say what was left out, a completeness line states whether a body was served whole, and no source is served twice in one response (#2125). Tool telemetry carries response size, execution flows carry freshness, and a stale index with a low-confidence answer points at `update` (#2122).
+- `get_answer`, `get_context` and `get_symbol` responses are documented to match the envelope they actually return (#2126).
+
+### Fixed
+
+- **Five places the incremental path knew less than a full index** (#2129), and stale `file_page` rows no longer survive `repowise update` (#1744, #1906).
+- **Page regeneration prioritizes the oldest stale pages** when the budget is constrained, instead of whatever came first (#1845), and `update` warns when the cascade budget truncated regeneration rather than silently skipping pages (#1720).
+- **`doctor` stops reporting excluded files as missing** (#2085).
+- **The MCP server drops to single-repo mode for a nested indexed repo** that is not a workspace member (#2088).
+- **`repowise hook` resolves the hooks directory git actually runs**, including a husky-managed one, rather than assuming `.git/hooks` (#1511, #1512).
+- **Graph hooks are declared above the loading early-return**, which is a rule React does not let you break (#2111).
+- Symbol-only headings no longer crash `init` (#2101).
+- Boolean defaults compile per dialect during persistence (#2087).
+- `REPOWISE_EMBEDDING_DIMS` is validated where it is parsed, not where it fails (#1979).
+- `ingested_commit_sha` for coverage is stamped from the live HEAD rather than a stale stored column (#1800).
+- The `temporal_hotspot` risk-semantics contract is corrected to unbounded (#1971).
+
+### Documentation
+
+- `LANGUAGE_SUPPORT.md` keeps to the support ladder; the parsing mechanics move to the architecture note (#2124).
+
+### Dependencies
+
+- Adds `tree-sitter-gdscript`, `tree-sitter-vb-dotnet`, `tree-sitter-elixir`, `tree-sitter-fsharp` and `tree-sitter-objc`.
+- Bumps `fast-uri` from 3.1.5 to 3.1.7 (#2081).
+
+---
+
 ## [0.48.0] — 2026-09-02
 
 Architectural decisions stop being a passive record and become a review queue. A decision is captured under one policy, keyed by the identity it dedupes on, and acceptance is the only thing that grants it authority — recorded as an event, on a tracked manifest, so every read can say who vouched for what. On top of that sits a queue that leads with the work you can actually finish. The other change you will see first is the repo overview: the front page described a file tree because a file tree was all it was given, and it now reads like a description of a product. Elsewhere: `doctor` stops trusting config files and launches the MCP server for real, the keyless and degraded paths report why they degraded, and a cycle of persistence and generation performance work.

--- a/packages/cli/src/repowise/cli/__init__.py
+++ b/packages/cli/src/repowise/cli/__init__.py
@@ -16,4 +16,4 @@ from repowise.cli._stdio import _ensure_utf8_stdio
 # is already UTF-8.
 _ensure_utf8_stdio()
 
-__version__ = "0.48.0"
+__version__ = "0.49.0"

--- a/packages/core/src/repowise/core/__init__.py
+++ b/packages/core/src/repowise/core/__init__.py
@@ -6,4 +6,4 @@ generation engine. This is the heart of repowise — all other packages depend o
 Namespace package: repowise.core is part of the repowise namespace.
 """
 
-__version__ = "0.48.0"
+__version__ = "0.49.0"

--- a/packages/core/src/repowise/core/analysis/health/engine.py
+++ b/packages/core/src/repowise/core/analysis/health/engine.py
@@ -92,13 +92,21 @@ log = structlog.get_logger(__name__)
 # Not a licence to move a calibrated scoring weight — those are frozen
 # independently of this stamp.
 #
-# Current stamp: paired-test detection changed. ``_has_paired_test_file`` had
+# Current stamp: C gained a complexity node map. ``LANGUAGE_NODE_MAPS`` had no
+# ``c`` entry, so every C file scored as if it had no branches: ``max_ccn`` and
+# the maintainability index were computed off an empty node set and persisted
+# that way. The map is present now, so a C file's stored complexity metrics and
+# the findings keyed off them change on the next update. C-free repos are
+# unaffected; the stamp is what makes a C repo re-score instead of waiting out
+# the decay timer.
+#
+# v8: paired-test detection changed. ``_has_paired_test_file`` had
 # ``test_<stem>.py`` hardcoded, so the prefix layout only ever matched Python;
 # it now follows the file's own suffix, and ``<stem>_spec`` joins the suffix
 # forms. Files that were counted untested and are not become tested, which
 # moves untested-hotspot findings and the scores that carry them, on every
 # language with a prefix or spec convention rather than Ruby alone.
-HEALTH_ANALYZER_VERSION = 8
+HEALTH_ANALYZER_VERSION = 9
 
 # Method-level smells that make the dataflow / Extract Method pass worthwhile.
 # Only files carrying one of these get a CFG + def/use + reaching pass built.

--- a/packages/core/src/repowise/core/upgrade/_data/CHANGELOG.md
+++ b/packages/core/src/repowise/core/upgrade/_data/CHANGELOG.md
@@ -9,6 +9,60 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.49.0] - 2026-09-05
+
+The largest language release so far: Elixir, F#, Objective-C, VB.NET and GDScript all move to the Good tier with real ASTs behind them, QML arrives at the import tier, and Razor/Blazor markup enters the graph. Alongside that, the Architecture Map stops being a picture and becomes somewhere you can drill into, `update` learns to size itself by what actually changed and reports which stage took the time, and the MCP tools stop returning bare zeros: every empty answer now says what it was measured against. Workspace mode gains cross-repo test impact and consumer contracts for five more languages.
+
+### Added
+
+- **Five languages reach the Good tier.** Elixir (#2127), F# (#2133) and Objective-C (#2135) each get a full AST parse rather than a regex skim. VB.NET arrives at Good with its own published grammar (#2048), and GDScript joins it (#1620). Symbol extraction and same-file call resolution work in all five.
+- **QML at the lightweight import tier** (#2039), and **Razor/Blazor markup** (`.razor`, `.cshtml`) is indexed into the graph (#1962).
+- **Flutter widget trees are edges.** `build()` bodies emit widget-tree edges, so a widget's children are reachable from the graph rather than buried in a method body (#2049).
+- **Godot scripts are reachable through the project.** Scenes, autoloads and `class_name` declarations connect scripts that no import statement ever linked (#1624).
+- **The Architecture Map is a place you can drill into** (#2104), with the map chrome moved off the canvas and given a ground to sit on (#2102). Communities count production files, read conductance, and name the group that was previously just "ungrouped" (#2112).
+- **File pages render the history they already carried.** The data was indexed and never shown (#2082).
+- **Cross-repo test impact.** Workspace mode works out which tests in other repos a change can break (#2008), and surfaces it on `get_change_risk`, `get_blast_radius`, the API and the contract page (#2123).
+- **HTTP consumer contracts for Go, Ruby, Java, Kotlin and PHP** (#2114), **provider contracts for Flask, Micronaut and Remix** (#2115), and breaking changes on the contracts page behind a contract drawer (#2116).
+- **Branch overlap on `get_risk`**: the other open branches editing the files you are editing (#2131).
+- **`get_change_risk` says when a diff is several changes** the index cannot connect to each other (#2130).
+- **Conventions the import graph proves** are proposed as decisions, rather than waiting for someone to write them down (#2141).
+- **Unresolved Python imports become external nodes.** `resolve_python_import` returned `None` for any absolute import no repo file defines, so a Python file's third-party and stdlib dependencies never became `external:` nodes or import edges, the way every other language resolver already registered them (#2136).
+- **A C complexity node map.** `LANGUAGE_NODE_MAPS` had no `c` entry, so C files got no complexity or maintainability signal at all (#2113).
+
+### Changed
+
+- **`HEALTH_ANALYZER_VERSION` is 9.** The C node map above changes `max_ccn` and the maintainability index for every C file, which were previously computed against an empty node set and persisted that way. A repo containing C re-scores on its next update; a repo without C is unaffected, and neither is asked to re-index.
+- **`PARSER_SCHEMA_VERSION` is 3**, so the Python external-node change reconciles every file's edges once instead of leaving an updated index with new edges on changed files only (#2136). The cost is one reparse per existing index. `STORE_FORMAT_VERSION` is unchanged.
+- **`update` sizes itself by what changed.** A one-file commit no longer pays for a whole-repo shaped update (#2134).
+- **`update` records a phase timing row per stage**, the way `init` has since 0.47.0, so a slow update can say which stage was slow (#2128).
+- **MCP responses account for themselves.** Every zero carries the basis it was measured against, scope hints say what was left out, a completeness line states whether a body was served whole, and no source is served twice in one response (#2125). Tool telemetry carries response size, execution flows carry freshness, and a stale index with a low-confidence answer points at `update` (#2122).
+- `get_answer`, `get_context` and `get_symbol` responses are documented to match the envelope they actually return (#2126).
+
+### Fixed
+
+- **Five places the incremental path knew less than a full index** (#2129), and stale `file_page` rows no longer survive `repowise update` (#1744, #1906).
+- **Page regeneration prioritizes the oldest stale pages** when the budget is constrained, instead of whatever came first (#1845), and `update` warns when the cascade budget truncated regeneration rather than silently skipping pages (#1720).
+- **`doctor` stops reporting excluded files as missing** (#2085).
+- **The MCP server drops to single-repo mode for a nested indexed repo** that is not a workspace member (#2088).
+- **`repowise hook` resolves the hooks directory git actually runs**, including a husky-managed one, rather than assuming `.git/hooks` (#1511, #1512).
+- **Graph hooks are declared above the loading early-return**, which is a rule React does not let you break (#2111).
+- Symbol-only headings no longer crash `init` (#2101).
+- Boolean defaults compile per dialect during persistence (#2087).
+- `REPOWISE_EMBEDDING_DIMS` is validated where it is parsed, not where it fails (#1979).
+- `ingested_commit_sha` for coverage is stamped from the live HEAD rather than a stale stored column (#1800).
+- The `temporal_hotspot` risk-semantics contract is corrected to unbounded (#1971).
+
+### Documentation
+
+- `LANGUAGE_SUPPORT.md` keeps to the support ladder; the parsing mechanics move to the architecture note (#2124).
+
+### Dependencies
+
+- Adds `tree-sitter-gdscript`, `tree-sitter-vb-dotnet`, `tree-sitter-elixir`, `tree-sitter-fsharp` and `tree-sitter-objc`.
+- Bumps `fast-uri` from 3.1.5 to 3.1.7 (#2081).
+
+---
+
 ## [0.48.0] — 2026-09-02
 
 Architectural decisions stop being a passive record and become a review queue. A decision is captured under one policy, keyed by the identity it dedupes on, and acceptance is the only thing that grants it authority — recorded as an event, on a tracked manifest, so every read can say who vouched for what. On top of that sits a queue that leads with the work you can actually finish. The other change you will see first is the repo overview: the front page described a file tree because a file tree was all it was given, and it now reads like a description of a product. Elsewhere: `doctor` stops trusting config files and launches the MCP server for real, the keyless and degraded paths report why they degraded, and a cycle of persistence and generation performance work.

--- a/packages/server/src/repowise/server/__init__.py
+++ b/packages/server/src/repowise/server/__init__.py
@@ -7,4 +7,4 @@ Provides:
     - Background job scheduler (APScheduler)
 """
 
-__version__ = "0.48.0"
+__version__ = "0.49.0"

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "repowise",
   "description": "Codebase intelligence for Claude Code. Indexes your codebase into five layers (Graph, Git, Docs, Decisions, Code Health) and exposes them through ten task-shaped MCP tools — so Claude understands architecture, ownership, hotspots, why code is built the way it is, and where the defect risk lives.",
-  "version": "0.48.0",
+  "version": "0.49.0",
   "author": {
     "name": "Repowise",
     "email": "hello@repowise.dev",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "repowise"
-version = "0.48.0"
+version = "0.49.0"
 description = "The codebase intelligence layer for your AI coding agent — dependency graph, git history, dead code, decisions, and code health, exposed over MCP"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/server.json
+++ b/server.json
@@ -8,12 +8,12 @@
     "source": "github"
   },
   "websiteUrl": "https://www.repowise.dev",
-  "version": "0.48.0",
+  "version": "0.49.0",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "repowise",
-      "version": "0.48.0",
+      "version": "0.49.0",
       "transport": {
         "type": "stdio"
       },

--- a/tests/unit/health/test_model_version_coupling.py
+++ b/tests/unit/health/test_model_version_coupling.py
@@ -22,7 +22,7 @@ from repowise.core.analysis.health.refactoring.identity import (
 
 # The three stamps as they stand together. Moving either identity model means
 # moving the analyzer with it, and updating this tuple in the same commit.
-_STAMPS = (8, 2, 2)
+_STAMPS = (9, 2, 2)
 
 
 def test_the_identity_models_and_the_analyzer_stamp_are_pinned_together() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -3051,7 +3051,7 @@ wheels = [
 
 [[package]]
 name = "repowise"
-version = "0.48.0"
+version = "0.49.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Version bump and changelog for v0.49.0, cut from `f84d250ff`.

The four Python version constants, both Claude Code plugin manifests, `server.json` (twice) and the `uv.lock` self-entry all move to `0.49.0`. `plugins/codex/.codex-plugin/plugin.json` shipped nothing this cycle and stays at `0.6.1`.

`HEALTH_ANALYZER_VERSION` moves 8 to 9. #2113 gave C a complexity node map, so `max_ccn` and the maintainability index for every C file had been computed against an empty node set and persisted that way. The stamp is what makes a repo containing C re-score on its next update instead of waiting out the decay timer. A repo without C is unaffected, and neither is asked to re-index. `tests/unit/health/test_model_version_coupling.py` pins the three identity stamps together on purpose, so its tuple moves in the same commit.

`STORE_FORMAT_VERSION` stays at 2. `PARSER_SCHEMA_VERSION` already moved to 3 in #2136.

The README's foundations table still claimed 19 AST-parsed languages while the ladder below it said 25. The ladder is right: Full (13) plus Good (10) plus Partial (2) are all tree-sitter parsed, and five of them landed this cycle.

## After merge

- Tag `v0.49.0` on `main`, watch `publish.yml`.
- `mcp-publisher publish` once PyPI serves the wheel.
- Install `repowise==0.49.0` from PyPI into a throwaway venv and cold-index a real repo with it.

## Separately

The VS Code extension is behind. Eight `packages/ui/src/` commits have landed since `vscode-v0.10.0` (architecture map, communities, decisions, file-page history), all in subpaths the webviews import, and `packages/vscode/` itself changed in #2104. It needs its own bump and `vscode-v*` tag in this window. Not part of this PR, since it rides its own tag namespace.
