### PR TITLE
fix(init): skip interactive prompts when --resume is passed (closes #2098)

### DIFF
--- a/packages/cli/src/repowise/cli/commands/init_cmd/command.py
+++ b/packages/cli/src/repowise/cli/commands/init_cmd/command.py
@@ -1007,7 +1007,12 @@ def init_command(
     # ---- Interactive mode (TTY, no explicit flags) ----
     # --yes forces non-interactive even on a TTY (mirrors the workspace path),
     # so a scripted `init -y` never blocks on the mode-selection menu.
-    is_interactive = sys.stdin.isatty() and provider_name is None and not index_only and not yes
+    # --resume also forces non-interactive: reuse stored answers and resume without
+    # re-prompting (fixes issue #2098).
+    if resume:
+        mode_desc = "fast index-only" if index_only else "full"
+        console.print(f"[dim]Resuming a {mode_desc} run — reusing stored configuration.[/dim]")
+    is_interactive = sys.stdin.isatty() and provider_name is None and not index_only and not yes and not resume
 
     # Output language picked in the advanced-mode generation section; None
     # until chosen. Resolved below: flag > this > config.yaml > English.


### PR DESCRIPTION
## Summary

When `repowise init --resume` is run on a TTY, the entire interactive questionnaire runs again (banner, mode menu, provider selection, etc.), defeating the purpose of `--resume`.

The git-tier is already handled correctly by `effective_run_mode_for_resume()` (computed before the interactive gate, so a fast resume never re-prompts for it). All other prompts were not similarly gated.

## Root cause

`is_interactive` at line 1010 had no check for `resume`:

```python
is_interactive = sys.stdin.isatty() and provider_name is None and not index_only and not yes
```

## Fix

1. Added `and not resume` to the `is_interactive` expression, so resume runs always fall through to the non-interactive path.
2. Added a one-line console notice (e.g. `[dim]Resuming a full run — reusing stored configuration.[/dim]`) so the user can see the run was picked up rather than restarted.

The non-interactive path reads stored configuration from `.repowise/config.yaml` and `state.json`, so the prior run's provider, model, language, and other choices are reused automatically.

Fixes [#2098](https://github.com/repowise-dev/repowise/issues/2098)
