### PR TITLE
fix(web): load active provider from providers API

### DIFF
--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -226,7 +226,7 @@ Job progress events (`JobProgressEvent`) carry: `event` type, `file` currently b
 
 | Method | Path | Description |
 |--------|------|-------------|
-| `GET` | `/api/health` | Server health — db connectivity, embedder info, scheduler status |
+| `GET` | `/health` | Server liveness/readiness, version, and database connectivity |
 
 ---
 

--- a/packages/web/src/components/settings/connection-section.tsx
+++ b/packages/web/src/components/settings/connection-section.tsx
@@ -21,7 +21,7 @@ import { toFriendlyMessage } from "@repowise-dev/ui/lib/errors";
  * Server connection, and the page's only connection test.
  *
  * `ProviderSection` used to ship a second "Server Connection" card with its own
- * Test button hitting the same `/api/health`, reporting the result in a
+ * Test button hitting the same `/health`, reporting the result in a
  * different vocabulary through a hand-rolled `<button>` whose border token did
  * not exist. This one reports more (version and DB), so that one went.
  */

--- a/packages/web/src/components/settings/provider-section.test.tsx
+++ b/packages/web/src/components/settings/provider-section.test.tsx
@@ -1,0 +1,66 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getProviders: vi.fn(),
+}));
+
+vi.mock("@/lib/api/providers", () => ({ getProviders: mocks.getProviders }));
+vi.mock("@/lib/config", () => ({
+  config: {
+    getProvider: () => "gemini",
+    getModel: () => "",
+    getEmbedder: () => "mock",
+    setProvider: vi.fn(),
+    setModel: vi.fn(),
+    setEmbedder: vi.fn(),
+  },
+}));
+
+import { ProviderSection } from "./provider-section";
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("ProviderSection server provider", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("loads the active provider through the shared providers client", async () => {
+    mocks.getProviders.mockResolvedValue({
+      active: { provider: "openai", model: "gpt-5.6-luna" },
+      providers: [],
+    });
+
+    render(<ProviderSection />);
+
+    await waitFor(() => expect(mocks.getProviders).toHaveBeenCalledOnce());
+    expect(
+      await screen.findByText(/server itself is currently configured with openai/i),
+    ).toBeTruthy();
+  });
+
+  it("warns when the provider probe fails instead of swallowing the error", async () => {
+    const error = new Error("server unavailable");
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    mocks.getProviders.mockRejectedValue(error);
+
+    render(<ProviderSection />);
+
+    await waitFor(() =>
+      expect(warn).toHaveBeenCalledWith(
+        "[settings] Could not load the active server provider",
+        error,
+      ),
+    );
+    expect(
+      screen.getByText("Used when you trigger init or sync from this dashboard."),
+    ).toBeTruthy();
+  });
+});

--- a/packages/web/src/components/settings/provider-section.tsx
+++ b/packages/web/src/components/settings/provider-section.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { config } from "@/lib/config";
+import { getProviders } from "@/lib/api/providers";
 import { OverviewSection } from "@repowise-dev/ui/overview";
 import { Input } from "@repowise-dev/ui/ui/input";
 import {
@@ -63,7 +64,7 @@ const EMBEDDER_ENV_VARS: Record<string, string[]> = {
  * Model and embedder defaults for init/sync triggered from the UI.
  *
  * This used to render a second card, "Server Connection", with its own Test
- * button against the same `/api/health` that `ConnectionSection` already tests
+ * button against the same `/health` that `ConnectionSection` already tests
  * — a hand-rolled `<button>` painted with `--color-border`, a token defined in
  * no stylesheet, reporting with literal ✓/✗ glyphs. It is gone; what it
  * uniquely showed, the provider the *server* is configured with, is a line
@@ -82,12 +83,17 @@ export function ProviderSection() {
     setProvider(config.getProvider());
     setModel(config.getModel());
     setEmbedder(config.getEmbedder());
-    fetch("/api/health")
-      .then((r) => r.json())
-      .then((data) => {
-        if (data?.provider) setServerProvider(data.provider);
+    let cancelled = false;
+    void getProviders()
+      .then(({ active }) => {
+        if (!cancelled) setServerProvider(active.provider);
       })
-      .catch(() => {});
+      .catch((error: unknown) => {
+        console.warn("[settings] Could not load the active server provider", error);
+      });
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   useEffect(


### PR DESCRIPTION
## Summary

- replace the dead `fetch("/api/health")` provider probe with `getProviders()`, so it uses the configured API base URL and the endpoint whose response actually contains the active provider
- preserve the global-settings semantics by reading the server-global active provider, while guarding against state updates after unmount
- surface provider-probe failures with a console warning instead of swallowing them
- document `/health` as the canonical liveness/readiness route and correct both stale UI comments
- add focused component coverage for success and failure paths

Fixes #2151

## Validation

- `npm test --workspace packages/web -- src/components/settings/provider-section.test.tsx` — 2 passed
- `NODE_OPTIONS=--localstorage-file=/tmp/repowise-2151-localstorage.json npm test --workspace packages/web` — 86 passed
- `npm run type-check --workspace packages/web` — passed
- `npm run lint --workspace packages/web` — passed (one pre-existing hook warning in `freshness-table-wrapper.tsx`)
- `npm run lint:shared` — passed
- `git diff --check` — passed

## Notes

No `/api/health` alias is added. The existing route, API client, auth exemption, middleware, and server tests already agree on `/health`.