### PR TITLE
fix(ingestion): parse tsconfig.json as JSONC, not JSON

### DIFF
--- a/packages/core/src/repowise/core/ingestion/tsconfig_resolver.py
+++ b/packages/core/src/repowise/core/ingestion/tsconfig_resolver.py
@@ -447,16 +447,82 @@ class TsconfigResolver:
     # ------------------------------------------------------------------
 
     @staticmethod
+    def _strip_jsonc_comments(text: str) -> str:
+        """Remove ``//`` and ``/* */`` comments, respecting strings and escapes.
+
+        A hand-written scanner rather than a regex: a regex cannot tell a ``//``
+        inside a string literal (``"url": "https://example.com"``) from a real
+        comment, and tsconfig files carry both.
+        """
+        out: list[str] = []
+        i, n = 0, len(text)
+        in_str = esc = False
+        while i < n:
+            c = text[i]
+            if in_str:
+                out.append(c)
+                if esc:
+                    esc = False
+                elif c == "\\":
+                    esc = True
+                elif c == '"':
+                    in_str = False
+                i += 1
+                continue
+            if c == '"':
+                in_str = True
+                out.append(c)
+                i += 1
+                continue
+            if c == "/" and i + 1 < n and text[i + 1] == "/":
+                while i < n and text[i] != "\n":
+                    i += 1
+                continue
+            if c == "/" and i + 1 < n and text[i + 1] == "*":
+                i += 2
+                while i + 1 < n and not (text[i] == "*" and text[i + 1] == "/"):
+                    i += 1
+                i += 2
+                continue
+            out.append(c)
+            i += 1
+        return "".join(out)
+
+    @staticmethod
     def _parse_json_lenient(config_path: Path) -> dict[str, Any] | None:
-        """Parse JSON with trailing-comma tolerance (common in tsconfig)."""
+        """Parse JSON tolerating trailing commas *and* comments.
+
+        tsconfig.json is JSONC, not JSON: ``tsc`` accepts ``//`` and ``/* */``
+        and real configs carry them. Tolerating only trailing commas meant a
+        commented root tsconfig raised, was swallowed at debug level, and the
+        resolver came up with zero path aliases -- so every aliased import was
+        minted as an ``external:`` node and every aliased file read as
+        unreachable to the dead-code analyzer. Same symptom as #648, reached
+        through the config loader rather than the rebuild wiring.
+
+        Candidates are tried cheapest-first, so a plain JSON file still costs
+        one ``json.loads`` and no scanning.
+        """
         try:
             text = config_path.read_text(encoding="utf-8", errors="ignore")
-            try:
-                data = json.loads(text)
-            except json.JSONDecodeError:
-                cleaned = re.sub(r",\s*([}\]])", r"\1", text)
-                data = json.loads(cleaned)
-            return data if isinstance(data, dict) else None
+            stripped = TsconfigResolver._strip_jsonc_comments(text)
+            for candidate in (
+                text,
+                re.sub(r",\s*([}\]])", r"\1", text),
+                stripped,
+                re.sub(r",\s*([}\]])", r"\1", stripped),
+            ):
+                try:
+                    data = json.loads(candidate)
+                except json.JSONDecodeError:
+                    continue
+                return data if isinstance(data, dict) else None
+            log.debug(
+                "tsconfig_parse_failed",
+                path=str(config_path),
+                error="not parseable as JSON or JSONC",
+            )
+            return None
         except Exception as exc:
             log.debug("tsconfig_parse_failed", path=str(config_path), error=str(exc))
             return None

--- a/tests/unit/ingestion/test_tsconfig_resolver.py
+++ b/tests/unit/ingestion/test_tsconfig_resolver.py
@@ -558,3 +558,78 @@ class TestMtsCtsAliasResolution:
         resolver = self._resolver(tmp_path, {"src/pkg/index.mts"})
         result = resolver.resolve("@/pkg", _importer(tmp_path, "src/app.ts"))
         assert result == "src/pkg/index.mts"
+
+
+# ---------------------------------------------------------------------------
+# JSONC — comments in tsconfig.json / jsconfig.json
+# ---------------------------------------------------------------------------
+
+
+class TestJsoncComments:
+    """``tsconfig.json`` is JSONC, not JSON: ``tsc`` accepts ``//`` and ``/* */``.
+
+    A commented config used to raise inside ``_parse_json_lenient``; the error
+    was swallowed at debug level and the resolver came up with zero aliases, so
+    every aliased import was minted as an ``external:`` node and every aliased
+    file read as unreachable to the dead-code analyzer.
+    """
+
+    @staticmethod
+    def _parse(tmp_path: Path, text: str) -> dict | None:
+        path = tmp_path / "tsconfig.json"
+        path.write_text(text, encoding="utf-8")
+        return TsconfigResolver._parse_json_lenient(path)
+
+    # -- the four shapes tsc accepts ------------------------------------
+
+    def test_plain_json_still_parses(self, tmp_path: Path) -> None:
+        assert self._parse(tmp_path, '{"a": 1}') == {"a": 1}
+
+    def test_trailing_comma_still_parses(self, tmp_path: Path) -> None:
+        """The pre-existing tolerance must survive the change."""
+        assert self._parse(tmp_path, '{"a": 1,}') == {"a": 1}
+
+    def test_line_comment(self, tmp_path: Path) -> None:
+        assert self._parse(tmp_path, '{\n  // why this is here\n  "a": 1\n}') == {"a": 1}
+
+    def test_block_comment(self, tmp_path: Path) -> None:
+        assert self._parse(tmp_path, '{\n  /* why\n     this is here */\n  "a": 1\n}') == {"a": 1}
+
+    def test_comment_and_trailing_comma(self, tmp_path: Path) -> None:
+        assert self._parse(tmp_path, '{\n  "a": 1, // trailing\n}') == {"a": 1}
+
+    # -- the traps a regex-based stripper falls into ---------------------
+
+    def test_double_slash_inside_string_is_not_a_comment(self, tmp_path: Path) -> None:
+        """``"https://example.com"`` must survive intact."""
+        assert self._parse(tmp_path, '{"u": "https://example.com"}') == {"u": "https://example.com"}
+
+    def test_escaped_quote_does_not_end_the_string(self, tmp_path: Path) -> None:
+        assert self._parse(tmp_path, '{"u": "a\\"//b"}') == {"u": 'a"//b'}
+
+    # -- and the negative -----------------------------------------------
+
+    def test_not_json_at_all_returns_none(self, tmp_path: Path) -> None:
+        assert self._parse(tmp_path, "this is not json") is None
+
+    def test_non_dict_top_level_returns_none(self, tmp_path: Path) -> None:
+        assert self._parse(tmp_path, "[1, 2, 3]") is None
+
+    # -- end to end: the symptom that made this worth fixing -------------
+
+    def test_aliases_resolve_through_a_commented_config(self, tmp_path: Path) -> None:
+        (tmp_path / "tsconfig.json").write_text(
+            """{
+  "compilerOptions": {
+    "baseUrl": ".",
+    // the app's own source
+    "paths": {
+      "@/*": ["./src/*"] /* everything under src */
+    }
+  }
+}""",
+            encoding="utf-8",
+        )
+        resolver = TsconfigResolver(repo_path=tmp_path, path_set={"src/components/Button.tsx"})
+        result = resolver.resolve("@/components/Button", _importer(tmp_path, "src/app.tsx"))
+        assert result == "src/components/Button.tsx"


### PR DESCRIPTION
## Summary

- `tsconfig.json` is JSONC — `tsc` accepts `//` and `/* */`, and real configs carry them. `TsconfigResolver._parse_json_lenient` tolerated trailing commas only, so a commented root config raised, the error was swallowed at `log.debug`, and the resolver came up with **zero path aliases**.
- Downstream that is silent and expensive: every aliased import (`@/components/Button`, `~/lib/x`) is minted as an `external:` node instead of an edge to the real file, the real file's in-degree stays 0, and the dead-code analyzer reports it unreachable.
- The stripper is a hand-written scanner, not a regex — a regex cannot tell a `//` inside a string literal (`"url": "https://example.com"`) from a real comment, and tsconfig files carry both.

## What it looked like in the field

One TypeScript monorepo, one `//` comment at line 76 of the root `tsconfig.json`:

| | dead-code findings |
|---|---:|
| stock 0.48.0 / 0.49.0 | **1,288** |
| with this fix | **618** |

670 false rows from one comment. Eleven aliases were being silently lost — `~/*`, `@/*`, `@assets/*`, `@styles/*`, `@ui/*`, two package roots and their wildcards, and two macro paths. Nothing surfaced: the only trace was one `log.debug("tsconfig_parse_failed", …)`.

`tsconfig_resolver.py` is byte-identical in 0.48.0, 0.49.0 and `main`, so this is live on `main` today.

## Related Issues

Same symptom as #648, reached through the config loader rather than the rebuild wiring. Not a duplicate — #648's path is fixed; this one is not.

## Notes on the implementation

- Candidates are tried cheapest-first (`text` → trailing-comma strip → comment strip → both), so a plain JSON file still costs one `json.loads` and no scanning.
- A file that parses as neither JSON nor JSONC now logs a clear reason instead of a `JSONDecodeError` byte offset.
- No behaviour change for any config that parsed before — the first two candidates are exactly the old code path.

## Test Plan

`TestJsoncComments` in `tests/unit/ingestion/test_tsconfig_resolver.py` — 10 cases:

- the four shapes `tsc` accepts: plain JSON, trailing comma, `//`, `/* */`, and comment + trailing comma together;
- the two traps a regex-based stripper falls into: `"https://example.com"` and an escaped quote `"a\"//b"`;
- two negatives: not-JSON-at-all and a non-dict top level both return `None`;
- one end-to-end: `resolve("@/components/Button", …)` through a config with comments in it.

Four of the ten fail on `main` before the change. Full file: **39 passed**.

- [x] Tests pass (`pytest tests/unit/ingestion tests/unit/dead_code`) — failure set identical to `main` on the same machine, and +10 passing
- [x] Lint passes (`ruff check`, `ruff format --check` on both touched files)
- [ ] Web build — no frontend changes

## Checklist

- [x] My code follows the project's code style
- [x] I have added tests for new functionality
- [x] All existing tests still pass
- [x] I have updated documentation if needed (none needed — no user-facing surface changes)
