### PR TITLE
fix(server): detect repo index presence from database in list_repos (#2139)

### DIFF
--- a/packages/cli/src/repowise/cli/commands/augment_cmd/search.py
+++ b/packages/cli/src/repowise/cli/commands/augment_cmd/search.py
@@ -412,7 +412,7 @@ def _wiki_db_exists(repo_path: Path) -> bool:
     return (repo_path / ".repowise" / "wiki.db").exists()
 
 
-def _fast_pagerank_file_order(repo_path: Path, paths: list[str]) -> list[str] | None | object:
+def _fast_pagerank_file_order(repo_path: Path, paths: list[str]) -> list[str] | object | None:
     """``_pagerank_file_order`` over stdlib sqlite3. ``_ORM`` to fall back."""
     if not _wiki_db_exists(repo_path):
         return None
@@ -438,7 +438,7 @@ def _fast_search_enrich(
     mode: str,
     result_count: int,
     matched: dict[str, int] | None,
-) -> str | None | object:
+) -> str | object | None:
     """Triage and the widened rescue without the ORM. ``_ORM`` to fall back.
 
     The zero-result rescue is not served here on purpose: 45% of its queries

--- a/packages/server/src/repowise/server/routers/repos.py
+++ b/packages/server/src/repowise/server/routers/repos.py
@@ -250,9 +250,12 @@ async def list_repos(
     # Reuses the workspace "needs_index" / "missing_dir" contract the sidebar renders.
     for resp in responses:
         if resp.workspace_status is None and resp.id not in indexed_repo_ids:
-            if resp.local_path and not Path(resp.local_path).is_dir():
-                resp.workspace_status = "missing_dir"
-            else:
+            try:
+                if resp.local_path and not Path(resp.local_path).is_dir():
+                    resp.workspace_status = "missing_dir"
+                else:
+                    resp.workspace_status = "needs_index"
+            except OSError:
                 resp.workspace_status = "needs_index"
 
     # Augment with workspace metadata. We do this in a second pass (rather

--- a/packages/server/src/repowise/server/routers/repos.py
+++ b/packages/server/src/repowise/server/routers/repos.py
@@ -170,8 +170,23 @@ async def list_repos(
     what powers the web UI sidebar — silently dropping unindexed repos
     used to cause the "I only see the primary" Discord report.
     """
-    result = await session.execute(select(Repository).order_by(Repository.updated_at.desc()))
-    repos = list(result.scalars().all())
+    has_files_subq = (
+        select(GraphNode.repository_id)
+        .where(GraphNode.node_type == "file")
+        .group_by(GraphNode.repository_id)
+        .subquery()
+    )
+    result = await session.execute(
+        select(Repository, has_files_subq.c.repository_id.is_not(None))
+        .outerjoin(has_files_subq, Repository.id == has_files_subq.c.repository_id)
+        .order_by(Repository.updated_at.desc())
+    )
+    repos: list[Repository] = []
+    indexed_repo_ids: set[str] = set()
+    for r, is_indexed in result.all():
+        repos.append(r)
+        if is_indexed:
+            indexed_repo_ids.add(r.id)
     seen_ids = {r.id for r in repos}
 
     # In workspace mode, also fetch repos from other workspace DBs
@@ -182,12 +197,17 @@ async def list_repos(
         try:
             async with ws_factory() as ws_session:
                 ws_result = await ws_session.execute(
-                    select(Repository).where(Repository.id == repo_id)
+                    select(Repository, has_files_subq.c.repository_id.is_not(None))
+                    .outerjoin(has_files_subq, Repository.id == has_files_subq.c.repository_id)
+                    .where(Repository.id == repo_id)
                 )
-                ws_repo = ws_result.scalar_one_or_none()
-                if ws_repo:
+                row = ws_result.first()
+                if row:
+                    ws_repo, ws_is_indexed = row
                     repos.append(ws_repo)
                     seen_ids.add(ws_repo.id)
+                    if ws_is_indexed:
+                        indexed_repo_ids.add(ws_repo.id)
         except Exception:
             pass
 
@@ -206,43 +226,6 @@ async def list_repos(
     for resp in responses:
         if resp.local_path:
             resp.head_commit = resolve_indexed_commit(resp.head_commit, resp.local_path)
-
-    # Collect IDs of repositories that have actually been indexed (i.e. have
-    # at least one file-typed GraphNode). Checking the database directly works
-    # identically across SQLite and PostgreSQL (shared REPOWISE_DB_URL), unlike
-    # checking for a local .repowise/wiki.db file.
-    indexed_repo_ids: set[str] = set()
-    if responses:
-        with contextlib.suppress(Exception):
-            node_result = await session.execute(
-                select(GraphNode.repository_id)
-                .where(
-                    GraphNode.repository_id.in_([r.id for r in responses]),
-                    GraphNode.node_type == "file",
-                )
-                .group_by(GraphNode.repository_id)
-            )
-            indexed_repo_ids.update(row[0] for row in node_result.all())
-
-        # In multi-database workspace mode, secondary workspace sessions may hold
-        # their own graph_nodes tables.
-        for repo_id, ws_factory in ws_sessions.items():
-            if repo_id in indexed_repo_ids:
-                continue
-            try:
-                async with ws_factory() as ws_session:
-                    ws_node_result = await ws_session.execute(
-                        select(GraphNode.repository_id)
-                        .where(
-                            GraphNode.repository_id == repo_id,
-                            GraphNode.node_type == "file",
-                        )
-                        .limit(1)
-                    )
-                    if ws_node_result.first():
-                        indexed_repo_ids.add(repo_id)
-            except Exception:
-                pass
 
     # Flag registered-but-never-indexed repos. head_commit can't signal this
     # (registration stamps it from the live git HEAD), so the honest check is

--- a/packages/server/src/repowise/server/routers/repos.py
+++ b/packages/server/src/repowise/server/routers/repos.py
@@ -207,20 +207,53 @@ async def list_repos(
         if resp.local_path:
             resp.head_commit = resolve_indexed_commit(resp.head_commit, resp.local_path)
 
+    # Collect IDs of repositories that have actually been indexed (i.e. have
+    # at least one file-typed GraphNode). Checking the database directly works
+    # identically across SQLite and PostgreSQL (shared REPOWISE_DB_URL), unlike
+    # checking for a local .repowise/wiki.db file.
+    indexed_repo_ids: set[str] = set()
+    if responses:
+        with contextlib.suppress(SQLAlchemyError):
+            node_result = await session.execute(
+                select(GraphNode.repository_id)
+                .where(
+                    GraphNode.repository_id.in_([r.id for r in responses]),
+                    GraphNode.node_type == "file",
+                )
+                .group_by(GraphNode.repository_id)
+            )
+            indexed_repo_ids.update(row[0] for row in node_result.all())
+
+        # In multi-database workspace mode, secondary workspace sessions may hold
+        # their own graph_nodes tables.
+        for repo_id, ws_factory in ws_sessions.items():
+            if repo_id in indexed_repo_ids:
+                continue
+            try:
+                async with ws_factory() as ws_session:
+                    ws_node_result = await ws_session.execute(
+                        select(GraphNode.repository_id)
+                        .where(
+                            GraphNode.repository_id == repo_id,
+                            GraphNode.node_type == "file",
+                        )
+                        .limit(1)
+                    )
+                    if ws_node_result.first():
+                        indexed_repo_ids.add(repo_id)
+            except Exception:
+                pass
+
     # Flag registered-but-never-indexed repos. head_commit can't signal this
     # (registration stamps it from the live git HEAD), so the honest check is
-    # the repo-local store: since the initial-index path always establishes
-    # <repo>/.repowise/wiki.db, its absence means the first index hasn't run.
-    # Reuses the workspace "needs_index" contract the sidebar already renders.
-    from pathlib import Path as _Path
-
+    # whether file-typed graph nodes exist in the database.
+    # Reuses the workspace "needs_index" / "missing_dir" contract the sidebar renders.
     for resp in responses:
-        if resp.workspace_status is None and resp.local_path:
-            try:
-                if not (_Path(resp.local_path) / ".repowise" / "wiki.db").is_file():
-                    resp.workspace_status = "needs_index"
-            except OSError:
-                pass
+        if resp.workspace_status is None and resp.id not in indexed_repo_ids:
+            if resp.local_path and not Path(resp.local_path).is_dir():
+                resp.workspace_status = "missing_dir"
+            else:
+                resp.workspace_status = "needs_index"
 
     # Augment with workspace metadata. We do this in a second pass (rather
     # than during from_orm) because the workspace context lives on
@@ -233,21 +266,24 @@ async def list_repos(
     import json as _json
 
     ws_root_path = Path(ws_root)
-    # Map local_path → alias entry for quick attach on indexed rows.
+    # Map local_path → alias entry for quick attach on registered rows.
     by_path: dict[str, object] = {
         str((ws_root_path / e.path).resolve()): e for e in ws_config.repos
     }
 
-    # Attach alias + status + docs status to already-indexed rows.
-    indexed_aliases: set[str] = set()
+    # Attach alias + identity + docs status to registered rows.
+    matched_aliases: set[str] = set()
     for resp in responses:
+        if not resp.local_path:
+            continue
         entry = by_path.get(str(Path(resp.local_path).resolve()))
         if entry is None:
             continue
         resp.workspace_alias = entry.alias
         resp.is_primary = bool(entry.is_primary)
-        resp.workspace_status = "indexed"
-        indexed_aliases.add(entry.alias)
+        if resp.id in indexed_repo_ids:
+            resp.workspace_status = "indexed"
+        matched_aliases.add(entry.alias)
 
         # The docs mode and index tier are recorded per-repo in state.json.
         # Read it once per response: cheap, and never failing.
@@ -270,13 +306,13 @@ async def list_repos(
             except Exception:
                 pass
 
-    # Synthesize entries for repos in the workspace that aren't indexed yet.
+    # Synthesize entries for repos in the workspace that aren't registered yet.
     from datetime import UTC as _UTC
     from datetime import datetime
 
     now = datetime.now(_UTC)
     for entry in ws_config.repos:
-        if entry.alias in indexed_aliases:
+        if entry.alias in matched_aliases:
             continue
         abs_path = (ws_root_path / entry.path).resolve()
         status = "needs_index" if abs_path.is_dir() else "missing_dir"

--- a/packages/server/src/repowise/server/routers/repos.py
+++ b/packages/server/src/repowise/server/routers/repos.py
@@ -213,7 +213,7 @@ async def list_repos(
     # checking for a local .repowise/wiki.db file.
     indexed_repo_ids: set[str] = set()
     if responses:
-        with contextlib.suppress(SQLAlchemyError):
+        with contextlib.suppress(Exception):
             node_result = await session.execute(
                 select(GraphNode.repository_id)
                 .where(
@@ -249,9 +249,9 @@ async def list_repos(
     # whether file-typed graph nodes exist in the database.
     # Reuses the workspace "needs_index" / "missing_dir" contract the sidebar renders.
     for resp in responses:
-        if resp.workspace_status is None and resp.id not in indexed_repo_ids:
+        if resp.workspace_status is None and resp.local_path and resp.id not in indexed_repo_ids:
             try:
-                if resp.local_path and not Path(resp.local_path).is_dir():
+                if not Path(resp.local_path).is_dir():
                     resp.workspace_status = "missing_dir"
                 else:
                     resp.workspace_status = "needs_index"

--- a/tests/unit/server/test_repos_status.py
+++ b/tests/unit/server/test_repos_status.py
@@ -1,0 +1,172 @@
+"""Tests for GET /api/repos workspace_status determination (Issue #2139).
+
+Verifies that registered-but-never-indexed repositories report 'needs_index'
+based on actual database index presence (GraphNode file rows) rather than
+the presence of a local .repowise/wiki.db file.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from repowise.core.persistence.crud import upsert_repository
+from repowise.core.persistence.models import GraphNode
+from repowise.core.workspace.config import RepoEntry, WorkspaceConfig
+
+
+@pytest.mark.asyncio
+async def test_registered_unindexed_repo_reports_needs_index(
+    client: AsyncClient, session: AsyncSession
+) -> None:
+    """A repo registered in DB but with 0 file nodes reports needs_index."""
+    repo_dir = Path(tempfile.mkdtemp()) / "unindexed-repo"
+    repo_dir.mkdir()
+
+    repo = await upsert_repository(session, name="unindexed-repo", local_path=str(repo_dir))
+    await session.commit()
+
+    resp = await client.get("/api/repos")
+    assert resp.status_code == 200
+    data = resp.json()
+
+    target = next((r for r in data if r["id"] == repo.id), None)
+    assert target is not None
+    assert target["workspace_status"] == "needs_index"
+
+
+@pytest.mark.asyncio
+async def test_registered_indexed_repo_without_wiki_db_reports_indexed_on_shared_db(
+    client: AsyncClient, session: AsyncSession
+) -> None:
+    """Under PostgreSQL (or no local wiki.db file), presence of file nodes signals indexed."""
+    repo_dir = Path(tempfile.mkdtemp()) / "indexed-repo"
+    repo_dir.mkdir()
+    # Explicitly ensure no .repowise/wiki.db exists
+    assert not (repo_dir / ".repowise" / "wiki.db").exists()
+
+    repo = await upsert_repository(session, name="indexed-repo", local_path=str(repo_dir))
+    session.add(
+        GraphNode(
+            repository_id=repo.id,
+            node_id="src/app.py",
+            node_type="file",
+            symbol_count=10,
+        )
+    )
+    await session.commit()
+
+    resp = await client.get("/api/repos")
+    assert resp.status_code == 200
+    data = resp.json()
+
+    target = next((r for r in data if r["id"] == repo.id), None)
+    assert target is not None
+    # In non-workspace mode, indexed repos have workspace_status == None (not falsely 'needs_index')
+    assert target["workspace_status"] is None
+
+
+@pytest.mark.asyncio
+async def test_workspace_mode_unindexed_member_is_not_overwritten_to_indexed(
+    client: AsyncClient, session: AsyncSession, app
+) -> None:
+    """Workspace attach pass must not unconditionally stamp workspace_status='indexed'."""
+    ws_root = Path(tempfile.mkdtemp())
+    member_path = ws_root / "services" / "payment"
+    member_path.mkdir(parents=True)
+
+    # Register member in database with 0 file nodes (e.g. POST /api/repos with index: false)
+    repo = await upsert_repository(session, name="payment-service", local_path=str(member_path))
+    await session.commit()
+
+    ws_config = WorkspaceConfig(
+        version=1,
+        repos=[
+            RepoEntry(path="services/payment", alias="payment", is_primary=True),
+        ],
+        default_repo="payment",
+    )
+    app.state.workspace_config = ws_config
+    app.state.workspace_root = str(ws_root)
+
+    try:
+        resp = await client.get("/api/repos")
+        assert resp.status_code == 200
+        data = resp.json()
+
+        target = next((r for r in data if r["id"] == repo.id), None)
+        assert target is not None
+        assert target["workspace_alias"] == "payment"
+        assert target["is_primary"] is True
+        # Must honestly stay needs_index, NOT overwritten to indexed
+        assert target["workspace_status"] == "needs_index"
+    finally:
+        app.state.workspace_config = None
+        app.state.workspace_root = None
+
+
+@pytest.mark.asyncio
+async def test_workspace_mode_indexed_member_reports_indexed(
+    client: AsyncClient, session: AsyncSession, app
+) -> None:
+    """Workspace member with file nodes in DB reports workspace_status='indexed'."""
+    ws_root = Path(tempfile.mkdtemp())
+    member_path = ws_root / "services" / "auth"
+    member_path.mkdir(parents=True)
+
+    repo = await upsert_repository(session, name="auth-service", local_path=str(member_path))
+    session.add(
+        GraphNode(
+            repository_id=repo.id,
+            node_id="src/main.py",
+            node_type="file",
+            symbol_count=5,
+        )
+    )
+    await session.commit()
+
+    ws_config = WorkspaceConfig(
+        version=1,
+        repos=[
+            RepoEntry(path="services/auth", alias="auth", is_primary=False),
+        ],
+        default_repo="auth",
+    )
+    app.state.workspace_config = ws_config
+    app.state.workspace_root = str(ws_root)
+
+    try:
+        resp = await client.get("/api/repos")
+        assert resp.status_code == 200
+        data = resp.json()
+
+        target = next((r for r in data if r["id"] == repo.id), None)
+        assert target is not None
+        assert target["workspace_alias"] == "auth"
+        assert target["workspace_status"] == "indexed"
+    finally:
+        app.state.workspace_config = None
+        app.state.workspace_root = None
+
+
+@pytest.mark.asyncio
+async def test_missing_local_directory_reports_missing_dir(
+    client: AsyncClient, session: AsyncSession
+) -> None:
+    """If local_path does not exist on disk, workspace_status reports missing_dir."""
+    nonexistent_path = "/nonexistent/path/to/repo/xyz123"
+
+    repo = await upsert_repository(session, name="ghost-repo", local_path=nonexistent_path)
+    await session.commit()
+
+    resp = await client.get("/api/repos")
+    assert resp.status_code == 200
+    data = resp.json()
+
+    target = next((r for r in data if r["id"] == repo.id), None)
+    assert target is not None
+    assert target["workspace_status"] == "missing_dir"

--- a/tests/unit/server/test_workspace_sidebar.py
+++ b/tests/unit/server/test_workspace_sidebar.py
@@ -115,10 +115,16 @@ async def workspace_app(tmp_path, app):
     backend_path = ws_root / "backend"
     engine, sf, fts, repo_id = await _build_repo_engine(backend_path)
 
-    # The primary engine in the conftest fixture has no repository row;
-    # for these tests we want the primary list_repos query to return the
-    # backend repo. Simplest fix: swap the primary session_factory for
-    # the backend's, so /api/repos sees the seeded backend repo.
+    orig_sf = app.state.session_factory
+    orig_engine = app.state.engine
+    orig_fts = app.state.fts
+    orig_config = getattr(app.state, "workspace_config", None)
+    orig_root = getattr(app.state, "workspace_root", None)
+    orig_sessions = getattr(app.state, "workspace_sessions", {})
+    orig_engines = getattr(app.state, "workspace_engines", [])
+    orig_wf_fts = getattr(app.state, "workspace_fts", {})
+    orig_vs = getattr(app.state, "workspace_vector_stores", {})
+
     app.state.session_factory = sf
     app.state.engine = engine
     app.state.fts = fts
@@ -130,7 +136,19 @@ async def workspace_app(tmp_path, app):
     app.state.workspace_fts = {repo_id: fts}
     app.state.workspace_vector_stores = {}
 
-    yield app, ws_root, ws_config, repo_id
+    try:
+        yield app, ws_root, ws_config, repo_id
+    finally:
+        app.state.session_factory = orig_sf
+        app.state.engine = orig_engine
+        app.state.fts = orig_fts
+        app.state.workspace_config = orig_config
+        app.state.workspace_root = orig_root
+        app.state.workspace_sessions = orig_sessions
+        app.state.workspace_engines = orig_engines
+        app.state.workspace_fts = orig_wf_fts
+        app.state.workspace_vector_stores = orig_vs
+        await engine.dispose()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/server/test_workspace_sidebar.py
+++ b/tests/unit/server/test_workspace_sidebar.py
@@ -82,6 +82,15 @@ async def _build_repo_engine(repo_path: Path):
         repo = await upsert_repository(
             session, name=repo_path.name, local_path=str(repo_path)
         )
+        from repowise.core.persistence.models import GraphNode
+
+        session.add(
+            GraphNode(
+                repository_id=repo.id,
+                node_id="src/main.py",
+                node_type="file",
+            )
+        )
         await session.commit()
     fts = FullTextSearch(engine)
     await fts.ensure_index()
@@ -208,7 +217,7 @@ async def workspace_app_with_workspace_router(workspace_app):
 
     # Including the same router twice is harmless — FastAPI dedupes by
     # path, but to keep the test isolation tidy we check membership.
-    if not any(r.path.startswith("/api/workspace") for r in app.routes):
+    if not any(getattr(r, "path", "").startswith("/api/workspace") for r in app.routes):
         app.include_router(ws_router.router)
     return (app, *rest)
 


### PR DESCRIPTION
Fixes #2139

### Summary of Changes
- **Router (`packages/server/src/repowise/server/routers/repos.py`)**:
  - Replaced the local filesystem probe `(Path(local_path) / ".repowise" / "wiki.db").is_file()` with an honest database query checking for file-typed `GraphNode` rows across active primary and secondary workspace sessions.
  - Correctly marks registered repositories with `0` file nodes as `needs_index` (or `missing_dir` if directory does not exist on disk) under both SQLite and PostgreSQL.
  - Removed the unconditional `resp.workspace_status = "indexed"` assignment in the workspace attach loop, allowing registered-but-unindexed workspace members to honestly retain `needs_index`.
- **Tests (`tests/unit/server/test_repos_status.py` & `test_workspace_sidebar.py`)**:
  - Added unit test suite covering registered-but-unindexed repos, PostgreSQL/shared DB environments without local `wiki.db`, workspace status persistence, and missing directories.

### Verification
- `pytest tests/unit/server/test_repos_status.py` (5 passed)
- `pytest tests/unit/server/test_workspace_sidebar.py` (6 passed)
- `pytest tests/unit/server/test_repos.py` (18 passed)
- `pytest tests/unit/server/test_workspace_router.py` (63 passed)
- `ruff check packages/server/ tests/unit/server/` (0 errors)

