### PR TITLE
perf(server): cache HTTP query embeddings

### DIFF
--- a/packages/server/src/repowise/server/app.py
+++ b/packages/server/src/repowise/server/app.py
@@ -35,7 +35,9 @@ from repowise.core.persistence.database import (
 )
 from repowise.core.persistence.models import GenerationJob
 from repowise.core.persistence.search import FullTextSearch
+from repowise.core.providers.embedding import is_semantic_embedder
 from repowise.core.providers.embedding.base import KeylessEmbedder
+from repowise.core.providers.embedding.caching import CachingEmbedder
 from repowise.server import __version__
 from repowise.server.routers import (
     blast_radius,
@@ -158,6 +160,16 @@ def _build_embedder():
     return KeylessEmbedder()
 
 
+def _build_query_embedder():
+    """Build the HTTP server's long-lived, query-side embedder.
+
+    Keyless is left bare because semantic-search routing identifies it by type;
+    wrapping it would incorrectly enable a vector leg with no signal.
+    """
+    embedder = _build_embedder()
+    return CachingEmbedder(embedder) if is_semantic_embedder(embedder) else embedder
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     """Startup: create DB engine, session factory, FTS, vector store, scheduler.
@@ -231,7 +243,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     # Reuse the repo-local LanceDB index written by CLI init/update. A fresh
     # in-memory store is used only when this database cannot be associated with
     # a repository or the optional LanceDB runtime is unavailable.
-    embedder = _build_embedder()
+    embedder = _build_query_embedder()
     from repowise.server.search_helpers import build_primary_vector_store
 
     vector_store, primary_vector_repo_id = await build_primary_vector_store(
@@ -369,7 +381,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
             repo_registry = RepoRegistry(
                 workspace_root=_Path(ws_root),
                 ws_config=ws_config,
-                embedder_factory=_build_embedder,
+                embedder_factory=_build_query_embedder,
             )
             app.state.repo_registry = repo_registry
             set_tool_workspace(registry=repo_registry, workspace_root=str(ws_root))

--- a/tests/unit/server/test_app_embedder_backends.py
+++ b/tests/unit/server/test_app_embedder_backends.py
@@ -14,8 +14,10 @@ from __future__ import annotations
 import pytest
 
 from repowise.core.providers.embedding.base import KeylessEmbedder
+from repowise.core.providers.embedding.caching import CachingEmbedder
 from repowise.core.providers.embedding.edenai import EdenAIEmbedder
-from repowise.server.app import _build_embedder
+from repowise.server import app as app_module
+from repowise.server.app import _build_embedder, _build_query_embedder
 
 
 @pytest.fixture(autouse=True)
@@ -46,3 +48,33 @@ def test_an_unknown_backend_still_degrades_to_the_keyless_mock(
 ) -> None:
     monkeypatch.setenv("REPOWISE_EMBEDDER", "not-a-backend")
     assert isinstance(_build_embedder(), KeylessEmbedder)
+
+
+@pytest.mark.asyncio
+async def test_query_embedder_caches_repeated_text(monkeypatch: pytest.MonkeyPatch) -> None:
+    class SpyEmbedder:
+        dimensions = 2
+
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def embed(self, texts: list[str]) -> list[list[float]]:
+            self.calls += 1
+            return [[1.0, 2.0] for _ in texts]
+
+    inner = SpyEmbedder()
+    monkeypatch.setattr(app_module, "_build_embedder", lambda: inner)
+
+    embedder = _build_query_embedder()
+    assert isinstance(embedder, CachingEmbedder)
+
+    assert await embedder.embed(["same query"]) == [[1.0, 2.0]]
+    assert await embedder.embed(["same query"]) == [[1.0, 2.0]]
+    assert inner.calls == 1
+
+
+def test_query_embedder_leaves_keyless_embedder_bare(monkeypatch: pytest.MonkeyPatch) -> None:
+    inner = KeylessEmbedder()
+    monkeypatch.setattr(app_module, "_build_embedder", lambda: inner)
+
+    assert _build_query_embedder() is inner


### PR DESCRIPTION
## What

Install the existing `CachingEmbedder` on the long-lived HTTP query path that #2189 explicitly left as a follow-up.

The wrapper is applied both to the primary HTTP vector store and to lazy workspace repo contexts. This keeps one cache per embedder instance/configuration and avoids repeated provider calls for repeated searches.

## Safety

- Leaves `KeylessEmbedder` bare so `is_semantic_embedder()` continues to disable the signal-free vector leg.
- Reuses the bounded, copy-on-read LRU from #2189; no new cache policy or persistence.
- Keeps `_build_embedder()` returning the concrete backend for callers that need backend-specific attributes.
- Bulk embedding remains pass-through, so indexing batches do not fill the query cache.

## Tests

- Repeated HTTP query text reaches the underlying embedder once.
- Keyless HTTP embedder is not wrapped.
- `uv run ruff check packages/server/src/repowise/server/app.py tests/unit/server/test_app_embedder_backends.py`
- `uv run pytest tests/unit/server/test_app_embedder_backends.py tests/unit/test_persistence/test_caching_embedder.py -q` (14 passed)
- `uv run pytest tests/unit/server/test_app_workspace_registry.py tests/unit/server/test_jobs.py -q` (10 passed)
- `uv run pytest tests/unit/server --ignore=tests/unit/server/mcp -q` (1323 passed)