### PR TITLE
fix(workspace): stop dropping the repo you pointed at when it is a submodule

### DIFF
--- a/packages/core/src/repowise/core/workspace/scanner.py
+++ b/packages/core/src/repowise/core/workspace/scanner.py
@@ -88,7 +88,10 @@ def scan_for_repos(
     - If *root* itself is a git repo, returns a single-element result.
     - Stops descending once a ``.git`` boundary is found (no nested repos).
     - Skips common junk directories (``node_modules``, ``.venv``, etc.).
-    - Submodules (``.git`` is a file) are excluded unless *include_submodules* is True.
+    - Submodules (``.git`` is a file) found *during the walk* are excluded
+      unless *include_submodules* is True. The flag never applies to *root*
+      itself: that is the repo the caller explicitly pointed at, not something
+      discovery turned up, so it is always eligible.
     """
     root = Path(root).resolve()
 
@@ -134,17 +137,21 @@ def scan_for_repos(
 
     # If root is a git repo and no sub-repos found → single-repo result
     # If root is a git repo AND sub-repos found → include root in the list
+    #
+    # Neither branch consults ``include_submodules``. That flag decides whether
+    # the walk descends into submodules it *discovers*; the root is not a
+    # discovery, it is the path the caller named. Gating it here meant that
+    # running `repowise init` inside a submodule that itself contains ordinary
+    # nested clones built a workspace out of the clones and silently left the
+    # targeted repo unindexed and unselectable.
     if root_is_repo:
         if not found:
             # Pure single-repo — no sub-repos
-            if root_is_sub and not include_submodules:
-                return ScanResult(repos=[], root=root)
             aliases = _generate_aliases([(root, root)])
             repo = _make_repo(root, root, aliases[root], root_is_sub)
             return ScanResult(repos=[repo], root=root)
         # Root + sub-repos → workspace mode; add root to the list
-        if not root_is_sub or include_submodules:
-            found.insert(0, (root, root_is_sub))
+        found.insert(0, (root, root_is_sub))
 
     # Sort by relative path for deterministic ordering
     found.sort(key=lambda item: item[0].relative_to(root).as_posix())

--- a/tests/unit/workspace/test_scanner.py
+++ b/tests/unit/workspace/test_scanner.py
@@ -193,12 +193,48 @@ class TestScanSubmodules:
         sub = next(r for r in result.repos if r.name == "sub-repo")
         assert sub.is_submodule is True
 
-    def test_submodule_at_root_excluded(self, tmp_path: Path) -> None:
-        """Root itself is a submodule and include_submodules=False."""
+    def test_root_submodule_is_scannable_on_its_own(self, tmp_path: Path) -> None:
+        """`include_submodules` filters discovery, never the path you named.
+
+        Pointing repowise at a directory is the decision to index it. Returning
+        nothing here left `repowise init` inside any submodule with no repo to
+        work on.
+        """
         (tmp_path / ".git").write_text("gitdir: ../.git/modules/x")
 
         result = scan_for_repos(tmp_path, include_submodules=False)
-        assert len(result.repos) == 0
+        assert [r.path for r in result.repos] == [tmp_path.resolve()]
+        assert result.repos[0].is_submodule is True
+
+    def test_root_submodule_leads_its_own_workspace(self, tmp_path: Path) -> None:
+        """A submodule holding ordinary clones must head the workspace list.
+
+        The real topology this comes from: `silo` is a submodule of a parent
+        checkout and carries two plain nested clones. The clones are not
+        submodules, so they are discovered whatever the flag says, which used to
+        flip the run into workspace mode and then drop the one repo the user was
+        standing in -- unselectable, unindexed, and with no hint why.
+        """
+        (tmp_path / ".git").write_text("gitdir: ../.git/modules/silo")
+        _make_repo(tmp_path, "server_bases/Exorth-rsps")
+        _make_repo(tmp_path, "tools/osrs-world-map-object-dumper")
+
+        result = scan_for_repos(tmp_path, include_submodules=False)
+
+        assert result.repos[0].path == tmp_path.resolve()
+        assert result.repos[0].is_submodule is True
+        assert [r.name for r in result.repos[1:]] == [
+            "Exorth-rsps",
+            "osrs-world-map-object-dumper",
+        ]
+
+    def test_discovered_submodule_still_respects_the_flag(self, tmp_path: Path) -> None:
+        """The root rule must not leak into discovery: a submodule *found* under
+        a plain root stays excluded by default."""
+        _make_repo(tmp_path, "main-repo")
+        _make_submodule(tmp_path, "sub-repo")
+
+        assert [r.name for r in scan_for_repos(tmp_path).repos] == ["main-repo"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## The bug

Running `repowise init` inside a git submodule that also contains ordinary nested clones builds a workspace out of the clones and silently drops the repo you were standing in. Reported from `seedpatch/silo`:

```
  #       Repository                      Path                                  Status
  [1]     Exorth-rsps                     server_bases/Exorth-rsps              new
  [2]     osrs-world-map-object-dumper    tools/osrs-world-map-object-dumper    new
```

`silo` is absent, unselectable, and nothing says why.

## Why

`silo/.git` is a file (`gitdir: ../.git/modules/silo`), so `_is_submodule(root)` is true. Its two nested repos are plain clones — `.git` directories, not submodules — so they are discovered regardless of the flag, which makes `found` non-empty and tips the run into workspace mode. `scanner.py` then reached:

```python
if not root_is_sub or include_submodules:
    found.insert(0, (root, root_is_sub))
```

`include_submodules` decides whether the walk descends into submodules it *discovers*. The root is not a discovery — it is the path the caller named — so gating it there removed the one repo the user explicitly asked for.

Confirmed directly against the reporter's checkout, old scanner vs new:

```
BEFORE (main): 2 repo(s) -> ['Exorth-rsps', 'osrs-world-map-object-dumper']   silo present: False
AFTER  (fix): 3 repo(s) -> ['.', 'Exorth-rsps', 'osrs-world-map-object-dumper']  silo present: True
```

## Scope: two branches, one rule

The single-repo branch carried the same confusion pointing the other way:

```python
if root_is_sub and not include_submodules:
    return ScanResult(repos=[], root=root)
```

A submodule with no nested repos scanned to **zero** repos rather than the one it was handed.

To be straight about this half: **no current caller is visibly broken by it.** `init` falls through to its single-repo path when the scan is empty and works fine, and `workspace scan` filters the root against `existing_paths` anyway. It is changed because a function asked "which git repos are here" should not answer "none" about a directory that is one, and because leaving it would apply `include_submodules` to the root in one branch and not the other — the exact confusion that produced this bug, preserved half-fixed for the next reader. If a reviewer would rather keep this PR to the one-line workspace fix, that half can be dropped without affecting the report.

Discovery itself is untouched: a submodule found *under* a plain root still requires `--include-submodules`.

## Workaround on affected versions

`--include-submodules` does make the root selectable, so it unblocks anyone on a released build. It is not equivalent to this fix — it also un-filters genuine submodules during discovery. On the reporter's checkout it yields four repos rather than three:

```
OLD code, --include-submodules=False -> 2 repo(s), silo present: False
OLD code, --include-submodules=True  -> 4 repo(s), silo present: True
```

## Tests

`test_submodule_at_root_excluded` asserted `len(result.repos) == 0`. It pinned exactly this bug, so it is replaced rather than re-pinned:

- `test_root_submodule_is_scannable_on_its_own` — a bare submodule root returns itself, flagged `is_submodule`.
- `test_root_submodule_leads_its_own_workspace` — the reporter's topology: a submodule holding two plain clones lists the root first, then the clones. This is the regression test for the report.
- `test_discovered_submodule_still_respects_the_flag` — guards the other side, so the root rule cannot leak into discovery.

`tests/unit/workspace` is green (1136 passed). Across `tests/unit/{cli,workspace,server}`: 6706 passed, 3 failed — `test_mascot.py::test_short_tagline_below_the_banner_width` and two in `test_update_provider_prompt.py`, all of which reproduce on unmodified `main` (this branch is `main` plus the scanner change only). `ruff check`, `ruff format --check` and `mypy` are clean on both touched files.
