### PR TITLE
fix(workspace): give the index phase the provider it was launched with

### DIFF
--- a/packages/cli/src/repowise/cli/commands/init_cmd/workspace.py
+++ b/packages/cli/src/repowise/cli/commands/init_cmd/workspace.py
@@ -314,6 +314,20 @@ def _ingest_and_generate_repo(repo: Any, idx: int, total: int, ctx: _WorkspaceCt
     )
     ensure_repowise_dir(repo.path)
 
+    # The index phase mines decisions with a model too -- pull requests, git
+    # history and code comments all have a model stage -- so it needs the
+    # provider as much as generation does. Leaving it out made every one of
+    # those sources report "No LLM provider is configured" on a workspace run
+    # that had been given a perfectly good one, while the single-repo path
+    # (which passes its client) mined them normally.
+    #
+    # Bound to this repo rather than reused verbatim: a provider that shells
+    # out with a working directory has to point at the repo being indexed, not
+    # at whichever one resolved the provider first.
+    repo_provider = (
+        None if ctx.dry_run else _workspace_generation_provider_for_repo(ctx.provider, repo.path)
+    )
+
     try:
         with Progress(
             SpinnerColumn(spinner_name=OWL_SPINNER, style=BRAND_STYLE),
@@ -338,6 +352,7 @@ def _ingest_and_generate_repo(repo: Any, idx: int, total: int, ctx: _WorkspaceCt
                     exclude_patterns=ctx.exclude_patterns if ctx.exclude_patterns else None,
                     include_submodules=ctx.include_submodules,
                     generate_docs=False,
+                    llm_client=repo_provider,
                     mode=(
                         OrchestratorMode.FAST
                         if ctx.run_mode == "fast"
@@ -403,7 +418,7 @@ def _ingest_and_generate_repo(repo: Any, idx: int, total: int, ctx: _WorkspaceCt
         skip_reason = "fast mode"
     elif not index_only and provider is not None:
         try:
-            repo_provider = _workspace_generation_provider_for_repo(provider, repo.path)
+            # Already bound to this repo above, for the index phase.
             generated_pages = _run_workspace_generation(
                 repo_path=repo.path,
                 result=result,

--- a/tests/unit/cli/test_workspace_init_provider.py
+++ b/tests/unit/cli/test_workspace_init_provider.py
@@ -1,0 +1,125 @@
+"""A workspace init must hand its provider to the index phase, not just to generation.
+
+The index phase mines decisions with a model — pull requests, git history and
+code comments each have a model stage — and it decides whether those stages can
+run from the ``llm_client`` it was given. The workspace path resolved a provider
+and then called ``run_pipeline`` without it, so a run launched with an explicit
+``--provider`` reported "No LLM provider is configured" for every one of those
+sources while single-repo init mined them normally.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from repowise.cli.commands.init_cmd import workspace as ws_mod
+from repowise.cli.commands.init_cmd.workspace import _ingest_and_generate_repo, _WorkspaceCtx
+
+
+def _fake_result() -> SimpleNamespace:
+    return SimpleNamespace(
+        file_count=3,
+        symbol_count=9,
+        generated_pages=[],
+        knowledge_graph_result=None,
+        repo_name="repo",
+    )
+
+
+def _fake_repo(path: Path) -> SimpleNamespace:
+    return SimpleNamespace(alias="repo", path=path)
+
+
+def _ctx(repo: Path, *, provider: Any, dry_run: bool = False) -> _WorkspaceCtx:
+    return _WorkspaceCtx(
+        provider=provider,
+        ws_config=SimpleNamespace(get_repo=lambda _alias: SimpleNamespace()),
+        editor_options=SimpleNamespace(),
+        index_only=False,
+        dry_run=dry_run,
+        force=False,
+        follow_renames=False,
+        include_submodules=False,
+        exclude_patterns=[],
+        skip_tests=False,
+        skip_infra=False,
+        concurrency=1,
+        test_run=False,
+        yes=True,
+        resume=False,
+        onboarding=False,
+        wiki_style="default",
+        language="en",
+        resolved_reasoning="auto",
+        embedder_name_resolved="mock",
+        embedder_was_requested=False,
+        resolved_commit_limit=10,
+        # Fast mode indexes without generating, which isolates the index phase:
+        # whatever reaches ``run_pipeline`` got there on the index phase's
+        # account, not generation's.
+        run_mode="fast",
+    )
+
+
+@pytest.fixture
+def captured(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    """Run the index phase against a stubbed pipeline, capturing its kwargs."""
+    seen: dict[str, Any] = {}
+
+    async def fake_pipeline(*_a: object, **kwargs: object) -> SimpleNamespace:
+        seen.update(kwargs)
+        return _fake_result()
+
+    async def noop_async(*_a: object, **_k: object) -> None:
+        return None
+
+    monkeypatch.setattr("repowise.core.pipeline.run_pipeline", fake_pipeline)
+    monkeypatch.setattr(ws_mod, "persist_result", noop_async)
+    monkeypatch.setattr(ws_mod, "get_head_commit", lambda *_a, **_k: "c0ffee")
+    monkeypatch.setattr(ws_mod, "save_state", lambda *_a, **_k: None)
+    monkeypatch.setattr(ws_mod, "write_editor_project_files", lambda *_a, **_k: None)
+    return seen
+
+
+def _run(tmp_path: Path, ctx_provider: Any, **ctx_kwargs: Any) -> SimpleNamespace:
+    repo = _fake_repo(tmp_path / "repo")
+    (repo.path / ".repowise").mkdir(parents=True, exist_ok=True)
+    _ingest_and_generate_repo(repo, 1, 1, _ctx(repo.path, provider=ctx_provider, **ctx_kwargs))
+    return repo
+
+
+def test_the_index_phase_is_given_the_resolved_provider(
+    tmp_path: Path, captured: dict[str, Any]
+) -> None:
+    provider = SimpleNamespace(provider_name="omp", model_name="omp/ccs/claude-opus-5")
+
+    _run(tmp_path, provider)
+
+    assert captured["llm_client"] is provider
+
+
+def test_a_repo_path_provider_is_rebound_to_the_repo_being_indexed(
+    tmp_path: Path, captured: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A provider that shells out with a working directory has to point at the
+    repo under index, not at whichever one resolved it first."""
+    rebound = SimpleNamespace(provider_name="codex_cli", model_name="codex_cli/gpt-5.5")
+    monkeypatch.setattr(ws_mod, "resolve_provider", lambda *_a, **_k: rebound)
+
+    _run(tmp_path, SimpleNamespace(provider_name="codex_cli", model_name="codex_cli/gpt-5.5"))
+
+    assert captured["llm_client"] is rebound
+
+
+def test_a_dry_run_keeps_the_index_phase_modelless(
+    tmp_path: Path, captured: dict[str, Any]
+) -> None:
+    """Mirrors single-repo init: decision extraction and KG enrichment both call
+    the client before the dry-run return is reached, so a dry run passes none."""
+    _run(tmp_path, SimpleNamespace(provider_name="omp", model_name="omp/default"), dry_run=True)
+
+    assert captured["llm_client"] is None


### PR DESCRIPTION
## The bug

Running `repowise init --provider omp --model omp/ccs/claude-opus-5` across a workspace reports:

```
Not run: pull requests (No LLM provider is configured), git history (No LLM
provider is configured), comments (No LLM provider is configured)
```

The run was given a provider. It generated pages with it. The decision sources still reported that none was configured.

Not provider-specific — any `--provider` hits this in workspace mode. Single-repo init is unaffected.

## Why

The index phase mines decisions with a model. `pr`, `git_history` and `comments` each declare a model stage, and `analysis.py` decides whether those stages can run from the client it was handed:

```python
runtime = {rt.key: rt for rt in policy.runtime(provider_available=llm_client is not None)}
```

Single-repo init passes one (`init_cmd/command.py`):

```python
llm_client = None if dry_run else (provider if not index_only else decision_provider)
...
run_pipeline(..., generate_docs=False, llm_client=llm_client, ...)
```

The workspace path did not (`init_cmd/workspace.py`):

```python
run_pipeline(
    repo.path,
    ...
    generate_docs=False,
    mode=(...),
)
```

`llm_client` defaults to `None`, so `provider_available` was `False` for every repo in the workspace. `ctx.provider` was sitting right there — the very next block used it for generation. Nothing failed; the model-backed sources silently did not run, and the report honestly said why.

## The fix

Bind the provider to the repo once, before the pipeline call, and pass it:

```python
repo_provider = (
    None if ctx.dry_run else _workspace_generation_provider_for_repo(ctx.provider, repo.path)
)
```

Bound rather than reused verbatim because a provider that shells out with a working directory (`REPO_PATH_PROVIDERS`) has to point at the repo being indexed, not at whichever one resolved it first. Generation now reuses that same instance instead of re-deriving it a few lines later.

A dry run still passes `None`, matching single-repo init — decision extraction and KG enrichment both reach for the client before the dry-run return.

**Not addressed here:** single-repo init resolves a separate `decision_provider` so `--index-only` still mines decisions with a model. The workspace path has no equivalent, so an index-only workspace stays modelless. That is a distinct gap from the one reported and is left alone rather than widened into this PR.

## Tests

`tests/unit/cli/test_workspace_init_provider.py`, reusing the stub harness already established by `test_workspace_init_dry_run.py`. `run_mode="fast"` isolates the index phase — generation is skipped, so whatever reaches `run_pipeline` got there on the index phase's account.

- `test_the_index_phase_is_given_the_resolved_provider` — the reported bug.
- `test_a_repo_path_provider_is_rebound_to_the_repo_being_indexed` — a `codex_cli`-shaped provider arrives rebound.
- `test_a_dry_run_keeps_the_index_phase_modelless` — guards the single-repo parity so the dry-run contract is not lost to a later refactor.

Each was confirmed non-vacuous: deleting the `llm_client=repo_provider` line fails all three with `KeyError: 'llm_client'`, and they pass with it restored.

`test_workspace_init_provider.py` + `test_workspace_init_dry_run.py` + `test_editor_setup.py`: 59 passed. `ruff check` and `mypy` clean. The wider `tests/unit/cli` sweep was not run to completion on this branch.

`ruff format --check` flags `workspace.py`, but it does so on unmodified `main` too — the only reformat it wants is a pre-existing mis-indented `console.print` block that this change does not touch, so it is left alone rather than folded in as unrelated churn.
