### PR TITLE
fix(server): index with the provider the dashboard picked, not a guess

### DIFF
--- a/packages/server/src/repowise/server/job_executor.py
+++ b/packages/server/src/repowise/server/job_executor.py
@@ -393,10 +393,14 @@ async def execute_job(
             try:
                 from repowise.server.provider_config import get_chat_provider_instance
 
-                # Pass the repo path so the job reuses the provider/model/key the
-                # repo was configured with (``.repowise/config.yaml`` + ``.env``)
-                # rather than the server-global default.
-                llm_client = get_chat_provider_instance(repo_path=repo_path)
+                # Pass the repo id *and* path so the job resolves exactly what
+                # the UI's provider picker chose. The picker persists its choice
+                # per repo, under ``repos[repo_id]`` — the most specific step in
+                # the resolver and the only one that carries a deliberate user
+                # decision. Resolving on path alone skipped it entirely, so a
+                # repo whose settings named a provider still fell through to the
+                # auto-detect step and indexed with whatever it guessed.
+                llm_client = get_chat_provider_instance(repo_path=repo_path, repo_id=repo_id)
             except Exception as exc:
                 docs_skip_reason = f"no provider configured: {exc}"
                 logger.warning("no_provider_configured", error=str(exc))

--- a/tests/unit/server/test_job_executor.py
+++ b/tests/unit/server/test_job_executor.py
@@ -706,6 +706,43 @@ async def test_execute_job_defaults_to_sync_when_mode_empty_string(session_facto
 
 
 @pytest.mark.asyncio
+async def test_execute_job_resolves_the_provider_the_ui_picked_for_this_repo(
+    session_factory, tmp_path
+):
+    """The dashboard's provider picker persists its choice per repo, keyed by
+    repo id. Resolving on path alone skipped that entry -- the most specific
+    step in the resolver, and the only one carrying a deliberate user decision
+    -- so a repo whose settings named a provider still indexed with whatever
+    auto-detection guessed from the server's own environment.
+    """
+    async with session_factory() as session:
+        repo = await upsert_repository(session, name="test-repo", local_path=str(tmp_path))
+        job = await upsert_generation_job(
+            session,
+            repository_id=repo.id,
+            config={"mode": "sync"},
+        )
+        await session.commit()
+        job_id, repo_id = job.id, repo.id
+
+    app_state = SimpleNamespace(session_factory=session_factory, fts=None, vector_store=None)
+
+    get_provider_mock = MagicMock(side_effect=RuntimeError("no provider"))
+    with (
+        patch("repowise.server.job_executor.run_pipeline", AsyncMock(return_value=_fake_result())),
+        patch("repowise.server.job_executor.persist_pipeline_result", AsyncMock()),
+        patch(
+            "repowise.server.provider_config.get_chat_provider_instance",
+            get_provider_mock,
+        ),
+    ):
+        await execute_job(job_id, app_state)
+
+    get_provider_mock.assert_called_once()
+    assert get_provider_mock.call_args.kwargs.get("repo_id") == repo_id
+
+
+@pytest.mark.asyncio
 async def test_execute_job_dispatches_generate_mode(session_factory, tmp_path):
     """A job with mode='generate' passes validation and dispatches to _run_generate_job."""
     async with session_factory() as session:


### PR DESCRIPTION
## The bug

Set a provider for a repo in the dashboard, index from the dashboard, and the job uses a different one. Reported against a repo explicitly set to `omp`:

```
decision_extractor.batch_failed error=[ollama] Connection error. source=git_archaeology
decision_extractor.source_failed error=all 4 batch(es) failed — ProviderError: [ollama] Connection error.
ollama.generate.start max_tokens=2000 model=qwen3.5:4b
```

`qwen3.5:4b` is the catalog's *default* ollama model — nothing configured produced it.

## Why

The picker's choice is persisted per repo:

```json
{"repos": {"e59eaa32…": {"provider": "omp", "model": "omp/default"}}}
```

That is step 1 of `_resolve_active_for_repo`, described in its own docstring as "an explicit override the user made for *this* repo" — the only step carrying a deliberate user decision. It is keyed by `repo_id`.

`job_executor` resolved without one:

```python
llm_client = get_chat_provider_instance(repo_path=repo_path)
```

So `repo_id` was `None`, step 1 was skipped, and with no `.repowise/config.yaml` yet (a first index from the UI, before init has written one) steps 2–4 had nothing either. Step 5 is auto-detect:

```python
for p in PROVIDER_CATALOG:
    if _get_key_for_provider(p["id"], repo_env) or not p["requires_key"]:
        return _with_default(p["id"], None)
```

On a server whose environment carries no keys, the first entry satisfying that is `ollama` (`requires_key: False`, catalog index 7) with default `qwen3.5:4b` — a local endpoint that need not be running. Every model-backed decision source then failed with a connection error.

Verified against the reporter's own stored config:

```
WITHOUT repo_id (today) : ('anthropic', 'claude-haiku-4-5')
WITH    repo_id (fixed) : ('omp', 'omp/default')
```

It resolves `anthropic` rather than `ollama` in that shell only because `ANTHROPIC_API_KEY` happens to be set there — which is the point: the fallback is environment-dependent and arbitrary, so the explicit per-repo choice has to be consulted first.

## The fix

Pass `repo_id` alongside `repo_path`. One line.

**Not addressed here:** step 5 treats "needs no API key" as "is usable", so a keyless provider is chosen on the strength of needing no configuration even when it cannot reach a model, and catalog order puts `ollama` ahead of every agent-CLI provider. The registry layer draws exactly this distinction on purpose — `provider_credentials_present` ("did the user point at *this* provider") versus `provider_is_usable`, with auto-detect excluding keyless providers because "runs without configuration is not a reason to pick it over what the user configured". This fallback predates that reasoning. Left alone rather than widened into a one-line fix.

## Tests

`test_execute_job_resolves_the_provider_the_ui_picked_for_this_repo` asserts the job passes the repo's id to provider resolution. Confirmed non-vacuous: reverting the one-line change fails it (`call_args.kwargs` carries only `repo_path`), restoring it passes.

`tests/unit/server/test_job_executor.py`: 25 passed. `ruff check` and `mypy` clean.

`job_executor.py` is one of the repo's pre-existing `ruff format` offenders on `main`; the unrelated hunk formatting would introduce is deliberately left out so the diff stays at one hunk.
