### PR TITLE
docs(quickstart): --no-editor-setup covers the repo-root .mcp.json too

### DIFF
--- a/docs/start/QUICKSTART.md
+++ b/docs/start/QUICKSTART.md
@@ -86,12 +86,16 @@ This is the payoff: your agent reads the index instead of your codebase.
 
 <details open><summary><b>Claude Code</b></summary>
 
-**`repowise init` already did this.** It writes a repo-root `.mcp.json`
-unconditionally, and unless you passed `--no-editor-setup` or set
-`REPOWISE_SKIP_EDITOR_SETUP=1`, it also registers repowise with
-`~/.claude/settings.json`. A Claude Code session opened in this repo already
-sees the MCP server. Check with `repowise agents` (Claude Code should show as
-wired) or `repowise doctor`.
+**`repowise init` already did this.** Unless you passed `--no-editor-setup` or
+set `REPOWISE_SKIP_EDITOR_SETUP=1`, it writes a repo-root `.mcp.json` and
+registers repowise with `~/.claude/settings.json`. One switch covers both: the
+flag used to gate only the machine-wide registration, so a run that opted out
+of editor setup still wrote files into the working tree. `.repowise/mcp.json`
+is the one deliberate exception — it is written either way, because it is what
+`repowise mcp .` prints and is how you opt back in by hand.
+
+A Claude Code session opened in this repo already sees the MCP server. Check
+with `repowise agents` (Claude Code should show as wired) or `repowise doctor`.
 
 Skipped editor setup, or setting up a machine where you did? Wire it up now:
 


### PR DESCRIPTION
The Claude Code section said `repowise init` writes a repo-root `.mcp.json` "unconditionally", and that `--no-editor-setup` / `REPOWISE_SKIP_EDITOR_SETUP=1` gates only the `~/.claude/settings.json` registration.

That describes the behaviour before the flag was widened. `write_editor_project_files` now covers both halves — its own docstring records why ("a user who read the flag as 'leave my repo alone' still got `.mcp.json`, `.claude/CLAUDE.md` and two `.vscode` files written into their working tree") — with `.repowise/mcp.json` as the one deliberate exception, written either way because it is what `repowise mcp .` prints and is how you opt back in by hand.

So a reader following this page expected a file that opting out no longer writes. Found while wiring a non-Claude MCP client to a repo whose `.mcp.json` was missing.

Text only; one hunk.