### PR TITLE
fix(cli): warn Windows users before upgrading

### DIFF
--- a/packages/cli/src/repowise/cli/commands/doctor_cmd/advisories.py
+++ b/packages/cli/src/repowise/cli/commands/doctor_cmd/advisories.py
@@ -70,7 +70,7 @@ def _print_cli_version_status() -> None:
     Runs once per invocation (the CLI version is global, not per-repo).
     """
     try:
-        from repowise.cli.update_check import get_cli_update_check
+        from repowise.cli.update_check import get_cli_update_check, windows_upgrade_caveat
 
         check = get_cli_update_check()
     except Exception:
@@ -106,5 +106,8 @@ def _print_cli_version_status() -> None:
     console.print(table)
 
     if check.update_available:
+        caveat = windows_upgrade_caveat()
+        if caveat:
+            console.print(f"  [dim]{caveat}[/dim]")
         console.print(f"  [yellow]Update available:[/yellow] {check.suggested_command}")
         console.print("  [dim]Restart Claude/Codex/Cursor or any MCP client after updating.[/dim]")

--- a/packages/cli/src/repowise/cli/update_check.py
+++ b/packages/cli/src/repowise/cli/update_check.py
@@ -38,6 +38,7 @@ __all__ = [
     "get_cli_update_check_cached",
     "is_newer_version",
     "suggest_update_command",
+    "windows_upgrade_caveat",
 ]
 
 
@@ -77,6 +78,17 @@ def suggest_update_command(executable: str | None, python: str) -> tuple[str, st
     if "/uv/" in path or "uv/tools" in path or "/uv/tools/" in path:
         return ("uv tool upgrade repowise", "uv tool")
     return (f"{python} -m pip install -U repowise", "pip")
+
+
+def windows_upgrade_caveat() -> str | None:
+    """Return the pre-upgrade process warning needed on Windows."""
+    if sys.platform != "win32":
+        return None
+    return (
+        "On Windows, stop any running Repowise server or MCP process before upgrading. "
+        "`Repowise: Stop Server` only stops a server started by the VS Code extension; "
+        "otherwise close the MCP client or stop the server in its terminal."
+    )
 
 
 def _editable_checkout() -> Path | None:

--- a/packages/cli/src/repowise/cli/whats_new.py
+++ b/packages/cli/src/repowise/cli/whats_new.py
@@ -27,6 +27,7 @@ from repowise.core.upgrade.changelog import (
 from repowise.core.upgrade.release import BUNDLED_CHANGELOG_PATH
 
 from .helpers import user_global_dir
+from .update_check import windows_upgrade_caveat
 
 RELEASES_URL = "https://github.com/repowise-dev/repowise/releases"
 
@@ -160,13 +161,22 @@ def render_whats_new(
 
 
 def render_update_advisory(console: Console, check) -> bool:
-    """Print a one-line, non-blocking advisory when a newer release exists.
+    """Print a non-blocking advisory when a newer release exists.
 
     *check* is an :class:`~repowise.cli.update_check.UpdateCheck`. Returns
     ``True`` if an advisory was printed (i.e. an update is available).
     """
     if not check.update_available or not check.latest_version:
         return False
+    caveat = windows_upgrade_caveat()
+    if caveat:
+        console.print(
+            f"[yellow]repowise {check.latest_version} is available[/yellow] "
+            f"[dim](you have {check.current_version}).[/dim]"
+        )
+        console.print(f"[dim]{caveat}[/dim]")
+        console.print(f"Upgrade: [bold]{check.suggested_command}[/bold]")
+        return True
     console.print(
         f"[yellow]repowise {check.latest_version} is available[/yellow] "
         f"[dim](you have {check.current_version}).[/dim] "

--- a/tests/unit/cli/test_doctor_cli_version.py
+++ b/tests/unit/cli/test_doctor_cli_version.py
@@ -38,6 +38,7 @@ def _make(**overrides) -> UpdateCheck:
 def test_update_available_shows_warn_and_command(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    monkeypatch.setattr("sys.platform", "linux")
     out = _capture(monkeypatch, _make())
     assert "CLI version" in out
     assert "WARN" in out
@@ -47,6 +48,36 @@ def test_update_available_shows_warn_and_command(
     assert "/tmp/venv/bin/repowise" in out  # full running command (may differ)
     assert "pip install -U repowise" in out
     assert "Restart" in out
+
+
+def test_windows_update_available_warns_to_stop_locking_processes_first(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("sys.platform", "win32")
+
+    out = _capture(
+        monkeypatch,
+        _make(suggested_command="uv tool upgrade repowise", install_hint="uv tool"),
+    )
+    rendered = " ".join(out.split())
+
+    assert "stop any running Repowise server or MCP process before upgrading" in rendered
+    assert "Repowise: Stop Server" in rendered
+    assert "only stops a server started by the VS Code extension" in rendered
+    assert "stop the server in its terminal" in rendered
+    assert rendered.index("before upgrading") < rendered.index("uv tool upgrade repowise")
+
+
+def test_non_windows_update_available_preserves_existing_guidance(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("sys.platform", "linux")
+
+    out = _capture(monkeypatch, _make())
+
+    assert "stop any running Repowise server or MCP process" not in out
+    assert "Repowise: Stop Server" not in out
+    assert "Restart Claude/Codex/Cursor or any MCP client after updating." in out
 
 
 def test_up_to_date_shows_ok_no_command(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/upgrade/test_whats_new.py
+++ b/tests/unit/upgrade/test_whats_new.py
@@ -86,7 +86,7 @@ def test_render_whats_new_empty_entries_shows_fallback_link():
     assert wn.RELEASES_URL in buf.getvalue()
 
 
-def _check(update_available, latest="9.9.9"):
+def _check(update_available, latest="9.9.9", command="pipx upgrade repowise"):
     return UpdateCheck(
         current_version="0.21.0",
         latest_version=latest,
@@ -94,19 +94,59 @@ def _check(update_available, latest="9.9.9"):
         running_executable="repowise",
         python="python",
         update_available=update_available,
-        suggested_command="pipx upgrade repowise",
+        suggested_command=command,
         install_hint="pipx",
     )
 
 
-def test_advisory_prints_when_update_available():
+def test_advisory_prints_when_update_available(monkeypatch):
     import io
 
+    monkeypatch.setattr("sys.platform", "linux")
     buf = io.StringIO()
     console = Console(file=buf, width=100)
     assert wn.render_update_advisory(console, _check(True)) is True
     assert "9.9.9" in buf.getvalue()
     assert "pipx upgrade repowise" in buf.getvalue()
+
+
+def test_advisory_warns_windows_users_to_stop_locking_processes_first(monkeypatch):
+    import io
+
+    monkeypatch.setattr("sys.platform", "win32")
+    buf = io.StringIO()
+    console = Console(file=buf, width=200)
+
+    assert (
+        wn.render_update_advisory(
+            console,
+            _check(True, command="uv tool upgrade repowise"),
+        )
+        is True
+    )
+
+    out = buf.getvalue()
+    rendered = " ".join(out.split())
+    assert "stop any running Repowise server or MCP process before upgrading" in rendered
+    assert "Repowise: Stop Server" in rendered
+    assert "only stops a server started by the VS Code extension" in rendered
+    assert "stop the server in its terminal" in rendered
+    assert rendered.index("before upgrading") < rendered.index("uv tool upgrade repowise")
+
+
+def test_advisory_preserves_non_windows_output(monkeypatch):
+    import io
+
+    monkeypatch.setattr("sys.platform", "linux")
+    buf = io.StringIO()
+    console = Console(file=buf, width=200)
+
+    assert wn.render_update_advisory(console, _check(True)) is True
+
+    assert (
+        buf.getvalue().strip()
+        == "repowise 9.9.9 is available (you have 0.21.0). Upgrade: pipx upgrade repowise"
+    )
 
 
 def test_advisory_silent_when_up_to_date():


### PR DESCRIPTION
## Summary

- Warn Windows users to stop running Repowise server or MCP processes before an upgrade command is shown.
- Apply the guidance to both `doctor` and the shared update/what's-new advisory while preserving non-Windows output.
- Clarify that `Repowise: Stop Server` only stops a server started by the VS Code extension; otherwise the MCP client must be closed or a manually started server stopped in its terminal.

## Related Issues

Fixes #2149

## Test Plan

- [x] Focused update-advisory suite: 45 passed in an isolated Python 3.11 dependency slice
- [x] Windows and non-Windows guidance regressions cover both advisory surfaces, including the reported `uv tool upgrade repowise` path
- [x] `ruff check` passes on all five changed files
- [x] `ruff format --check` passes on all five changed files
- [ ] Full project `pytest`: dependency installation is blocked on Linux/aarch64 because `tree-sitter-gdscript==6.1.0` cannot find `tree_sitter/parser.h`; the same failure reproduces on unmodified `main`

## Checklist

- [x] My code follows the project's code style
- [x] I have added tests for new functionality
- [x] All focused existing tests pass
- [x] Documentation is not separately needed; this change corrects the user-facing guidance itself
