### PR TITLE
chore(deps): group Dependabot updates, and bump gitpython

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,78 @@
+# Dependabot configuration.
+#
+# Until this file existed, Dependabot ran on its defaults: one pull request per
+# package, ungrouped, with no schedule of our own. That produced a steady trickle
+# of single-package PRs that nobody wanted to review one at a time, and a backlog
+# of thirteen open at once — six of which were already satisfied on main and were
+# only still open because nothing had re-evaluated them.
+#
+# The fix is grouping. Routine minor and patch bumps arrive as one PR per
+# ecosystem per week, which is a single review of a single lockfile diff.
+# Major bumps are deliberately left ungrouped: those are the ones that need a
+# real read (pytest 8 -> 9 rewrites test collection, uuid 11 -> 14 drops Node 18),
+# and burying one inside a group of patches is how a breaking change gets merged
+# on a green check without anyone looking at it.
+version: 2
+
+updates:
+  # --- Python (uv) ----------------------------------------------------------
+  # The manifest pins ranges (`gitpython>=3.1,<4`), so these PRs move `uv.lock`
+  # rather than `pyproject.toml`, unless a bump needs its cap raised.
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
+    groups:
+      python-minor-and-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+      python-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+
+  # --- JavaScript (npm workspaces) ------------------------------------------
+  # One entry covers every workspace: packages/types, ui, api-client, web and
+  # vscode all resolve through the root package-lock.json, so a per-workspace
+  # entry would split one lockfile into five competing PRs.
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "build(deps)"
+      prefix-development: "build(deps-dev)"
+    groups:
+      npm-minor-and-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+      npm-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+
+  # --- GitHub Actions -------------------------------------------------------
+  # Never configured before, so action versions in .github/workflows have been
+  # drifting silently with nothing watching them.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "ci(deps)"
+    groups:
+      actions-all:
+        patterns:
+          - "*"

--- a/uv.lock
+++ b/uv.lock
@@ -1001,14 +1001,14 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.58"
+version = "3.1.62"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/26/d6/5f358ff283325580c2003a6d953aea18cfe10ae87b46f5ebc80fa3a386dc/gitpython-3.1.58.tar.gz", hash = "sha256:621416df10ef3fd0e19fabf9172ddeed0fa704d353d04f194eec56a625a95b22", size = 228498, upload-time = "2026-08-04T15:05:49.47Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/db/3ca813cbacb23ab6fe46ff38a9b5ef8e73e970c8051f2ce903aacafe0446/gitpython-3.1.62.tar.gz", hash = "sha256:1791de66309bc0c7cfca40bf8d2e3de7ca091cbf94e6051be1ad0722c61062af", size = 231728, upload-time = "2026-09-07T02:57:21.155Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/0c/9d8752098bc442f0726e64aa6135940b3a96809915d1aa4206c1bb97881d/gitpython-3.1.58-py3-none-any.whl", hash = "sha256:d331e722577f0fd7fc1f857419b3ecc07af66282b933d2a4d95f84a042fdd50f", size = 220183, upload-time = "2026-08-04T15:05:48.025Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/0b/29d7965215f8ef830a7ca1f42997fe13e5693d85e9edb18f938d063ef5f2/gitpython-3.1.62-py3-none-any.whl", hash = "sha256:7002251225e10e29d2e1f49e6532613fe5d5d9f0b6f1f02997a52b38fe56899e", size = 222753, upload-time = "2026-09-07T02:57:19.762Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why

Thirteen Dependabot PRs were open at once. The reason is that **there was no `.github/dependabot.yml`**, so Dependabot has been running on its defaults: one pull request per package, ungrouped, on its own schedule. Nobody wants to review those one at a time, so they accumulated.

Merging thirteen PRs would clear the list and change nothing about why it filled up.

## What this does

**Adds `.github/dependabot.yml`** with grouping, so routine updates arrive as one PR per ecosystem per week instead of one per package.

Majors are deliberately left ungrouped. `pytest` 8 → 9 and `uuid` 11 → 14 are exactly the bumps that need a real read, and burying a breaking change inside a group of patches is how one gets merged on a green check with nobody looking at it.

npm is configured once at the root rather than per workspace: all five workspaces (`types`, `ui`, `api-client`, `web`, `vscode`) resolve through the same `package-lock.json`, so a per-workspace entry would split one lockfile into five competing PRs.

GitHub Actions was never watched at all. It is now, monthly.

**Bumps `gitpython` 3.1.58 → 3.1.62** in `uv.lock`. Of the thirteen open PRs this is the only one whose target version main had not already passed.

## What happens to the existing backlog

Six of the thirteen are **already satisfied on main** and are only still open because nothing has re-evaluated them. Verified against `uv.lock`:

| PR | Package | Target | On main |
|---|---|---|---|
| #997 | pyasn1 | 0.6.4 | 0.6.4 |
| #969 | pillow | 12.3.0 | 12.3.0 |
| #525 | pydantic-settings | 2.14.2 | 2.14.2 |
| #494 | starlette | 1.3.1 | 1.3.1 |
| #216 | idna | 3.15 | 3.18 |
| #138 | mako | 1.3.12 | 1.3.12 |

Those are being closed as already-applied.

The four npm PRs (#2182 `vitest`, #2183 `sharp`+`next`, #2184 `next`, #2185 `js-yaml`) and #229 (`uuid`) are left for Dependabot to regroup into a single grouped PR on the next run, which is the whole point of the config. I tried combining their lockfile edits by hand first and it is not worth it: `npm` would not re-resolve the changed `overrides` against an existing tree, a targeted `npm update` pulled in `next` 16.3.4 (an unrequested major), and a from-scratch regenerate rewrote 4,800 lines of `package-lock.json` against the local tree state. Four small, correct, machine-generated lockfile edits beat one large one I cannot vouch for.

#79 (`pytest` 8 → 9) stays open on purpose. It needs the `pytest>=8,<9` cap raised in two places in `pyproject.toml`, which is a deliberate decision rather than a routine bump, and it deserves its own PR.

## Note for after merge

`package-ecosystem: "uv"` is the right ecosystem for a `uv.lock` project, but if it is ever rejected the whole config is ignored rather than partially applied. Worth a glance at Insights → Dependency graph → Dependabot after this lands to confirm all three entries registered.
