### PR TITLE
feat(risk): disclose when the indexed checkout was a shallow clone

### DIFF
--- a/docs/agent/MCP_TOOLS.md
+++ b/docs/agent/MCP_TOOLS.md
@@ -154,6 +154,7 @@ Resolve refs with `repowise expand <ref>` from a shell, or
 | `indexed_commit` | Short (12-char) SHA the index was built against |
 | `live_head` | Short (12-char) SHA of the current checkout, whenever `.git/HEAD` is readable. Equal to `indexed_commit` when the index is current |
 | `stale_warning` | Only on a real signal: HEAD mismatch **that actually changed files**, or age over ~90 days when git is unreachable. Two commits with identical trees (an empty commit, a no-op merge) report `index_behind` with no warning |
+| `shallow` | Only when the indexed checkout was a shallow clone. Every history-derived figure in the response (commit counts, project age, co-change support) stops at the graft point, so a total here is a floor, not a count. Absent for a full clone and for an index written before the check existed |
 | `index_behind` | Whenever the live-vs-indexed comparison ran: `true` if HEAD has moved (alongside `stale_warning` when served content actually changed), `false` if the commits match. Absent means the comparison could not run (no git, or a repo-level tool that serves no file content) |
 | `embedder_degraded` | Whenever an embedder is resolved, `true` or `false`. Absent means none was initialised |
 | `embedder`, `embedder_warning` | Only when the embedder fell back to a mock/degraded mode |

--- a/packages/core/alembic/versions/0065_repository_shallow_clone.py
+++ b/packages/core/alembic/versions/0065_repository_shallow_clone.py
@@ -1,0 +1,42 @@
+"""Record whether the indexed checkout was a shallow clone.
+
+Every whole-history figure on ``repositories`` (commit count, first commit date,
+contributor count, lifetime churn) is capped at the graft point on a shallow
+clone, and nothing said so, so a truncated history was reported in the same
+shape as a complete one. A typed column rather than ``settings_json`` because
+this is captured at index time, not user configuration. See
+``Repository.is_shallow_clone`` for why it is nullable rather than a defaulted
+boolean.
+
+``init_db``'s additive schema reconciler picks the column up from the model for
+local SQLite stores that never run Alembic; this migration covers the managed
+Postgres ones.
+
+Revision ID: 0065
+Revises: 0064
+Create Date: 2026-09-11
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers
+revision: str = "0065"
+down_revision: str | None = "0064"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "repositories",
+        sa.Column("is_shallow_clone", sa.Boolean(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("repositories", "is_shallow_clone")

--- a/packages/core/src/repowise/core/ingestion/git_indexer/indexer.py
+++ b/packages/core/src/repowise/core/ingestion/git_indexer/indexer.py
@@ -38,6 +38,7 @@ from .records import (
     _should_skip_index,
     _tz_offset_minutes,
     capture_repo_totals,
+    is_shallow_repo,
 )
 from .tiers import GitIndexTier
 
@@ -709,7 +710,10 @@ class GitIndexer:
         if repo is None:
             return None
         try:
-            if repo.git.rev_parse("--is-shallow-repository").strip() == "true":
+            # Only a definite "not shallow" is safe to prune on. An unknown
+            # answer is treated like a shallow one, since the rows this would
+            # delete are real.
+            if is_shallow_repo(repo) is not False:
                 return None
             out = repo.git.rev_list("--no-merges", "HEAD")
         except Exception as exc:

--- a/packages/core/src/repowise/core/ingestion/git_indexer/records.py
+++ b/packages/core/src/repowise/core/ingestion/git_indexer/records.py
@@ -22,6 +22,7 @@ __all__ = [
     "_parse_commit_record",
     "_should_skip_index",
     "capture_repo_totals",
+    "is_shallow_repo",
 ]
 
 # Git log record/field separators (NUL byte + US 0x1f) — chosen so they can't
@@ -228,6 +229,20 @@ def _extract_rename_paths(stat_path: str, known_paths: set[str]) -> tuple[str | 
     return None, None
 
 
+def is_shallow_repo(repo: Any) -> bool | None:
+    """Whether git calls *repo* a shallow clone, or ``None`` if it would not say.
+
+    Three-valued because the answers are not interchangeable. A shallow clone
+    stops at its graft point, so every whole-history figure taken from it is a
+    floor rather than a count; a clone git could not classify is simply unknown,
+    and reporting that as "complete" would invent the one fact worth having.
+    """
+    try:
+        return repo.git.rev_parse("--is-shallow-repository").strip() == "true"
+    except Exception:
+        return None
+
+
 @dataclass
 class RepoTotals:
     """Whole-history git facts, captured independently of ``commit_limit``.
@@ -250,6 +265,9 @@ class RepoTotals:
     # anchors. Doubles as this capture's *prior* record — see
     # :func:`capture_repo_totals`.
     churn_anchor_sha: str | None = None
+    # Whether the clone was shallow, and so whether every total above stops at
+    # the graft point rather than at the root. See :func:`is_shallow_repo`.
+    is_shallow_clone: bool | None = None
 
 
 # Lifetime churn walks every commit's shortstat, so unlike the other totals it
@@ -448,6 +466,8 @@ def capture_repo_totals(repo: Any, prior: RepoTotals | None = None) -> RepoTotal
     # An unresolvable HEAD (unborn, no repo) leaves every call below on the name,
     # exactly as before; the anchor is simply not stored for such a capture.
     rev = head_sha or "HEAD"
+
+    totals.is_shallow_clone = is_shallow_repo(repo)
 
     with contextlib.suppress(Exception):
         totals.total_commit_count = int(repo.git.rev_list("--count", rev).strip())

--- a/packages/core/src/repowise/core/persistence/crud/repository.py
+++ b/packages/core/src/repowise/core/persistence/crud/repository.py
@@ -141,6 +141,7 @@ async def update_repo_git_totals(
     total_lines_added: int | None = None,
     total_lines_deleted: int | None = None,
     churn_anchor_sha: str | None = None,
+    is_shallow_clone: bool | None = None,
 ) -> None:
     """Store a repo's whole-history git totals, captured at index time (#730).
 
@@ -163,6 +164,7 @@ async def update_repo_git_totals(
         # anchor and totals moving together rather than letting one advance
         # past the other.
         "churn_anchor_sha": churn_anchor_sha,
+        "is_shallow_clone": is_shallow_clone,
     }
     if all(v is None for v in updates.values()):
         return

--- a/packages/core/src/repowise/core/persistence/models.py
+++ b/packages/core/src/repowise/core/persistence/models.py
@@ -118,6 +118,12 @@ class Repository(Base):
     # update's edge reconcile to every parsed file, once. NULL on stores written
     # before this, which is treated as a mismatch and heals the same way.
     graph_edges_parser_fingerprint: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    # Whether the checkout this index was built from was a shallow clone. The
+    # whole-history totals above can only describe what the clone actually has,
+    # so a reader that is not told this reads a truncated history as a complete
+    # one. NULL on indexes written before this and whenever the check could not
+    # run, which is why it is not a plain boolean: unknown is not "full".
+    is_shallow_clone: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
     settings_json: Mapped[str] = mapped_column(Text, nullable=False, default="{}")
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, default=_now_utc

--- a/packages/core/src/repowise/core/pipeline/incremental.py
+++ b/packages/core/src/repowise/core/pipeline/incremental.py
@@ -1341,6 +1341,7 @@ async def persist_incremental_commits(
         total_lines_added=totals.total_lines_added,
         total_lines_deleted=totals.total_lines_deleted,
         churn_anchor_sha=totals.churn_anchor_sha,
+        is_shallow_clone=totals.is_shallow_clone,
     )
 
     with timed(timings, "persist.commits.fix_events"):

--- a/packages/core/src/repowise/core/pipeline/persist.py
+++ b/packages/core/src/repowise/core/pipeline/persist.py
@@ -1535,6 +1535,7 @@ async def persist_git(result: Any, session: Any, repo_id: str) -> None:
             total_lines_added=totals.total_lines_added,
             total_lines_deleted=totals.total_lines_deleted,
             churn_anchor_sha=getattr(totals, "churn_anchor_sha", None),
+            is_shallow_clone=getattr(totals, "is_shallow_clone", None),
         )
 
 

--- a/packages/server/src/repowise/server/mcp_server/_meta.py
+++ b/packages/server/src/repowise/server/mcp_server/_meta.py
@@ -226,6 +226,11 @@ def freshness_from_repo(repository: Any | None, targets: list[str] | None = None
 
     Conditionally emitted:
       * ``live_head``       — current checkout commit whenever readable
+      * ``shallow``         — only when the checkout was a shallow clone, whose
+        graft point caps every history-derived figure in the response. Absent
+        for a full clone and for an index written before the check existed;
+        unlike ``index_behind`` there is no false case, because "nothing to
+        warn about" is not worth a line
       * ``stale_warning``   — only on a real signal (a served target changed,
         HEAD mismatch with real file changes on a repo-level response, OR very
         old with no git)
@@ -251,6 +256,9 @@ def freshness_from_repo(repository: Any | None, targets: list[str] | None = None
         ua = updated_at if updated_at.tzinfo else updated_at.replace(tzinfo=UTC)
         age_days = max(0, (datetime.now(UTC) - ua).days)
         out["index_age_days"] = age_days
+
+    if getattr(repository, "is_shallow_clone", None) is True:
+        out["shallow"] = True
 
     local_path = getattr(repository, "local_path", None)
     # Prefer state.json's last_sync_commit over a possibly-stale DB head_commit

--- a/tests/unit/ingestion/test_git_commit_rows_integration.py
+++ b/tests/unit/ingestion/test_git_commit_rows_integration.py
@@ -173,6 +173,32 @@ def test_capture_repo_totals_method(tmp_path) -> None:
     assert totals.total_commit_count == 2
     assert totals.total_contributor_count == 1
     assert totals.first_commit_author == "Grace Hopper"
+    assert totals.is_shallow_clone is False
+
+
+def test_capture_repo_totals_reports_a_shallow_clone(tmp_path) -> None:
+    """A depth-capped clone has to say so, because its totals are capped too.
+
+    The count below is the tell: three commits exist, the clone can see one, and
+    without the flag that 1 is indistinguishable from a repo that genuinely has
+    one commit.
+    """
+    import git as gitpython
+
+    origin_path = tmp_path / "origin"
+    origin_path.mkdir()
+    origin = gitpython.Repo.init(origin_path)
+    _configure_author(origin, "Grace Hopper", "grace@example.com")
+    for i in range(3):
+        _commit(origin, origin_path / f"f{i}.py", f"x = {i}\n", f"feat: add f{i}")
+
+    clone_path = tmp_path / "shallow"
+    gitpython.Repo.clone_from(origin_path.as_uri(), clone_path, depth=1)
+
+    totals = GitIndexer(clone_path, tier=GitIndexTier.FULL).capture_repo_totals()
+
+    assert totals.is_shallow_clone is True
+    assert totals.total_commit_count == 1
 
 
 @pytest.mark.asyncio

--- a/tests/unit/persistence/test_repo_shallow_clone.py
+++ b/tests/unit/persistence/test_repo_shallow_clone.py
@@ -1,0 +1,32 @@
+"""``update_repo_git_totals`` keeps the shallow flag three-valued.
+
+The capture side is covered against real clones in
+``tests/unit/ingestion/test_git_commit_rows_integration.py``. This is the wiring
+in between, and specifically the one way it could quietly go wrong: the writer
+applies a field only when it is not ``None``, so a falsy check anywhere on that
+path would drop ``False`` and leave "this clone is complete" indistinguishable
+from never having looked.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from repowise.core.persistence.crud import get_repository, update_repo_git_totals
+from tests.unit.persistence.helpers import insert_repo
+
+
+@pytest.mark.asyncio
+async def test_the_shallow_flag_round_trips_and_stays_three_valued(async_session) -> None:
+    repo = await insert_repo(async_session)
+    assert (await get_repository(async_session, repo.id)).is_shallow_clone is None
+
+    await update_repo_git_totals(async_session, repo.id, is_shallow_clone=False)
+    assert (await get_repository(async_session, repo.id)).is_shallow_clone is False
+
+    await update_repo_git_totals(async_session, repo.id, is_shallow_clone=True)
+    assert (await get_repository(async_session, repo.id)).is_shallow_clone is True
+
+    # A later capture that could not run the check must not blank the answer.
+    await update_repo_git_totals(async_session, repo.id, total_commit_count=7)
+    assert (await get_repository(async_session, repo.id)).is_shallow_clone is True

--- a/tests/unit/server/mcp/test_meta_freshness.py
+++ b/tests/unit/server/mcp/test_meta_freshness.py
@@ -36,8 +36,13 @@ def _clear_changed_files_cache():
     _meta._changed_files_cache.clear()
 
 
-def _repo(tmp_path, head_commit: str = _INDEXED):
-    return types.SimpleNamespace(updated_at=None, local_path=str(tmp_path), head_commit=head_commit)
+def _repo(tmp_path, head_commit: str = _INDEXED, is_shallow_clone: bool | None = None):
+    return types.SimpleNamespace(
+        updated_at=None,
+        local_path=str(tmp_path),
+        head_commit=head_commit,
+        is_shallow_clone=is_shallow_clone,
+    )
 
 
 def _prime(tmp_path, changed: frozenset[str] | None):
@@ -299,3 +304,21 @@ async def test_execution_flows_targets_name_the_traced_files(setup_mcp, monkeypa
     assert result["_meta"]["indexed_commit"] == _INDEXED[:12]
     assert seen[-1]["repository"] is not None
     assert "src/auth/service.py" in seen[-1]["targets"]
+
+
+def test_a_shallow_clone_is_disclosed(tmp_path, monkeypatch):
+    """Its graft point caps every history-derived figure in the response."""
+    monkeypatch.setattr(_meta, "read_live_head", lambda p: _INDEXED)
+    out = _meta.freshness_from_repo(_repo(tmp_path, is_shallow_clone=True), targets=["a.py"])
+    assert out["shallow"] is True
+
+
+@pytest.mark.parametrize("stored", [False, None])
+def test_a_clone_with_no_warning_to_give_stays_silent(tmp_path, monkeypatch, stored):
+    """A complete clone and an index written before the check both say nothing.
+
+    Emitting ``false`` for the second would claim a completeness nobody checked.
+    """
+    monkeypatch.setattr(_meta, "read_live_head", lambda p: _INDEXED)
+    out = _meta.freshness_from_repo(_repo(tmp_path, is_shallow_clone=stored), targets=["a.py"])
+    assert "shallow" not in out

--- a/tests/unit/server/mcp/test_risk.py
+++ b/tests/unit/server/mcp/test_risk.py
@@ -693,3 +693,20 @@ async def test_get_risk_co_change_rows_carry_direction(setup_mcp):
         assert p["direction"] == "undirected"
         assert "conf_ab" not in p
         assert "conf_ba" not in p
+
+
+
+@pytest.mark.asyncio
+async def test_get_risk_meta_discloses_a_shallow_clone(setup_mcp, session):
+    """The flag has to survive the real tool, not just the envelope builder."""
+    from repowise.core.persistence.crud import update_repo_git_totals
+    from repowise.server.mcp_server import get_risk
+
+    before = await get_risk(["src/auth/service.py"])
+    assert "shallow" not in before["_meta"]
+
+    await update_repo_git_totals(session, "repo1", is_shallow_clone=True)
+    await session.flush()
+
+    after = await get_risk(["src/auth/service.py"])
+    assert after["_meta"]["shallow"] is True


### PR DESCRIPTION
A shallow clone only has history back to its graft point, so every
whole-history figure the index stores from it is a floor rather than a count:
total commit count, project age, contributor count, lifetime churn, and the
commit totals co-change support is measured against. Nothing said so. On a
three-commit repo cloned with `--depth=1`, the stored total is `1`,
indistinguishable from a repo that genuinely has one commit.

The capture now asks git and records the answer on the repository row, beside
the other whole-history totals it already writes, and `get_risk` and
`get_change_risk` carry `"shallow": true` in the `_meta` envelope. Both tools
build that envelope from one function, so neither has to know about the field.

The column is nullable rather than a defaulted boolean because the three
answers are not interchangeable. `true` means git reported a shallow clone,
`false` means it reported a complete one, and `NULL` means the check never ran,
which covers every index written before this and any checkout where the call
failed. Reading `NULL` as "complete" would claim something nobody verified, so
the envelope emits the key only for the true case and stays silent for the
other two.

Detection was already written out once in the git indexer and discarded after
the pruning decision. Both sites now call one helper. The pruning side keeps
its old behaviour by treating an unknown answer the same as a shallow one,
since the rows it would otherwise delete are real.

Local SQLite stores pick the column up from the model through `init_db`'s
additive schema reconciler; migration `0064` covers the managed ones.

## Verification

`tests/unit/server/mcp/`, `tests/unit/persistence/` and `tests/unit/ingestion/`,
5662 passed. New tests cover the capture against a real `--depth=1` clone, the
three-valued round trip through the column, the envelope in both the disclosed
and silent cases, and `get_risk` end to end. `ruff check .` clean.
