### PR TITLE
fix(ui): clamp generation progress percentages

### DIFF
--- a/packages/ui/__tests__/jobs/generation-progress.test.tsx
+++ b/packages/ui/__tests__/jobs/generation-progress.test.tsx
@@ -3,6 +3,39 @@ import { render, screen, fireEvent } from "@testing-library/react";
 import { GenerationProgress } from "../../src/jobs/generation-progress.js";
 
 describe("GenerationProgress", () => {
+  it.each([
+    { completed: 241, total: 5, percentage: 100 },
+    { completed: -1, total: 5, percentage: 0 },
+    { completed: 3, total: 10, percentage: 30 },
+    { completed: 5, total: 5, percentage: 100 },
+    { completed: 241, total: 0, percentage: 0 },
+  ])("shows $percentage% for $completed / $total pages", ({ completed, total, percentage }) => {
+    render(
+      <GenerationProgress
+        job={{
+          id: "j1",
+          status: "running",
+          total_pages: total,
+          completed_pages: completed,
+        }}
+        log={[]}
+        elapsed={1000}
+        actualCost={null}
+        stuckPending={false}
+        cancelling={false}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText(`${percentage}%`)).toBeInTheDocument();
+    expect(screen.getByText(`${completed} / ${total} pages`)).toBeInTheDocument();
+    const bar = screen.getByRole("progressbar");
+    expect(bar).toHaveAttribute("aria-valuenow", String(percentage));
+    expect(bar.firstElementChild).toHaveStyle({
+      transform: `translateX(${percentage - 100}%)`,
+    });
+  });
+
   it("renders the queued state for pending jobs", () => {
     render(
       <GenerationProgress

--- a/packages/ui/__tests__/ui/progress.test.tsx
+++ b/packages/ui/__tests__/ui/progress.test.tsx
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { Progress } from "../../src/ui/progress.js";
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("Progress", () => {
+  it.each([
+    { value: 4820, expected: 100 },
+    { value: -20, expected: 0 },
+    { value: 48, expected: 48 },
+    { value: 0, expected: 0 },
+    { value: 100, expected: 100 },
+  ])("uses $expected for the bar and accessibility when value is $value", ({ value, expected }) => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    render(<Progress value={value} />);
+
+    const bar = screen.getByRole("progressbar");
+    expect(bar).toHaveAttribute("aria-valuenow", String(expected));
+    expect(bar).toHaveAttribute("aria-valuemax", "100");
+    expect(bar).toHaveAttribute("data-state", expected === 100 ? "complete" : "loading");
+    expect(bar.firstElementChild).toHaveStyle({ transform: `translateX(${expected - 100}%)` });
+    expect(error).not.toHaveBeenCalled();
+  });
+
+  it.each([undefined, NaN, Infinity, -Infinity])("is indeterminate for %s", (value) => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    render(<Progress {...(value === undefined ? {} : { value })} />);
+
+    const bar = screen.getByRole("progressbar");
+    expect(bar).not.toHaveAttribute("aria-valuenow");
+    expect(bar).toHaveAttribute("data-state", "indeterminate");
+    expect(bar.firstElementChild).toHaveStyle({ transform: "translateX(-100%)" });
+    expect(error).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/jobs/generation-progress.tsx
+++ b/packages/ui/src/jobs/generation-progress.tsx
@@ -66,10 +66,11 @@ export function GenerationProgress({
   onRetry,
   settingsHref,
 }: GenerationProgressProps) {
-  const progress = job
-    ? job.total_pages > 0
-      ? Math.round((job.completed_pages / job.total_pages) * 100)
-      : 0
+  const rawProgress = job?.total_pages && job.total_pages > 0
+    ? Math.round((job.completed_pages / job.total_pages) * 100)
+    : 0;
+  const progress = Number.isFinite(rawProgress)
+    ? Math.max(0, Math.min(100, rawProgress))
     : 0;
 
   const elapsedStr = `${Math.floor(elapsed / 60000)}m ${Math.floor((elapsed % 60000) / 1000)}s`;

--- a/packages/ui/src/ui/progress.tsx
+++ b/packages/ui/src/ui/progress.tsx
@@ -12,9 +12,13 @@ export function Progress({
   className?: string;
   indicatorClassName?: string;
 }) {
+  const boundedValue = value != null && Number.isFinite(value)
+    ? Math.max(0, Math.min(100, value))
+    : undefined;
+
   return (
     <ProgressPrimitive.Root
-      value={value}
+      value={boundedValue}
       className={cn(
         "relative h-2 w-full overflow-hidden rounded-full bg-[var(--color-bg-elevated)]",
         className,
@@ -25,7 +29,7 @@ export function Progress({
           "h-full w-full flex-1 bg-[var(--color-accent-primary)] transition-all duration-300",
           indicatorClassName,
         )}
-        style={{ transform: `translateX(-${100 - (value ?? 0)}%)` }}
+        style={{ transform: `translateX(${(boundedValue ?? 0) - 100}%)` }}
       />
     </ProgressPrimitive.Root>
   );


### PR DESCRIPTION
## What changed

`GenerationProgress` could display percentages above 100% when a job reported more completed pages than its stale total. For `241 / 5`, the UI rendered `4820%`, passed an invalid value to Radix, dropped `aria-valuenow`, and generated malformed transform CSS.

This change clamps the displayed generation percentage to `0-100`. It also hardens the shared `Progress` primitive so all finite inputs are bounded before reaching Radix or the indicator transform; non-finite inputs retain the indeterminate state.

## Validation

- Focused generation and progress tests: 21 passed
- Shared UI TypeScript check: passed
- Shared-package import boundary check: passed
- Full shared UI suite: 1,658 passed; two unrelated system-map suites could not load a user-level PostCSS plugin, and two existing heavy UI tests timed out on this Windows machine
- Regression tests were run before implementation: 9 failed on overflow, negative, and non-finite inputs

Closes #2176
