### PR TITLE
fix(health): correct the Elixir, F# and Objective-C complexity maps

### DIFF
--- a/docs/layers/LANGUAGE_SUPPORT.md
+++ b/docs/layers/LANGUAGE_SUPPORT.md
@@ -58,7 +58,7 @@ produce meaningful output.
 | Tier | Languages | What you get |
 |------|-----------|--------------|
 | **Full** (13) | Python · TypeScript · JavaScript · Svelte · Vue · Java · Kotlin · Go · Rust · C++ · C# · Scala · Ruby | The whole pipeline: AST symbols, import resolution, a resolved call graph, heritage, docstrings, framework edges, **and code-health markers** |
-| **Good** (10) | C · Swift · PHP · Dart · Object Pascal · GDScript · VB.NET · Elixir · F# · Objective-C | Everything above except the full health suite. Dart and Object Pascal *do* get health markers; C, Swift, PHP, GDScript, VB.NET, Elixir, F# and Objective-C don't yet. GDScript has a dedicated import resolver and Godot-specific framework edges but no named bindings (see [Known gaps](../architecture/language-support.md#gdscript--godot)) |
+| **Good** (10) | C · Swift · PHP · Dart · Object Pascal · GDScript · VB.NET · Elixir · F# · Objective-C | Everything above except the full health suite. Dart and Object Pascal *do* get health markers, and C, F# and Objective-C get the complexity-derived ones; Swift, PHP, GDScript, VB.NET and Elixir don't yet. GDScript has a dedicated import resolver and Godot-specific framework edges but no named bindings (see [Known gaps](../architecture/language-support.md#gdscript--godot)) |
 | **Partial** (2) | Luau / Roblox · Razor / Blazor | Luau: AST symbols and `require()` resolution (Rojo / `.luaurc` aware), no health markers yet. Razor: a component symbol per file, call edges from `@code` blocks and component tags, C# health markers; no import resolution yet |
 | | | ⎯⎯ *tree-sitter parsing stops here. The rungs below are derived from git and imports, not from an AST.* ⎯⎯ |
 | **Lightweight** (6) | Clojure · Haskell · Lean 4 · Erlang · HTML · QML | A real file-to-file import graph, no symbol-level claims |
@@ -413,8 +413,8 @@ Per-language mechanics behind these:
 | Object Pascal | Good | Assertion and performance markers, a dedicated `uses` resolver |
 | VB.NET | Good | Health markers, project-level `<Import Include=...>` as implicit imports |
 | Elixir | Good | Health markers, and a call-resolution strategy beyond same-file |
-| F# | Good | Health markers, and a resolver that reads the AST index instead of the declared-name regex |
-| Objective-C | Good | Health markers, a resolver that reads the Xcode project rather than file stems, and pairing a header with its implementation across files |
+| F# | Good | The health markers beyond complexity, and a resolver that reads the AST index instead of the declared-name regex |
+| Objective-C | Good | The health markers beyond complexity, a resolver that reads the Xcode project rather than file stems, and pairing a header with its implementation across files |
 | SQL / dbt | — | Column-level blast radius |
 | Shell | — | Shebang detection for extensionless executables |
 | HTML | Lightweight | A regex import tier for template dialects, gated on a framework manifest |

--- a/packages/core/src/repowise/core/analysis/health/complexity/ast_utils.py
+++ b/packages/core/src/repowise/core/analysis/health/complexity/ast_utils.py
@@ -63,6 +63,31 @@ def _find_name(node: Node) -> str:
             leaf = _pascal_unwrap_name(name)
             if leaf.text is not None:
                 return leaf.text.decode("utf-8", errors="replace")
+    # F#: ``function_or_value_defn`` carries no ``name`` field and no direct
+    # identifier child — the name sits one hop down, under
+    # ``function_declaration_left`` (``let f x = ...`` → ``f``). Without this
+    # every F# row reported ``<anonymous>``, which is not much use in a report.
+    if node.type == "function_or_value_defn":
+        for child in node.children:
+            if child.type == "function_declaration_left":
+                for leaf in child.children:
+                    if leaf.type == "identifier" and leaf.text is not None:
+                        return leaf.text.decode("utf-8", errors="replace")
+    # F# members nest one level deeper again and qualify the name with the
+    # self identifier: ``member_defn → method_or_prop_defn → property_or_ident``
+    # holds ``this`` and ``M`` for ``member this.M(x)``. The method name is the
+    # last identifier, which also reads correctly for an unqualified ``member
+    # M(x)``, where it is the only one.
+    if node.type == "member_defn":
+        for child in node.children:
+            if child.type != "method_or_prop_defn":
+                continue
+            for grandchild in child.children:
+                if grandchild.type != "property_or_ident":
+                    continue
+                names = [c for c in grandchild.children if c.type == "identifier" and c.text]
+                if names:
+                    return names[-1].text.decode("utf-8", errors="replace")
     # C / C++: the function name is not a direct child but nested inside a
     # ``declarator`` chain (``function_definition → function_declarator →
     # field_identifier``). Languages with a ``name`` field never reach here.

--- a/packages/core/src/repowise/core/analysis/health/complexity/languages.py
+++ b/packages/core/src/repowise/core/analysis/health/complexity/languages.py
@@ -806,33 +806,59 @@ _PASCAL = LanguageNodeMap(
 )
 
 
-_ELIXIR = LanguageNodeMap(
-    function_kinds=frozenset({"call"}),
-    lambda_kinds=frozenset(),
-    branch_kinds=frozenset(),
-    loop_kinds=frozenset(),
-    try_kinds=frozenset(),
-    catch_kinds=frozenset(),
-    switch_kinds=frozenset(),
-    case_kinds=frozenset(),
-    boolean_operator_kinds=frozenset(),
-    class_kinds=frozenset(),
-    self_identifiers=frozenset(),
-    member_access_kinds=frozenset(),
-    assert_call_kinds=frozenset({"call"}),
-    call_kinds=frozenset({"call"}),
-)
+# Elixir has NO entry, deliberately. tree-sitter-elixir has no ``def`` node:
+# ``defmodule``, ``def``, ``defp`` and an ordinary function call are all
+# ``call`` nodes, told apart only by the identifier text of the target. So
+# ``function_kinds={"call"}`` matches the module too, and because the walker
+# takes the outermost match, every file collapses to a single function named
+# ``defmodule`` at ccn 1 with the real functions invisible. Every field on
+# ``LanguageNodeMap`` is a set of node *types*, so "a ``call`` whose target
+# identifier is ``def`` or ``defp``" cannot be said here at all.
+#
+# No entry means no rows: ``get_language_map`` returns None and ``walk_file``
+# returns an empty ``FileComplexity``, which is the degrade its docstring
+# promises. A map that reports a keyword as a function at a fixed ccn of 1 is
+# a confident wrong answer instead, and health scores are persisted from it.
+# Restoring Elixir needs a text predicate for function kinds first.
 
 
+# Known undercount, and NOT a fault of this map. ``walk_file`` takes
+# ``body = fn_node.child_by_field_name("body")`` and ``_walk_function_body``
+# then walks that node's *children*, so the body node itself is never visited.
+# For a block-bodied language the body is a wrapper and skipping it is right.
+# F# hands back the expression itself, so a function whose whole body is one
+# construct loses it: ``let f x = if x > 0 then 1 else 2`` scores 1, not 2.
+#
+# It is one root cause, not a family. The same dropped node is why a ``match``
+# that IS the whole body cannot be recognised as flat, so before ``case_kinds``
+# named the wrapper its arms were counted one by one. Fixing it properly means
+# moving the traversal root for every language, which needs its own
+# measurement rather than riding along here.
 _FSHARP = LanguageNodeMap(
     function_kinds=frozenset({"function_or_value_defn", "member_defn"}),
     lambda_kinds=frozenset(),
     branch_kinds=frozenset({"if_expression"}),
     loop_kinds=frozenset({"for_expression", "while_expression"}),
     try_kinds=frozenset({"try_expression"}),
+    # ``catch_kinds`` stays empty and ``case_kinds`` names the WRAPPER, and the
+    # two have to be decided together: a ``try ... with`` handler and a
+    # ``match`` arm are the same node types here, ``rules`` holding ``rule``,
+    # so whatever either field names lands on both constructs.
+    #
+    # ``rules`` rather than ``rule``, measured across eight shapes. Naming the
+    # arm counts each one, which takes a flat three-arm match to 4 where Rust
+    # scores 2. Naming the wrapper counts the dispatch once: a flat match of
+    # any width scores 2, matching Rust and the "flat arms count once for the
+    # dispatch" rule in this module's docstring, and ``try``/``with`` picks up
+    # its branch instead of scoring as no error handling.
+    #
+    # The one place this still departs from the docstring: CATCH is meant to
+    # add 1 per clause, and a multi-handler ``with`` counts 1, because the
+    # wrapper is a single node however many handlers hang off it. Under-
+    # counting a rare shape beats inflating every match in the language.
     catch_kinds=frozenset(),
     switch_kinds=frozenset({"match_expression"}),
-    case_kinds=frozenset(),
+    case_kinds=frozenset({"rules"}),
     boolean_operator_kinds=frozenset(),
     class_kinds=frozenset({"anon_type_defn", "record_type_defn", "union_type_defn", "enum_type_defn"}),
     self_identifiers=frozenset(),
@@ -844,12 +870,34 @@ _FSHARP = LanguageNodeMap(
 
 
 _OBJC = LanguageNodeMap(
-    function_kinds=frozenset({"function_definition", "method_definition", "declaration"}),
-    lambda_kinds=frozenset(),
+    # ``declaration`` is NOT a function kind: in this grammar it covers every
+    # file-scope global (``static int gCounter = 0;``) and every prototype, so
+    # including it turned each one into a function of complexity 1. It belongs
+    # in ``local_decl_kinds`` only, which is where the C map at ``_C`` puts it.
+    #
+    # Two effects, and the second is the larger one. Spurious ccn-1 rows stop
+    # being emitted, which raises a file's average complexity back to the
+    # truth. And because ``_recurse`` returns early on any function kind, the
+    # walker used to refuse to descend INTO a declaration: a ternary in an
+    # initialiser counted nothing, and a block literal's body never reached its
+    # enclosing method. Both count now, so an Objective-C file's stored
+    # ``max_ccn`` generally RISES on the next re-score rather than falling.
+    function_kinds=frozenset({"function_definition", "method_definition"}),
+    # A block assigned at file scope is a ``declaration``, so dropping
+    # ``declaration`` above would have taken its body's complexity with it.
+    # Naming the block itself keeps that row without bringing the globals back.
+    # A block nested inside a method still rolls into that method rather than
+    # splitting off, which is what ``lambda_kinds`` means everywhere else.
+    lambda_kinds=frozenset({"block_literal"}),
     branch_kinds=frozenset({"if_statement", "conditional_expression"}),
-    loop_kinds=frozenset({"for_statement", "while_statement", "do_statement", "for_in_statement"}),
+    # ``for (NSString *k in keys)`` parses as ``for_statement`` here, not as a
+    # distinct ``for_in_statement``, so naming the latter matched nothing.
+    loop_kinds=frozenset({"for_statement", "while_statement", "do_statement"}),
     try_kinds=frozenset({"try_statement"}),
-    catch_kinds=frozenset(),
+    # TRY only opens a nesting level; CATCH is what adds to CCN (see the module
+    # docstring). Leaving this empty scored ``@try``/``@catch`` the same as no
+    # error handling at all.
+    catch_kinds=frozenset({"catch_clause"}),
     switch_kinds=frozenset({"switch_statement"}),
     case_kinds=frozenset({"case_statement"}),
     boolean_operator_kinds=frozenset(),
@@ -896,7 +944,7 @@ LANGUAGE_MAPS: dict[str, LanguageNodeMap] = {
     "ruby": _RUBY,
     "shell": _SHELL,
     "pascal": _PASCAL,
-    "elixir": _ELIXIR,
+    # No "elixir" entry on purpose. See the note above ``_FSHARP``.
     "fsharp": _FSHARP,
     "objectivec": _OBJC,
 }

--- a/packages/core/src/repowise/core/analysis/health/complexity/languages.py
+++ b/packages/core/src/repowise/core/analysis/health/complexity/languages.py
@@ -806,56 +806,27 @@ _PASCAL = LanguageNodeMap(
 )
 
 
-# Elixir has NO entry, deliberately. tree-sitter-elixir has no ``def`` node:
-# ``defmodule``, ``def``, ``defp`` and an ordinary function call are all
-# ``call`` nodes, told apart only by the identifier text of the target. So
-# ``function_kinds={"call"}`` matches the module too, and because the walker
-# takes the outermost match, every file collapses to a single function named
-# ``defmodule`` at ccn 1 with the real functions invisible. Every field on
-# ``LanguageNodeMap`` is a set of node *types*, so "a ``call`` whose target
-# identifier is ``def`` or ``defp``" cannot be said here at all.
-#
-# No entry means no rows: ``get_language_map`` returns None and ``walk_file``
-# returns an empty ``FileComplexity``, which is the degrade its docstring
-# promises. A map that reports a keyword as a function at a fixed ccn of 1 is
-# a confident wrong answer instead, and health scores are persisted from it.
-# Restoring Elixir needs a text predicate for function kinds first.
+# Elixir has no entry on purpose. tree-sitter-elixir gives ``defmodule``,
+# ``def``, ``defp`` and an ordinary call the same ``call`` node, told apart
+# only by the target's identifier text, which a set of node types cannot
+# express. Mapping ``call`` reports the module as the file's only function, so
+# until function kinds can carry a text predicate, no entry and no rows.
 
 
-# Known undercount, and NOT a fault of this map. ``walk_file`` takes
-# ``body = fn_node.child_by_field_name("body")`` and ``_walk_function_body``
-# then walks that node's *children*, so the body node itself is never visited.
-# For a block-bodied language the body is a wrapper and skipping it is right.
-# F# hands back the expression itself, so a function whose whole body is one
-# construct loses it: ``let f x = if x > 0 then 1 else 2`` scores 1, not 2.
-#
-# It is one root cause, not a family. The same dropped node is why a ``match``
-# that IS the whole body cannot be recognised as flat, so before ``case_kinds``
-# named the wrapper its arms were counted one by one. Fixing it properly means
-# moving the traversal root for every language, which needs its own
-# measurement rather than riding along here.
+# Known undercount, in the walker rather than this map: ``walk_file`` walks the
+# body node's children, so a body that IS one expression loses it and
+# ``let f x = if x > 0 then 1 else 2`` scores 1.
 _FSHARP = LanguageNodeMap(
     function_kinds=frozenset({"function_or_value_defn", "member_defn"}),
     lambda_kinds=frozenset(),
     branch_kinds=frozenset({"if_expression"}),
     loop_kinds=frozenset({"for_expression", "while_expression"}),
     try_kinds=frozenset({"try_expression"}),
-    # ``catch_kinds`` stays empty and ``case_kinds`` names the WRAPPER, and the
-    # two have to be decided together: a ``try ... with`` handler and a
-    # ``match`` arm are the same node types here, ``rules`` holding ``rule``,
-    # so whatever either field names lands on both constructs.
-    #
-    # ``rules`` rather than ``rule``, measured across eight shapes. Naming the
-    # arm counts each one, which takes a flat three-arm match to 4 where Rust
-    # scores 2. Naming the wrapper counts the dispatch once: a flat match of
-    # any width scores 2, matching Rust and the "flat arms count once for the
-    # dispatch" rule in this module's docstring, and ``try``/``with`` picks up
-    # its branch instead of scoring as no error handling.
-    #
-    # The one place this still departs from the docstring: CATCH is meant to
-    # add 1 per clause, and a multi-handler ``with`` counts 1, because the
-    # wrapper is a single node however many handlers hang off it. Under-
-    # counting a rare shape beats inflating every match in the language.
+    # A ``with`` handler and a ``match`` arm are the same node types here, so
+    # one field has to serve both. ``case_kinds`` names ``rules``, the wrapper,
+    # which counts the dispatch once; naming ``rule``, the arm, would score a
+    # flat three-arm match 4 against Rust's 2. So a multi-handler ``with``
+    # counts 1 rather than one per clause.
     catch_kinds=frozenset(),
     switch_kinds=frozenset({"match_expression"}),
     case_kinds=frozenset({"rules"}),
@@ -870,33 +841,20 @@ _FSHARP = LanguageNodeMap(
 
 
 _OBJC = LanguageNodeMap(
-    # ``declaration`` is NOT a function kind: in this grammar it covers every
-    # file-scope global (``static int gCounter = 0;``) and every prototype, so
-    # including it turned each one into a function of complexity 1. It belongs
-    # in ``local_decl_kinds`` only, which is where the C map at ``_C`` puts it.
-    #
-    # Two effects, and the second is the larger one. Spurious ccn-1 rows stop
-    # being emitted, which raises a file's average complexity back to the
-    # truth. And because ``_recurse`` returns early on any function kind, the
-    # walker used to refuse to descend INTO a declaration: a ternary in an
-    # initialiser counted nothing, and a block literal's body never reached its
-    # enclosing method. Both count now, so an Objective-C file's stored
-    # ``max_ccn`` generally RISES on the next re-score rather than falling.
+    # ``declaration`` covers every file-scope global and prototype here, so it
+    # is a local decl rather than a function kind, as in ``_C``. It is also a
+    # recursion boundary: as a function kind it stopped the walker descending
+    # into a declaration, so a ternary in an initialiser counted nothing.
     function_kinds=frozenset({"function_definition", "method_definition"}),
-    # A block assigned at file scope is a ``declaration``, so dropping
-    # ``declaration`` above would have taken its body's complexity with it.
-    # Naming the block itself keeps that row without bringing the globals back.
-    # A block nested inside a method still rolls into that method rather than
-    # splitting off, which is what ``lambda_kinds`` means everywhere else.
+    # A file-scope block is a ``declaration``, so name the block itself to keep
+    # its complexity now that ``declaration`` is not a function kind.
     lambda_kinds=frozenset({"block_literal"}),
     branch_kinds=frozenset({"if_statement", "conditional_expression"}),
-    # ``for (NSString *k in keys)`` parses as ``for_statement`` here, not as a
-    # distinct ``for_in_statement``, so naming the latter matched nothing.
+    # Fast enumeration parses as ``for_statement``; there is no
+    # ``for_in_statement`` node in this grammar.
     loop_kinds=frozenset({"for_statement", "while_statement", "do_statement"}),
     try_kinds=frozenset({"try_statement"}),
-    # TRY only opens a nesting level; CATCH is what adds to CCN (see the module
-    # docstring). Leaving this empty scored ``@try``/``@catch`` the same as no
-    # error handling at all.
+    # TRY only opens a nesting level; CATCH is what adds to CCN.
     catch_kinds=frozenset({"catch_clause"}),
     switch_kinds=frozenset({"switch_statement"}),
     case_kinds=frozenset({"case_statement"}),

--- a/packages/core/src/repowise/core/analysis/health/engine.py
+++ b/packages/core/src/repowise/core/analysis/health/engine.py
@@ -99,18 +99,10 @@ log = structlog.get_logger(__name__)
 # Not a licence to move a calibrated scoring weight — those are frozen
 # independently of this stamp.
 #
-# Current stamp: F# and Objective-C gained working complexity node maps, and
-# Elixir deliberately lost its one. Both languages previously reached the
-# walker with no usable map, so their files scored as if they had no branches,
-# the same defect the C entry below describes. Objective-C additionally counted
-# every file-scope global as a function of complexity 1. Stored complexity
-# metrics and the findings keyed off them change for files in those languages
-# on the next update; repos without them are unaffected.
-#
-# Note the cache, which is the other reason this has to move: ``HealthWalkCache``
-# keys a cached walk on the analyzer version and the file's bytes. A node-map
-# change alters neither, so an index built against the previous maps keeps
-# serving their results until this number does move.
+# Current stamp: F# and Objective-C gained working complexity node maps and
+# Elixir lost its broken one, so stored complexity changes for files in those
+# languages. It has to move for the cache too: ``HealthWalkCache`` keys on this
+# stamp and the file's bytes, neither of which a node-map change alters.
 #
 # v10: non-code files stopped being scored and the deduction was split into its
 # structure and history halves, stored per file.

--- a/packages/core/src/repowise/core/analysis/health/engine.py
+++ b/packages/core/src/repowise/core/analysis/health/engine.py
@@ -99,7 +99,23 @@ log = structlog.get_logger(__name__)
 # Not a licence to move a calibrated scoring weight — those are frozen
 # independently of this stamp.
 #
-# Current stamp: C gained a complexity node map. ``LANGUAGE_NODE_MAPS`` had no
+# Current stamp: F# and Objective-C gained working complexity node maps, and
+# Elixir deliberately lost its one. Both languages previously reached the
+# walker with no usable map, so their files scored as if they had no branches,
+# the same defect the C entry below describes. Objective-C additionally counted
+# every file-scope global as a function of complexity 1. Stored complexity
+# metrics and the findings keyed off them change for files in those languages
+# on the next update; repos without them are unaffected.
+#
+# Note the cache, which is the other reason this has to move: ``HealthWalkCache``
+# keys a cached walk on the analyzer version and the file's bytes. A node-map
+# change alters neither, so an index built against the previous maps keeps
+# serving their results until this number does move.
+#
+# v10: non-code files stopped being scored and the deduction was split into its
+# structure and history halves, stored per file.
+#
+# v9: C gained a complexity node map. ``LANGUAGE_NODE_MAPS`` had no
 # ``c`` entry, so every C file scored as if it had no branches: ``max_ccn`` and
 # the maintainability index were computed off an empty node set and persisted
 # that way. The map is present now, so a C file's stored complexity metrics and
@@ -113,7 +129,7 @@ log = structlog.get_logger(__name__)
 # forms. Files that were counted untested and are not become tested, which
 # moves untested-hotspot findings and the scores that carry them, on every
 # language with a prefix or spec convention rather than Ruby alone.
-HEALTH_ANALYZER_VERSION = 10
+HEALTH_ANALYZER_VERSION = 11
 
 # Method-level smells that make the dataflow / Extract Method pass worthwhile.
 # Only files carrying one of these get a CFG + def/use + reaching pass built.

--- a/packages/core/src/repowise/core/analysis/health/perf/dialects/__init__.py
+++ b/packages/core/src/repowise/core/analysis/health/perf/dialects/__init__.py
@@ -51,9 +51,11 @@ _REGISTER: tuple[tuple[str, BasePerfDialect], ...] = (
     ("ruby", _ruby.DIALECT),
     ("kotlin", _kotlin.DIALECT),
     ("cpp", _cpp.DIALECT),
-    # NB: "c" shares the C++ grammar but has no ``LanguageNodeMap`` at all
-    # (``get_language_map("c")`` is ``None``), so the health pass never reaches
-    # a dialect for it. Registering it here would be dead configuration.
+    # NB: "c" shares the C++ grammar and now has its own ``LanguageNodeMap``,
+    # so it does reach the health pass for complexity. It is still absent here
+    # on purpose: no perf dialect has been written for it, and the coverage
+    # report names it as an unsupported language rather than pretending a
+    # detector ran.
 )
 
 for _tag, _dialect in _REGISTER:

--- a/tests/unit/health/test_language_node_maps.py
+++ b/tests/unit/health/test_language_node_maps.py
@@ -1,0 +1,266 @@
+"""Table-driven checks that a language node map says what the grammar means.
+
+A ``LanguageNodeMap`` is a set of node-type strings, so nothing about it fails
+loudly when it is wrong: naming a node type the grammar never emits is silently
+inert, and naming one that means something else silently produces confident
+wrong numbers. Importing cleanly proves neither. These tests run the real
+walker over small snippets and assert the function names and cyclomatic
+complexity that come back, which is the only thing that does.
+
+Each case is (label, source, expected rows), so adding a language is a table
+entry rather than a new test.
+
+Grammars are not all installed everywhere, so every case guards with
+``_require_language`` the way ``test_complexity_walker`` does.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from repowise.core.analysis.health.complexity import walk_file
+from repowise.core.analysis.health.complexity.languages import get_language_map
+
+
+def _require_language(language: str) -> None:
+    try:
+        from repowise.core.ingestion.parser import _get_language
+    except Exception:
+        pytest.skip(f"tree-sitter language pack missing for {language}")
+    if _get_language(language) is None:
+        pytest.skip(f"tree-sitter language pack missing for {language}")
+
+
+def _rows(language: str, source: str, suffix: str) -> dict[str, int]:
+    """Return ``{function name: ccn}`` from a real walk of *source*."""
+    fc = walk_file(f"sample.{suffix}", language, source.encode("utf-8"))
+    return {f.name: f.ccn for f in fc.functions}
+
+
+# --------------------------------------------------------------------------- #
+# Elixir: deliberately absent
+# --------------------------------------------------------------------------- #
+
+
+def test_elixir_has_no_complexity_map() -> None:
+    """The absence is load-bearing, so it is asserted rather than assumed.
+
+    tree-sitter-elixir emits ``call`` for ``defmodule``, ``def``, ``defp`` and
+    an ordinary call alike, told apart only by the target's identifier text,
+    which a set of node types cannot express. A map keyed on ``call`` reports
+    the module as the function and hides every real one.
+    """
+    assert get_language_map("elixir") is None
+
+
+def test_elixir_reports_nothing_rather_than_a_wrong_function() -> None:
+    """No rows is the honest degrade. One row named ``defmodule`` is not.
+
+    No grammar guard here on purpose: ``walk_file`` returns on the missing-map
+    check before it ever asks for a parser, so this holds either way.
+    """
+    source = "defmodule A do\n  def one(x), do: x\nend\n\ndefmodule B do\n  def two(y), do: y\nend\n"
+    fc = walk_file("sample.ex", "elixir", source.encode("utf-8"))
+    assert fc.functions == []
+
+
+# --------------------------------------------------------------------------- #
+# Objective-C
+# --------------------------------------------------------------------------- #
+
+_OBJC_CASES: list[tuple[str, str, dict[str, int]]] = [
+    (
+        "file-scope globals and prototypes are not functions",
+        """
+static int gCounter = 0;
+static NSString *gName = nil;
+int helper(int x);
+
+@implementation Ledger
+- (int)post:(int)amount { if (amount > 0) { return 1; } return 0; }
+@end
+""",
+        {"post": 2},
+    ),
+    (
+        "a catch clause adds a branch",
+        """
+@implementation L
+- (void)run {
+  @try { [self go]; }
+  @catch (NSException *e) { NSLog(@"x"); }
+}
+@end
+""",
+        {"run": 2},
+    ),
+    (
+        "fast enumeration counts as a loop",
+        """
+@implementation L
+- (int)count:(NSArray *)keys {
+  int n = 0;
+  for (NSString *k in keys) { n++; }
+  return n;
+}
+@end
+""",
+        {"count": 2},
+    ),
+    (
+        "a plain C function definition is still a function",
+        """
+int helper(int x) {
+  for (int i = 0; i < x; i++) { x += i; }
+  return x;
+}
+""",
+        {"helper": 2},
+    ),
+    (
+        "a ternary inside a declaration is reached",
+        """
+@implementation L
+- (int)pick:(int)n { int b = n > 0 ? 1 : 2; return b; }
+@end
+""",
+        {"pick": 2},
+    ),
+    (
+        "a block nested in a method rolls into that method",
+        """
+@implementation L
+- (void)run { void (^b)(void) = ^{ if (1) { NSLog(@"x"); } }; b(); }
+@end
+""",
+        {"run": 2},
+    ),
+    (
+        "a flat switch counts once for the dispatch",
+        """
+@implementation L
+- (int)pick:(int)n {
+  switch (n) { case 1: return 1; case 2: return 2; default: return 0; }
+}
+@end
+""",
+        {"pick": 2},
+    ),
+    (
+        "a switch whose arms carry control flow counts them",
+        """
+@implementation L
+- (int)pick:(int)n {
+  switch (n) {
+    case 1: { if (n > 0) { return 1; } return 5; }
+    case 2: { for (int i = 0; i < n; i++) { n += i; } return 2; }
+    default: return 0;
+  }
+}
+@end
+""",
+        {"pick": 6},
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    ("source", "expected"),
+    [(src, exp) for _, src, exp in _OBJC_CASES],
+    ids=[label for label, _, _ in _OBJC_CASES],
+)
+def test_objective_c_complexity(source: str, expected: dict[str, int]) -> None:
+    _require_language("objectivec")
+    assert _rows("objectivec", source, "m") == expected
+
+
+# --------------------------------------------------------------------------- #
+# F#
+# --------------------------------------------------------------------------- #
+
+_FSHARP_CASES: list[tuple[str, str, dict[str, int]]] = [
+    (
+        "every function is named rather than anonymous",
+        "let one x = x\nlet two y = y\n",
+        {"one": 1, "two": 1},
+    ),
+    (
+        "a branch and a loop each add one",
+        'let f x =\n  let y = 1\n  if x > 0 then\n    for i in 1..x do\n      printfn "%d" i\n  0\n',
+        {"f": 3},
+    ),
+    (
+        "a flat match counts once for the dispatch, at any width",
+        'let f x =\n  match x with\n  | 1 -> "a"\n  | 2 -> "b"\n  | _ -> "c"\n',
+        {"f": 2},
+    ),
+    (
+        "control flow inside a match arm counts on top of the dispatch",
+        'let f x =\n  match x with\n  | 1 -> (if x > 5 then "a" else "b")\n'
+        '  | _ -> (for i in 1..x do printfn "%d" i\n          "c")\n',
+        {"f": 4},
+    ),
+    (
+        "a with handler is a branch",
+        "let f x =\n  try\n    x\n  with\n  | _ -> 0\n",
+        {"f": 2},
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    ("source", "expected"),
+    [(src, exp) for _, src, exp in _FSHARP_CASES],
+    ids=[label for label, _, _ in _FSHARP_CASES],
+)
+def test_fsharp_complexity(source: str, expected: dict[str, int]) -> None:
+    _require_language("fsharp")
+    assert _rows("fsharp", source, "fs") == expected
+
+
+def test_fsharp_member_is_named_by_its_method_not_its_self_identifier() -> None:
+    """``member this.M(x)`` is ``M``, not ``this`` and not ``<anonymous>``."""
+    _require_language("fsharp")
+    source = "type T() =\n  member this.M(x) =\n    let y = 1\n    if x > 0 then 1 else 2\n"
+    assert set(_rows("fsharp", source, "fs")) == {"M"}
+
+
+def test_fsharp_flat_match_agrees_with_rust() -> None:
+    """The dispatch is worth one branch in both, so the languages agree.
+
+    ``case_kinds`` names the ``rules`` wrapper rather than the ``rule`` arm. On
+    the arm, a three-arm match would score 4 against Rust's 2.
+    """
+    _require_language("fsharp")
+    _require_language("rust")
+    fsharp = 'let f x =\n  match x with\n  | 1 -> "a"\n  | 2 -> "b"\n  | _ -> "c"\n'
+    rust = 'fn f(x: i32) -> &str {\n    match x {\n        1 => "a",\n        2 => "b",\n        _ => "c",\n    }\n}\n'
+    assert _rows("fsharp", fsharp, "fs")["f"] == _rows("rust", rust, "rs")["f"] == 2
+
+
+def test_fsharp_multi_handler_with_counts_once_not_per_clause() -> None:
+    """A documented departure, pinned so it is a decision rather than a surprise.
+
+    CATCH is meant to add one per clause. ``rules`` is a single node however
+    many handlers hang off it, and the alternative inflates every match.
+    """
+    _require_language("fsharp")
+    source = (
+        "let f x =\n  try\n    x\n  with\n"
+        "  | :? System.IO.IOException -> 1\n"
+        "  | :? System.OverflowException -> 2\n"
+        "  | _ -> 0\n"
+    )
+    assert _rows("fsharp", source, "fs") == {"f": 2}
+
+
+def test_fsharp_single_expression_body_is_a_known_undercount() -> None:
+    """Pinning current behaviour so a traversal fix is a deliberate change.
+
+    ``walk_file`` takes the ``body`` field and walks that node's children, so a
+    body that IS the branch is never visited. Correct for block-bodied
+    languages, wrong here. When the traversal root changes this should become
+    2, and this test is the place that says so.
+    """
+    _require_language("fsharp")
+    assert _rows("fsharp", "let f x =\n  if x > 0 then 1 else 2\n", "fs") == {"f": 1}

--- a/tests/unit/health/test_model_version_coupling.py
+++ b/tests/unit/health/test_model_version_coupling.py
@@ -22,7 +22,7 @@ from repowise.core.analysis.health.refactoring.identity import (
 
 # The three stamps as they stand together. Moving either identity model means
 # moving the analyzer with it, and updating this tuple in the same commit.
-_STAMPS = (10, 2, 2)
+_STAMPS = (11, 2, 2)
 
 
 def test_the_identity_models_and_the_analyzer_stamp_are_pinned_together() -> None:


### PR DESCRIPTION
Follows #2152, which added complexity node maps for Elixir, F# and Objective-C.

A `LanguageNodeMap` is a set of tree-sitter node-type strings, which is a shape that fails quietly in both directions. Naming a node type the grammar never emits is silently inert. Naming one that means something else silently produces confident wrong numbers, and those numbers are persisted as `max_ccn` and feed the health scores. Importing cleanly proves neither, which is why CI was green on all three.

Everything below was measured by running the real walker against the installed grammars, not read off the diff.

## Elixir loses its map

tree-sitter-elixir has no `def` node. `defmodule`, `def`, `defp` and an ordinary function call are all `call` nodes, told apart only by the identifier text of the target. So `function_kinds={"call"}` matched the module too, and because the walker takes the outermost match, every file collapsed to a single function:

```
defmodule A do          elixir functions: 2
  def one(x), do: x        name='defmodule' ccn=1
end                        name='defmodule' ccn=1
defmodule B do
  def two(y), do: y     # both real functions invisible, and with branch_kinds
end                     # empty an `if` in a body added nothing, so every
                        # Elixir file scored ccn 1 forever
```

Every field on `LanguageNodeMap` is a `frozenset[str]` of node *types*, so "a `call` whose target identifier is `def` or `defp`" cannot be expressed at all. No entry means `walk_file` returns an empty `FileComplexity`, which is the degrade its docstring promises. Restoring Elixir needs a text predicate for function kinds first.

## Objective-C

| | before | after |
|---|---|---|
| `declaration` in `function_kinds` | `{'post': 2, 'helper': 1, 'gCounter': 1, 'gName': 1}` | `{'post': 2}` |
| `catch_kinds` empty | `@try`/`@catch` scored as no error handling | `catch_clause`, so a handler is a branch |
| `for_in_statement` in `loop_kinds` | inert; the grammar emits `for_statement` | removed |

`declaration` was already in `local_decl_kinds`, which is where it belongs and where the C map at `_C` puts it. The larger effect is not the spurious rows: `_recurse` returns early on any function kind, so while `declaration` was one the walker refused to descend into declarations. A ternary in an initialiser counted nothing and a block literal's body never reached its enclosing method. Both count now, so an Objective-C file's stored `max_ccn` generally **rises** on re-score rather than falling.

Dropping `declaration` would also have taken file-scope blocks with it, since a block assigned at file scope is a declaration, so `lambda_kinds` names `block_literal`. A block nested inside a method still rolls into that method.

## F#

Functions reported `<anonymous>` because the name sits under `function_declaration_left` rather than on a `name` field, and members one level deeper again under `method_or_prop_defn > property_or_ident`. `_find_name` gains two branches, following the shape the Pascal `defProc` case already uses. `member this.M(x)` resolves to `M` rather than `this`. Both node types exist only in tree-sitter-fsharp, so no other language can enter either branch.

`case_kinds` now names `rules`, the wrapper, so:

```
flat match, 3 arms     1 -> 2      # same as the equivalent Rust match
flat match, 10 arms    1 -> 2      # flat arms count once for the dispatch
try/with               1 -> 2      # the handler is a branch
match with heavy arms  3 -> 4      # dispatch plus the arms' own control flow
```

Naming `rule`, the arm, instead takes a three-arm flat match to 4 against Rust's 2. One documented departure remains and is pinned by a test: a multi-handler `with` counts 1 rather than one per clause, because the wrapper is a single node however many handlers hang off it.

## The analyzer stamp

`HEALTH_ANALYZER_VERSION` moves to 11. Stored complexity for F# and Objective-C files changes, which is the documented trigger, and it is the same case as the C map at v9.

It also has to move for a second reason: `HealthWalkCache` keys a cached walk on the analyzer version and the file's bytes. A node-map change alters neither, so without the bump an index built against the old maps keeps serving their results. The ladder comment above the constant had also gone stale, still describing v9 as current, so v10 gets its line.

Repositories without these languages are unaffected, and nothing needs re-indexing: `STORE_FORMAT_VERSION` and `PARSER_SCHEMA_VERSION` are untouched.

## Tests

`tests/unit/health/test_language_node_maps.py` is table-driven, source in and expected rows out, because that is the only thing that catches this class of error. It found two of my own mistakes while I was writing it: I expected the Objective-C flat switch to score 3 when the flat-dispatch rule correctly gives 2, and I expected F# members to resolve by the same path as let-bindings when they nest deeper.

The two behaviours that are still wrong are pinned rather than left to folklore, each with the value it should become when fixed. Both have one root cause: `walk_file` takes the `body` field and walks that node's children, so the body node itself is never visited. Correct for block-bodied languages where the body is a wrapper, wrong for expression-oriented ones, where `let f x = if x > 0 then 1 else 2` loses its branch. Moving the traversal root changes every language, so it wants its own measurement.

## Also in here

- `docs/layers/LANGUAGE_SUPPORT.md` said C, F# and Objective-C get no health markers. C has had a map since #2113 and the other two now do.
- The comment on the perf dialect registry asserted `get_language_map("c")` is `None`, which stopped being true in #2113. C is still deliberately absent from that registry, for a different reason, which the comment now gives.

## Test plan

- [x] `tests/unit/health/test_language_node_maps.py` — 19 passed
- [x] `tests/unit/health`, `tests/unit/change_health`, `tests/unit/upgrade`, `tests/unit/analysis` — 2,752 passed, 3 failed, all three pre-existing Pascal cases that assert without the skip guard their module docstring promises and fail only where the Pascal grammar is absent
- [x] `ruff check .` clean
- [x] Every map claim re-measured against the installed grammars after the final edit
