### PR TITLE
feat(workspace): compare OpenAPI schemas directionally

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,16 +402,17 @@ change, and the architecture rule the new dependency violates before it ships.
 | Workspace intelligence | What it answers |
 |---|---|
 | **Contract map** | Which services provide and consume each HTTP, gRPC, event, socket, and data contract? Links retain exact/candidate confidence and the source evidence. |
-| **Cross-repo blast radius** | If this provider changes, which downstream services **will break** through structural dependencies, and which ones **may drift** through historical co-change? |
-| **Breaking-change guard** | Was an endpoint removed or a typed contract changed incompatibly, and which exact consumer files call it? |
+| **Cross-repo blast radius** | If this provider changes, which downstream services are in structural reach, and which ones may drift through historical co-change? |
+| **Breaking-change guard** | Was an endpoint removed or a supported OpenAPI / proto / signature shape changed incompatibly, and which consumer files are linked to that contract? |
 | **Test impact** | Which tests in the consumer repos should run for this provider change, measured from coverage or inferred from the call graph, and which links could not be determined? |
 | **Architecture as code** | Does the live system graph violate declared dependency rules or contain cycles? `repowise workspace check` gates CI. |
 | **Architecture health** | How coupled is the estate? Track propagation cost, the cyclic core, service roles, and a deterministic 1–10 architecture score. |
 | **Federated context** | One dashboard and one MCP server answer across every repository while preserving repo-level evidence. |
 
 The system map models **services**, not merely repository boxes, and never conflates a
-real contract with “these files often changed together.” Field-level breaking diffs
-currently require a gRPC schema; HTTP supports endpoint-level removal detection.
+real contract with “these files often changed together.” HTTP field-level comparison
+supports the bounded OpenAPI 3.x JSON subset documented in the workspace guide;
+matched consumers prove endpoint exposure, not field use or runtime failure.
 
 **[Workspace guide and exact support matrix →](docs/scale/WORKSPACES.md)**
 

--- a/docs/agent/MCP_TOOLS.md
+++ b/docs/agent/MCP_TOOLS.md
@@ -527,7 +527,7 @@ When `changed_files` is passed, the exact serialized response starts with a `dir
 
 - `will_break_consumers`: deprecated compatibility name for services in *other* repos that structurally depend on this one. Rows carry `claim: structural_reach`, `runtime_breakage_claim: false`, both repository roles, direction, distance, and aggregated edge kinds; the sibling `will_break_consumers_semantics` is `structural_reach_only`. Matching total/emitted/truncated fields describe the exact pre-cap structural population, while `cross_repo_relationship_analysis` labels unavailable or partial edge provenance.
 - `missing_cross_repo_cochanges`: services in other repos that historically co-change with this one but aren't in the diff.
-- `breaking_changes`: provider contracts in this repo that changed *incompatibly* since the last index (a removed route or field, a type or field-number change, a newly-required field), each with the changed `contract_id`, the change `kind`/`severity`, and the `impacted_consumers` (repo, service, file) it endangers across repos. Schema-level truth, distinct from the topology-level `will_break_consumers`; non-breaking changes (added optional field, new endpoint) never appear. See [Breaking-Change Guard](../scale/WORKSPACES.md#breaking-change-guard).
+- `breaking_changes`: compatibility-named list of provider incompatibilities and comparison warnings since the last index. Entries carry `contract_id`, `kind`/`severity`, optional request/response `side`, `comparison_source`/`comparison_key`, and endpoint-exposed `impacted_consumers` (repo, service, file). OpenAPI findings require complete sides with matching fidelity; unsupported or changed extraction evidence becomes uncertainty, not field removals. Consumer links do not prove field use or runtime failure. See [Breaking-Change Guard](../scale/WORKSPACES.md#breaking-change-guard).
 - `conformance_violations`: declared dependency-rule breaches the diff's repo participates in, each with the offending `source`/`target` services, the `rule` (e.g. `frontend !-> db`), and `edge_kind`. See [Architecture Conformance](../scale/WORKSPACES.md#architecture-conformance).
 - `dependency_cycles`: circular service dependencies involving this repo, each with the participating `nodes` and `length`.
 
@@ -681,14 +681,16 @@ on an index with no fix history.
 In workspace mode the response also holds `cross_repo`, built from the artifacts
 of the last `repowise update --workspace` rather than from a graph traversal. It
 appears when the commit touches a file that provides a contract some other repo
-consumes, or when the breaking-change report attributes a break to one of the
+consumes, or when the compatibility report attributes a finding to one of the
 changed files. `consumers[]` names each link with its `provider_file`, the
 consumer's `repo`, `file` and `contract_id`, the `contract_type` and the
 `match_type` that joined them, plus `provider_symbol_id` and `symbol_id` when the
 link is symbol-level; `consumer_repos` lists the other repos in one place.
 `breaking_changes[]` carries the `contract_id`, `type`, `kind`, `severity`,
-`detail`, `provider_file` and `impacted_repos` of each contract that changed
-incompatibly. `breaking_changes_available` says whether a detection pass ran at
+`detail`, `provider_file` and `impacted_repos` of each incompatibility or
+comparison warning, together with side/source/key evidence when available.
+Impacted repositories are directly linked endpoint exposure, not proof of a
+runtime failure. `breaking_changes_available` says whether a detection pass ran at
 all, so an empty list reads as silence rather than as an all-clear, and
 `breaking_changes_as_of` stamps that half only. `consumers` is capped at ten and
 `breaking_changes` at five, with `consumers_truncated` and
@@ -1348,7 +1350,7 @@ The MCP server automatically enriches responses with cross-repo intelligence:
 - **API contract links** (HTTP, gRPC, topics) between repos
 - **Package dependencies** between repos
 - **Cross-repo blast radius** via the workspace-only `get_blast_radius` tool, and a cross-repo `directive` in `get_risk` PR-mode
-- **Breaking-change guard**: incompatible provider-contract changes and the consumers they endanger, in the `get_risk` PR-mode `breaking_changes` directive
+- **Breaking-change guard**: provider incompatibilities and explicit comparison uncertainty, plus endpoint-exposed consumers, in the `get_risk` PR-mode `breaking_changes` directive
 - **Architecture conformance**: declared dependency-rule violations and dependency cycles via the workspace-only, opt-in `get_conformance` tool, and `conformance_violations` / `dependency_cycles` in the `get_risk` PR-mode directive
 - **Architecture metrics**: whole-system coupling (propagation cost), the cyclic core, per-service roles, and a deterministic 1-10 architecture score via the workspace-only `get_architecture` tool
 

--- a/docs/layers/CHANGE_RISK.md
+++ b/docs/layers/CHANGE_RISK.md
@@ -416,15 +416,19 @@ ranking (one named constant, `BEHAVIORAL_EDGE_WEIGHT`, in
 model.
 
 The directive carries a third cross-repo field, `breaking_changes`, when a
-provider contract in the changed repo changed *incompatibly* (a removed route or
-field, a type or field-number change, a newly-required field). Where
+provider contract in the changed repo has an incompatibility or an explicit
+comparison warning. The compatibility-named key includes removed operations,
+legacy proto/signature rules, and direction-aware OpenAPI request/response rules
+for complete sides with matching fidelity. Where
 `will_break_consumers` is topology ("who depends on this repo"),
 `breaking_changes` is schema-level truth ("this specific contract changed in a
-way that breaks these consumers"), each entry listing the changed contract and
-the consumer files it endangers across repos. It is computed by diffing the
+way that is incompatible"), each entry listing its side, schema source/fidelity,
+and endpoint-exposed consumer files across repos. Those links do not prove exact
+field use, runtime failure, or deployment safety. It is computed by diffing the
 current contracts against the previously-indexed set during
-`repowise update --workspace`; non-breaking changes (an added optional field, a
-new endpoint) never appear. See
+`repowise update --workspace`; unsupported/unresolved sides and source, fidelity,
+or selected-response transitions surface as uncertainty rather than field
+removals. Compatible directional changes and new endpoints do not appear. See
 [Breaking-Change Guard](../scale/WORKSPACES.md#breaking-change-guard) for the full model.
 
 ## Branch overlap

--- a/docs/scale/WORKSPACES.md
+++ b/docs/scale/WORKSPACES.md
@@ -369,11 +369,11 @@ The map appears once the workspace has at least two indexed repositories with de
 
 ## Cross-Repo Blast Radius
 
-Blast radius answers a single question: **if I change this service, what downstream services and repos break?** It walks the [system graph](#system-graph) *against* its edge direction, a `consumer → provider` edge means changing the provider impacts the consumer, and returns every reachable service ranked by an impact score.
+Blast radius answers a single question: **if I change this service, which downstream services and repos are structurally exposed?** It walks the [system graph](#system-graph) *against* its edge direction, a `consumer → provider` edge means changing the provider may impact the consumer, and returns every reachable service ranked by an impact score.
 
 Two edge classes are weighted and labelled distinctly:
 
-- **Structural** edges (http / grpc / event / package / db) assert a real dependency, a contract or an import. They propagate impact at full weight and surface as **will break**.
+- **Structural** edges (http / grpc / event / package / db) assert a real dependency, a contract or an import. They propagate impact at full weight and surface under the compatibility-named **will break** field, but mean structural reach rather than certain runtime failure.
 - **Behavioral** co-change edges only assert that two files historically *changed together*. They are correlation, not a call, so they propagate at half weight (one named constant, `BEHAVIORAL_EDGE_WEIGHT`) and surface as **may drift**.
 
 Each impacted service carries its `distance` (hops from the change) and `score` (0-1, with distance decay and the behavioral weighting baked in). Nearer, structural impact ranks highest.
@@ -388,7 +388,7 @@ Use it three ways:
 
 ## Breaking-Change Guard
 
-Where blast radius answers *what could be affected*, the breaking-change guard answers a sharper question: **did a provider change in a way that actually breaks its consumers?** On every `repowise update --workspace`, the freshly-extracted contracts are diffed against the previously-indexed set and each incompatible provider change is reported with the exact consumer files that call it.
+Where blast radius answers *what could be affected*, the breaking-change guard answers a sharper question: **did a provider contract change incompatibly?** On every `repowise update --workspace`, freshly extracted contracts are diffed against the previously indexed set. Each finding carries the consumer files linked to the endpoint, but that link proves endpoint exposure only. It does not prove use of the changed field, a runtime failure, or deployment safety.
 
 Detected change kinds (a registry, adding a kind is one new rule, never an `if/elif`):
 
@@ -398,23 +398,31 @@ Detected change kinds (a registry, adding a kind is one new rule, never an `if/e
 | `removed_field` | breaking (response) / warning (request) | A request or response field disappeared |
 | `field_type_changed` | breaking | A field's type changed (e.g. `string → int64`) |
 | `field_number_changed` | breaking | A proto field's wire number changed |
-| `field_required` | breaking | A field became required, or a new required field was added |
+| `field_required` | breaking | A request field became required, or a new required request field was added; legacy proto/signature behavior is preserved |
+| `field_required_relaxed` | breaking | A required OpenAPI response field became optional |
+| `field_nullability_changed` | breaking | An OpenAPI request stopped accepting null, or a response started allowing null |
+| `field_enum_changed` | breaking | An OpenAPI request enum lost values, or a response enum gained values |
+| `schema_comparison_uncertain` | warning | Schema source/fidelity, completeness, or selected response changed, so field compatibility was not inferred |
 
-**Non-breaking changes never flag**, an added *optional* field, a widened set, or a brand-new endpoint produces no record. Field-level diffs need a contract *schema*; today only gRPC carries one (proto message fields, recovered by the existing proto parser), so field-level checks are gRPC-only. HTTP contracts have no schema, and OpenAPI specs are not read. Route-level removal is detected for every transport from the contract id alone, HTTP included.
+OpenAPI comparison covers the common supported subset of `3.0.x`, `3.1.x`, and `3.2.x`: JSON/YAML documents; path/query/header/cookie parameters using OpenAPI's default `style`, `explode`, and `allowReserved` behavior; one `application/json` request body; exactly one explicit JSON 2xx response; recursive objects and arrays; exact primitive types; requiredness; normalized nullability; finite homogeneous scalar enums; and bounded same-document JSON Pointer references. Request rules describe values the provider accepts; response rules describe values consumers may receive, so requiredness, nullability, enum values, and constrained/unconstrained enum transitions reverse between the two sides. Operation removal remains the transport-neutral contract rule.
 
-Impacted consumers are resolved from the matched contract links, the same provider↔consumer evidence the [system graph](#system-graph)'s edges are built from, so impact is endpoint-precise (the consumer file that calls the changed contract) and direct (the first reachability hop, which is exactly what a contract break endangers; transitive ripple stays the job of blast radius).
+Only complete sides with the same schema source and comparison-fidelity key are field-diffed. Unsupported/unresolved nodes, extraction-strategy changes, and response-selection changes become warning-level uncertainty rather than shortened schemas or false removals. Remote/cross-file references, composition, additional-properties semantics, arbitrary JSON Schema constraints, non-JSON or ambiguous media, multiple materially different success responses, and OpenAPI 2.0 are outside this boundary. No network dereferencing occurs.
+
+**Compatible changes stay quiet**: examples include an optional request addition, a request enum widening, a request becoming nullable, a response enum narrowing, a response becoming non-nullable, an additional response field in the supported open-object subset, and a brand-new endpoint. A rename remains a removal plus an addition; no rename inference is attempted.
+
+Endpoint-exposed consumers are resolved from the matched contract links, the same provider↔consumer evidence the [system graph](#system-graph)'s edges are built from. The evidence is direct and endpoint-level: it identifies a consumer file linked to the changed contract, but not the exact field it uses. Transitive structural reach stays the job of blast radius.
 
 Use it three ways:
 
 - **REST**, `GET /api/workspace/breaking-changes` returns the report from the most recent update (filterable by `repo` or `severity`). Each change carries its provider, detail, and impacted consumers with both code sides.
-- **MCP**, the `get_risk` PR-mode directive gains a `breaking_changes` block listing the provider contracts that changed incompatibly in the diff's repo and the consumers they endanger, across repos.
-- **System Map**, toggle **Breaking changes** above the map: changed providers are badged with their breaking count, the consumers they endanger are badged *at risk*, and the seams between them are highlighted (additive overlay, the map stays whole). A side panel lists each change with both the provider and consumer files.
+- **MCP**, the `get_risk` PR-mode directive's compatibility-named `breaking_changes` block lists provider incompatibilities and comparison warnings with side, source/fidelity, and endpoint-exposed consumers across repos.
+- **System Map**, toggle **Breaking changes** above the map: changed providers are badged by severity. Consumers and seams are marked *exposed* only for provider incompatibilities; warning-only uncertainty is never rendered as a consumer failure claim. A side panel lists each finding with both code sides.
 
 ---
 
 ## Cross-Repo Test Impact
 
-Where the breaking-change guard answers *did this change break a consumer*, test impact answers the question you ask before you push: **I changed this provider file, which tests in the other repos should I run?** It starts from the matched contract links, so the answer is scoped to the consumers that actually call the changed code, and then walks each consumer's own index to find the tests that exercise the call site.
+Where the breaking-change guard identifies provider incompatibility and endpoint exposure, test impact answers the question you ask before you push: **I changed this provider file, which tests in the other repos should I run?** It starts from the same matched contract links and then walks each consumer's own index to find tests that exercise the call site. A recommended test validates the exposed consumer path; it is not proof that the changed field is used or that a deployment will fail.
 
 ```bash
 repowise workspace impacted-tests backend:app/routers/users.py

--- a/packages/core/src/repowise/core/workspace/breaking_change.py
+++ b/packages/core/src/repowise/core/workspace/breaking_change.py
@@ -2,9 +2,9 @@
 
 When ``repowise update --workspace`` re-extracts contracts, this module diffs the
 freshly-extracted set against the *previously persisted* one and reports the
-provider changes that break consumers across repos: a removed endpoint, a removed
+provider incompatibilities across repos: a removed endpoint, a removed
 or retyped request/response field, a reused field number, a newly-required field.
-Each :class:`BreakingChange` resolves its impacted consumers from the matched
+Each :class:`BreakingChange` resolves its endpoint-exposed consumers from the matched
 contract links — the same provider→consumer evidence the system graph's edges are
 built from — so a break is reported with the exact consumer files that call it.
 
@@ -32,6 +32,7 @@ import logging
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
+from decimal import Decimal
 from pathlib import Path
 from typing import Any
 
@@ -74,10 +75,10 @@ def _node_id(repo: str, service: str | None) -> str:
 class ImpactedConsumer:
     """A consumer endangered by a provider's breaking change.
 
-    Resolved from the matched contract link, so ``file``/``symbol`` point at the
-    exact code that calls the changed contract. ``node_id`` is the system-graph
-    node (for map badging); ``match_type`` carries how confidently the link was
-    matched (an ``exact`` consumer is more certainly broken than a ``candidate``).
+    Resolved from the matched contract link, so ``file``/``symbol`` point at code
+    linked to the changed contract. This proves endpoint exposure, not exact field
+    use or runtime failure. ``node_id`` is the system-graph node (for map badging);
+    ``match_type`` carries the link confidence.
     """
 
     repo: str
@@ -122,7 +123,7 @@ class ImpactedConsumer:
 
 @dataclass
 class BreakingChange:
-    """One incompatible provider change and the consumers it endangers."""
+    """One provider incompatibility or comparison warning plus exposed consumers."""
 
     kind: str  # registry key — removed_endpoint | removed_field | ...
     severity: str  # SEVERITY_BREAKING | SEVERITY_WARNING
@@ -135,6 +136,9 @@ class BreakingChange:
     detail: str  # human-readable one-liner
     #: The provider handler's symbol id, when its contract bound to one.
     provider_symbol_id: str | None = None
+    side: str | None = None
+    comparison_source: str | None = None
+    comparison_key: str | None = None
     field_name: str | None = None
     old_value: str | None = None
     new_value: str | None = None
@@ -160,6 +164,12 @@ class BreakingChange:
         }
         if self.provider_symbol_id is not None:
             d["provider_symbol_id"] = self.provider_symbol_id
+        if self.side is not None:
+            d["side"] = self.side
+        if self.comparison_source is not None:
+            d["comparison_source"] = self.comparison_source
+        if self.comparison_key is not None:
+            d["comparison_key"] = self.comparison_key
         if self.field_name is not None:
             d["field_name"] = self.field_name
         if self.old_value is not None:
@@ -181,6 +191,9 @@ class BreakingChange:
             provider_symbol_id=data.get("provider_symbol_id"),
             provider_service=data.get("provider_service"),
             detail=data.get("detail", ""),
+            side=data.get("side"),
+            comparison_source=data.get("comparison_source"),
+            comparison_key=data.get("comparison_key"),
             field_name=data.get("field_name"),
             old_value=data.get("old_value"),
             new_value=data.get("new_value"),
@@ -275,6 +288,9 @@ class _RawChange:
     kind: str
     severity: str
     detail: str
+    side: str | None = None
+    comparison_source: str | None = None
+    comparison_key: str | None = None
     field_name: str | None = None
     old_value: str | None = None
     new_value: str | None = None
@@ -307,9 +323,41 @@ def field_rule(fn: FieldRule) -> FieldRule:
 class _FieldDiff:
     """One field's previous/current state on a request or response side."""
 
-    side: str  # "request" | "response"
+    context: _ComparisonContext
+    path: str
     prev: SchemaField | None
     curr: SchemaField | None
+
+
+@dataclass(frozen=True)
+class _ComparisonContext:
+    """Evidence fidelity shared by every rule for one schema side."""
+
+    side: str  # "request" | "response"
+    source: str
+    comparison_key: str | None
+
+
+def _raw_field_change(
+    diff: _FieldDiff,
+    *,
+    kind: str,
+    severity: str,
+    detail: str,
+    old_value: str | None = None,
+    new_value: str | None = None,
+) -> _RawChange:
+    return _RawChange(
+        kind=kind,
+        severity=severity,
+        detail=detail,
+        side=diff.context.side,
+        comparison_source=diff.context.source,
+        comparison_key=diff.context.comparison_key,
+        field_name=diff.path,
+        old_value=old_value,
+        new_value=new_value,
+    )
 
 
 # -- contract-level rules ---------------------------------------------------
@@ -345,12 +393,12 @@ def _removed_field(diff: _FieldDiff) -> _RawChange | None:
     field is a source-compat warning (a server simply stops reading it).
     """
     if diff.prev is not None and diff.curr is None:
-        severity = SEVERITY_BREAKING if diff.side == "response" else SEVERITY_WARNING
-        return _RawChange(
+        severity = SEVERITY_BREAKING if diff.context.side == "response" else SEVERITY_WARNING
+        return _raw_field_change(
+            diff,
             kind="removed_field",
             severity=severity,
-            detail=f"{diff.side} field '{diff.prev.name}' was removed",
-            field_name=diff.prev.name,
+            detail=f"{diff.context.side} field '{diff.path}' was removed",
             old_value=diff.prev.type,
         )
     return None
@@ -360,14 +408,14 @@ def _removed_field(diff: _FieldDiff) -> _RawChange | None:
 def _field_type_changed(diff: _FieldDiff) -> _RawChange | None:
     """A field whose type changed — wire-incompatible on either side."""
     if diff.prev is not None and diff.curr is not None and diff.prev.type != diff.curr.type:
-        return _RawChange(
+        return _raw_field_change(
+            diff,
             kind="field_type_changed",
             severity=SEVERITY_BREAKING,
             detail=(
-                f"{diff.side} field '{diff.curr.name}' type changed "
+                f"{diff.context.side} field '{diff.path}' type changed "
                 f"{diff.prev.type} → {diff.curr.type}"
             ),
-            field_name=diff.curr.name,
             old_value=diff.prev.type,
             new_value=diff.curr.type,
         )
@@ -384,14 +432,14 @@ def _field_number_changed(diff: _FieldDiff) -> _RawChange | None:
         and diff.curr.number is not None
         and diff.prev.number != diff.curr.number
     ):
-        return _RawChange(
+        return _raw_field_change(
+            diff,
             kind="field_number_changed",
             severity=SEVERITY_BREAKING,
             detail=(
-                f"{diff.side} field '{diff.curr.name}' number changed "
+                f"{diff.context.side} field '{diff.path}' number changed "
                 f"{diff.prev.number} → {diff.curr.number}"
             ),
-            field_name=diff.curr.name,
             old_value=str(diff.prev.number),
             new_value=str(diff.curr.number),
         )
@@ -410,16 +458,140 @@ def _field_required_tightened(diff: _FieldDiff) -> _RawChange | None:
         diff.curr is not None
         and diff.curr.required
         and (diff.prev is None or not diff.prev.required)
+        and (diff.context.source != "openapi" or diff.context.side == "request")
     ):
         action = "added as required" if diff.prev is None else "became required"
-        return _RawChange(
+        return _raw_field_change(
+            diff,
             kind="field_required",
             severity=SEVERITY_BREAKING,
-            detail=f"{diff.side} field '{diff.curr.name}' {action}",
-            field_name=diff.curr.name,
+            detail=f"{diff.context.side} field '{diff.path}' {action}",
             new_value=diff.curr.type,
         )
     return None
+
+
+@field_rule
+def _openapi_response_required_relaxed(diff: _FieldDiff) -> _RawChange | None:
+    """A response value consumers could assume is no longer guaranteed."""
+    if (
+        diff.context.source == "openapi"
+        and diff.context.side == "response"
+        and diff.prev is not None
+        and diff.curr is not None
+        and diff.prev.required
+        and not diff.curr.required
+    ):
+        return _raw_field_change(
+            diff,
+            kind="field_required_relaxed",
+            severity=SEVERITY_BREAKING,
+            detail=f"response field '{diff.path}' became optional",
+            old_value="required",
+            new_value="optional",
+        )
+    return None
+
+
+@field_rule
+def _openapi_nullability_changed(diff: _FieldDiff) -> _RawChange | None:
+    """Apply opposite request/response variance to explicit nullability."""
+    if (
+        diff.context.source != "openapi"
+        or diff.prev is None
+        or diff.curr is None
+        or diff.prev.nullable is None
+        or diff.curr.nullable is None
+        or diff.prev.nullable == diff.curr.nullable
+    ):
+        return None
+    breaking = (
+        diff.context.side == "request" and diff.prev.nullable and not diff.curr.nullable
+    ) or (diff.context.side == "response" and not diff.prev.nullable and diff.curr.nullable)
+    if not breaking:
+        return None
+    became = "nullable" if diff.curr.nullable else "non-nullable"
+    return _raw_field_change(
+        diff,
+        kind="field_nullability_changed",
+        severity=SEVERITY_BREAKING,
+        detail=f"{diff.context.side} field '{diff.path}' became {became}",
+        old_value="nullable" if diff.prev.nullable else "non-nullable",
+        new_value=became,
+    )
+
+
+def _enum_tokens(field: SchemaField) -> dict[tuple[str, Any], Any]:
+    """Key enums by OpenAPI scalar semantics without conflating booleans and numbers."""
+    tokens: dict[tuple[str, Any], Any] = {}
+    for value in field.enum_values or []:
+        if value is None:
+            token = ("null", "")
+        elif field.type == "number" and isinstance(value, (int, float)):
+            token = ("number", Decimal(str(value)))
+        else:
+            token = (type(value).__name__, json.dumps(value, sort_keys=True))
+        tokens[token] = value
+    return tokens
+
+
+@field_rule
+def _openapi_enum_changed(diff: _FieldDiff) -> _RawChange | None:
+    """Requests may widen; responses may narrow."""
+    if diff.context.source != "openapi" or diff.prev is None or diff.curr is None:
+        return None
+    previous_values = diff.prev.enum_values
+    current_values = diff.curr.enum_values
+    constraint_break = (
+        diff.context.side == "request" and previous_values is None and current_values is not None
+    ) or (
+        diff.context.side == "response" and previous_values is not None and current_values is None
+    )
+    if constraint_break:
+        became = "constrained" if current_values is not None else "unconstrained"
+        return _raw_field_change(
+            diff,
+            kind="field_enum_changed",
+            severity=SEVERITY_BREAKING,
+            detail=f"{diff.context.side} field '{diff.path}' became {became}",
+            old_value=(
+                "unconstrained"
+                if previous_values is None
+                else json.dumps(previous_values, ensure_ascii=False)
+            ),
+            new_value=(
+                "unconstrained"
+                if current_values is None
+                else json.dumps(current_values, ensure_ascii=False)
+            ),
+        )
+    if previous_values is None or current_values is None:
+        return None
+    previous = _enum_tokens(diff.prev)
+    current = _enum_tokens(diff.curr)
+    incompatible = (
+        previous.keys() - current.keys()
+        if diff.context.side == "request"
+        else current.keys() - previous.keys()
+    )
+    if not incompatible:
+        return None
+    values = [
+        (previous if diff.context.side == "request" else current)[key]
+        for key in sorted(incompatible)
+    ]
+    direction = "removed" if diff.context.side == "request" else "added"
+    return _raw_field_change(
+        diff,
+        kind="field_enum_changed",
+        severity=SEVERITY_BREAKING,
+        detail=(
+            f"{diff.context.side} field '{diff.path}' enum value(s) {direction}: "
+            f"{json.dumps(values, ensure_ascii=False)}"
+        ),
+        old_value=json.dumps(diff.prev.enum_values, ensure_ascii=False),
+        new_value=json.dumps(diff.curr.enum_values, ensure_ascii=False),
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -427,27 +599,196 @@ def _field_required_tightened(diff: _FieldDiff) -> _RawChange | None:
 # ---------------------------------------------------------------------------
 
 
-def _diff_field_side(
-    side: str, prev: list[SchemaField], curr: list[SchemaField]
+def _field_identity(field: SchemaField) -> tuple[str, str]:
+    return (field.location or "", field.name)
+
+
+def _field_path(parent: str, field: SchemaField) -> str:
+    if field.name == "$body":
+        return parent or "body"
+    if field.name == "$response":
+        return parent or "response"
+    if field.name == "$items":
+        return f"{parent}[]" if parent else "[]"
+    name = f"{field.location}:{field.name}" if field.location not in {None, "body"} else field.name
+    return f"{parent}.{name}" if parent else name
+
+
+def _diff_field_pair(
+    context: _ComparisonContext,
+    path: str,
+    prev: SchemaField | None,
+    curr: SchemaField | None,
 ) -> list[_RawChange]:
-    """Run every field rule over the union of field names on one side."""
-    prev_by_name = {f.name: f for f in prev}
-    curr_by_name = {f.name: f for f in curr}
+    diff = _FieldDiff(context=context, path=path, prev=prev, curr=curr)
     raws: list[_RawChange] = []
-    for name in list(prev_by_name) + [n for n in curr_by_name if n not in prev_by_name]:
-        diff = _FieldDiff(side=side, prev=prev_by_name.get(name), curr=curr_by_name.get(name))
-        for rule in _FIELD_RULES:
-            raw = rule(diff)
-            if raw is not None:
-                raws.append(raw)
+    for rule in _FIELD_RULES:
+        raw = rule(diff)
+        if raw is not None:
+            raws.append(raw)
+    if prev is None or curr is None or prev.type != curr.type:
+        return raws
+    if prev.type == "object":
+        raws.extend(_diff_field_side(context, prev.children, curr.children, parent=path))
+    elif prev.type == "array" and prev.items is not None and curr.items is not None:
+        item_path = f"{path}[]" if path else "[]"
+        raws.extend(_diff_field_pair(context, item_path, prev.items, curr.items))
+    return raws
+
+
+def _diff_field_side(
+    context: _ComparisonContext,
+    prev: list[SchemaField],
+    curr: list[SchemaField],
+    *,
+    parent: str = "",
+) -> list[_RawChange]:
+    """Run every field rule recursively over one complete schema side."""
+    prev_by_name = {_field_identity(field): field for field in prev}
+    curr_by_name = {_field_identity(field): field for field in curr}
+    keys = list(prev_by_name) + [key for key in curr_by_name if key not in prev_by_name]
+    raws: list[_RawChange] = []
+    for key in keys:
+        representative = prev_by_name.get(key) or curr_by_name[key]
+        path = _field_path(parent, representative)
+        raws.extend(_diff_field_pair(context, path, prev_by_name.get(key), curr_by_name.get(key)))
     return raws
 
 
 def _diff_schemas(prev: ContractSchema, curr: ContractSchema) -> list[_RawChange]:
-    """Diff request and response field sets of two schemas."""
-    return _diff_field_side("request", prev.request_fields, curr.request_fields) + _diff_field_side(
-        "response", prev.response_fields, curr.response_fields
+    """Diff complete request and response field sets of two comparable schemas."""
+    return _diff_field_side(
+        _ComparisonContext("request", curr.source, curr.comparison_key),
+        prev.request_fields,
+        curr.request_fields,
+    ) + _diff_field_side(
+        _ComparisonContext("response", curr.source, curr.comparison_key),
+        prev.response_fields,
+        curr.response_fields,
     )
+
+
+def _side_state(schema: ContractSchema, side: str) -> str:
+    state = getattr(schema, f"{side}_state")
+    return state or "complete"
+
+
+def _side_snapshot(schema: ContractSchema, side: str) -> tuple[Any, ...]:
+    fields = getattr(schema, f"{side}_fields")
+    issues = tuple(
+        (issue.code, issue.source_pointer, issue.detail)
+        for issue in schema.issues
+        if issue.side in {side, "both"}
+    )
+    selection = (
+        schema.request_media_type
+        if side == "request"
+        else (schema.response_media_type, schema.response_status_code)
+    )
+    return (_side_state(schema, side), [field.to_dict() for field in fields], selection, issues)
+
+
+def _uncertain(
+    *,
+    side: str | None,
+    detail: str,
+    source: str | None,
+    comparison_key: str | None,
+    old_value: str | None = None,
+    new_value: str | None = None,
+) -> _RawChange:
+    return _RawChange(
+        kind="schema_comparison_uncertain",
+        severity=SEVERITY_WARNING,
+        detail=detail,
+        side=side,
+        comparison_source=source,
+        comparison_key=comparison_key,
+        old_value=old_value,
+        new_value=new_value,
+    )
+
+
+def _compare_schemas(prev: ContractSchema | None, curr: ContractSchema | None) -> list[_RawChange]:
+    """Gate by fidelity and completeness before dispatching directional rules."""
+    if prev is None and curr is None:
+        return []
+    if prev is None or curr is None:
+        present = curr or prev
+        assert present is not None
+        return [
+            _uncertain(
+                side=None,
+                detail="schema extraction coverage changed; field compatibility was not inferred",
+                source=present.source,
+                comparison_key=present.comparison_key,
+                old_value=prev.source if prev else "absent",
+                new_value=curr.source if curr else "absent",
+            )
+        ]
+    if (
+        not prev.comparison_ready
+        or not curr.comparison_ready
+        or prev.source != curr.source
+        or prev.comparison_key != curr.comparison_key
+    ):
+        if prev.to_dict() == curr.to_dict():
+            return []
+        return [
+            _uncertain(
+                side=None,
+                detail="schema source or comparison fidelity changed; field compatibility was not inferred",
+                source=curr.source,
+                comparison_key=curr.comparison_key,
+                old_value=f"{prev.source}:{prev.comparison_key or 'legacy'}",
+                new_value=f"{curr.source}:{curr.comparison_key or 'legacy'}",
+            )
+        ]
+
+    raws: list[_RawChange] = []
+    for side in ("request", "response"):
+        prev_state = _side_state(prev, side)
+        curr_state = _side_state(curr, side)
+        if prev_state != "complete" or curr_state != "complete":
+            if _side_snapshot(prev, side) != _side_snapshot(curr, side):
+                raws.append(
+                    _uncertain(
+                        side=side,
+                        detail=(
+                            f"{side} schema is not complete on both revisions "
+                            f"({prev_state} → {curr_state}); field compatibility was not inferred"
+                        ),
+                        source=curr.source,
+                        comparison_key=curr.comparison_key,
+                        old_value=prev_state,
+                        new_value=curr_state,
+                    )
+                )
+            continue
+        if side == "response" and (
+            prev.response_media_type != curr.response_media_type
+            or prev.response_status_code != curr.response_status_code
+        ):
+            raws.append(
+                _uncertain(
+                    side=side,
+                    detail="selected response status or media type changed; field compatibility was not inferred",
+                    source=curr.source,
+                    comparison_key=curr.comparison_key,
+                    old_value=f"{prev.response_status_code}:{prev.response_media_type}",
+                    new_value=f"{curr.response_status_code}:{curr.response_media_type}",
+                )
+            )
+            continue
+        context = _ComparisonContext(side, curr.source, curr.comparison_key)
+        raws.extend(
+            _diff_field_side(
+                context,
+                getattr(prev, f"{side}_fields"),
+                getattr(curr, f"{side}_fields"),
+            )
+        )
+    return raws
 
 
 # ---------------------------------------------------------------------------
@@ -545,18 +886,7 @@ def detect_breaking_changes(
         if prev_c is not None and curr_c is not None:
             prev_schema = prev_c.schema
             curr_schema = curr_c.schema
-            # Same source only. A parameter list and a .proto message describe
-            # the same endpoint at different fidelities, so diffing one against
-            # the other reports the change of parser as a change of contract.
-            if (
-                prev_schema is not None
-                and curr_schema is not None
-                and prev_schema.comparison_ready
-                and curr_schema.comparison_ready
-                and prev_schema.source == curr_schema.source
-                and prev_schema.comparison_key == curr_schema.comparison_key
-            ):
-                raws.extend(_diff_schemas(prev_schema, curr_schema))
+            raws.extend(_compare_schemas(prev_schema, curr_schema))
 
         if not raws:
             continue
@@ -577,6 +907,9 @@ def detect_breaking_changes(
                     provider_symbol_id=rep.symbol_id,
                     provider_service=rep.service,
                     detail=raw.detail,
+                    side=raw.side,
+                    comparison_source=raw.comparison_source,
+                    comparison_key=raw.comparison_key,
                     field_name=raw.field_name,
                     old_value=raw.old_value,
                     new_value=raw.new_value,
@@ -604,9 +937,7 @@ def save_breaking_change_report(report: BreakingChangeReport, workspace_root: Pa
     out_path = data_dir / BREAKING_CHANGES_FILENAME
     # Atomic: the MCP enricher reads these artifacts from a separate
     # process and must never observe a half-written file.
-    atomic_write_text(
-        out_path, json.dumps(report.to_dict(), indent=2, ensure_ascii=False)
-    )
+    atomic_write_text(out_path, json.dumps(report.to_dict(), indent=2, ensure_ascii=False))
     return out_path
 
 

--- a/packages/core/src/repowise/core/workspace/contract_schema.py
+++ b/packages/core/src/repowise/core/workspace/contract_schema.py
@@ -99,9 +99,8 @@ class SchemaIssue:
 class ContractSchema:
     """The structured request/response shape of a contract, when recoverable.
 
-    The source names the producing parser. comparison_ready is false for newly
-    extracted OpenAPI schemas until the direction-aware Phase 3 rules are
-    enabled, preventing the legacy flat-field rules from overstating changes.
+    The source names the producing parser. ``comparison_ready`` lets an extractor
+    opt into the registry only when rules understand its fidelity and direction.
     """
 
     source: str

--- a/packages/core/src/repowise/core/workspace/extractors/openapi.py
+++ b/packages/core/src/repowise/core/workspace/extractors/openapi.py
@@ -8,6 +8,7 @@ whole request or response side when a construct cannot be represented faithfully
 from __future__ import annotations
 
 import json
+import math
 import re
 from collections import defaultdict
 from collections.abc import Callable, Mapping, Sequence
@@ -110,10 +111,7 @@ def _is_candidate(rel_path: str) -> bool:
         "swagger.json",
         "swagger.yaml",
         "swagger.yml",
-    } or any(
-        name.endswith(suffix)
-        for suffix in (".openapi.json", ".openapi.yaml", ".openapi.yml")
-    )
+    } or any(name.endswith(suffix) for suffix in (".openapi.json", ".openapi.yaml", ".openapi.yml"))
 
 
 def _load_document(content: str, suffix: str, rel_path: str) -> Mapping[str, Any]:
@@ -220,7 +218,11 @@ def _value_matches_type(value: Any, type_name: str) -> bool:
     if type_name == "integer":
         return isinstance(value, int) and not isinstance(value, bool)
     if type_name == "number":
-        return isinstance(value, (int, float)) and not isinstance(value, bool)
+        return (
+            isinstance(value, (int, float))
+            and not isinstance(value, bool)
+            and (not isinstance(value, float) or math.isfinite(value))
+        )
     return False
 
 
@@ -237,6 +239,8 @@ def _enum_values(
     for value in raw:
         if value is None and nullable:
             continue
+        if type_name == "number" and isinstance(value, float) and not math.isfinite(value):
+            raise _Refusal("openapi_enum_number_non_finite", "unresolved", pointer)
         if not _value_matches_type(value, type_name):
             raise _Refusal("openapi_enum_mixed_types", "unsupported", pointer)
     return list(raw)
@@ -364,6 +368,41 @@ def _parameter_entries(
     return list(merged.values())
 
 
+def _validate_parameter_serialization(
+    parameter: Mapping[str, Any], location: str, pointer: str
+) -> None:
+    """Accept only OpenAPI's default parameter serialization, which we model."""
+    default_style = "form" if location in {"query", "cookie"} else "simple"
+    style = parameter.get("style", default_style)
+    if not isinstance(style, str):
+        raise _Refusal("openapi_parameter_style_invalid", "unresolved", pointer)
+    if style != default_style:
+        raise _Refusal("openapi_parameter_serialization_unsupported", "unsupported", pointer, style)
+
+    default_explode = style == "form"
+    explode = parameter.get("explode", default_explode)
+    if not isinstance(explode, bool):
+        raise _Refusal("openapi_parameter_explode_invalid", "unresolved", pointer)
+    if explode != default_explode:
+        raise _Refusal(
+            "openapi_parameter_serialization_unsupported",
+            "unsupported",
+            pointer,
+            f"explode={str(explode).lower()}",
+        )
+
+    allow_reserved = parameter.get("allowReserved", False)
+    if not isinstance(allow_reserved, bool):
+        raise _Refusal("openapi_parameter_allow_reserved_invalid", "unresolved", pointer)
+    if allow_reserved:
+        raise _Refusal(
+            "openapi_parameter_serialization_unsupported",
+            "unsupported",
+            pointer,
+            "allowReserved=true",
+        )
+
+
 def _build_request(
     document: Mapping[str, Any],
     path_item: Mapping[str, Any],
@@ -387,6 +426,7 @@ def _build_request(
             )
         if "schema" not in parameter:
             raise _Refusal("openapi_parameter_schema_missing", "unresolved", parameter_pointer)
+        _validate_parameter_serialization(parameter, location, parameter_pointer)
         required = bool(parameter.get("required", False))
         if location == "path" and not required:
             raise _Refusal("openapi_path_parameter_optional", "unresolved", parameter_pointer)
@@ -546,7 +586,7 @@ def _operation_contract(
             response_fields=response_fields,
             source_version=version,
             comparison_key=OPENAPI_COMPARISON_KEY,
-            comparison_ready=False,
+            comparison_ready=True,
             request_state=request_state,
             response_state=response_state,
             request_media_type=request_media_type,
@@ -667,7 +707,7 @@ def merge_openapi_providers(contracts: list[Any], stats: dict[str, int]) -> list
                     source=OPENAPI_SCHEMA_SOURCE,
                     source_version=selected.schema.source_version,
                     comparison_key=OPENAPI_COMPARISON_KEY,
-                    comparison_ready=False,
+                    comparison_ready=True,
                     request_state="unresolved",
                     response_state="unresolved",
                     issues=[
@@ -699,9 +739,7 @@ def merge_openapi_providers(contracts: list[Any], stats: dict[str, int]) -> list
             continue
         target.schema = selected.schema
         target.meta["schema_source_file"] = selected.file_path
-        target.meta["schema_operation_pointer"] = selected.meta.get(
-            "schema_operation_pointer", ""
-        )
+        target.meta["schema_operation_pointer"] = selected.meta.get("schema_operation_pointer", "")
         target.meta["openapi_version"] = selected.meta.get("openapi_version", "")
         _increment(stats, "openapi_schemas_merged")
     return source_rows + retained_specs

--- a/packages/server/src/repowise/server/mcp_server/tool_change_risk.py
+++ b/packages/server/src/repowise/server/mcp_server/tool_change_risk.py
@@ -115,6 +115,7 @@ _CHANGE_SHAPE_FIELDS = (
     "is_fix",
 )
 
+
 @mcp.tool(
     surface_order=60,
     artifact_type="change_risk",
@@ -354,13 +355,17 @@ async def _attach_health_references(ctx: Any, delta: Any) -> None:
         async with get_session(session_factory) as session:
             repository = await _get_repo(session)
             rows = (
-                await session.execute(
-                    select(HealthFinding).where(
-                        HealthFinding.repository_id == repository.id,
-                        HealthFinding.file_path.in_(paths),
+                (
+                    await session.execute(
+                        select(HealthFinding).where(
+                            HealthFinding.repository_id == repository.id,
+                            HealthFinding.file_path.in_(paths),
+                        )
                     )
                 )
-            ).scalars().all()
+                .scalars()
+                .all()
+            )
     except SQLAlchemyError:
         return
     if not rows:
@@ -426,9 +431,7 @@ def _change_shape(
 
 def _drill_down(payload: dict, delta: Any, finding_id: str, revspec: str | None) -> dict:
     """Expand one ephemeral change finding, or say why it is not there."""
-    match = next(
-        (f for f in delta.findings if f.change_finding_id == finding_id), None
-    )
+    match = next((f for f in delta.findings if f.change_finding_id == finding_id), None)
     if match is None:
         return {
             "error": f"No change finding {finding_id!r} in {payload.get('ref', 'this change')}.",
@@ -560,6 +563,7 @@ def _cross_repo_block(
 
         breaking: list[dict[str, Any]] = []
         breaking_total = 0
+        breaking_incompatible_total = 0
         has_breaking_report = bool(getattr(enricher, "has_breaking_changes", False))
         if has_breaking_report:
             for change in enricher.get_breaking_changes_for_repo(alias):
@@ -569,6 +573,8 @@ def _cross_repo_block(
                 if not cross:
                     continue
                 breaking_total += 1
+                if change.get("severity") == "breaking":
+                    breaking_incompatible_total += 1
                 if len(breaking) >= _CROSS_REPO_BREAKING_LIMIT:
                     continue
                 breaking.append(
@@ -579,6 +585,20 @@ def _cross_repo_block(
                         "severity": change.get("severity"),
                         "detail": change.get("detail"),
                         "provider_file": change.get("provider_file"),
+                        **({"side": side} if (side := change.get("side")) else {}),
+                        **(
+                            {"comparison_source": source}
+                            if (source := change.get("comparison_source"))
+                            else {}
+                        ),
+                        **(
+                            {"comparison_key": key} if (key := change.get("comparison_key")) else {}
+                        ),
+                        **(
+                            {"field_name": field_name}
+                            if (field_name := change.get("field_name"))
+                            else {}
+                        ),
                         "impacted_repos": sorted({c.get("repo") or "" for c in cross}),
                         **(
                             {"provider_symbol_id": psid}
@@ -602,7 +622,11 @@ def _cross_repo_block(
             f"files this change edits"
         )
         if breaking_total:
-            summary += f"; {breaking_total} of the changed contracts broke them."
+            warnings = breaking_total - breaking_incompatible_total
+            summary += (
+                f"; {breaking_incompatible_total} provider incompatibility finding(s) and "
+                f"{warnings} comparison warning(s) have endpoint-exposed consumers."
+            )
         elif has_breaking_report:
             summary += "; the last workspace update found no break in them."
         else:
@@ -858,15 +882,11 @@ async def _independent_changes_block(
         return None
     # Returns [] without a git call for anything that is not a range, so the
     # range test lives in one place rather than here as well.
-    sets = await asyncio.to_thread(
-        commit_file_sets, str(ctx.path), _normalize_revspec(revspec)
-    )
+    sets = await asyncio.to_thread(commit_file_sets, str(ctx.path), _normalize_revspec(revspec))
     try:
         async with get_session(session_factory) as session:
             repo_id = (await _get_repo(session)).id
-            result = await independent_changes(
-                session, repo_id, list(changed), commit_sets=sets
-            )
+            result = await independent_changes(session, repo_id, list(changed), commit_sets=sets)
     except (LookupError, SQLAlchemyError):
         return None
     if result is None:
@@ -879,8 +899,7 @@ async def _independent_changes_block(
         _UNGROUPED_FILES_LIMIT,
         collector,
         label=(
-            "change_shape.independent_changes.ungrouped_files "
-            f"beyond cap={_UNGROUPED_FILES_LIMIT}"
+            f"change_shape.independent_changes.ungrouped_files beyond cap={_UNGROUPED_FILES_LIMIT}"
         ),
     )
     return block

--- a/packages/server/src/repowise/server/mcp_server/tool_risk/directives.py
+++ b/packages/server/src/repowise/server/mcp_server/tool_risk/directives.py
@@ -62,11 +62,11 @@ _TESTS_TO_RUN_LIMIT = 10
 def _breaking_change_directive(
     repo_alias: str, collector: OmissionCollector | None = None
 ) -> tuple[list[dict[str, Any]], int]:
-    """Breaking-change half of the PR directive: incompatible provider changes.
+    """Contract-comparison half of the PR directive: incompatibilities and warnings.
 
     Reads the persisted breaking-change report (current HEAD vs the previously
     indexed contracts), filtered to providers in the changed repo, and reports
-    each change with the consumers it endangers across repos. Carries every
+    each finding with its endpoint-exposed consumers across repos. Carries every
     contract type the report holds, ``code`` (a published package symbol)
     included. Returns ``(changes, dropped)`` where ``dropped`` counts the
     cross-repo changes the cap left out — a shared-package bump can produce
@@ -84,39 +84,47 @@ def _breaking_change_directive(
             return out, 0
         for change in enricher.get_breaking_changes_for_repo(repo_alias):
             consumers = change.get("impacted_consumers", [])
-            # Only surface changes that actually endanger a cross-repo consumer —
-            # an internal-only removed endpoint isn't a cross-repo break.
+            # This directive is cross-repo scoped, so retain only findings with
+            # endpoint-exposed consumers outside the provider repository.
             cross = [c for c in consumers if c.get("repo") != repo_alias]
             if not cross:
                 continue
             entry = {
-                    "contract_id": change.get("contract_id"),
-                    "type": change.get("contract_type"),
-                    "kind": change.get("kind"),
-                    "severity": change.get("severity"),
-                    "detail": change.get("detail"),
-                    "provider_file": change.get("provider_file"),
-                    # The changed symbol itself, when the contract bound to one.
-                    # It is what the reader passes to get_symbol to see the
-                    # signature that broke.
-                    **(
-                        {"provider_symbol_id": psid}
-                        if (psid := change.get("provider_symbol_id"))
-                        else {}
-                    ),
-                    "impacted_consumers": [
-                        # symbol_id only when the contract bound to one: it is
-                        # what the reader can pass to get_symbol, and a null
-                        # would just cost budget.
-                        {
-                            "repo": c.get("repo"),
-                            "service": c.get("service"),
-                            "file": c.get("file"),
-                            **({"symbol_id": sid} if (sid := c.get("symbol_id")) else {}),
-                        }
-                        for c in cross
-                    ],
-                }
+                "contract_id": change.get("contract_id"),
+                "type": change.get("contract_type"),
+                "kind": change.get("kind"),
+                "severity": change.get("severity"),
+                "detail": change.get("detail"),
+                "provider_file": change.get("provider_file"),
+                **({"side": side} if (side := change.get("side")) else {}),
+                **(
+                    {"comparison_source": source}
+                    if (source := change.get("comparison_source"))
+                    else {}
+                ),
+                **({"comparison_key": key} if (key := change.get("comparison_key")) else {}),
+                **({"field_name": field_name} if (field_name := change.get("field_name")) else {}),
+                # The changed symbol itself, when the contract bound to one.
+                # It is what the reader passes to get_symbol to see the
+                # signature that broke.
+                **(
+                    {"provider_symbol_id": psid}
+                    if (psid := change.get("provider_symbol_id"))
+                    else {}
+                ),
+                "impacted_consumers": [
+                    # symbol_id only when the contract bound to one: it is
+                    # what the reader can pass to get_symbol, and a null
+                    # would just cost budget.
+                    {
+                        "repo": c.get("repo"),
+                        "service": c.get("service"),
+                        "file": c.get("file"),
+                        **({"symbol_id": sid} if (sid := c.get("symbol_id")) else {}),
+                    }
+                    for c in cross
+                ],
+            }
             cap_collection(
                 entry,
                 "impacted_consumers",
@@ -423,9 +431,7 @@ async def _governance_directive(ctx: Any, changed_files: list[str]) -> list[dict
     return governance_risk
 
 
-def _governance_reason(
-    dr: Any, currency: str, conflict_decision_ids: set[str]
-) -> str | None:
+def _governance_reason(dr: Any, currency: str, conflict_decision_ids: set[str]) -> str | None:
     """Map an accepted decision to a directive reason, or None when clean.
 
     *currency* is the effective currency from the acceptance, so the caller has
@@ -587,16 +593,18 @@ def _build_pr_directive(
             f"cross-repo co-changer(s) missing."
         )
 
-    # Breaking-change guard — incompatible provider changes (removed route /
-    # field, type change, ...) in this repo and the consumers they endanger.
-    # Schema-level truth, distinct from the topology-level will_break_consumers.
+    # Contract guard — provider incompatibilities and explicit comparison
+    # uncertainty in this repo, scoped to endpoint-exposed consumers. Distinct
+    # from topology-level structural reach.
     breaking_changes, breaking_changes_dropped = _breaking_change_directive(alias, collector)
     bc_suffix = ""
     if breaking_changes:
         bc_consumers = sum(len(b["impacted_consumers"]) for b in breaking_changes)
+        bc_incompatible = sum(b.get("severity") == "breaking" for b in breaking_changes)
+        bc_warnings = len(breaking_changes) - bc_incompatible
         bc_suffix = (
-            f" Breaking changes: {len(breaking_changes)} provider contract(s) changed "
-            f"incompatibly, endangering {bc_consumers} consumer(s)."
+            f" Contract findings: {bc_incompatible} provider incompatibility finding(s), "
+            f"{bc_warnings} warning(s), and {bc_consumers} endpoint-exposed consumer link(s)."
         )
         if breaking_changes_dropped:
             bc_suffix += f" {breaking_changes_dropped} more not listed."

--- a/packages/server/src/repowise/server/routers/workspace.py
+++ b/packages/server/src/repowise/server/routers/workspace.py
@@ -151,7 +151,7 @@ def _query_repo_stats(db_path: Path) -> dict:
         if row:
             result["repo_id"] = row[0]
 
-        # file count (graph_nodes) 
+        # file count (graph_nodes)
         row = c.execute("SELECT COUNT(*) FROM graph_nodes WHERE node_type = 'file'").fetchone()
         result["file_count"] = row[0] if row else 0
 
@@ -298,7 +298,9 @@ def _contract_link(lk: dict) -> WorkspaceContractLinkEntry:
 async def get_contracts(
     ws_config=Depends(get_workspace_config),
     enricher=Depends(get_cross_repo_enricher),
-    contract_type: str | None = Query(None, description="Filter: http, grpc, socket, topic, or data"),
+    contract_type: str | None = Query(
+        None, description="Filter: http, grpc, socket, topic, or data"
+    ),
     repo: str | None = Query(None, description="Filter by repo alias"),
     role: str | None = Query(None, description="Filter: provider or consumer"),
     limit: int = Query(200, ge=1, le=1000),
@@ -404,9 +406,7 @@ async def get_contract_detail(
         (
             c
             for c in getattr(enricher, "_contracts", [])
-            if c.get("repo") == repo
-            and c.get("file_path") == file
-            and c.get("contract_id") == id
+            if c.get("repo") == repo and c.get("file_path") == file and c.get("contract_id") == id
         ),
         None,
     )
@@ -743,12 +743,13 @@ async def get_breaking_changes(
     repo: str | None = Query(None, description="Filter to changes whose provider is in this repo."),
     severity: str | None = Query(None, description="Filter: breaking or warning."),
 ):
-    """Provider contract changes that break consumers across repos.
+    """Provider contract findings and directly linked consumer exposure across repos.
 
     Computed during the most recent ``repowise update --workspace`` by diffing the
     freshly-extracted contracts against the previously-indexed set, then resolving
-    each change's direct consumers from the matched links. Returns an empty report
-    (not 404) when no breaking changes were detected or no report exists yet.
+    each finding's direct consumers from the matched links. Returns an empty report
+    (not 404) when no findings were detected or no report exists yet; ``generated_at``
+    distinguishes those states.
     """
     _require_workspace(ws_config)
 

--- a/packages/server/src/repowise/server/schemas/workspace.py
+++ b/packages/server/src/repowise/server/schemas/workspace.py
@@ -336,6 +336,9 @@ class WorkspaceBreakingChange(BaseModel):
     provider_service: str | None = None
     provider_node_id: str = ""
     detail: str
+    side: str | None = None
+    comparison_source: str | None = None
+    comparison_key: str | None = None
     field_name: str | None = None
     old_value: str | None = None
     new_value: str | None = None

--- a/packages/types/src/generated/http.ts
+++ b/packages/types/src/generated/http.ts
@@ -2710,6 +2710,9 @@ export interface WorkspaceBreakingChange {
   provider_service?: string | null;
   provider_node_id?: string;
   detail: string;
+  side?: string | null;
+  comparison_source?: string | null;
+  comparison_key?: string | null;
   field_name?: string | null;
   old_value?: string | null;
   new_value?: string | null;

--- a/packages/types/src/workspace.ts
+++ b/packages/types/src/workspace.ts
@@ -261,6 +261,19 @@ export interface SchemaField {
   required?: boolean;
   number?: number | null;
   repeated?: boolean;
+  nullable?: boolean | null;
+  enum_values?: Array<string | number | boolean> | null;
+  location?: "path" | "query" | "header" | "cookie" | "body" | null;
+  source_pointer?: string | null;
+  children?: SchemaField[];
+  items?: SchemaField | null;
+}
+
+export interface ContractSchemaIssue {
+  code: string;
+  side: "request" | "response" | "both" | string;
+  source_pointer: string;
+  detail?: string;
 }
 
 export interface ContractSchema {
@@ -268,6 +281,15 @@ export interface ContractSchema {
   source: string;
   request_fields: SchemaField[];
   response_fields: SchemaField[];
+  source_version?: string | null;
+  comparison_key?: string | null;
+  comparison_ready?: boolean;
+  request_state?: "complete" | "partial" | "unsupported" | "unresolved" | null;
+  response_state?: "complete" | "partial" | "unsupported" | "unresolved" | null;
+  request_media_type?: string | null;
+  response_media_type?: string | null;
+  response_status_code?: string | null;
+  issues?: ContractSchemaIssue[];
 }
 
 // ---------------------------------------------------------------------------
@@ -279,7 +301,7 @@ export interface ContractSchema {
 /** How a breaking change ranks. `breaking` = wire-incompatible; `warning` = source risk. */
 export type BreakingChangeSeverity = "breaking" | "warning";
 
-/** A consumer endangered by a provider's breaking change (from a matched link). */
+/** A consumer exposed to a provider finding through a matched contract link. */
 export interface BreakingChangeConsumer {
   repo: string;
   service: string | null;
@@ -310,6 +332,11 @@ export interface BreakingChange {
   provider_node_id: string;
   /** Human-readable one-liner. */
   detail: string;
+  /** Request/response side when the finding is side-specific. */
+  side?: "request" | "response" | null;
+  /** Parser family and fidelity key used for the comparison. */
+  comparison_source?: string | null;
+  comparison_key?: string | null;
   field_name?: string | null;
   old_value?: string | null;
   new_value?: string | null;
@@ -327,9 +354,9 @@ export interface BreakingChangeReport {
   total: number;
   breaking_count: number;
   warning_count: number;
-  /** Distinct repos with an endangered consumer. */
+  /** Distinct repos with an endpoint-exposed consumer. */
   impacted_repos: string[];
-  /** Distinct system-graph node ids with an endangered consumer. */
+  /** Distinct system-graph node ids with an endpoint-exposed consumer. */
   impacted_services: string[];
   total_impacted_consumers: number;
 }

--- a/packages/ui/__tests__/workspace/breaking-changes-view.test.tsx
+++ b/packages/ui/__tests__/workspace/breaking-changes-view.test.tsx
@@ -70,7 +70,7 @@ describe("BreakingChangesView", () => {
     noTimestamp.unmount();
 
     render(<BreakingChangesView report={report([])} />);
-    expect(screen.getByText(/no breaking changes/i)).toBeInTheDocument();
+    expect(screen.getByText(/no contract compatibility findings/i)).toBeInTheDocument();
   });
 
   it("says it is still checking while loading", () => {
@@ -81,6 +81,27 @@ describe("BreakingChangesView", () => {
   it("summarises the counts and the impacted repos", () => {
     render(<BreakingChangesView report={report([change()])} />);
     expect(screen.getByText(/1 breaking, 0 warnings across 1 repo/i)).toBeInTheDocument();
+  });
+
+  it("renders comparison fidelity and endpoint exposure without failure claims", () => {
+    render(
+      <BreakingChangesView
+        report={
+          report([
+            change({
+              severity: "warning",
+              kind: "schema_comparison_uncertain",
+              side: "response",
+              comparison_source: "openapi",
+              comparison_key: "openapi-wire-v1",
+            }),
+          ])
+        }
+      />,
+    );
+    expect(screen.getByText("response · openapi · openapi-wire-v1")).toBeInTheDocument();
+    expect(screen.getByText("1 endpoint-exposed consumer")).toBeInTheDocument();
+    expect(screen.queryByText(/endangers/i)).not.toBeInTheDocument();
   });
 
   it("links the provider symbol and the consumer symbol when hrefs are supplied", () => {

--- a/packages/ui/__tests__/workspace/contract-drawer.test.tsx
+++ b/packages/ui/__tests__/workspace/contract-drawer.test.tsx
@@ -2,7 +2,46 @@ import { describe, it, expect, vi } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import type { WorkspaceContractLinkEntry } from "@repowise-dev/types/workspace";
 import { ContractDrawer } from "../../src/workspace/contract-drawer.js";
-import { linksForContract, type ContractEntry } from "../../src/workspace/contract-facts.js";
+import {
+  flattenSchemaFields,
+  linksForContract,
+  schemaFieldConstraints,
+  type ContractEntry,
+} from "../../src/workspace/contract-facts.js";
+
+it("flattens recursive OpenAPI fields with locations, arrays, and constraints", () => {
+  const rows = flattenSchemaFields([
+    {
+      name: "$body",
+      type: "object",
+      location: "body",
+      children: [
+        {
+          name: "orders",
+          type: "array",
+          required: true,
+          items: {
+            name: "$items",
+            type: "object",
+            children: [
+              { name: "status", type: "string", nullable: true, enum_values: ["new", "done"] },
+            ],
+          },
+        },
+      ],
+    },
+    { name: "trace", type: "string", location: "header" },
+  ]);
+
+  expect(rows.map((row) => row.path)).toEqual([
+    "body",
+    "body.orders",
+    "body.orders[]",
+    "body.orders[].status",
+    "header:trace",
+  ]);
+  expect(schemaFieldConstraints(rows[3]!.field)).toBe("Optional · Nullable · Enum: new, done");
+});
 
 function contract(overrides: Partial<ContractEntry> = {}): ContractEntry {
   return {

--- a/packages/ui/__tests__/workspace/system-map-logic.test.ts
+++ b/packages/ui/__tests__/workspace/system-map-logic.test.ts
@@ -334,14 +334,14 @@ describe("buildBreakingChangeOverlay", () => {
     [edge("web", "api"), edge("idle", "api")],
   );
 
-  it("badges the changed provider and at-risk consumers, highlighting the seam", () => {
+  it("badges the changed provider and exposed consumers, highlighting the seam", () => {
     const overlay = buildBreakingChangeOverlay(g, report([change()]));
     expect(overlay.nodeBadges?.api).toEqual({ label: "1 breaking", tone: "danger" });
-    expect(overlay.nodeBadges?.web).toEqual({ label: "at risk", tone: "warning" });
+    expect(overlay.nodeBadges?.web).toEqual({ label: "exposed", tone: "warning" });
     // Only the consumer→provider edge in the report is highlighted.
     expect(overlay.highlightEdgeIds?.has("web->api")).toBe(true);
     expect(overlay.highlightEdgeIds?.has("idle->api")).toBe(false);
-    expect(overlay.edgeBadges?.["web->api"]).toEqual({ label: "breaking", tone: "danger" });
+    expect(overlay.edgeBadges?.["web->api"]).toEqual({ label: "incompatible", tone: "danger" });
     // Additive overlay: nothing is dimmed.
     expect(overlay.dimNodeIds).toBeUndefined();
   });
@@ -349,9 +349,11 @@ describe("buildBreakingChangeOverlay", () => {
   it("a warning-only provider reads as a warning badge", () => {
     const overlay = buildBreakingChangeOverlay(
       g,
-      report([change({ severity: "warning", kind: "removed_field", impacted_consumers: [] })]),
+      report([change({ severity: "warning", kind: "schema_comparison_uncertain" })]),
     );
     expect(overlay.nodeBadges?.api).toEqual({ label: "1 change", tone: "warning" });
+    expect(overlay.nodeBadges?.web).toBeUndefined();
+    expect(overlay.highlightEdgeIds).toBeUndefined();
   });
 
   it("returns an empty overlay when there are no changes", () => {

--- a/packages/ui/src/workspace/breaking-change-row.tsx
+++ b/packages/ui/src/workspace/breaking-change-row.tsx
@@ -55,7 +55,7 @@ export function breakingChangeSummary(report: BreakingChangeReport): string {
 
 /** Stable key for a change inside a report. */
 export function breakingChangeKey(change: BreakingChange): string {
-  return `${change.contract_id}:${change.kind}:${change.field_name ?? ""}`;
+  return `${change.contract_id}:${change.kind}:${change.side ?? ""}:${change.field_name ?? ""}`;
 }
 
 /** Prefer the symbol page, fall back to the file page, then to plain text. */
@@ -104,6 +104,13 @@ export function BreakingChangeRow({
         </button>
       </div>
       <div className="mt-[3px] text-[var(--color-text-secondary)]">{change.detail}</div>
+      {(change.side || change.comparison_source || change.comparison_key) && (
+        <div className="mt-0.5 text-[10px] text-[var(--color-text-tertiary)]">
+          {[change.side, change.comparison_source, change.comparison_key]
+            .filter(Boolean)
+            .join(" · ")}
+        </div>
+      )}
       <div className="mt-0.5 text-[10px] text-[var(--color-text-tertiary)]">
         {change.provider_repo} ·{" "}
         {providerHref ? (
@@ -122,8 +129,8 @@ export function BreakingChangeRow({
         <div className="mt-1.5">
           <div className="text-[10px] font-bold text-[var(--color-text-tertiary)]">
             {change.impacted_consumers.length === 1
-              ? "Endangers 1 consumer"
-              : `Endangers ${change.impacted_consumers.length} consumers`}
+              ? "1 endpoint-exposed consumer"
+              : `${change.impacted_consumers.length} endpoint-exposed consumers`}
           </div>
           {change.impacted_consumers.map((c) => (
             <ConsumerLine

--- a/packages/ui/src/workspace/breaking-changes-view.tsx
+++ b/packages/ui/src/workspace/breaking-changes-view.tsx
@@ -2,8 +2,8 @@
 
 /**
  * Breaking changes as a page section rather than a map rail: the provider
- * contracts that changed in the last workspace update and the consumers they
- * endanger, breaking first.
+ * contracts that changed in the last workspace update and their endpoint-exposed
+ * consumers, breaking first.
  *
  * The empty states are two different facts and are worded as two: a report that
  * never ran is silence, and only a report with a timestamp can say "nothing
@@ -62,8 +62,8 @@ export function BreakingChangesView({
     return (
       <EmptyState
         className="p-6"
-        title="No breaking changes in the most recent update"
-        description="Every provider contract that changed still matches the consumers linked to it."
+        title="No contract compatibility findings in the most recent update"
+        description="No provider incompatibility or comparison uncertainty was found."
       />
     );
   }

--- a/packages/ui/src/workspace/contract-drawer.tsx
+++ b/packages/ui/src/workspace/contract-drawer.tsx
@@ -36,6 +36,8 @@ import {
   contractMetaEntries,
   contractMetaLabel,
   contractMetaString,
+  flattenSchemaFields,
+  schemaFieldConstraints,
   type ContractEntry,
 } from "./contract-facts";
 
@@ -311,26 +313,24 @@ function CounterpartRow({
 }
 
 function FieldList({ caption, fields }: { caption: string; fields: SchemaField[] }) {
+  const rows = flattenSchemaFields(fields);
   return (
     <div>
       <div className="mb-1 text-xs font-medium text-[var(--color-text-secondary)]">{caption}</div>
       <ul className="flex flex-col">
-        {fields.map((f, i) => (
+        {rows.map(({ field: f, path }, i) => (
           <li
-            key={`${f.name}|${f.number ?? i}`}
+            key={`${path}|${f.number ?? i}`}
             className="flex flex-wrap items-baseline gap-x-2 border-t border-[var(--color-border-default)] py-1"
           >
             <span className="font-mono text-xs text-[var(--color-text-primary)] [overflow-wrap:anywhere]">
-              {f.name}
-              {f.repeated ? (
-                <span className="text-[var(--color-text-tertiary)]"> (repeated)</span>
-              ) : null}
+              {path}
             </span>
             <span className="font-mono text-xs text-[var(--color-text-secondary)] [overflow-wrap:anywhere]">
               {f.type}
             </span>
             <span className="text-[11px] text-[var(--color-text-tertiary)]">
-              {f.required ? "Required" : "Optional"}
+              {schemaFieldConstraints(f)}
             </span>
           </li>
         ))}

--- a/packages/ui/src/workspace/contract-facts.ts
+++ b/packages/ui/src/workspace/contract-facts.ts
@@ -137,13 +137,75 @@ export function contractMetaString(
  */
 export function asContractSchema(raw: Record<string, unknown> | null): ContractSchema | null {
   if (!raw) return null;
-  return {
+  const text = (key: string) => (typeof raw[key] === "string" ? raw[key] : undefined);
+  const state = (key: string): ContractSchema["request_state"] => {
+    const value = raw[key];
+    return value === "complete" ||
+      value === "partial" ||
+      value === "unsupported" ||
+      value === "unresolved"
+      ? value
+      : undefined;
+  };
+  const schema: ContractSchema = {
     source: typeof raw.source === "string" ? raw.source : "unknown",
     request_fields: Array.isArray(raw.request_fields) ? (raw.request_fields as SchemaField[]) : [],
     response_fields: Array.isArray(raw.response_fields)
       ? (raw.response_fields as SchemaField[])
       : [],
   };
+  const sourceVersion = text("source_version");
+  const comparisonKey = text("comparison_key");
+  const requestState = state("request_state");
+  const responseState = state("response_state");
+  const requestMediaType = text("request_media_type");
+  const responseMediaType = text("response_media_type");
+  const responseStatusCode = text("response_status_code");
+  if (sourceVersion !== undefined) schema.source_version = sourceVersion;
+  if (comparisonKey !== undefined) schema.comparison_key = comparisonKey;
+  if (typeof raw.comparison_ready === "boolean") schema.comparison_ready = raw.comparison_ready;
+  if (requestState !== undefined) schema.request_state = requestState;
+  if (responseState !== undefined) schema.response_state = responseState;
+  if (requestMediaType !== undefined) schema.request_media_type = requestMediaType;
+  if (responseMediaType !== undefined) schema.response_media_type = responseMediaType;
+  if (responseStatusCode !== undefined) schema.response_status_code = responseStatusCode;
+  if (Array.isArray(raw.issues)) {
+    schema.issues = raw.issues as NonNullable<ContractSchema["issues"]>;
+  }
+  return schema;
+}
+
+export interface SchemaFieldRow {
+  field: SchemaField;
+  path: string;
+}
+
+/** Flatten a bounded recursive schema for the existing list/table surfaces. */
+export function flattenSchemaFields(fields: SchemaField[]): SchemaFieldRow[] {
+  const rows: SchemaFieldRow[] = [];
+  const visit = (field: SchemaField, parent: string) => {
+    let segment = field.name;
+    if (segment === "$body") segment = "body";
+    else if (segment === "$response") segment = "response";
+    else if (segment === "$items") segment = "[]";
+    else if (field.location && field.location !== "body") {
+      segment = `${field.location}:${segment}`;
+    }
+    const path = segment === "[]" ? `${parent}[]` : parent ? `${parent}.${segment}` : segment;
+    rows.push({ field, path });
+    for (const child of field.children ?? []) visit(child, path);
+    if (field.items) visit(field.items, path);
+  };
+  for (const field of fields) visit(field, "");
+  return rows;
+}
+
+export function schemaFieldConstraints(field: SchemaField): string {
+  const values = [field.required ? "Required" : "Optional"];
+  if (field.nullable === true) values.push("Nullable");
+  if (field.enum_values?.length) values.push(`Enum: ${field.enum_values.join(", ")}`);
+  if (field.repeated) values.push("Repeated");
+  return values.join(" · ");
 }
 
 /**

--- a/packages/ui/src/workspace/system-map/breaking-changes.ts
+++ b/packages/ui/src/workspace/system-map/breaking-changes.ts
@@ -2,10 +2,9 @@
  * Breaking-change overlay — turns a `BreakingChangeReport` (computed by the core
  * / REST layer) into a `SystemMapOverlay` the Live System Map renders without any
  * component change. Changed provider services are badged with their breaking
- * count, the consumers they endanger are badged "at risk", and the edges between
- * them are highlighted. This is additive (no dimming): the whole map stays
- * legible, with the at-risk seams called out. The Phase 4 attach point promised
- * by the Phase 2 overlay API.
+ * count, endpoint-exposed consumers of incompatible changes are badged "exposed",
+ * and the edges between them are highlighted. Warning-only uncertainty never
+ * becomes a claim that a consumer will fail. This is additive (no dimming).
  */
 
 import type { BreakingChangeReport, SystemGraph } from "@repowise-dev/types";
@@ -36,6 +35,7 @@ export function buildBreakingChangeOverlay(
     providerCount.set(pid, (providerCount.get(pid) ?? 0) + 1);
     if (change.severity === "breaking") providerSeverity.set(pid, "breaking");
     else if (!providerSeverity.has(pid)) providerSeverity.set(pid, "warning");
+    if (change.severity !== "breaking") continue;
     for (const consumer of change.impacted_consumers) {
       consumerNodeIds.add(consumer.node_id);
       atRiskPairs.add(`${consumer.node_id}->${pid}`);
@@ -51,7 +51,7 @@ export function buildBreakingChangeOverlay(
     };
   }
   for (const nid of consumerNodeIds) {
-    if (!nodeBadges[nid]) nodeBadges[nid] = { label: "at risk", tone: "warning" };
+    if (!nodeBadges[nid]) nodeBadges[nid] = { label: "exposed", tone: "warning" };
   }
 
   const highlightEdgeIds = new Set<string>();
@@ -59,7 +59,7 @@ export function buildBreakingChangeOverlay(
   for (const edge of graph.edges) {
     if (atRiskPairs.has(`${edge.source}->${edge.target}`)) {
       highlightEdgeIds.add(edge.id);
-      edgeBadges[edge.id] = { label: "breaking", tone: "danger" };
+      edgeBadges[edge.id] = { label: "incompatible", tone: "danger" };
     }
   }
 

--- a/packages/ui/src/workspace/system-map/system-map-breaking-panel.tsx
+++ b/packages/ui/src/workspace/system-map/system-map-breaking-panel.tsx
@@ -2,10 +2,10 @@
 
 /**
  * Breaking-changes rail for the Live System Map. Given a `BreakingChangeReport`,
- * it lists each changed provider contract (breaking first) and the consumers it
- * endangers, showing both code sides — the provider file that changed and the
- * consumer file that calls it. Pure presentation: the host owns the fetch and
- * passes the report in; the at-risk badges ride the map's overlay prop.
+ * it lists each provider compatibility finding (breaking first) and consumers
+ * exposed through direct links, showing both code sides — the provider file and
+ * the consumer file that calls it. Pure presentation: the host owns the fetch and
+ * passes the report in; compatibility badges ride the map's overlay prop.
  *
  * The rows themselves are `BreakingChangeRow`, shared with the contracts page.
  * The rail passes no href builders, so they stay plain text and every click

--- a/packages/web/src/app/workspace/contracts/detail/contract-body.tsx
+++ b/packages/web/src/app/workspace/contracts/detail/contract-body.tsx
@@ -18,6 +18,8 @@ import {
   contractLede,
   contractMetaEntries,
   contractMetaLabel,
+  flattenSchemaFields,
+  schemaFieldConstraints,
 } from "@repowise-dev/ui/workspace/contract-facts";
 import { fileEntityPath } from "@repowise-dev/ui/shared/entity";
 import { formatNumber } from "@repowise-dev/ui/lib/format";
@@ -408,6 +410,7 @@ function noSchemaProse(type: string): string {
 }
 
 function FieldTable({ caption, fields }: { caption: string; fields: SchemaField[] }) {
+  const rows = flattenSchemaFields(fields);
   return (
     <TableScroll>
       <table className="w-full border-collapse text-left">
@@ -422,17 +425,14 @@ function FieldTable({ caption, fields }: { caption: string; fields: SchemaField[
           </tr>
         </thead>
         <tbody>
-          {fields.map((f, i) => (
+          {rows.map(({ field: f, path }, i) => (
             <tr
-              key={`${f.name}|${f.number ?? i}`}
+              key={`${path}|${f.number ?? i}`}
               className="border-t border-[var(--color-border-default)]"
             >
               <Td>
                 <span className="font-mono text-xs text-[var(--color-text-primary)] [overflow-wrap:anywhere]">
-                  {f.name}
-                  {f.repeated && (
-                    <span className="text-[var(--color-text-tertiary)]"> (repeated)</span>
-                  )}
+                  {path}
                 </span>
               </Td>
               <Td>
@@ -442,7 +442,7 @@ function FieldTable({ caption, fields }: { caption: string; fields: SchemaField[
               </Td>
               <Td>
                 <span className="text-xs text-[var(--color-text-tertiary)]">
-                  {f.required ? "Required" : "Optional"}
+                  {schemaFieldConstraints(f)}
                 </span>
               </Td>
             </tr>

--- a/tests/fixtures/openapi_contracts/compatible-3.0-after.yaml
+++ b/tests/fixtures/openapi_contracts/compatible-3.0-after.yaml
@@ -1,0 +1,34 @@
+openapi: 3.0.4
+info: {title: Orders, version: '2'}
+paths:
+  /orders:
+    post:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: {$ref: '#/components/schemas/OrderCreate'}
+      responses:
+        '201':
+          description: created
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/Order'}
+components:
+  schemas:
+    OrderCreate:
+      type: object
+      required: [sku]
+      properties:
+        sku: {type: string}
+        priority: {type: string, enum: [standard, express, bulk]}
+        note: {type: string, nullable: true}
+        coupon: {type: string}
+    Order:
+      type: object
+      required: [id, status]
+      properties:
+        id: {type: string}
+        status: {type: string, enum: [pending]}
+        note: {type: string}
+        traceId: {type: string}

--- a/tests/fixtures/openapi_contracts/compatible-3.1-before.yaml
+++ b/tests/fixtures/openapi_contracts/compatible-3.1-before.yaml
@@ -1,0 +1,21 @@
+openapi: 3.1.2
+info: {title: Notes, version: '1'}
+paths:
+  /notes:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                note: {type: string}
+      responses:
+        '200':
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  note: {type: [string, 'null']}

--- a/tests/fixtures/openapi_contracts/incompatible-3.0-after.yaml
+++ b/tests/fixtures/openapi_contracts/incompatible-3.0-after.yaml
@@ -1,0 +1,35 @@
+openapi: 3.0.4
+info: {title: Orders, version: '2'}
+paths:
+  /orders:
+    post:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: {$ref: '#/components/schemas/OrderCreate'}
+      responses:
+        '201':
+          description: created
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/Order'}
+components:
+  schemas:
+    OrderCreate:
+      type: object
+      required: [sku, region]
+      properties:
+        sku: {type: string}
+        region: {type: string}
+        priority: {type: string, enum: [standard]}
+        note: {type: string}
+    Order:
+      type: object
+      required: [status, customer]
+      properties:
+        id: {type: string}
+        status: {type: string, enum: [pending, complete, cancelled]}
+        customer:
+          type: object
+          properties: {}

--- a/tests/fixtures/openapi_contracts/incompatible-3.0-before.yaml
+++ b/tests/fixtures/openapi_contracts/incompatible-3.0-before.yaml
@@ -1,0 +1,36 @@
+openapi: 3.0.4
+info: {title: Orders, version: '1'}
+paths:
+  /orders:
+    post:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: {$ref: '#/components/schemas/OrderCreate'}
+      responses:
+        '201':
+          description: created
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/Order'}
+components:
+  schemas:
+    OrderCreate:
+      type: object
+      required: [sku]
+      properties:
+        sku: {type: string}
+        priority: {type: string, enum: [standard, express]}
+        note: {type: string, nullable: true}
+    Order:
+      type: object
+      required: [id, status, customer]
+      properties:
+        id: {type: string}
+        status: {type: string, enum: [pending, complete]}
+        customer:
+          type: object
+          required: [email]
+          properties:
+            email: {type: string}

--- a/tests/unit/server/test_mcp_change_risk_cross_repo.py
+++ b/tests/unit/server/test_mcp_change_risk_cross_repo.py
@@ -199,7 +199,8 @@ def test_carries_the_break_attributed_to_that_file(tmp_path: Path):
     assert block["consumer_repos"] == ["frontend"]
     assert block["summary"] == (
         "0 consumer link(s) in 1 other repo(s) touch the files this change edits"
-        "; 1 of the changed contracts broke them."
+        "; 1 provider incompatibility finding(s) and 0 comparison warning(s) "
+        "have endpoint-exposed consumers."
     )
 
 
@@ -294,7 +295,7 @@ def test_breaking_list_is_capped_and_says_by_how_much(tmp_path: Path):
     block = _block(_enricher(tmp_path, [], report), [PROVIDER_FILE])
     assert len(block["breaking_changes"]) == _CROSS_REPO_BREAKING_LIMIT
     assert block["breaking_changes_truncated"] == 2
-    assert f"{over} of the changed contracts broke them" in block["summary"]
+    assert f"{over} provider incompatibility finding(s)" in block["summary"]
 
 
 def test_cross_repo_participates_in_the_response_ceiling(tmp_path: Path):

--- a/tests/unit/server/test_workspace_router.py
+++ b/tests/unit/server/test_workspace_router.py
@@ -859,7 +859,6 @@ class TestQueryRepoStats:
 
         assert stats["hotspot_count"] == 0
 
-    
     def test_file_count_excludes_symbol_nodes(self, tmp_path: Path) -> None:
         """Regression: graph_nodes stores file *and* symbol rows.
 
@@ -1155,6 +1154,28 @@ def _make_breaking_enricher(tmp_path: Path) -> CrossRepoEnricher:
 
 
 class TestGetBreakingChanges:
+    def test_response_model_preserves_comparison_evidence(self) -> None:
+        from repowise.server.schemas.workspace import WorkspaceBreakingChange
+
+        payload = WorkspaceBreakingChange(
+            kind="field_enum_changed",
+            severity="breaking",
+            contract_id="http::POST::/orders",
+            contract_type="http",
+            provider_repo="api",
+            provider_file="openapi.yaml",
+            provider_symbol="openapi:POST /orders",
+            detail="request enum narrowed",
+            side="request",
+            comparison_source="openapi",
+            comparison_key="openapi-wire-v1",
+            field_name="body.priority",
+        ).model_dump(exclude_none=True)
+
+        assert payload["side"] == "request"
+        assert payload["comparison_source"] == "openapi"
+        assert payload["comparison_key"] == "openapi-wire-v1"
+
     @pytest.mark.asyncio
     async def test_not_workspace_mode(self) -> None:
         app = _make_workspace_app()
@@ -1373,9 +1394,7 @@ class TestRepoQueryBudget:
         return statements, connections
 
     @pytest.mark.asyncio
-    async def test_per_repo_cost_does_not_grow_with_repo_count(
-        self, tmp_path: Path
-    ) -> None:
+    async def test_per_repo_cost_does_not_grow_with_repo_count(self, tmp_path: Path) -> None:
         two_stmts, two_conns = await self._measure(tmp_path, 2)
         six_stmts, six_conns = await self._measure(tmp_path, 6)
 
@@ -1456,9 +1475,7 @@ class TestGetTestImpact:
             return None
 
         self._install_helper(monkeypatch, _none)
-        app = _make_workspace_app(
-            ws_config=_make_ws_config(), enricher=_make_enricher(tmp_path)
-        )
+        app = _make_workspace_app(ws_config=_make_ws_config(), enricher=_make_enricher(tmp_path))
         transport = ASGITransport(app=app)
         async with AsyncClient(transport=transport, base_url="http://test") as c:
             resp = await c.get(
@@ -1480,9 +1497,7 @@ class TestGetTestImpact:
             return WorkspaceTestImpactResult()
 
         self._install_helper(monkeypatch, _capture)
-        app = _make_workspace_app(
-            ws_config=_make_ws_config(), enricher=_make_enricher(tmp_path)
-        )
+        app = _make_workspace_app(ws_config=_make_ws_config(), enricher=_make_enricher(tmp_path))
         transport = ASGITransport(app=app)
         async with AsyncClient(transport=transport, base_url="http://test") as c:
             resp = await c.get(
@@ -1555,9 +1570,7 @@ class TestGetTestImpact:
             return result
 
         self._install_helper(monkeypatch, _result)
-        app = _make_workspace_app(
-            ws_config=_make_ws_config(), enricher=_make_enricher(tmp_path)
-        )
+        app = _make_workspace_app(ws_config=_make_ws_config(), enricher=_make_enricher(tmp_path))
         transport = ASGITransport(app=app)
         async with AsyncClient(transport=transport, base_url="http://test") as c:
             resp = await c.get(

--- a/tests/unit/workspace/test_breaking_change.py
+++ b/tests/unit/workspace/test_breaking_change.py
@@ -64,7 +64,7 @@ def _schema(request=None, response=None):
     )
 
 
-def test_schema_diff_waits_until_source_declares_comparison_ready():
+def test_schema_diff_reports_uncertainty_until_source_declares_comparison_ready():
     before = ContractSchema(
         source="openapi",
         request_fields=[SchemaField("id", "string", required=True)],
@@ -77,10 +77,11 @@ def test_schema_diff_waits_until_source_declares_comparison_ready():
         _store([_provider("http::POST::/orders", schema=after)]),
     )
 
-    assert report.changes == []
+    assert _kinds(report) == ["schema_comparison_uncertain"]
+    assert report.changes[0].severity == SEVERITY_WARNING
 
 
-def test_schema_diff_requires_matching_comparison_fidelity():
+def test_schema_diff_reports_uncertainty_for_mismatched_comparison_fidelity():
     before = ContractSchema(
         source="openapi",
         comparison_key="openapi-wire-v1",
@@ -93,7 +94,8 @@ def test_schema_diff_requires_matching_comparison_fidelity():
         _store([_provider("http::POST::/orders", schema=after)]),
     )
 
-    assert report.changes == []
+    assert _kinds(report) == ["schema_comparison_uncertain"]
+    assert report.changes[0].comparison_key == "openapi-wire-v2"
 
 
 def _kinds(report):
@@ -301,6 +303,33 @@ def test_report_round_trips_through_dict():
     assert _kinds(restored) == _kinds(report)
     assert restored.changes[0].impacted_consumers[0].node_id == "web"
     assert restored.changes[0].provider_node_id == "api"
+
+
+def test_comparison_evidence_round_trips_through_report() -> None:
+    change = BreakingChangeReport.from_dict(
+        {
+            "changes": [
+                {
+                    "kind": "field_enum_changed",
+                    "severity": "breaking",
+                    "contract_id": "http::POST::/orders",
+                    "contract_type": "http",
+                    "provider_repo": "api",
+                    "provider_file": "openapi.yaml",
+                    "provider_symbol": "openapi:POST /orders",
+                    "provider_service": None,
+                    "detail": "request enum narrowed",
+                    "side": "request",
+                    "comparison_source": "openapi",
+                    "comparison_key": "openapi-wire-v1",
+                }
+            ]
+        }
+    ).to_dict()["changes"][0]
+
+    assert change["side"] == "request"
+    assert change["comparison_source"] == "openapi"
+    assert change["comparison_key"] == "openapi-wire-v1"
 
 
 def test_save_and_load_report(tmp_path):

--- a/tests/unit/workspace/test_openapi_compatibility.py
+++ b/tests/unit/workspace/test_openapi_compatibility.py
@@ -1,0 +1,282 @@
+"""Directional compatibility coverage for complete OpenAPI wire schemas."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from repowise.core.workspace.breaking_change import (
+    SEVERITY_BREAKING,
+    SEVERITY_WARNING,
+    detect_breaking_changes,
+)
+from repowise.core.workspace.contract_schema import ContractSchema, SchemaField, SchemaIssue
+from repowise.core.workspace.contracts import Contract, ContractLink, ContractStore
+from repowise.core.workspace.extractors.openapi import OpenApiExtractor
+
+FIXTURES = Path(__file__).parents[2] / "fixtures" / "openapi_contracts"
+CONTRACT_ID = "http::POST::/orders"
+
+
+def _extract(name: str) -> Contract:
+    content = (FIXTURES / name).read_text(encoding="utf-8")
+    return OpenApiExtractor().extract(Path("."), "api", files=[("openapi.yaml", ".yaml", content)])[
+        0
+    ]
+
+
+def _link(contract_id: str = CONTRACT_ID) -> ContractLink:
+    return ContractLink(
+        contract_id=contract_id,
+        contract_type="http",
+        match_type="exact",
+        confidence=0.9,
+        provider_repo="api",
+        provider_file="openapi.yaml",
+        provider_symbol="openapi:POST /orders",
+        provider_service=None,
+        consumer_repo="web",
+        consumer_file="src/consumer.ts",
+        consumer_symbol="createOrder",
+        consumer_service=None,
+    )
+
+
+def _report(before: Contract, after: Contract):
+    return detect_breaking_changes(
+        ContractStore(contracts=[before], contract_links=[_link(before.contract_id)]),
+        ContractStore(contracts=[after], contract_links=[_link(after.contract_id)]),
+    )
+
+
+def _wire_schema(
+    *,
+    request=None,
+    response=None,
+    request_state="complete",
+    response_state="complete",
+    **kwargs,
+) -> ContractSchema:
+    return ContractSchema(
+        source="openapi",
+        comparison_key="openapi-wire-v1",
+        request_state=request_state,
+        response_state=response_state,
+        request_fields=request or [],
+        response_fields=response or [],
+        **kwargs,
+    )
+
+
+def _provider(schema: ContractSchema) -> Contract:
+    return Contract(
+        repo="api",
+        contract_id=CONTRACT_ID,
+        contract_type="http",
+        role="provider",
+        file_path="openapi.yaml",
+        symbol_name="openapi:POST /orders",
+        confidence=0.98,
+        schema=schema,
+    )
+
+
+def test_accepted_30_widening_and_narrowing_pair_is_compatible() -> None:
+    assert (
+        _report(
+            _extract("compatible-3.0-before.yaml"),
+            _extract("compatible-3.0-after.yaml"),
+        ).changes
+        == []
+    )
+
+
+def test_accepted_31_nullability_reversals_are_compatible() -> None:
+    assert (
+        _report(
+            _extract("compatible-3.1-before.yaml"),
+            _extract("compatible-3.1-after.yaml"),
+        ).changes
+        == []
+    )
+
+
+def test_incompatible_fixture_reports_all_six_directional_changes_and_exposure() -> None:
+    report = _report(
+        _extract("incompatible-3.0-before.yaml"),
+        _extract("incompatible-3.0-after.yaml"),
+    )
+
+    assert [(change.kind, change.side, change.field_name) for change in report.changes] == [
+        ("field_enum_changed", "request", "body.priority"),
+        ("field_enum_changed", "response", "response.status"),
+        ("field_nullability_changed", "request", "body.note"),
+        ("field_required", "request", "body.region"),
+        ("field_required_relaxed", "response", "response.id"),
+        ("removed_field", "response", "response.customer.email"),
+    ]
+    assert all(change.severity == SEVERITY_BREAKING for change in report.changes)
+    assert all(change.comparison_source == "openapi" for change in report.changes)
+    assert all(change.comparison_key == "openapi-wire-v1" for change in report.changes)
+    assert all(change.impacted_consumers[0].file == "src/consumer.ts" for change in report.changes)
+
+
+@pytest.mark.parametrize(
+    ("side", "before", "after"),
+    [
+        ("request", SchemaField("value", "string", required=True), SchemaField("value", "string")),
+        ("response", SchemaField("value", "string"), SchemaField("value", "string", required=True)),
+        (
+            "request",
+            SchemaField("value", "string", nullable=False),
+            SchemaField("value", "string", nullable=True),
+        ),
+        (
+            "response",
+            SchemaField("value", "string", nullable=True),
+            SchemaField("value", "string", nullable=False),
+        ),
+        (
+            "request",
+            SchemaField("value", "string", enum_values=["a"]),
+            SchemaField("value", "string", enum_values=["a", "b"]),
+        ),
+        (
+            "response",
+            SchemaField("value", "string", enum_values=["a", "b"]),
+            SchemaField("value", "string", enum_values=["a"]),
+        ),
+    ],
+)
+def test_directional_reverse_is_compatible(
+    side: str, before: SchemaField, after: SchemaField
+) -> None:
+    before_schema = _wire_schema(**{side: [before]})
+    after_schema = _wire_schema(**{side: [after]})
+    assert _report(_provider(before_schema), _provider(after_schema)).changes == []
+
+
+def test_array_items_recurse_with_the_same_directional_rules() -> None:
+    before = SchemaField(
+        "orders",
+        "array",
+        items=SchemaField(
+            "$items",
+            "object",
+            children=[SchemaField("id", "string", required=True)],
+        ),
+    )
+    after = SchemaField(
+        "orders",
+        "array",
+        items=SchemaField(
+            "$items",
+            "object",
+            children=[SchemaField("id", "string")],
+        ),
+    )
+    report = _report(
+        _provider(_wire_schema(response=[before])),
+        _provider(_wire_schema(response=[after])),
+    )
+    assert [(c.kind, c.field_name) for c in report.changes] == [
+        ("field_required_relaxed", "orders[].id")
+    ]
+
+
+def test_incomplete_side_change_is_uncertainty_not_field_removal() -> None:
+    before = _wire_schema(response=[SchemaField("id", "string")])
+    after = _wire_schema(
+        response_state="unresolved",
+        issues=[SchemaIssue("openapi_ref_cycle", "response", "#/components/schemas/Node")],
+    )
+
+    report = _report(_provider(before), _provider(after))
+
+    assert [(change.kind, change.severity, change.side) for change in report.changes] == [
+        ("schema_comparison_uncertain", SEVERITY_WARNING, "response")
+    ]
+
+
+def test_response_selection_change_is_uncertainty_not_a_field_diff() -> None:
+    field = SchemaField("id", "string", required=True)
+    before = _wire_schema(
+        response=[field], response_media_type="application/json", response_status_code="200"
+    )
+    after = _wire_schema(
+        response=[field], response_media_type="application/json", response_status_code="201"
+    )
+
+    report = _report(_provider(before), _provider(after))
+
+    assert [(change.kind, change.side) for change in report.changes] == [
+        ("schema_comparison_uncertain", "response")
+    ]
+
+
+def test_schema_source_transition_is_uncertainty_not_field_changes() -> None:
+    signature = ContractSchema(
+        source="signature", request_fields=[SchemaField("id", "str", required=True)]
+    )
+    openapi = _wire_schema(request=[SchemaField("id", "integer")])
+
+    report = _report(_provider(signature), _provider(openapi))
+
+    assert [change.kind for change in report.changes] == ["schema_comparison_uncertain"]
+
+
+@pytest.mark.parametrize(
+    ("side", "before_values", "after_values"),
+    [
+        ("request", None, ["a"]),
+        ("response", ["a"], None),
+    ],
+)
+def test_enum_constraint_boundary_detects_incompatible_direction(
+    side: str, before_values: list[str] | None, after_values: list[str] | None
+) -> None:
+    before = SchemaField("value", "string", enum_values=before_values)
+    after = SchemaField("value", "string", enum_values=after_values)
+
+    report = _report(
+        _provider(_wire_schema(**{side: [before]})),
+        _provider(_wire_schema(**{side: [after]})),
+    )
+
+    assert [(change.kind, change.side) for change in report.changes] == [
+        ("field_enum_changed", side)
+    ]
+
+
+@pytest.mark.parametrize(
+    ("side", "before_values", "after_values"),
+    [
+        ("request", ["a"], None),
+        ("response", None, ["a"]),
+    ],
+)
+def test_enum_constraint_boundary_allows_compatible_direction(
+    side: str, before_values: list[str] | None, after_values: list[str] | None
+) -> None:
+    before = SchemaField("value", "string", enum_values=before_values)
+    after = SchemaField("value", "string", enum_values=after_values)
+    assert (
+        _report(
+            _provider(_wire_schema(**{side: [before]})),
+            _provider(_wire_schema(**{side: [after]})),
+        ).changes
+        == []
+    )
+
+
+def test_number_enum_uses_json_numeric_equality() -> None:
+    before = SchemaField("value", "number", enum_values=[1])
+    after = SchemaField("value", "number", enum_values=[1.0])
+    assert (
+        _report(
+            _provider(_wire_schema(request=[before])),
+            _provider(_wire_schema(request=[after])),
+        ).changes
+        == []
+    )

--- a/tests/unit/workspace/test_openapi_extractor.py
+++ b/tests/unit/workspace/test_openapi_extractor.py
@@ -41,7 +41,7 @@ def test_openapi_30_recovers_recursive_shapes_enums_and_provenance() -> None:
     assert row.meta["schema_operation_pointer"] == "#/paths/~1orders/post"
     assert row.schema is not None
     assert row.schema.source_version == "3.0.4"
-    assert row.schema.comparison_ready is False
+    assert row.schema.comparison_ready is True
     assert row.schema.request_state == row.schema.response_state == "complete"
 
     body = row.schema.request_fields[0]
@@ -85,6 +85,64 @@ def test_parameters_merge_by_location_and_operation_overrides_path_item() -> Non
     assert _field(response.items.children, "id").type == "integer"
 
 
+@pytest.mark.parametrize(
+    ("serialization", "expected_state"),
+    [
+        ("style: form\n          explode: true\n          allowReserved: false", "complete"),
+        ("style: pipeDelimited", "unsupported"),
+        ("style: form\n          explode: false", "unsupported"),
+        ("style: form\n          allowReserved: true", "unsupported"),
+    ],
+)
+def test_parameter_serialization_is_complete_only_for_modeled_defaults(
+    serialization: str, expected_state: str
+) -> None:
+    document = f"""
+openapi: 3.0.4
+paths:
+  /search:
+    get:
+      parameters:
+        - in: query
+          name: tags
+          {serialization}
+          schema:
+            type: array
+            items: {{type: string}}
+      responses:
+        '204': {{description: empty}}
+"""
+    rows = OpenApiExtractor().extract(Path("."), "api", files=[("openapi.yaml", ".yaml", document)])
+
+    assert rows[0].schema is not None
+    assert rows[0].schema.request_state == expected_state
+    if expected_state == "unsupported":
+        assert rows[0].schema.issues[0].code == "openapi_parameter_serialization_unsupported"
+
+
+@pytest.mark.parametrize("value", [".nan", ".inf", "-.inf"])
+def test_non_finite_numeric_enums_are_unresolved(value: str) -> None:
+    document = f"""
+openapi: 3.0.4
+paths:
+  /numbers:
+    get:
+      parameters:
+        - in: query
+          name: value
+          schema:
+            type: number
+            enum: [{value}]
+      responses:
+        '204': {{description: empty}}
+"""
+    rows = OpenApiExtractor().extract(Path("."), "api", files=[("openapi.yaml", ".yaml", document)])
+
+    assert rows[0].schema is not None
+    assert rows[0].schema.request_state == "unresolved"
+    assert rows[0].schema.issues[0].code == "openapi_enum_number_non_finite"
+
+
 def test_unsupported_constructs_refuse_only_the_affected_side() -> None:
     rows, stats = _extract("unresolved-3.2.yaml")
 
@@ -95,12 +153,7 @@ def test_unsupported_constructs_refuse_only_the_affected_side() -> None:
     assert by_path["http::POST::/choice"].response_state == "unresolved"
     assert by_path["http::GET::/tree"].response_state == "unresolved"
     assert by_path["http::GET::/xml"].response_state == "unsupported"
-    assert {
-        issue.code
-        for schema in by_path.values()
-        if schema
-        for issue in schema.issues
-    } == {
+    assert {issue.code for schema in by_path.values() if schema for issue in schema.issues} == {
         "openapi_remote_ref",
         "openapi_composition_unsupported",
         "openapi_response_content_missing",

--- a/tests/unit/workspace/test_signature_schema.py
+++ b/tests/unit/workspace/test_signature_schema.py
@@ -124,9 +124,9 @@ class TestAmbientParameters:
     def test_the_request_and_response_objects_are_dropped(self):
         # Renaming one of these is a no-op on the wire; counting it as a
         # required field reports that rename as a breaking change.
-        assert _fields(
-            "async def h(request: Request, response: Response, q: str)", "python"
-        ) == [("q", "str", True)]
+        assert _fields("async def h(request: Request, response: Response, q: str)", "python") == [
+            ("q", "str", True)
+        ]
         assert _fields("Get(HttpContext ctx, [FromQuery] string q)", "csharp") == [
             ("q", "string", True)
         ]
@@ -252,9 +252,7 @@ def _symbol(name: str, signature: str, *, kind="function", language="python", li
 
 class TestAttachPass:
     async def test_the_route_template_protects_its_own_parameters(self, tmp_path: Path):
-        index = await _index_for(
-            tmp_path, [_symbol("h", "def h(request: Request, repo_id: str)")]
-        )
+        index = await _index_for(tmp_path, [_symbol("h", "def h(request: Request, repo_id: str)")])
         contract = _provider("app/api.py::h")
         contract.symbol_name = "fastapi:GET /repos/{request}"
         try:
@@ -286,9 +284,7 @@ class TestAttachPass:
         # The function making a call says nothing about the request it sends.
         assert consumer.schema is None
 
-    async def test_a_symbol_carrying_several_providers_is_a_registration_site(
-        self, tmp_path: Path
-    ):
+    async def test_a_symbol_carrying_several_providers_is_a_registration_site(self, tmp_path: Path):
         index = await _index_for(
             tmp_path, [_symbol("create_app", "def create_app(settings: Settings) -> FastAPI")]
         )
@@ -330,9 +326,7 @@ class TestAttachPass:
         assert [f.name for f in contract.schema.request_fields] == ["id"]
 
     async def test_a_non_callable_symbol_is_counted_not_read(self, tmp_path: Path):
-        index = await _index_for(
-            tmp_path, [_symbol("Order", "class Order", kind="class", line=6)]
-        )
+        index = await _index_for(tmp_path, [_symbol("Order", "class Order", kind="class", line=6)])
         contracts = [_provider("app/api.py::Order")]
         try:
             counts = attach_signature_schemas(contracts, index)
@@ -369,7 +363,7 @@ class TestFidelityIsNotMixed:
         # The fields differ in both type and requiredness, so a source-blind
         # diff reports two breaking changes for a change of parser.
         assert _diff_schemas(proto, signature)
-        assert _report_kinds(proto, signature) == []
+        assert _report_kinds(proto, signature) == ["schema_comparison_uncertain"]
 
     def test_two_signature_shapes_are_diffed(self):
         before = ContractSchema(source=SCHEMA_SOURCE, request_fields=[SchemaField("a", "str")])


### PR DESCRIPTION
## Summary

- compare complete OpenAPI request and response schemas with direction-aware compatibility rules
- recurse through object properties and array items for type, requiredness, nullability, and enum changes
- retain schema side, extraction source, and comparison key evidence through reports, risk directives, server models, shared types, and UI surfaces
- surface extraction or fidelity transitions as comparison warnings instead of definitive field removals
- document the supported OpenAPI subset, static evidence boundary, and endpoint-exposure vocabulary

## Compatibility boundary

OpenAPI field comparison runs only when both sides are complete and use the same extraction source and comparison key. Request rules follow values the provider accepts; response rules follow values consumers may receive. Unsupported parameter serialization, ambiguous response selection, incomplete extraction, and source/key transitions produce uncertainty rather than a compatibility claim.

The extractor remains local-only and bounded: default OpenAPI parameter serialization, one JSON request body, one explicit JSON 2xx response, recursive objects/arrays, finite scalar enums, and bounded same-document references. Existing protobuf, signature, code-API, report, risk, and test-impact behavior remains covered.

Impacted consumers are described as directly linked endpoint exposure. The result is static evidence, not proof that a runtime failure occurred.

## Independent review

An independent read-only review identified four fidelity gaps before commit. This revision now:

- refuses non-default parameter `style`, `explode`, or `allowReserved` behavior instead of marking it fully comparable
- detects incompatible constrained/unconstrained enum transitions in both request and response directions
- treats equivalent OpenAPI numbers such as `1` and `1.0` as the same enum value while keeping booleans distinct
- rejects non-finite YAML numeric enums as unresolved so persisted schemas stay JSON-safe

The review also found stale risk wording in REST, MCP, and system-map comments; those descriptions now use finding/exposure language.

## Verification

- `161 passed` — focused OpenAPI, compatibility, protobuf, signature, code-API, diagnostics, and system-graph tests
- `80 passed` — workspace router and change-risk projection tests
- `52 passed` — workspace CLI tests
- `35 passed` — extraction walk-budget and workspace update tests
- `27 passed` — risk-directed UI contract/system-map tests
- `npm run type-check --workspace packages/types`
- `npm run type-check --workspace packages/ui`
- Ruff lint and format checks on all touched Python files
- `git diff --cached --check`

The web package type-check still encounters the pre-existing generated `.next/types/validator.ts` reference to the absent `src/app/repos/[id]/health/page.js`; no generated state was changed.

## Overlap check

- #1799 touches the legacy field diff, but treats a missing schema as empty. This change intentionally reports extraction/source fidelity transitions as uncertainty, so the behavior is not adopted here.
- #2208 overlaps only `docs/agent/MCP_TOOLS.md` in an unrelated shallow-clone disclosure section.
- #2041 overlaps only shared workspace schema/type files for unrelated co-change evidence.
